### PR TITLE
ci: wire NY/RI/VT/CT/ME into scheduled scraper workflows

### DIFF
--- a/.github/workflows/scrape-courses-http.yml
+++ b/.github/workflows/scrape-courses-http.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       state:
-        description: "State to scrape (va/nc/sc/ga/md/de/dc or all)"
+        description: "State to scrape (va/nc/sc/ga/md/de/dc/ny/ri/ct or all)"
         default: "all"
 
 env:
@@ -190,3 +190,57 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx tsx scripts/dc/scrape-banner.ts
+
+  # ── New York (CUNY Global Class Search) ─────────────────────────────
+  # 7 CUNY community colleges via CUNYfirst PeopleSoft form API (HTTP).
+  # Scraper auto-imports to Supabase on success.
+  scrape-ny:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'ny'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/ny/scrape-cuny.ts --all
+
+  # ── Rhode Island (CCRI Banner 8) ────────────────────────────────────
+  # Single college (Community College of RI) via legacy Banner 8 HTTP forms.
+  # Scraper auto-imports to Supabase on success.
+  scrape-ri:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'ri'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/ri/scrape-banner8.ts
+
+  # ── Connecticut (CT State Community College Banner SSB) ─────────────
+  # Single state system endpoint covering all 12 former campuses (HTTP).
+  # Scraper auto-imports to Supabase on success.
+  scrape-ct:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'ct'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/ct/scrape-banner.ts

--- a/.github/workflows/scrape-courses-playwright.yml
+++ b/.github/workflows/scrape-courses-playwright.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       state:
-        description: "State to scrape (nc/sc/md/va or all)"
+        description: "State to scrape (nc/sc/md/va/vt/me or all)"
         default: "all"
 
 env:
@@ -160,3 +160,43 @@ jobs:
           name: va-peoplesoft-courses
           path: data/va/courses/
           retention-days: 7
+
+  # ── Vermont (CCV Colleague SPA) ─────────────────────────────────────
+  # Single college (Community College of Vermont) via shared VSC Colleague
+  # Self-Service SPA. Scraper auto-imports to Supabase on success.
+  scrape-vt:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'vt'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install chromium --with-deps
+      - run: npx tsx scripts/vt/scrape-colleague.ts
+
+  # ── Maine (MCCS WordPress DataTables) ───────────────────────────────
+  # 6 MCCS colleges via WordPress sites with client-side DataTables (JS
+  # required, hence Playwright). KVCC excluded — it's PDF-only.
+  # Writes local JSON only — needs explicit import-courses step.
+  scrape-me:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'me'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install chromium --with-deps
+      - run: npx tsx scripts/me/scrape-mccs.ts
+      - run: npx tsx scripts/import-courses.ts --state me

--- a/.github/workflows/scrape-transfers.yml
+++ b/.github/workflows/scrape-transfers.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       state:
-        description: "State to scrape (va/nc/sc/md/ga/de or all)"
+        description: "State to scrape (va/nc/sc/md/ga/de/ny/ri/vt/ct or all)"
         default: "all"
 
 env:
@@ -200,3 +200,77 @@ jobs:
       - run: npm ci
       - run: npx tsx scripts/md/scrape-transfer-artsys.ts
       - run: npx tsx scripts/import-transfers.ts --state md
+
+  # ── New York Transfers (TREX) ───────────────────────────────────────
+  # 7 CUNY community colleges → major NY universities via TREX public API.
+  # Scraper auto-imports to Supabase.
+  scrape-ny-transfers:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'ny'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/ny/scrape-transfer-trex.ts
+
+  # ── Rhode Island Transfers (TES math CAPTCHA — solvable) ────────────
+  # CCRI → URI + RIC via TES Public View. The TES math CAPTCHA is solved
+  # programmatically in the scraper, so this does run headlessly.
+  # Scraper auto-imports to Supabase.
+  scrape-ri-transfers:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'ri'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/ri/scrape-transfer.ts
+
+  # ── Vermont Transfers ───────────────────────────────────────────────
+  # CCV → VT universities. Scraper auto-imports to Supabase.
+  scrape-vt-transfers:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'vt'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/vt/scrape-transfer.ts
+
+  # ── Connecticut Transfers (CCSU + ECSU + SCSU via all-orchestrator) ─
+  # scrape-transfer-all orchestrates the three university adapters
+  # sequentially and merges into a single data/ct/transfer-equiv.json —
+  # must run in one job to merge correctly (same pattern as GA transfers).
+  # Orchestrator auto-imports to Supabase after merge.
+  scrape-ct-transfers:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'ct'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/ct/scrape-transfer-all.ts


### PR DESCRIPTION
## Summary
Tier 2 states (NY, RI, VT, CT, ME) had working scrapers under \`scripts/<state>/\` but were never wired into the scheduled GitHub Actions, so their data only updated when someone ran the script manually. Latest manual runs were ~a week ago. This PR brings them up to the same automation tier as VA/NC/SC/MD/GA/DE/DC/TN.

## Jobs added

**scrape-courses-http.yml** (Sun/Tue/Thu 6 AM UTC):
- \`scrape-ny\` → 7 CUNY community colleges via CUNYfirst
- \`scrape-ri\` → CCRI Banner 8
- \`scrape-ct\` → CT State Community College system

**scrape-courses-playwright.yml** (Mon/Wed/Fri 8 AM UTC):
- \`scrape-vt\` → CCV via VSC Colleague Self-Service SPA
- \`scrape-me\` → 6 MCCS colleges via WordPress DataTables (+ explicit \`import-courses.ts --state me\` step because the ME scraper writes local JSON only)

**scrape-transfers.yml** (Wed/Sat 10 AM UTC):
- \`scrape-ny-transfers\` → TREX
- \`scrape-ri-transfers\` → TES public view (math CAPTCHA solved programmatically — runs headlessly)
- \`scrape-vt-transfers\`
- \`scrape-ct-transfers\` → uses \`scrape-transfer-all.ts\` orchestrator for CCSU/ECSU/SCSU (must run as a single job because they merge into the same \`transfer-equiv.json\`, same pattern as the existing GA transfers job)

## Not included (still gaps)
- **ME transfers** — no scraper exists. Needs to be built.
- **PA/NJ courses** — no course scrapers exist at all. These states currently only have one-time-scraped transfer + institution data.
- **Prerequisites** for NY/RI/VT/CT/ME — no scrapers exist.

## Test plan
- [x] \`node -e \"yaml.load(...)\"\` parses all three workflow files
- [x] Job names are unique within each workflow
- [x] \`if:\` conditions match the existing pattern (\`github.event_name == 'schedule' || inputs.state == 'all' || inputs.state == '<code>'\`)
- [ ] After merge, trigger each new job once via \`workflow_dispatch\` with the specific state input to smoke-test before the first scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)