### PR TITLE
perf+fix: modern browserslist + resilient CollegeTransfer.Net scrapers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,12 @@
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5"
-  }
+  },
+  "browserslist": [
+    "chrome >= 90",
+    "edge >= 90",
+    "firefox >= 90",
+    "safari >= 14",
+    "ios_saf >= 14"
+  ]
 }

--- a/scripts/dc/scrape-transfer.ts
+++ b/scripts/dc/scrape-transfer.ts
@@ -146,6 +146,16 @@ async function scrapeAllUdcEquivalencies(): Promise<TransferMapping[]> {
     const resp = await fetch(url);
 
     if (!resp.ok) {
+      // HTTP 402 = CollegeTransfer.Net free-tier quota exhausted. Don't
+      // fail the whole run — save what we've already fetched and exit
+      // cleanly. The next cron run will retry when the quota resets.
+      if (resp.status === 402) {
+        console.warn(
+          `\n  WARN: API quota exhausted at page ${skip / PAGE_SIZE + 1} (HTTP 402). ` +
+            `Saving ${mappings.length} mappings fetched so far; cron will retry next run.`
+        );
+        break;
+      }
       throw new Error(`OData API HTTP ${resp.status}: ${resp.statusText}`);
     }
 
@@ -273,17 +283,40 @@ async function main() {
   }
 
   if (transferable.length === 0) {
-    console.error("\nNo transferable mappings found. Aborting.");
-    process.exit(1);
+    console.warn(
+      "\n  WARN: no transferable mappings fetched (likely quota exhausted on page 1). " +
+        "Leaving existing data/dc/transfer-equiv.json untouched; cron will retry next run."
+    );
+    return;
   }
 
-  // Write output
+  // Preserve existing data if this run came back with fewer mappings than
+  // what's already on disk — CollegeTransfer.Net pages equivalencies in a
+  // stable order, so a partial scrape is a strict prefix of the full set;
+  // overwriting a 1,400-row file with 100 rows would regress published
+  // data.
   const outPath = path.join(
     process.cwd(),
     "data",
     "dc",
     "transfer-equiv.json"
   );
+  let existingCount = 0;
+  try {
+    const existing = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    if (Array.isArray(existing)) existingCount = existing.length;
+  } catch {
+    // No existing file — treat as zero.
+  }
+
+  if (mappings.length < existingCount) {
+    console.warn(
+      `\n  WARN: new scrape (${mappings.length}) < existing (${existingCount}). ` +
+        `Keeping existing file; cron will retry next run.`
+    );
+    return;
+  }
+
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, JSON.stringify(mappings, null, 2) + "\n");
   console.log(`\nSaved ${mappings.length} mappings → ${outPath}`);

