### PR TITLE
perf: prerender top subject pages + TTL cache for transfer lookups

### DIFF
--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -9,7 +9,7 @@ import {
   trimCoursesForClient,
 } from "@/lib/courses";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
-import { getStateConfig } from "@/lib/states/registry";
+import { getStateConfig, getAllStates } from "@/lib/states/registry";
 import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { subjectName } from "@/lib/subjects";
 import SubjectTermSection from "./SubjectTermSection";
@@ -26,17 +26,36 @@ type PageProps = {
 };
 
 // ---------------------------------------------------------------------------
-// Static params — generate one page per (state, college, subject)
+// Static params — prerender the highest-traffic subject pages at build time
 // ---------------------------------------------------------------------------
 
-// Prerender nothing at build time — there are ~9k college × subject
-// combinations across all states, which blows out the deploy output size.
-// Instead rely on ISR: Next will SSG each page on first request, cache the
-// HTML for `revalidate` seconds at the edge, and serve subsequent visitors
-// from cache. `dynamicParams` defaults to true so unknown params render
-// on-demand rather than 404ing.
-export async function generateStaticParams() {
-  return [];
+// The full cartesian product is ~9k pages (all colleges × all subjects
+// across 15 states), which blows out deploy output size. Instead, we
+// prerender a curated subset: common subjects at the first few colleges per
+// state. These are the pages most likely to be visited right after a deploy.
+// Everything else ISRs on first request (`dynamicParams` defaults to true).
+//
+// Uses only sync static data (loadInstitutions + getAllStates), so no
+// build-time DB calls. If a (college, subject) combo has no data at
+// render time, the page calls notFound() and Next caches a 404 — harmless.
+
+// Subjects present at virtually every US community college.
+const PRERENDER_SUBJECTS = ["eng", "mth", "bio", "csc", "psy", "his"];
+// First N colleges per state (institution lists are typically ordered by
+// largest / most campuses first).
+const COLLEGES_PER_STATE = 3;
+
+export function generateStaticParams() {
+  return getAllStates().flatMap((s) => {
+    const colleges = loadInstitutions(s.slug).slice(0, COLLEGES_PER_STATE);
+    return colleges.flatMap((c) =>
+      PRERENDER_SUBJECTS.map((prefix) => ({
+        state: s.slug,
+        id: c.id,
+        prefix,
+      }))
+    );
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/transfer-scoped.ts
+++ b/lib/transfer-scoped.ts
@@ -9,6 +9,43 @@
 
 import { supabase } from "./supabase";
 
+// ---------------------------------------------------------------------------
+// In-memory TTL cache + inflight dedup (same pattern as lib/courses.ts)
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry<T> {
+  data: T;
+  expires: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+async function cached<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const entry = cache.get(key) as CacheEntry<T> | undefined;
+  if (entry && entry.expires > Date.now()) return entry.data;
+
+  // Deduplicate concurrent requests for the same key
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const promise = fn()
+    .then((data) => {
+      cache.set(key, { data, expires: Date.now() + CACHE_TTL });
+      inflight.delete(key);
+      return data;
+    })
+    .catch((err) => {
+      inflight.delete(key);
+      throw err;
+    });
+
+  inflight.set(key, promise);
+  return promise;
+}
+
 /**
  * Client-side lookup shape: `"ENG-111" → [{ university, type, course }, …]`.
  */
@@ -77,37 +114,44 @@ export async function buildTransferLookupForCourses(
       number: c.course_number,
     });
   }
-  const pairArr = Array.from(pairs.values());
 
-  const chunks: (typeof pairArr)[] = [];
-  for (let i = 0; i < pairArr.length; i += CHUNK_SIZE) {
-    chunks.push(pairArr.slice(i, i + CHUNK_SIZE));
-  }
+  // Stable cache key: sorted pair keys so the same set of courses always
+  // hits the same cache entry regardless of input order.
+  const cacheKey = `xfer-courses:${state}:${Array.from(pairs.keys()).sort().join("|")}`;
 
-  const chunkResults = await Promise.all(
-    chunks.map(async (chunk) => {
-      const orClauses = chunk
-        .map(
-          (p) =>
-            `and(cc_prefix.eq.${encodeURIComponent(p.prefix)},cc_number.eq.${encodeURIComponent(p.number)})`
-        )
-        .join(",");
-      const { data, error } = await supabase
-        .from("transfers")
-        .select(
-          "cc_prefix, cc_number, university, univ_course, is_elective, no_credit"
-        )
-        .eq("state", state)
-        .or(orClauses);
-      if (error) {
-        console.error("buildTransferLookupForCourses error:", error.message);
-        return [] as TransferRow[];
-      }
-      return (data ?? []) as TransferRow[];
-    })
-  );
+  return cached(cacheKey, async () => {
+    const pairArr = Array.from(pairs.values());
 
-  return rowsToLookup(chunkResults.flat());
+    const chunks: (typeof pairArr)[] = [];
+    for (let i = 0; i < pairArr.length; i += CHUNK_SIZE) {
+      chunks.push(pairArr.slice(i, i + CHUNK_SIZE));
+    }
+
+    const chunkResults = await Promise.all(
+      chunks.map(async (chunk) => {
+        const orClauses = chunk
+          .map(
+            (p) =>
+              `and(cc_prefix.eq.${encodeURIComponent(p.prefix)},cc_number.eq.${encodeURIComponent(p.number)})`
+          )
+          .join(",");
+        const { data, error } = await supabase
+          .from("transfers")
+          .select(
+            "cc_prefix, cc_number, university, univ_course, is_elective, no_credit"
+          )
+          .eq("state", state)
+          .or(orClauses);
+        if (error) {
+          console.error("buildTransferLookupForCourses error:", error.message);
+          return [] as TransferRow[];
+        }
+        return (data ?? []) as TransferRow[];
+      })
+    );
+
+    return rowsToLookup(chunkResults.flat());
+  });
 }
 
 /**
@@ -122,17 +166,22 @@ export async function buildTransferLookupForSubjects(
 ): Promise<TransferLookup> {
   if (subjectPrefixes.length === 0) return {};
 
-  const { data, error } = await supabase
-    .from("transfers")
-    .select(
-      "cc_prefix, cc_number, university, univ_course, is_elective, no_credit"
-    )
-    .eq("state", state)
-    .in("cc_prefix", subjectPrefixes);
+  const sorted = [...subjectPrefixes].sort();
+  const cacheKey = `xfer-subjects:${state}:${sorted.join("|")}`;
 
-  if (error) {
-    console.error("buildTransferLookupForSubjects error:", error.message);
-    return {};
-  }
-  return rowsToLookup((data ?? []) as TransferRow[]);
+  return cached(cacheKey, async () => {
+    const { data, error } = await supabase
+      .from("transfers")
+      .select(
+        "cc_prefix, cc_number, university, univ_course, is_elective, no_credit"
+      )
+      .eq("state", state)
+      .in("cc_prefix", subjectPrefixes);
+
+    if (error) {
+      console.error("buildTransferLookupForSubjects error:", error.message);
+      return {};
+    }
+    return rowsToLookup((data ?? []) as TransferRow[]);
+  });
 }


### PR DESCRIPTION
## Summary
- Subject page `generateStaticParams` now returns ~270 pages (top 3 colleges per state × 6 common subjects: ENG, MTH, BIO, CSC, PSY, HIS) instead of `[]`. Highest-traffic pages are instant after a deploy instead of cold-ISR on first visit.
- `buildTransferLookupForCourses` and `buildTransferLookupForSubjects` now use a 5-minute in-memory TTL cache with inflight request dedup (same pattern as `lib/courses.ts`). Deduplicates concurrent requests from parallel ISR workers and prevents redundant Supabase round trips.
- Bundle audit: 400 KB gzipped total client JS. Supabase (59K gzip) is the largest app dependency — ~1/3 of its weight is the unused RealtimeClient. Leaflet (42K) already code-split. Flagged Supabase modular packages swap as a future optimization (~15-20K savings).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` — 699 static pages (up from 489), no edge warnings, no Bad Request
- [x] Dev preview `/va/college/gcc/courses/eng` — 35 sections, 11 courses, transfer pills
- [x] Edge route `?term=2026SP` — 82 courses, 10 transferLookup keys (cache dedup on repeat)
- [x] Schedule API with `targetUniversity: "vt"` — `transferStatus: "direct"`, `transferCourse: "ENGL 1105"`
- [x] No server/console errors
- [ ] Vercel preview build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)