### PR TITLE
Rename middleware.ts → proxy.ts for Next 16

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -2,13 +2,14 @@ import { updateSession } from "@/lib/supabase/middleware";
 import type { NextRequest } from "next/server";
 
 /**
- * Next.js middleware — refreshes the Supabase auth session cookie.
+ * Next.js proxy (formerly "middleware") — refreshes the Supabase auth
+ * session cookie.
  *
  * CRITICAL: only runs on auth-dependent routes. Running this on public pages
  * (college, course, subject, transfer, etc.) forces Next.js to emit
- * `cache-control: private, no-cache, no-store` because the middleware
- * reads/writes session cookies, which kills ISR edge caching and forces a
- * full server re-render on every request.
+ * `cache-control: private, no-cache, no-store` because the proxy reads and
+ * writes session cookies, which kills ISR edge caching and forces a full
+ * server re-render on every request.
  *
  * Only the 3 server files that import `@/lib/supabase/server` need this:
  *   - app/account/page.tsx
@@ -18,7 +19,7 @@ import type { NextRequest } from "next/server";
  * Client components that need to know the user is logged in should use
  * `createBrowserClient` and fetch the session client-side.
  */
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary

- Next 16 deprecated the `middleware` file convention; every build was logging a warning
- Ran `npx @next/codemod@canary middleware-to-proxy .` which renamed the file and function
- Matcher config unchanged: still scoped to `/account/:path*`, `/api/account/:path*`, `/auth/:path*` only
- Updated doc comment to use the new name

Before:
\`\`\`
⚠ The \"middleware\" file convention is deprecated. Please use \"proxy\" instead.
\`\`\`

After: no warning; build output shows \`ƒ Proxy (Middleware)\` in the route legend.

## Test plan

- [x] Local build: clean, no deprecation warning
- [ ] Preview deploy: auth flows (login, account page, signout) still work

No behavior change — same function, same matcher, just a rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)