--- a/scripts/me/scrape-transfer.ts
+++ b/scripts/me/scrape-transfer.ts
@@ -234,11 +234,17 @@ async function main() {
 
   console.log("CollegeTransfer.Net — Maine (MCCS) Transfer Scraper\n");
 
+  // Track which CCs succeeded this run so we can merge with existing
+  // data for CCs that didn't. CollegeTransfer.Net free-tier rate-limits
+  // after ~4-5 source institutions; the scraper should preserve data
+  // from previously-successful runs for any CCs that hit 402 this time.
+  const successfulSlugs = new Set<string>();
   const all: TransferMapping[] = [];
   for (const cc of ME_COLLEGES) {
     try {
       const mappings = await scrapeCollege(cc);
       all.push(...mappings);
+      successfulSlugs.add(cc.slug);
     } catch (err) {
       console.error(`  ${cc.slug}: FAILED — ${(err as Error).message}`);
     }
@@ -279,21 +285,49 @@ async function main() {
     console.log(`    ${slug}: ${count}`);
   }
 
-  if (transferable.length === 0) {
-    console.error("\nNo transferable mappings found. Aborting.");
-    process.exit(1);
+  if (successfulSlugs.size === 0) {
+    console.warn(
+      "\n  WARN: no colleges scraped successfully (likely API quota exhausted). " +
+        "Leaving existing data/me/transfer-equiv.json untouched; cron will retry next run."
+    );
+    return;
   }
 
-  // Write output
+  // Per-source merge: for any MCCS college that didn't succeed this run,
+  // preserve its rows from the existing file. CollegeTransfer.Net rate-
+  // limits after ~4-5 source institutions on the free tier, so partial
+  // runs are expected — this keeps previously-scraped colleges' data
+  // intact across retries.
   const outPath = path.join(
     process.cwd(),
     "data",
     "me",
     "transfer-equiv.json"
   );
+  let preserved: TransferMapping[] = [];
+  try {
+    const existing = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    if (Array.isArray(existing)) {
+      preserved = (existing as TransferMapping[]).filter((m) => {
+        const slug = m.notes.match(/^\[(\w+)\]/)?.[1];
+        return slug && !successfulSlugs.has(slug);
+      });
+    }
+  } catch {
+    // No existing file — fresh start.
+  }
+
+  const merged = [...preserved, ...all];
+  const preservedSlugs = new Set(
+    preserved.map((m) => m.notes.match(/^\[(\w+)\]/)?.[1]).filter(Boolean)
+  );
+  console.log(
+    `\n  Merged: ${preserved.length} preserved (from ${preservedSlugs.size} prior CC${preservedSlugs.size === 1 ? "" : "s"}) + ${all.length} new = ${merged.length} total`
+  );
+
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, JSON.stringify(all, null, 2) + "\n");
-  console.log(`\nSaved ${all.length} mappings → ${outPath}`);
+  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
+  console.log(`Saved ${merged.length} mappings → ${outPath}`);
 
   // Import to Supabase
   if (!skipImport) {


### PR DESCRIPTION
## Summary

Two related cleanups after the DC/ME transfer-data work (PR #16) and the Lighthouse CWV audit:

### 1. Modern browserslist (package.json)
Adds \`browserslist\` config targeting Chrome/Edge/Firefox ≥90 and Safari/iOS ≥14 — >97% of global traffic. Lighthouse flagged 14 KB "legacy-javascript-insight" on every audited page; a conservative modern target lets SWC skip down-leveling for user code. Most of the 14 KB likely originates from the Next/React runtime itself (not reducible from user config), so this may not fully clear the flag — will re-measure on prod after merge.

### 2. Scraper resilience (DC + ME CollegeTransfer.Net scrapers)

The scheduled cron smoke test after PR #16 revealed that the free-tier API rate-limits with **HTTP 402 Payment Required** after ~4-5 source institutions:

| State | Smoke result |
|---|---|
| ME transfers | 4 of 7 sources succeeded, 3 hit 402 → workflow exit 0 ✓ |
| DC transfers | 402 on page 2 of 15 → workflow exit **1** ✗ (failed) |

Without this fix, the DC workflow will keep failing on every Wed/Sat cron run until the quota resets, which is both noisy and potentially overwrites the committed 1,419-row dataset.

**Fix:**
- **DC scraper**: on HTTP 402 mid-pagination, log a warning and break the loop with the rows already fetched. Before writing, if the new count < existing count, keep the existing file (CollegeTransfer.Net pages in stable order so partial = strict prefix — overwriting 1,400 rows with 100 would regress).
- **ME scraper**: per-source merge via the \`[slug]\` notes prefix. CCs that didn't succeed this run get their existing rows preserved. If zero colleges succeed, leave the file untouched and exit 0.

Both keep prod data intact across rate-limited runs.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] After merge: re-trigger DC smoke test via \`workflow_dispatch\`; confirm exit 0 even if API 402s
- [ ] After merge: re-run Lighthouse on \`/va/state-landing\` and check if \`legacy-javascript-insight\` still shows 14 KiB
- [ ] Spot-check /dc/college/udc-cc still shows transfer pills (data/dc/transfer-equiv.json should be unchanged, since existing data is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)