### PR TITLE
perf: kill global transfer-lookup load on server-rendered pages

### DIFF
--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -7,11 +7,10 @@ import {
   getTermsWithDataForCollegeSubject,
   getUniqueSubjects,
   trimCoursesForClient,
-  filterTransferLookupToCourses,
 } from "@/lib/courses";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
 import { getStateConfig } from "@/lib/states/registry";
-import { buildTransferLookup } from "@/lib/transfer";
+import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { subjectName } from "@/lib/subjects";
 import SubjectTermSection from "./SubjectTermSection";
 import AdUnit from "@/components/AdUnit";
@@ -159,10 +158,11 @@ export default async function SubjectPage(props: PageProps) {
 
   // Transfer lookup is scoped to the default term's courses. When the client
   // switches terms, the API route returns a fresh lookup filtered to that
-  // term's courses.
-  const defaultTransferLookup = filterTransferLookupToCourses(
-    await buildTransferLookup(state),
-    defaultCoursesFull
+  // term's courses. Targeted Supabase query — avoids loading the full state
+  // transfer catalog just to discard 99% of it.
+  const defaultTransferLookup = await buildTransferLookupForCourses(
+    defaultCoursesFull,
+    state
   );
 
   const subject = subjectName(prefix);

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -7,12 +7,11 @@ import {
   isDataStale,
   getAvailableTerms,
   trimCoursesForClient,
-  filterTransferLookupToCourses,
 } from "@/lib/courses";
 import { getCurrentTerm } from "@/lib/terms";
 import CollegeMap from "./CollegeMap";
 import CollegeTermSection from "./CollegeTermSection";
-import { buildTransferLookup } from "@/lib/transfer";
+import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { getStateConfig, getAllStates } from "@/lib/states/registry";
 import { getTopInstructors } from "@/lib/instructors";
 import type { CourseSection } from "@/lib/types";
@@ -120,12 +119,10 @@ export default async function CollegeDetailPage(props: PageProps) {
     })
   );
 
-  // Shared transfer lookup, filtered to the union of courses across all terms
+  // Shared transfer lookup, scoped to the union of courses across all terms
   // so the map stays the same regardless of which term the client picks.
-  const transferLookup = filterTransferLookupToCourses(
-    await buildTransferLookup(state),
-    union
-  );
+  // Targeted Supabase query instead of loading the whole state catalog.
+  const transferLookup = await buildTransferLookupForCourses(union, state);
 
   const systemCollegeCoursesUrl = config.collegeCoursesUrl(collegeSlug);
 

--- a/app/api/[state]/college/[id]/courses/[prefix]/route.ts
+++ b/app/api/[state]/college/[id]/courses/[prefix]/route.ts
@@ -5,83 +5,22 @@ import {
 } from "@/lib/courses";
 import { loadInstitutions } from "@/lib/institutions";
 import { isValidState } from "@/lib/states/registry";
-import { supabase } from "@/lib/supabase";
-import type { CourseSection } from "@/lib/types";
+import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 
 // Run on Vercel's edge runtime — cuts cold function-start from ~2s (Node
 // serverless) to ~500ms. All our transitive deps are edge-safe:
-//  - `lib/institutions` now uses static JSON imports (no `fs`)
+//  - `lib/institutions` uses static JSON imports (no `fs`)
 //  - `lib/states/registry` uses static imports (no `require()`)
 //  - `@supabase/supabase-js` is edge-compatible
-//  - The transfer lookup is built inline via a targeted Supabase query so we
-//    don't drag in `lib/transfer`'s multi-MB `fs` fallback.
+//  - `buildTransferLookupForCourses` is a Supabase-only scoped query.
+//    `lib/transfer` still references `fs` for the global-lookup fallback,
+//    but Turbopack tree-shakes it out since the edge bundle only imports
+//    the scoped helper.
 export const runtime = "edge";
 
 type RouteContext = {
   params: Promise<{ state: string; id: string; prefix: string }>;
 };
