### PR TITLE
fix: BreadcrumbList missing 'item' field on 10 pages (SEO)

### DIFF
--- a/app/[state]/about/page.tsx
+++ b/app/[state]/about/page.tsx
@@ -77,7 +77,7 @@ export default async function AboutPage({ params }: Props) {
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Home", item: `${siteUrl}/${state}` },
-      { "@type": "ListItem", position: 2, name: "About Course Auditing" },
+      { "@type": "ListItem", position: 2, name: "About Course Auditing", item: `${siteUrl}/${state}/about` },
     ],
   };
 

--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -251,6 +251,7 @@ export default async function SubjectPage(props: PageProps) {
         "@type": "ListItem",
         position: 3,
         name: `${subject} Courses`,
+        item: `${siteUrl}/${state}/college/${id}/courses/${rawPrefix}`,
       },
     ],
   };

--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -261,11 +261,6 @@ export default async function InstructorPage(props: PageProps) {
       {
         "@type": "ListItem",
         position: 3,
-        name: "Instructors",
-      },
-      {
-        "@type": "ListItem",
-        position: 4,
         name: profile.displayName,
         item: `${siteUrl}/${state}/college/${id}/instructor/${slug}`,
       },

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -152,7 +152,7 @@ export default async function CollegeDetailPage(props: PageProps) {
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Home", item: `${siteUrl}/${state}` },
       { "@type": "ListItem", position: 2, name: "Colleges", item: `${siteUrl}/${state}/colleges` },
-      { "@type": "ListItem", position: 3, name: institution.name },
+      { "@type": "ListItem", position: 3, name: institution.name, item: `${siteUrl}/${state}/college/${id}` },
     ],
   };
 

--- a/app/[state]/colleges/page.tsx
+++ b/app/[state]/colleges/page.tsx
@@ -58,7 +58,7 @@ export default async function CollegesPage({ params }: Props) {
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Home", item: `${siteUrl}/${state}` },
-      { "@type": "ListItem", position: 2, name: "All Colleges" },
+      { "@type": "ListItem", position: 2, name: "All Colleges", item: `${siteUrl}/${state}/colleges` },
     ],
   };
 

--- a/app/[state]/courses/page.tsx
+++ b/app/[state]/courses/page.tsx
@@ -32,7 +32,7 @@ export default async function CoursesPage({ params }: Props) {
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Home", item: `${siteUrl}/${state}` },
-      { "@type": "ListItem", position: 2, name: "Find a Course" },
+      { "@type": "ListItem", position: 2, name: "Find a Course", item: `${siteUrl}/${state}/courses` },
     ],
   };
 

--- a/app/[state]/transfer/page.tsx
+++ b/app/[state]/transfer/page.tsx
@@ -66,7 +66,7 @@ export default async function TransferPage({ params }: Props) {
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Home", item: `${siteUrl}/${state}` },
-      { "@type": "ListItem", position: 2, name: "Transfer Course Finder" },
+      { "@type": "ListItem", position: 2, name: "Transfer Course Finder", item: `${siteUrl}/${state}/transfer` },
     ],
   };
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -98,7 +98,7 @@ export default async function BlogPostPage({ params }: Props) {
         name: "Blog",
         item: `${siteUrl}/blog`,
       },
-      { "@type": "ListItem", position: 3, name: meta.title },
+      { "@type": "ListItem", position: 3, name: meta.title, item: `${siteUrl}/blog/${meta.slug}` },
     ],
   };
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -60,7 +60,7 @@ export default async function BlogIndexPage({ searchParams }: Props) {
         name: "Home",
         item: siteUrl,
       },
-      { "@type": "ListItem", position: 2, name: "Blog" },
+      { "@type": "ListItem", position: 2, name: "Blog", item: `${siteUrl}/blog` },
     ],
   };
 

--- a/app/colleges/page.tsx
+++ b/app/colleges/page.tsx
@@ -96,6 +96,7 @@ export default async function AllCollegesPage() {
         "@type": "ListItem",
         position: 2,
         name: "All Colleges",
+        item: `${siteUrl}/colleges`,
       },
     ],
   };


### PR DESCRIPTION
## Summary
Google Search Console flagged the entire site as having a critical **\"Missing field 'item' (in 'itemListElement')\"** structured-data error. This prevents breadcrumb rich results from appearing in Search — a meaningful SEO regression.

**Root cause:** 10 pages had a \`BreadcrumbList\` JSON-LD where the final \`ListItem\` was given a \`name\` but no \`item\` URL. Schema.org requires every \`ListItem\` in a \`BreadcrumbList\` to include \`item\` — including the last one, which should point to the canonical URL of the current page.

## Pages fixed
Each got the last \`ListItem\`'s \`item\` field added (= canonical URL of the page):

| File | Last breadcrumb |
|---|---|
| \`app/[state]/college/[id]/page.tsx\` | College URL |
| \`app/[state]/college/[id]/courses/[prefix]/page.tsx\` | Subject URL |
| \`app/[state]/colleges/page.tsx\` | \`/[state]/colleges\` |
| \`app/[state]/courses/page.tsx\` | \`/[state]/courses\` |
| \`app/[state]/transfer/page.tsx\` | \`/[state]/transfer\` |
| \`app/[state]/about/page.tsx\` | \`/[state]/about\` |
| \`app/colleges/page.tsx\` | \`/colleges\` |
| \`app/blog/page.tsx\` | \`/blog\` |
| \`app/blog/[slug]/page.tsx\` | Post canonical |

**Special case:** \`app/[state]/college/[id]/instructor/[slug]/page.tsx\` had an intermediate \`"Instructors"\` ListItem with no URL (there's no instructors listing page). Dropped it entirely — the breadcrumb is now State → College → Instructor (3 levels), all three with a valid \`item\`.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] Dev preview parse: pulled HTML for \`/va/college/gcc/courses/eng\`, parsed all \`"@type":"ListItem"\` blocks in the BreadcrumbList JSON-LD, confirmed **0** entries with \`name\` but no \`item\`
- [ ] After merge, Google Search Console should re-validate on next recrawl (can also manually validate at https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)