### PR TITLE
Add instructor pages pSEO surface

### DIFF
--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -1,0 +1,525 @@
+/**
+ * Instructor detail pSEO page.
+ *
+ * Lists every section taught by an instructor at a specific college.
+ * Route: /[state]/college/[id]/instructor/[slug]
+ *
+ * Uses ISR (revalidate = 604800). Pages are rendered on-demand and cached
+ * for 7 days, same pattern as course/subject pSEO pages.
+ */
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { loadInstitutions } from "@/lib/institutions";
+import { getCurrentTerm, termLabel } from "@/lib/terms";
+import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { getInstructorBySlug, getTopInstructors } from "@/lib/instructors";
+import { subjectName } from "@/lib/subjects";
+import type { CourseSection } from "@/lib/types";
+import AdUnit from "@/components/AdUnit";
+import TrackView from "@/components/TrackView";
+
+export const revalidate = 604800; // 7 days — pSEO content rarely changes
+
+type PageProps = {
+  params: Promise<{ state: string; id: string; slug: string }>;
+};
+
+// All pages generated on-demand via ISR
+export async function generateStaticParams() {
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MODE_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  "in-person": { bg: "bg-emerald-50 dark:bg-emerald-900/30", text: "text-emerald-700 dark:text-emerald-400", label: "In-Person" },
+  online: { bg: "bg-blue-50 dark:bg-blue-900/30", text: "text-blue-700 dark:text-blue-400", label: "Online" },
+  hybrid: { bg: "bg-purple-50 dark:bg-purple-900/30", text: "text-purple-700 dark:text-purple-400", label: "Hybrid" },
+  zoom: { bg: "bg-sky-50 dark:bg-sky-900/30", text: "text-sky-700 dark:text-sky-400", label: "Zoom" },
+};
+
+function isValidTime(t: string): boolean {
+  return !!t && t !== "TBA" && t !== "0:00 AM" && t !== "0:00 PM";
+}
+
+function expandDays(days: string): string {
+  if (!days || !days.trim()) return "";
+  const DAY_MAP: Record<string, string> = {
+    M: "Mon", Tu: "Tue", W: "Wed", Th: "Thu", F: "Fri", Sa: "Sat", Su: "Sun",
+    TH: "Thu", SU: "Sun", TU: "Tue", SA: "Sat",
+  };
+  const result: string[] = [];
+  let i = 0;
+  const cleaned = days.replace(/[,\s]+/g, "").trim();
+  while (i < cleaned.length) {
+    if (i + 1 < cleaned.length) {
+      const two = cleaned.substring(i, i + 2);
+      if (DAY_MAP[two]) { result.push(DAY_MAP[two]); i += 2; continue; }
+    }
+    const one = cleaned[i];
+    if (DAY_MAP[one]) result.push(DAY_MAP[one]);
+    i++;
+  }
+  return result.join(" ");
+}
+
+function formatSchedule(s: CourseSection): string {
+  const hasTime = isValidTime(s.start_time) && isValidTime(s.end_time);
+  if (!s.days && !hasTime) return "Asynchronous / Online";
+  const days = s.days ? expandDays(s.days) : "";
+  const time = hasTime ? `${s.start_time}\u2013${s.end_time}` : "";
+  if (days && time) return `${days} ${time}`;
+  return days || time || "Asynchronous / Online";
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { state, id, slug } = await props.params;
+  if (!isValidState(state)) return { title: "Not Found" };
+
+  const institutions = loadInstitutions(state);
+  const institution = institutions.find((i) => i.id === id);
+  if (!institution) return { title: "Not Found" };
+
+  const config = getStateConfig(state);
+  const currentTerm = await getCurrentTerm(state);
+  const profile = await getInstructorBySlug(
+    institution.college_slug,
+    currentTerm,
+    state,
+    slug
+  );
+  if (!profile) return { title: "Not Found" };
+
+  const subjects = Array.from(
+    new Set(profile.sections.map((s) => s.course_prefix))
+  ).sort();
+  const subjectLabels = subjects.map((p) => subjectName(p)).join(", ");
+  const term = termLabel(currentTerm);
+
+  const title = `${profile.displayName} — ${institution.name} Instructor`;
+  const description = `Browse ${profile.sections.length} sections taught by ${profile.displayName} at ${institution.name} for ${term}. Subjects: ${subjectLabels}. Compare schedules and availability.`;
+
+  const canonical = `${process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"}/${state}/college/${id}/instructor/${slug}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "profile",
+      siteName: config.branding.siteName,
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default async function InstructorPage(props: PageProps) {
+  const { state, id, slug } = await props.params;
+  if (!isValidState(state)) notFound();
+
+  const institutions = loadInstitutions(state);
+  const institution = institutions.find((i) => i.id === id);
+  if (!institution) notFound();
+
+  const config = getStateConfig(state);
+  const currentTerm = await getCurrentTerm(state);
+  const profile = await getInstructorBySlug(
+    institution.college_slug,
+    currentTerm,
+    state,
+    slug
+  );
+  if (!profile) notFound();
+
+  const { sections } = profile;
+  const term = termLabel(currentTerm);
+
+  // Subjects taught
+  const subjectCounts = new Map<string, number>();
+  for (const s of sections) {
+    subjectCounts.set(
+      s.course_prefix,
+      (subjectCounts.get(s.course_prefix) || 0) + 1
+    );
+  }
+  const subjects = Array.from(subjectCounts.entries()).sort(
+    (a, b) => b[1] - a[1]
+  );
+
+  // Unique courses
+  const uniqueCourses = new Set(
+    sections.map((s) => `${s.course_prefix} ${s.course_number}`)
+  ).size;
+
+  // Mode breakdown
+  const modeBreakdown: Record<string, number> = {};
+  for (const s of sections) {
+    modeBreakdown[s.mode] = (modeBreakdown[s.mode] || 0) + 1;
+  }
+
+  // Sort sections: by prefix, then number, then start_time
+  const sortedSections = [...sections].sort((a, b) => {
+    const prefixCmp = a.course_prefix.localeCompare(b.course_prefix);
+    if (prefixCmp !== 0) return prefixCmp;
+    const numCmp = a.course_number.localeCompare(b.course_number);
+    if (numCmp !== 0) return numCmp;
+    return (a.start_time || "").localeCompare(b.start_time || "");
+  });
+
+  // Other instructors at this college (top 20, excluding current)
+  const topInstructors = await getTopInstructors(
+    institution.college_slug,
+    currentTerm,
+    state,
+    21
+  );
+  const otherInstructors = topInstructors
+    .filter((i) => i.slug !== slug)
+    .slice(0, 20);
+
+  // Seats summary
+  const totalSeats = sections.reduce(
+    (sum, s) => sum + (s.seats_open ?? 0),
+    0
+  );
+  const sectionsWithSeats = sections.filter(
+    (s) => s.seats_open !== null && s.seats_open > 0
+  ).length;
+
+  // JSON-LD
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: profile.displayName,
+    jobTitle: "Instructor",
+    worksFor: {
+      "@type": "EducationalOrganization",
+      name: institution.name,
+      url: `${siteUrl}/${state}/college/${id}`,
+    },
+    teaches: subjects.slice(0, 10).map(([prefix, count]) => ({
+      "@type": "Course",
+      name: subjectName(prefix),
+      courseCode: prefix,
+      description: `${count} sections`,
+    })),
+  };
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: config.name,
+        item: `${siteUrl}/${state}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: institution.name,
+        item: `${siteUrl}/${state}/college/${id}`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: "Instructors",
+      },
+      {
+        "@type": "ListItem",
+        position: 4,
+        name: profile.displayName,
+        item: `${siteUrl}/${state}/college/${id}/instructor/${slug}`,
+      },
+    ],
+  };
+
+  // RMP search link
+  const rmpUrl = `https://www.ratemyprofessors.com/search/professors?q=${encodeURIComponent(profile.displayName)}`;
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+
+      <TrackView
+        event="instructor_page_view"
+        params={{
+          state,
+          college: id,
+          instructor: profile.displayName,
+          sections: sections.length,
+          subjects: subjects.length,
+        }}
+      />
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Breadcrumb */}
+        <nav className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-slate-400 mb-6">
+          <Link
+            href={`/${state}`}
+            className="hover:text-teal-600 dark:hover:text-teal-400"
+          >
+            {config.name}
+          </Link>
+          <span>/</span>
+          <Link
+            href={`/${state}/college/${id}`}
+            className="hover:text-teal-600 dark:hover:text-teal-400"
+          >
+            {institution.name}
+          </Link>
+          <span>/</span>
+          <span className="text-gray-900 dark:text-slate-100 font-medium">
+            {profile.displayName}
+          </span>
+        </nav>
+
+        {/* Header */}
+        <div className="mb-8">
+          <p className="text-sm font-medium text-teal-600 dark:text-teal-400 mb-1">
+            Instructor
+          </p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
+            {profile.displayName}
+          </h1>
+          <p className="text-gray-600 dark:text-slate-400 mt-1.5">
+            <Link
+              href={`/${state}/college/${id}`}
+              className="text-teal-600 dark:text-teal-400 hover:underline"
+            >
+              {institution.name}
+            </Link>
+            {" "}&middot;{" "}
+            <span className="font-semibold text-gray-900 dark:text-slate-100">
+              {sections.length}
+            </span>{" "}
+            {sections.length === 1 ? "section" : "sections"} &middot;{" "}
+            <span className="font-semibold text-gray-900 dark:text-slate-100">
+              {uniqueCourses}
+            </span>{" "}
+            {uniqueCourses === 1 ? "course" : "courses"} &middot;{" "}
+            <span className="text-gray-400 dark:text-slate-500">{term}</span>
+          </p>
+          {sectionsWithSeats > 0 && (
+            <p className="text-emerald-600 dark:text-emerald-400 text-sm mt-1">
+              {totalSeats} {totalSeats === 1 ? "seat" : "seats"} open across{" "}
+              {sectionsWithSeats}{" "}
+              {sectionsWithSeats === 1 ? "section" : "sections"}
+            </p>
+          )}
+        </div>
+
+        {/* Subjects taught */}
+        <div className="flex flex-wrap gap-2 mb-6">
+          {subjects.map(([prefix, count]) => (
+            <Link
+              key={prefix}
+              href={`/${state}/college/${id}/courses/${prefix.toLowerCase()}`}
+              className="inline-flex items-center gap-1.5 rounded-full bg-gray-100 dark:bg-slate-800 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-slate-300 hover:bg-teal-100 dark:hover:bg-teal-900/40 hover:text-teal-700 dark:hover:text-teal-400 transition-colors"
+            >
+              <span>{subjectName(prefix)}</span>
+              <span className="text-gray-400 dark:text-slate-500">
+                ({prefix})
+              </span>
+              <span className="rounded-full bg-gray-200 dark:bg-slate-700 px-1.5 py-0.5 text-[10px] font-semibold text-gray-600 dark:text-slate-400">
+                {count}
+              </span>
+            </Link>
+          ))}
+        </div>
+
+        {/* Mode breakdown */}
+        <div className="flex flex-wrap gap-1.5 mb-8">
+          {Object.entries(modeBreakdown).map(([mode, count]) => {
+            const style = MODE_STYLES[mode] || MODE_STYLES["in-person"];
+            return (
+              <span
+                key={mode}
+                className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium ${style.bg} ${style.text}`}
+              >
+                {style.label}: {count}
+              </span>
+            );
+          })}
+        </div>
+
+        {/* Sections table */}
+        <section className="mb-8">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            Sections Taught
+          </h2>
+          <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-900">
+            <table className="w-full text-left text-xs">
+              <thead className="bg-gray-50 dark:bg-slate-800 text-[10px] uppercase tracking-wider text-gray-500 dark:text-slate-400">
+                <tr>
+                  <th className="px-3 py-2 font-medium">CRN</th>
+                  <th className="px-3 py-2 font-medium">Course</th>
+                  <th className="px-3 py-2 font-medium">Title</th>
+                  <th className="px-3 py-2 font-medium">Schedule</th>
+                  <th className="px-3 py-2 font-medium">Campus</th>
+                  <th className="px-3 py-2 font-medium">Mode</th>
+                  <th className="px-3 py-2 font-medium">Seats</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50 dark:divide-slate-700">
+                {sortedSections.map((s) => {
+                  const style =
+                    MODE_STYLES[s.mode] || MODE_STYLES["in-person"];
+                  return (
+                    <tr
+                      key={`${s.crn}-${s.start_time}`}
+                      className="hover:bg-gray-50 dark:hover:bg-slate-800"
+                    >
+                      <td className="px-3 py-2 font-mono text-gray-600 dark:text-slate-400">
+                        {s.crn}
+                      </td>
+                      <td className="px-3 py-2 font-mono font-medium">
+                        <Link
+                          href={`/${state}/course/${s.course_prefix.toLowerCase()}-${s.course_number.toLowerCase()}`}
+                          className="text-teal-600 dark:text-teal-400 hover:underline"
+                        >
+                          {s.course_prefix} {s.course_number}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 text-gray-700 dark:text-slate-300 max-w-[200px] truncate">
+                        {s.course_title}
+                      </td>
+                      <td className="px-3 py-2 text-gray-700 dark:text-slate-300">
+                        {formatSchedule(s)}
+                      </td>
+                      <td className="px-3 py-2 text-gray-600 dark:text-slate-400">
+                        {s.campus || "---"}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${style.bg} ${style.text}`}
+                        >
+                          {style.label}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        {s.seats_open !== null && s.seats_open !== undefined ? (
+                          <span
+                            className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                              s.seats_open > 10
+                                ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
+                                : s.seats_open > 0
+                                  ? "bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
+                                  : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-400"
+                            }`}
+                          >
+                            {s.seats_open}
+                            {s.seats_total ? `/${s.seats_total}` : ""}
+                          </span>
+                        ) : (
+                          <span className="text-[10px] text-gray-400 dark:text-slate-500">
+                            &mdash;
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* In-content ad */}
+        <div className="mb-8">
+          <AdUnit slot="7261548390" format="auto" className="min-h-[100px]" />
+        </div>
+
+        {/* Rate My Professors link */}
+        <div className="mb-8 rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 px-4 py-3">
+          <p className="text-sm text-gray-600 dark:text-slate-400">
+            Looking for reviews?{" "}
+            <a
+              href={rmpUrl}
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+              className="text-teal-600 dark:text-teal-400 hover:underline font-medium"
+            >
+              Search for {profile.displayName} on Rate My Professors &rarr;
+            </a>
+          </p>
+        </div>
+
+        {/* Other instructors at this college */}
+        {otherInstructors.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+              Other Instructors at {institution.name}
+            </h2>
+            <div className="flex flex-wrap gap-2">
+              {otherInstructors.map((inst) => (
+                <Link
+                  key={inst.slug}
+                  href={`/${state}/college/${id}/instructor/${inst.slug}`}
+                  className="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-slate-300 hover:border-teal-300 dark:hover:border-teal-700 hover:text-teal-700 dark:hover:text-teal-400 transition"
+                >
+                  {inst.displayName}
+                  <span className="text-gray-400 dark:text-slate-500 ml-1">
+                    ({inst.sectionCount})
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Quick links */}
+        <div className="flex flex-wrap gap-3 pt-4 border-t border-gray-100 dark:border-slate-800 text-sm">
+          <Link
+            href={`/${state}/college/${id}`}
+            className="text-teal-600 dark:text-teal-400 hover:underline"
+          >
+            &larr; Back to {institution.name}
+          </Link>
+          <Link
+            href={`/${state}/courses`}
+            className="text-teal-600 dark:text-teal-400 hover:underline"
+          >
+            Search courses
+          </Link>
+          <Link
+            href={`/${state}/schedule`}
+            className="text-teal-600 dark:text-teal-400 hover:underline"
+          >
+            Schedule Builder
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -12,6 +12,7 @@ import { buildTransferLookup } from "@/lib/transfer";
 import { getStateConfig, getAllStates } from "@/lib/states/registry";
 import { getUniqueSubjects } from "@/lib/courses";
 import { subjectName } from "@/lib/subjects";
+import { getTopInstructors } from "@/lib/instructors";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
 
@@ -443,6 +444,41 @@ export default async function CollegeDetailPage(props: PageProps) {
       <div className="mt-8">
         <AdUnit slot="3816492750" format="auto" className="min-h-[100px]" />
       </div>
+
+      {/* Browse Instructors */}
+      {await (async () => {
+        try {
+          const topInstructors = await getTopInstructors(
+            institution.college_slug,
+            currentTerm,
+            state
+          );
+          if (topInstructors.length === 0) return null;
+          return (
+            <section className="mt-8">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+                Browse Instructors
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                {topInstructors.map((inst) => (
+                  <Link
+                    key={inst.slug}
+                    href={`/${state}/college/${id}/instructor/${inst.slug}`}
+                    className="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-slate-300 hover:border-teal-300 dark:hover:border-teal-700 hover:text-teal-700 dark:hover:text-teal-400 transition"
+                  >
+                    {inst.displayName}
+                    <span className="text-gray-400 dark:text-slate-500 ml-1">
+                      ({inst.sectionCount})
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          );
+        } catch {
+          return null;
+        }
+      })()}
 
       {/* Other colleges in this state — internal linking for SEO */}
       {(() => {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@ import {
   getUniqueSubjects,
   getSitemapCourseIndex,
 } from "@/lib/courses";
+import { getInstructorSitemapEntries } from "@/lib/instructors";
 import { getCurrentTerm } from "@/lib/terms";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
@@ -113,6 +114,28 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   }
 
+  // Instructor pages (pSEO) — one page per instructor with ≥2 sections
+  const instructorPages: MetadataRoute.Sitemap = [];
+
+  for (const state of getAllStates()) {
+    try {
+      const currentTerm = await getCurrentTerm(state.slug);
+      const instructorEntries = await getInstructorSitemapEntries(
+        currentTerm,
+        state.slug
+      );
+      for (const entry of instructorEntries) {
+        instructorPages.push({
+          url: `${baseUrl}/${state.slug}/college/${entry.collegeId}/instructor/${entry.slug}`,
+          changeFrequency: "weekly" as const,
+          priority: 0.6,
+        });
+      }
+    } catch {
+      // Skip state if instructor loading fails
+    }
+  }
+
   // Blog pages
   const blogPages: MetadataRoute.Sitemap = [
     { url: `${baseUrl}/blog`, changeFrequency: "weekly" as const, priority: 0.7 },
@@ -130,6 +153,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...subjectPages,
     ...stateSubjectPages,
     ...coursePages,
+    ...instructorPages,
     ...blogPages,
   ];
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -22,6 +22,7 @@ export type AnalyticsEvent =
   | "course_detail_view"
   | "college_detail_view"
   | "subject_page_view"
+  | "instructor_page_view"
   // Transfer
   | "transfer_lookup_submit"
   | "transfer_course_add"

--- a/lib/instructors.ts
+++ b/lib/instructors.ts
@@ -1,0 +1,427 @@
+/**
+ * Instructor entity resolution and indexing.
+ *
+ * Derives instructor profiles from the free-text `instructor` column in the
+ * courses table. No DB schema changes needed — everything is computed from
+ * the existing course section data via loadCoursesForCollege (already cached).
+ */
+
+import type { CourseSection } from "./types";
+import { loadCoursesForCollege } from "./courses";
+import { loadInstitutions } from "./institutions";
+import { getCurrentTerm } from "./terms";
+
+// ---------------------------------------------------------------------------
+// In-memory cache (matches lib/courses.ts pattern)
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry<T> {
+  data: T;
+  expires: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+async function cached<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const entry = cache.get(key) as CacheEntry<T> | undefined;
+  if (entry && entry.expires > Date.now()) return entry.data;
+
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const promise = fn()
+    .then((data) => {
+      cache.set(key, { data, expires: Date.now() + CACHE_TTL });
+      inflight.delete(key);
+      return data;
+    })
+    .catch((err) => {
+      inflight.delete(key);
+      throw err;
+    });
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface InstructorProfile {
+  slug: string;
+  displayName: string;
+  rawNames: Set<string>;
+  sections: CourseSection[];
+}
+
+/** Serializable version for sitemap/index use */
+export interface InstructorEntry {
+  slug: string;
+  displayName: string;
+  sectionCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Name normalization
+// ---------------------------------------------------------------------------
+
+/** Names to skip — not real instructor identities */
+const SKIP_NAMES = new Set([
+  "staff",
+  "tba",
+  "tbd",
+  "instructor",
+  "adjunct",
+  "unknown",
+  "none",
+  "",
+]);
+
+/** Suffixes to preserve but move to end of slug */
+const SUFFIXES = new Set([
+  "jr",
+  "sr",
+  "ii",
+  "iii",
+  "iv",
+  "v",
+  "phd",
+  "md",
+  "esq",
+]);
+
+/**
+ * Normalize a raw instructor name string into a URL-safe slug.
+ *
+ * "Smith, Jane A" → "jane-smith"
+ * "JOHNSON III, ROBERT" → "robert-johnson-iii"
+ * "De La Cruz, Maria" → "maria-de-la-cruz"
+ */
+export function normalizeInstructorSlug(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+
+  let first = "";
+  let last = "";
+  let suffix = "";
+
+  if (trimmed.includes(",")) {
+    // "Last, First Middle" or "Last Suffix, First"
+    const [lastPart, ...rest] = trimmed.split(",").map((s) => s.trim());
+    const firstPart = rest.join(" ").trim();
+
+    // Extract suffix from last part: "Johnson III" → last="Johnson", suffix="III"
+    const lastTokens = lastPart.split(/\s+/);
+    const lastFiltered: string[] = [];
+    for (const token of lastTokens) {
+      if (SUFFIXES.has(token.toLowerCase())) {
+        suffix = token.toLowerCase();
+      } else {
+        lastFiltered.push(token);
+      }
+    }
+    last = lastFiltered.join(" ");
+
+    // Extract suffix from first part too, and strip middle initials
+    const firstTokens = firstPart.split(/\s+/);
+    const firstFiltered: string[] = [];
+    for (const token of firstTokens) {
+      if (SUFFIXES.has(token.toLowerCase())) {
+        suffix = token.toLowerCase();
+      } else if (token.length <= 1 || (token.length === 2 && token.endsWith("."))) {
+        // Skip single-letter middle initials like "A" or "A."
+        continue;
+      } else {
+        firstFiltered.push(token);
+      }
+    }
+    first = firstFiltered.join(" ");
+  } else {
+    // "Jane Smith" or "Jane A Smith"
+    const tokens = trimmed.split(/\s+/);
+    const filtered: string[] = [];
+    for (const token of tokens) {
+      if (SUFFIXES.has(token.toLowerCase())) {
+        suffix = token.toLowerCase();
+      } else if (token.length <= 1 || (token.length === 2 && token.endsWith("."))) {
+        continue;
+      } else {
+        filtered.push(token);
+      }
+    }
+    if (filtered.length >= 2) {
+      first = filtered.slice(0, -1).join(" ");
+      last = filtered[filtered.length - 1];
+    } else if (filtered.length === 1) {
+      first = filtered[0];
+    }
+  }
+
+  // Build slug: first-last-suffix
+  const parts = [first, last, suffix].filter(Boolean);
+  return parts
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Produce a display name from a raw instructor string.
+ *
+ * "Smith, Jane A" → "Jane Smith"
+ * "JOHNSON III, ROBERT" → "Robert Johnson III"
+ * If not comma-separated, return as-is with title case.
+ */
+export function displayName(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+
+  function titleCase(s: string): string {
+    return s
+      .toLowerCase()
+      .split(/\s+/)
+      .map((w) => {
+        // Preserve common short words in names, but capitalize first letter
+        if (w.length === 0) return w;
+        return w[0].toUpperCase() + w.slice(1);
+      })
+      .join(" ");
+  }
+
+  if (trimmed.includes(",")) {
+    const [lastPart, ...rest] = trimmed.split(",").map((s) => s.trim());
+    const firstPart = rest.join(" ").trim();
+
+    // Extract suffix from last
+    const lastTokens = lastPart.split(/\s+/);
+    const lastFiltered: string[] = [];
+    let suffix = "";
+    for (const token of lastTokens) {
+      if (SUFFIXES.has(token.toLowerCase())) {
+        suffix = token.toUpperCase();
+        // Keep roman numerals uppercase, lowercase others
+        if (!["II", "III", "IV", "V"].includes(suffix)) {
+          suffix = titleCase(token);
+        }
+      } else {
+        lastFiltered.push(token);
+      }
+    }
+
+    // Strip middle initials from first
+    const firstTokens = firstPart.split(/\s+/);
+    const firstFiltered: string[] = [];
+    for (const token of firstTokens) {
+      if (SUFFIXES.has(token.toLowerCase())) {
+        suffix = token.toUpperCase();
+        if (!["II", "III", "IV", "V"].includes(suffix)) {
+          suffix = titleCase(token);
+        }
+      } else if (token.length <= 1 || (token.length === 2 && token.endsWith("."))) {
+        continue;
+      } else {
+        firstFiltered.push(token);
+      }
+    }
+
+    const first = titleCase(firstFiltered.join(" "));
+    const last = titleCase(lastFiltered.join(" "));
+    return [first, last, suffix].filter(Boolean).join(" ");
+  }
+
+  return titleCase(trimmed);
+}
+
+/**
+ * Split multi-instructor strings into individual names.
+ *
+ * "Smith, J / Johnson, R" → ["Smith, J", "Johnson, R"]
+ * "Staff" → []
+ * null → []
+ */
+export function splitMultiInstructor(raw: string | null): string[] {
+  if (!raw) return [];
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+
+  // Split on common delimiters for team-teaching
+  const parts = trimmed.split(/\s*[\/|;]\s*/);
+
+  return parts.filter((name) => {
+    const lower = name.trim().toLowerCase();
+    return !SKIP_NAMES.has(lower) && name.trim().length > 0;
+  });
+}
+
+/**
+ * Check if a name is valid for an instructor page.
+ * Must have at least a first name with length ≥ 2.
+ */
+function isValidInstructorName(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (SKIP_NAMES.has(trimmed.toLowerCase())) return false;
+
+  // Must have more than one word (or comma-separated with 2+ char first name)
+  if (trimmed.includes(",")) {
+    const [, ...rest] = trimmed.split(",").map((s) => s.trim());
+    const firstPart = rest.join(" ").trim();
+    // First name tokens (excluding initials)
+    const firstTokens = firstPart.split(/\s+/).filter(
+      (t) => t.length > 1 && !t.endsWith(".") && !SUFFIXES.has(t.toLowerCase())
+    );
+    return firstTokens.length >= 1 && firstTokens[0].length >= 2;
+  }
+
+  // Space-separated: need at least 2 non-initial tokens
+  const tokens = trimmed.split(/\s+/).filter(
+    (t) => t.length > 1 && !SUFFIXES.has(t.toLowerCase())
+  );
+  return tokens.length >= 2;
+}
+
+// ---------------------------------------------------------------------------
+// Index building
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a college's course sections, build an instructor index.
+ * Returns Map<slug, InstructorProfile>.
+ *
+ * - Splits multi-instructor fields
+ * - Skips Staff/TBA/null/single-word names
+ * - Merges different raw strings that produce the same slug
+ * - Only includes instructors with ≥2 sections
+ */
+export function buildInstructorIndex(
+  sections: CourseSection[]
+): Map<string, InstructorProfile> {
+  const map = new Map<
+    string,
+    { rawNames: Set<string>; sections: CourseSection[] }
+  >();
+
+  for (const section of sections) {
+    const names = splitMultiInstructor(section.instructor);
+    for (const name of names) {
+      if (!isValidInstructorName(name)) continue;
+
+      const slug = normalizeInstructorSlug(name);
+      if (!slug) continue;
+
+      if (!map.has(slug)) {
+        map.set(slug, { rawNames: new Set(), sections: [] });
+      }
+      const entry = map.get(slug)!;
+      entry.rawNames.add(name);
+      entry.sections.push(section);
+    }
+  }
+
+  // Build final profiles, filtering to ≥2 sections
+  const result = new Map<string, InstructorProfile>();
+  for (const [slug, data] of map) {
+    if (data.sections.length < 2) continue;
+
+    // Pick the best display name (longest raw name = most complete)
+    const bestRaw = Array.from(data.rawNames).sort(
+      (a, b) => b.length - a.length
+    )[0];
+
+    result.set(slug, {
+      slug,
+      displayName: displayName(bestRaw),
+      rawNames: data.rawNames,
+      sections: data.sections,
+    });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Data access (wraps loadCoursesForCollege — no extra Supabase calls)
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the instructor index for a college, reusing the loadCoursesForCollege cache.
+ */
+export async function getInstructorIndex(
+  collegeSlug: string,
+  term: string,
+  state: string
+): Promise<Map<string, InstructorProfile>> {
+  return cached(
+    `instructorIndex:${state}:${collegeSlug}:${term}`,
+    async () => {
+      const courses = await loadCoursesForCollege(collegeSlug, term, state);
+      return buildInstructorIndex(courses);
+    }
+  );
+}
+
+/**
+ * Get a single instructor's profile by slug.
+ * Returns null if not found or doesn't meet inclusion thresholds.
+ */
+export async function getInstructorBySlug(
+  collegeSlug: string,
+  term: string,
+  state: string,
+  slug: string
+): Promise<InstructorProfile | null> {
+  const index = await getInstructorIndex(collegeSlug, term, state);
+  return index.get(slug) || null;
+}
+
+/**
+ * Get top instructors for a college (by section count), for the college detail
+ * page's "Browse Instructors" section.
+ */
+export async function getTopInstructors(
+  collegeSlug: string,
+  term: string,
+  state: string,
+  limit = 10
+): Promise<InstructorEntry[]> {
+  const index = await getInstructorIndex(collegeSlug, term, state);
+  return Array.from(index.values())
+    .sort((a, b) => b.sections.length - a.sections.length)
+    .slice(0, limit)
+    .map((p) => ({
+      slug: p.slug,
+      displayName: p.displayName,
+      sectionCount: p.sections.length,
+    }));
+}
+
+/**
+ * Get sitemap data: returns array of { collegeId, slug } for all instructors
+ * with ≥2 sections across all colleges in a state.
+ */
+export async function getInstructorSitemapEntries(
+  term: string,
+  state: string
+): Promise<{ collegeId: string; slug: string }[]> {
+  const institutions = loadInstitutions(state);
+  const entries: { collegeId: string; slug: string }[] = [];
+
+  for (const inst of institutions) {
+    try {
+      const index = await getInstructorIndex(inst.college_slug, term, state);
+      for (const [slug] of index) {
+        entries.push({ collegeId: inst.id, slug });
+      }
+    } catch {
+      // Skip if loading fails for this college
+    }
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Summary
- New `/[state]/college/[id]/instructor/[slug]` pSEO route — one page per instructor with ≥2 sections at each college
- `lib/instructors.ts`: name normalization, slug generation, multi-instructor splitting, instructor index builder — all derived from existing `instructor` column, zero schema changes
- Instructor detail page with sections table, subjects taught, mode breakdown, Rate My Professors link, other instructors, JSON-LD structured data, AdSense, GA4 analytics
- Sitemap updated to include all qualifying instructor URLs across all states
- College detail page now shows "Browse Instructors" section (top 10 by section count)
- Reuses `loadCoursesForCollege` cache — no additional Supabase queries

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] Visit `/va/college/nova/instructor/<slug>` — renders instructor page with sections table
- [ ] Visit `/va/college/nova` — "Browse Instructors" section appears near bottom
- [ ] Check `/sitemap.xml` includes instructor URLs
- [ ] Verify 404 for invalid instructor slugs (e.g. `/va/college/nova/instructor/doesnt-exist`)
- [ ] Verify Staff/TBA/null names are excluded (no thin pages)
- [ ] Check dark mode styling matches existing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)