-
-type TransferLookup = Record<
-  string,
-  { university: string; type: "direct" | "elective" | "no-credit"; course: string }[]
->;
-
-/**
- * Build a transfer lookup scoped to just the courses in `courses`. Uses a
- * single Supabase query with an `OR` of `(cc_prefix, cc_number)` pairs —
- * way smaller than loading the full state catalog and filtering in JS.
- */
-async function transferLookupForCourses(
-  courses: CourseSection[],
-  state: string
-): Promise<TransferLookup> {
-  if (courses.length === 0) return {};
-
-  // Dedup (prefix, number) pairs
-  const pairs = new Map<string, { prefix: string; number: string }>();
-  for (const c of courses) {
-    pairs.set(`${c.course_prefix}-${c.course_number}`, {
-      prefix: c.course_prefix,
-      number: c.course_number,
-    });
-  }
-
-  // Build an OR expression: (cc_prefix.eq.ENG,cc_number.eq.111),(cc_prefix.eq.MTH,cc_number.eq.263),...
-  const orClauses = Array.from(pairs.values())
-    .map(
-      (p) =>
-        `and(cc_prefix.eq.${encodeURIComponent(p.prefix)},cc_number.eq.${encodeURIComponent(p.number)})`
-    )
-    .join(",");
-
-  const { data, error } = await supabase
-    .from("transfers")
-    .select(
-      "cc_prefix, cc_number, university, univ_course, is_elective, no_credit"
-    )
-    .eq("state", state)
-    .or(orClauses);
-
-  if (error) {
-    console.error("transferLookupForCourses error:", error.message);
-    return {};
-  }
-
-  const lookup: TransferLookup = {};
-  for (const m of data ?? []) {
-    // Skip combo-credit entries (e.g. ODU's "**** ****") — only transfer when
-    // paired with other courses, not standalone.
-    if (m.univ_course && m.univ_course.includes("*")) continue;
-    const key = `${m.cc_prefix}-${m.cc_number}`;
-    if (!lookup[key]) lookup[key] = [];
-    lookup[key].push({
-      university: m.university,
-      type: m.no_credit ? "no-credit" : m.is_elective ? "elective" : "direct",
-      course: m.univ_course || "",
-    });
-  }
-  return lookup;
-}
 
 /**
  * Returns the trimmed course list and a filtered transfer lookup for a given
@@ -115,7 +54,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
   );
   const courses = full.filter((c) => c.course_prefix === prefix);
 
-  const transferLookup = await transferLookupForCourses(courses, state);
+  const transferLookup = await buildTransferLookupForCourses(courses, state);
 
   return NextResponse.json(
     {

--- a/app/api/[state]/schedule/build/route.ts
+++ b/app/api/[state]/schedule/build/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { ScheduleRequest } from "@/lib/types";
 import { generateSchedules } from "@/lib/schedule";
-import { buildTransferLookup } from "@/lib/transfer";
+import { buildTransferLookupForSubjects } from "@/lib/transfer-scoped";
 import { rateLimit, getClientKey } from "@/lib/rate-limit";
 import { loadInstitutions } from "@/lib/institutions";
 import { isValidState } from "@/lib/states/registry";
@@ -89,11 +89,16 @@ export async function POST(req: Request, context: RouteContext) {
 
     const institutions = loadInstitutions(state);
 
-    // Load transfer lookup if a target university is specified
+    // Load transfer lookup if a target university is specified. Scoped to the
+    // user's chosen subjects so we don't pull the whole state catalog just to
+    // discard 70-90% of it.
     let transferLookup = null;
     if (request.targetUniversity) {
       try {
-        transferLookup = await buildTransferLookup(state);
+        transferLookup = await buildTransferLookupForSubjects(
+          request.subjects,
+          state
+        );
       } catch {
         // Transfer data unavailable — continue without it
       }

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -273,26 +273,6 @@ export function trimCoursesForClient(
 }
 
 /**
- * Filter a state-wide transfer lookup down to only the courses present at
- * this college. Without this, a college page serializes transfer mappings
- * for every course in the whole state (can be 100k+ entries → megabytes).
- */
-export function filterTransferLookupToCourses<T>(
-  lookup: Record<string, T[]> | undefined,
-  courses: CourseSection[]
-): Record<string, T[]> | undefined {
-  if (!lookup) return lookup;
-  const keys = new Set(
-    courses.map((c) => `${c.course_prefix}-${c.course_number}`)
-  );
-  const filtered: Record<string, T[]> = {};
-  for (const k of keys) {
-    if (lookup[k]) filtered[k] = lookup[k];
-  }
-  return filtered;
-}
-
-/**
  * Extract a sorted list of unique course prefixes (subjects) from an array of
  * course sections.
  */

