### PR TITLE
Lazy-load non-default terms on subject page to cut cold ISR latency

### DIFF
--- a/app/[state]/college/[id]/courses/[prefix]/SubjectTermSection.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/SubjectTermSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import CollegeDetailClient from "../../CollegeDetailClient";
 import TermSelector from "../../TermSelector";
 import { termLabel } from "@/lib/term-label";
@@ -12,41 +12,108 @@ type TransferLookup = Record<
 >;
 
 interface Props {
-  /** Trimmed course sections for this prefix, grouped by term. */
-  coursesByTerm: Record<string, CourseSection[]>;
+  /** The term the server prerendered. */
+  defaultTerm: string;
+  /** Trimmed courses for the default term. */
+  defaultCourses: CourseSection[];
+  /** Transfer lookup filtered to the default term's courses. */
+  defaultTransferLookup?: TransferLookup;
   /** Terms that have at least one section of this prefix for this college. */
   termsWithData: string[];
-  defaultTerm: string;
   /** Per-term course-discovery URL template (uses __PREFIX__/__NUMBER__). */
   courseListingUrlByTerm: Record<string, string>;
-  /** Transfer lookup filtered to the union of courses across all shipped terms. */
-  transferLookup?: TransferLookup;
   institution: Institution;
   systemName: string;
   state: string;
+  /** College `id` from the route — used to build the lazy-load API URL. */
+  collegeId: string;
+  /** Upper-case subject prefix. */
+  prefix: string;
+}
+
+interface TermData {
+  courses: CourseSection[];
+  transferLookup?: TransferLookup;
 }
 
 export default function SubjectTermSection({
-  coursesByTerm,
-  termsWithData,
   defaultTerm,
+  defaultCourses,
+  defaultTransferLookup,
+  termsWithData,
   courseListingUrlByTerm,
-  transferLookup,
   institution,
   systemName,
   state,
+  collegeId,
+  prefix,
 }: Props) {
   const [currentTerm, setCurrentTerm] = useState(defaultTerm);
+  // Per-term cache seeded with the server-rendered default term so that
+  // toggling back to the default is instant and doesn't re-fetch.
+  const [termData, setTermData] = useState<Record<string, TermData>>({
+    [defaultTerm]: {
+      courses: defaultCourses,
+      transferLookup: defaultTransferLookup,
+    },
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  // Dedupe concurrent fetches for the same term (e.g. rapid back/forward).
+  const inflight = useRef<Map<string, Promise<TermData>>>(new Map());
+
+  async function fetchTerm(term: string): Promise<TermData> {
+    const existing = inflight.current.get(term);
+    if (existing) return existing;
+
+    const promise = (async () => {
+      const res = await fetch(
+        `/api/${state}/college/${collegeId}/courses/${prefix.toLowerCase()}?term=${encodeURIComponent(term)}`
+      );
+      if (!res.ok) {
+        throw new Error(`Failed to load ${term}: HTTP ${res.status}`);
+      }
+      const json = (await res.json()) as TermData;
+      return json;
+    })();
+
+    inflight.current.set(term, promise);
+    try {
+      return await promise;
+    } finally {
+      inflight.current.delete(term);
+    }
+  }
+
+  async function loadTerm(term: string) {
+    if (termData[term]) return; // already cached
+    setIsLoading(true);
+    try {
+      const data = await fetchTerm(term);
+      setTermData((prev) =>
+        prev[term] ? prev : { ...prev, [term]: data }
+      );
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }
 
   useEffect(() => {
     function readTermFromUrl() {
       const params = new URLSearchParams(window.location.search);
       const t = params.get("term");
-      setCurrentTerm(t && termsWithData.includes(t) ? t : defaultTerm);
+      const next = t && termsWithData.includes(t) ? t : defaultTerm;
+      setCurrentTerm(next);
+      if (next !== defaultTerm) void loadTerm(next);
     }
     window.addEventListener("popstate", readTermFromUrl);
     readTermFromUrl();
     return () => window.removeEventListener("popstate", readTermFromUrl);
+    // `loadTerm` is stable enough for this effect's intent — we only re-run
+    // when the set of valid terms or the default term changes, not on every
+    // render of the arrow function.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultTerm, termsWithData]);
 
   function handleTermChange(newTerm: string) {
@@ -58,10 +125,14 @@ export default function SubjectTermSection({
       url.searchParams.set("term", newTerm);
     }
     window.history.replaceState(null, "", url.toString());
+    void loadTerm(newTerm);
   }
 
-  const courses = coursesByTerm[currentTerm] ?? [];
+  const cached = termData[currentTerm];
+  const courses = cached?.courses ?? [];
+  const transferLookup = cached?.transferLookup;
   const courseListingUrl = courseListingUrlByTerm[currentTerm];
+  const showingPlaceholder = !cached && isLoading;
 
   // Mode counts recomputed client-side — cheap relative to what we already ship
   const onlineCount = courses.filter((c) => c.mode === "online").length;
@@ -83,8 +154,10 @@ export default function SubjectTermSection({
       {/* Term-scoped section header */}
       <div className="flex flex-wrap items-center gap-3 mb-4">
         <p className="text-gray-600 dark:text-slate-400 text-sm">
-          {termLabel(currentTerm)} &middot; {courses.length} sections across{" "}
-          {uniqueCourses} courses
+          {termLabel(currentTerm)} &middot;{" "}
+          {showingPlaceholder
+            ? "Loading…"
+            : `${courses.length} sections across ${uniqueCourses} courses`}
         </p>
         {termsWithData.length > 1 && (
           <TermSelector
@@ -125,16 +198,22 @@ export default function SubjectTermSection({
 
       {/* Course table */}
       <section>
-        <CollegeDetailClient
-          key={currentTerm}
-          courses={courses}
-          institution={institution}
-          collegeSlug={institution.college_slug}
-          transferLookup={transferLookup}
-          systemName={systemName}
-          courseListingUrl={courseListingUrl}
-          state={state}
-        />
+        {showingPlaceholder ? (
+          <div className="bg-gray-50 dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg p-8 text-center text-gray-600 dark:text-slate-400 text-sm">
+            Loading {termLabel(currentTerm)} sections…
+          </div>
+        ) : (
+          <CollegeDetailClient
+            key={currentTerm}
+            courses={courses}
+            institution={institution}
+            collegeSlug={institution.college_slug}
+            transferLookup={transferLookup}
+            systemName={systemName}
+            courseListingUrl={courseListingUrl}
+            state={state}
+          />
+        )}
       </section>
     </>
   );

--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { loadInstitutions } from "@/lib/institutions";
 import {
   loadCoursesForCollege,
-  getAvailableTerms,
+  getTermsWithDataForCollegeSubject,
   getUniqueSubjects,
   trimCoursesForClient,
   filterTransferLookupToCourses,
@@ -13,7 +13,6 @@ import { getCurrentTerm, termLabel } from "@/lib/terms";
 import { getStateConfig } from "@/lib/states/registry";
 import { buildTransferLookup } from "@/lib/transfer";
 import { subjectName } from "@/lib/subjects";
-import type { CourseSection } from "@/lib/types";
 import SubjectTermSection from "./SubjectTermSection";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
@@ -57,31 +56,26 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const subject = subjectName(prefix);
 
   // Resolve the default term for SEO copy — same fallback logic the page uses.
-  const allTerms = await getAvailableTerms(state);
-  let resolvedTerm = await getCurrentTerm(state);
-  const courses = await loadCoursesForCollege(
+  // Use the targeted `getTermsWithDataForCollegeSubject` query instead of
+  // loading every term's full catalog so metadata generation stays cheap.
+  const termsWithData = await getTermsWithDataForCollegeSubject(
+    institution.college_slug,
+    prefix,
+    state
+  );
+  if (termsWithData.length === 0) return { title: "Not Found" };
+
+  const preferredTerm = await getCurrentTerm(state);
+  const resolvedTerm = termsWithData.includes(preferredTerm)
+    ? preferredTerm
+    : termsWithData[termsWithData.length - 1];
+
+  const allCourses = await loadCoursesForCollege(
     institution.college_slug,
     resolvedTerm,
     state
   );
-  let filtered = courses.filter((c) => c.course_prefix === prefix);
-
-  if (filtered.length === 0) {
-    for (const t of [...allTerms].reverse()) {
-      if (t === resolvedTerm) continue;
-      const termCourses = await loadCoursesForCollege(
-        institution.college_slug,
-        t,
-        state
-      );
-      const termFiltered = termCourses.filter((c) => c.course_prefix === prefix);
-      if (termFiltered.length > 0) {
-        resolvedTerm = t;
-        filtered = termFiltered;
-        break;
-      }
-    }
-  }
+  const filtered = allCourses.filter((c) => c.course_prefix === prefix);
 
   const onlineCount = filtered.filter((c) => c.mode === "online").length;
   const uniqueCourses = new Set(
@@ -120,24 +114,14 @@ export default async function SubjectPage(props: PageProps) {
 
   if (!institution) notFound();
 
-  // Load courses for every term, filtered to this subject prefix, so the
-  // client can switch terms without a server round-trip. If no term has any
-  // sections for this prefix, the page 404s.
-  const allTerms = await getAvailableTerms(state);
-  const perTerm: { term: string; courses: CourseSection[] }[] = await Promise.all(
-    allTerms.map(async (t) => {
-      const full = await loadCoursesForCollege(
-        institution.college_slug,
-        t,
-        state
-      );
-      return { term: t, courses: full.filter((c) => c.course_prefix === prefix) };
-    })
+  // Discover which terms have data for this subject at this college via a
+  // targeted `SELECT term` query (~hundreds of rows). Cheap enough to run on
+  // every render, avoids loading every term's full catalog upfront.
+  const termsWithData = await getTermsWithDataForCollegeSubject(
+    institution.college_slug,
+    prefix,
+    state
   );
-  const termsWithData = perTerm
-    .filter((p) => p.courses.length > 0)
-    .map((p) => p.term)
-    .sort();
 
   if (termsWithData.length === 0) notFound();
 
@@ -147,27 +131,40 @@ export default async function SubjectPage(props: PageProps) {
     ? preferredTerm
     : termsWithData[termsWithData.length - 1];
 
-  const coursesByTerm: Record<string, CourseSection[]> = {};
+  // Load ONLY the default term's full catalog for this college. Other terms
+  // are lazy-loaded client-side via the `/api/[state]/college/[id]/courses/
+  // [prefix]?term=...` route when the user switches, keeping cold ISR
+  // latency bounded to a single-term round trip.
+  const defaultTermFullCourses = await loadCoursesForCollege(
+    institution.college_slug,
+    defaultTerm,
+    state
+  );
+  const defaultCoursesFull = defaultTermFullCourses.filter(
+    (c) => c.course_prefix === prefix
+  );
+  const defaultCourses = trimCoursesForClient(defaultCoursesFull);
+
+  // Build URL templates for every term up front — no DB work, just string
+  // formatting via the state config.
   const courseListingUrlByTerm: Record<string, string> = {};
-  const union: CourseSection[] = [];
   for (const t of termsWithData) {
-    const courses = perTerm.find((p) => p.term === t)?.courses ?? [];
-    coursesByTerm[t] = trimCoursesForClient(courses);
     courseListingUrlByTerm[t] = config.courseDiscoveryUrl(
       institution.college_slug,
       "__PREFIX__",
       "__NUMBER__",
       t
     );
-    union.push(...courses);
   }
 
-  const transferLookup = filterTransferLookupToCourses(
+  // Transfer lookup is scoped to the default term's courses. When the client
+  // switches terms, the API route returns a fresh lookup filtered to that
+  // term's courses.
+  const defaultTransferLookup = filterTransferLookupToCourses(
     await buildTransferLookup(state),
-    union
+    defaultCoursesFull
   );
 
-  const defaultCourses = coursesByTerm[defaultTerm];
   const subject = subjectName(prefix);
   const uniqueCoursesForJsonLd = [
     ...new Set(
@@ -176,13 +173,7 @@ export default async function SubjectPage(props: PageProps) {
   ].sort();
 
   // All subjects at this college for the "Browse Other Subjects" links.
-  // Uses the default term's full course list (the server-side registry of
-  // what this college offers this season).
-  const defaultTermFullCourses = await loadCoursesForCollege(
-    institution.college_slug,
-    defaultTerm,
-    state
-  );
+  // Reuses the default term's full course list we already loaded above.
   const allSubjects = getUniqueSubjects(defaultTermFullCourses);
 
   // Structured data — reflects the default term the page prerenders with.
@@ -296,14 +287,16 @@ export default async function SubjectPage(props: PageProps) {
 
       {/* Term-scoped content (stats bar, term picker, course table) */}
       <SubjectTermSection
-        coursesByTerm={coursesByTerm}
-        termsWithData={termsWithData}
         defaultTerm={defaultTerm}
+        defaultCourses={defaultCourses}
+        defaultTransferLookup={defaultTransferLookup}
+        termsWithData={termsWithData}
         courseListingUrlByTerm={courseListingUrlByTerm}
-        transferLookup={transferLookup}
         institution={institution}
         systemName={config.systemName}
         state={state}
+        collegeId={id}
+        prefix={prefix}
       />
 
       {/* In-content ad */}

--- a/app/api/[state]/college/[id]/courses/[prefix]/route.ts
+++ b/app/api/[state]/college/[id]/courses/[prefix]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  loadCoursesForCollege,
+  trimCoursesForClient,
+  filterTransferLookupToCourses,
+} from "@/lib/courses";
+import { loadInstitutions } from "@/lib/institutions";
+import { isValidState } from "@/lib/states/registry";
+import { buildTransferLookup } from "@/lib/transfer";
+
+type RouteContext = {
+  params: Promise<{ state: string; id: string; prefix: string }>;
+};
+
+/**
+ * Returns the trimmed course list and a filtered transfer lookup for a given
+ * (state, college, subject, term). Used by the subject page to lazy-load
+ * terms other than the default that the server prerendered — keeps cold ISR
+ * latency bounded to a single-term load.
+ */
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { state, id, prefix: rawPrefix } = await context.params;
+
+  if (!isValidState(state)) {
+    return NextResponse.json({ error: "Unknown state" }, { status: 404 });
+  }
+
+  const term = request.nextUrl.searchParams.get("term")?.trim();
+  if (!term) {
+    return NextResponse.json({ error: "Missing term" }, { status: 400 });
+  }
+
+  const prefix = rawPrefix.toUpperCase();
+  const institutions = loadInstitutions(state);
+  const institution = institutions.find((i) => i.id === id);
+  if (!institution) {
+    return NextResponse.json({ error: "Unknown college" }, { status: 404 });
+  }
+
+  const full = await loadCoursesForCollege(
+    institution.college_slug,
+    term,
+    state
+  );
+  const courses = full.filter((c) => c.course_prefix === prefix);
+
+  const transferLookup = filterTransferLookupToCourses(
+    await buildTransferLookup(state),
+    courses
+  );
+
+  return NextResponse.json(
+    {
+      courses: trimCoursesForClient(courses),
+      transferLookup: transferLookup ?? {},
+    },
+    {
+      headers: {
+        // Cache at the edge — contents only change when Supabase data updates,
+        // which we reflect via the same `revalidate = 86400` cadence as the
+        // page itself.
+        "Cache-Control":
+          "public, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    }
+  );
+}

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -126,6 +126,52 @@ export async function getAvailableTerms(state = "va"): Promise<string[]> {
 }
 
 /**
+ * Return the sorted list of terms that have at least one section of a given
+ * subject prefix at a given college. Targeted `SELECT term` scan — returns
+ * only the term column for matching rows (~hundreds of rows) instead of the
+ * full catalog per term. Used to build the term selector on the subject page
+ * without paying for a full `loadCoursesForCollege` × N_terms round trip.
+ */
+export async function getTermsWithDataForCollegeSubject(
+  collegeSlug: string,
+  prefix: string,
+  state = "va"
+): Promise<string[]> {
+  return cached(
+    `termsForCollegeSubject:${state}:${collegeSlug}:${prefix}`,
+    async () => {
+      // Paginate the term-only scan to handle subjects at large colleges
+      // that exceed the 1000-row default cap (rare but possible).
+      const seen = new Set<string>();
+      const PAGE_SIZE = 1000;
+      let page = 0;
+      while (true) {
+        const start = page * PAGE_SIZE;
+        const { data, error } = await supabase
+          .from("courses")
+          .select("term")
+          .eq("college_code", collegeSlug)
+          .eq("course_prefix", prefix)
+          .eq("state", state)
+          .range(start, start + PAGE_SIZE - 1);
+        if (error) {
+          console.error(
+            "getTermsWithDataForCollegeSubject error:",
+            error.message
+          );
+          break;
+        }
+        if (!data || data.length === 0) break;
+        for (const row of data) seen.add(row.term);
+        if (data.length < PAGE_SIZE) break;
+        page++;
+      }
+      return Array.from(seen).sort();
+    }
+  );
+}
+
+/**
  * Return the count of course sections for a college/term without loading all data.
  */
 export async function getCourseCount(


### PR DESCRIPTION
## Summary
- Subject page (`/[state]/college/[id]/courses/[prefix]`) was loading every term's full college catalog (~3× Supabase pagination) plus a state-wide transfer lookup on first render so the client could switch terms without a round-trip. Cold ISR: ~3.3s.
- Shift to a single-term server render with client-side lazy loading. Server loads only the default term; other terms fetch on demand via a new edge-cached API route; client caches per-term so back-and-forth is free after the first visit.
- Add a targeted `SELECT term` query (`getTermsWithDataForCollegeSubject`) so discovering which terms exist for this (college, subject) no longer requires loading full catalogs.
- `generateMetadata` switches to the same cheap path, so metadata generation stops paying the N-term tax.

## Changes
- `lib/courses.ts` — new `getTermsWithDataForCollegeSubject` (cached, 5 min TTL, paginated term-only scan).
- `app/api/[state]/college/[id]/courses/[prefix]/route.ts` — new handler returning `{ courses, transferLookup }` for a given term, edge-cached `s-maxage=86400, stale-while-revalidate=604800`.
- `app/[state]/college/[id]/courses/[prefix]/page.tsx` — server loads only default term + its transfer lookup. `defaultTermFullCourses` is reused for "Browse Other Subjects" (no extra round-trip).
- `app/[state]/college/[id]/courses/[prefix]/SubjectTermSection.tsx` — seeds a `termData` cache with the server default, lazy-fetches others, dedupes concurrent requests via `useRef<Map>`, shows "Loading…" placeholder on cold switches, instant for cached terms.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `next build` clean (489 prerendered pages, no errors; route tree shows `● /[state]/college/[id]/courses/[prefix]` and `ƒ /api/[state]/college/[id]/courses/[prefix]`)
- [x] Dev preview: default term renders (Summer 2026 · 150 sections)
- [x] Switching to Spring 2026 fires `/api/va/college/nova/courses/eng?term=2026SP`, shows 457 sections
- [x] URL updates to `?term=2026SP` via `replaceState` (no RSC refetch)
- [x] Switching back to default term: 0 API calls (cache hit), URL cleaned
- [x] Deep-link `?term=2026SP` on first load: server renders default → client reads URL → API fires → content swaps
- [x] No console errors
- [ ] Post-deploy: curl prod, confirm `x-vercel-cache: HIT` on warm subject page and measure cold ISR TTFB

🤖 Generated with [Claude Code](https://claude.com/claude-code)