--- a/lib/transfer-scoped.ts
+++ b/lib/transfer-scoped.ts
@@ -1,0 +1,138 @@
+// Edge-safe scoped transfer-lookup builders. This file deliberately does not
+// import `fs`/`path` or anything from `lib/transfer.ts` — keeping those
+// Node-only modules out of the edge bundle for the
+// `/api/[state]/college/[id]/courses/[prefix]` route.
+//
+// Callers that only need a lookup scoped to a handful of courses or subjects
+// should use these helpers instead of `buildTransferLookup(state)`, which
+// loads the entire state catalog (5.7 MB VA, 51 MB NJ/MD).
+
+import { supabase } from "./supabase";
+
+/**
+ * Client-side lookup shape: `"ENG-111" → [{ university, type, course }, …]`.
+ */
+export type TransferLookup = Record<
+  string,
+  {
+    university: string;
+    type: "direct" | "elective" | "no-credit";
+    course: string;
+  }[]
+>;
+
+type TransferRow = {
+  cc_prefix: string;
+  cc_number: string;
+  university: string;
+  univ_course: string | null;
+  is_elective: boolean | null;
+  no_credit: boolean | null;
+};
+
+function rowsToLookup(rows: TransferRow[]): TransferLookup {
+  const lookup: TransferLookup = {};
+  for (const m of rows) {
+    // Skip combo-credit entries (e.g. ODU's "**** ****") — they only transfer
+    // when paired with other courses, not standalone.
+    if (m.univ_course && m.univ_course.includes("*")) continue;
+    const key = `${m.cc_prefix}-${m.cc_number}`;
+    if (!lookup[key]) lookup[key] = [];
+    lookup[key].push({
+      university: m.university,
+      type: m.no_credit ? "no-credit" : m.is_elective ? "elective" : "direct",
+      course: m.univ_course || "",
+    });
+  }
+  return lookup;
+}
+
+// Max (prefix, number) pairs per Supabase `.or(...)` request. Each clause is
+// ~40 chars, URL-encoded; PostgREST rejects URLs past ~4-8 KB depending on
+// proxy config. 100 pairs ≈ 4 KB of `.or()` payload — safely under the limit.
+// Larger inputs (college-page union with thousands of courses) are split into
+// parallel chunks.
+const CHUNK_SIZE = 100;
+
+/**
+ * Build a transfer lookup scoped to a specific set of (course_prefix,
+ * course_number) pairs. For large inputs, fans out the request into parallel
+ * chunked Supabase `.or()` queries to stay under PostgREST's URL length limit.
+ *
+ * Used by the college page and subject page server-side to build a transfer
+ * lookup for only the courses actually on the page. Shared with the edge
+ * route `/api/[state]/college/[id]/courses/[prefix]`.
+ */
+export async function buildTransferLookupForCourses(
+  courses: { course_prefix: string; course_number: string }[],
+  state: string
+): Promise<TransferLookup> {
+  if (courses.length === 0) return {};
+
+  // Dedup (prefix, number) pairs
+  const pairs = new Map<string, { prefix: string; number: string }>();
+  for (const c of courses) {
+    pairs.set(`${c.course_prefix}-${c.course_number}`, {
+      prefix: c.course_prefix,
+      number: c.course_number,
+    });
+  }
+  const pairArr = Array.from(pairs.values());
+
+  const chunks: (typeof pairArr)[] = [];
+  for (let i = 0; i < pairArr.length; i += CHUNK_SIZE) {
+    chunks.push(pairArr.slice(i, i + CHUNK_SIZE));
+  }
+
+  const chunkResults = await Promise.all(
+    chunks.map(async (chunk) => {
+      const orClauses = chunk
+        .map(
+          (p) =>
+            `and(cc_prefix.eq.${encodeURIComponent(p.prefix)},cc_number.eq.${encodeURIComponent(p.number)})`
+        )
+        .join(",");
+      const { data, error } = await supabase
+        .from("transfers")
+        .select(
+          "cc_prefix, cc_number, university, univ_course, is_elective, no_credit"
+        )
+        .eq("state", state)
+        .or(orClauses);
+      if (error) {
+        console.error("buildTransferLookupForCourses error:", error.message);
+        return [] as TransferRow[];
+      }
+      return (data ?? []) as TransferRow[];
+    })
+  );
+
+  return rowsToLookup(chunkResults.flat());
+}
+
+/**
+ * Build a transfer lookup scoped to a set of subject prefixes. For callers
+ * that know which subjects but not which course numbers yet (e.g. schedule
+ * builder before candidate section generation). Narrower than
+ * `buildTransferLookup(state)` — typically 10–30% of the full state catalog.
+ */
+export async function buildTransferLookupForSubjects(
+  subjectPrefixes: string[],
+  state: string
+): Promise<TransferLookup> {
+  if (subjectPrefixes.length === 0) return {};
+
+  const { data, error } = await supabase
+    .from("transfers")
+    .select(
+      "cc_prefix, cc_number, university, univ_course, is_elective, no_credit"
+    )
+    .eq("state", state)
+    .in("cc_prefix", subjectPrefixes);
+
+  if (error) {
+    console.error("buildTransferLookupForSubjects error:", error.message);
+    return {};
+  }
+  return rowsToLookup((data ?? []) as TransferRow[]);
+}

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -272,29 +272,19 @@ export async function getUniversitiesWithCounts(state = "va"): Promise<
     .sort((a, b) => b.totalCount - a.totalCount);
 }
 
+// Re-export the lookup shape from the edge-safe module so callers that need
+// the type can import it from either module. The scoped helpers themselves
+// live in `lib/transfer-scoped.ts` to keep `fs`/`path` out of edge bundles.
+export type { TransferLookup } from "./transfer-scoped";
+import type { TransferLookup } from "./transfer-scoped";
+
 /**
  * Build a lookup map for client-side filtering:
  * { "ENG-111": [{ university: "vt", type: "direct" }], ... }
  */
-export async function buildTransferLookup(state = "va"): Promise<
-  Record<
-    string,
-    {
-      university: string;
-      type: "direct" | "elective" | "no-credit";
-      course: string;
-    }[]
-  >
-> {
+export async function buildTransferLookup(state = "va"): Promise<TransferLookup> {
   const mappings = await loadTransferMappings(state);
-  const lookup: Record<
-    string,
-    {
-      university: string;
-      type: "direct" | "elective" | "no-credit";
-      course: string;
-    }[]
-  > = {};
+  const lookup: TransferLookup = {};
 
   for (const m of mappings) {
     // Skip combo-credit entries (e.g. ODU's "**** ****") — they only


### PR DESCRIPTION
## Summary
- College page, subject page, and schedule API no longer call `buildTransferLookup(state)` — three server-rendered entry points stop pulling the entire state `transfers` table just to discard 99%+ of it.
- Two new scoped helpers live in `lib/transfer-scoped.ts`: `buildTransferLookupForCourses(courses, state)` and `buildTransferLookupForSubjects(subjects, state)`. Same pattern PR #6 shipped on edge, lifted into a shared module.
- `buildTransferLookupForCourses` chunks at 100 (prefix, number) pairs per Supabase `.or()` request so the college-page union (can be 1k+ unique pairs on large systems) doesn't exceed PostgREST's URL length limit.
- Helpers live in a sibling file rather than `lib/transfer.ts` because `lib/transfer.ts` imports `fs`/`path` for its JSON fallback — Turbopack couldn't tree-shake those out of the edge bundle when the scoped helpers lived there, and emitted Node-API-in-edge warnings on build. `lib/transfer-scoped.ts` imports only `./supabase`, keeping the edge route fs-free.
- `filterTransferLookupToCourses` in `lib/courses.ts` has zero callers after this — deleted. `buildTransferLookup(state)` still ships (one caller, `/api/[state]/transfer/lookup`, legitimately needs the full state map).

## Expected impact
- College page ISR prerender (e.g. `/va/college/nova`): drops the 5.7–51 MB state transfer JSON load + filter pass from the critical path.
- Subject page ISR prerender: same pattern at a smaller scale (default-term courses only).
- Schedule API cold path when `targetUniversity` is set: single targeted query on `cc_prefix IN (...)` instead of full catalog.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — no Node-API-in-edge warnings, no Bad Request, no fetch failures
- [x] Dev preview `/va/college/gcc` renders 441 sections with 407 "Transfers to" pills
- [x] Dev preview `/va/college/gcc/courses/eng` renders 35 sections across 11 courses with pills
- [x] Edge route `/api/va/college/gcc/courses/eng?term=2026SP` returns 82 courses + 10 transferLookup keys (`ENG-111`, `ENG-112`, `ENG-211`, …)
- [x] `POST /api/va/schedule/build` with `targetUniversity: "vt"` decorates sections with `transferStatus: "direct"`, `transferCourse: "ENGL 1105"` (proves `buildTransferLookupForSubjects` reaches the schedule builder)
- [ ] Vercel preview build green
- [ ] Prod curl spot-checks after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)