### PR TITLE
ci: wire Tennessee into scheduled HTTP course scraper

### DIFF
--- a/.github/workflows/scrape-courses-http.yml
+++ b/.github/workflows/scrape-courses-http.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       state:
-        description: "State to scrape (va/nc/sc/ga/md/de/dc/ny/ri/ct or all)"
+        description: "State to scrape (va/nc/sc/ga/md/de/dc/ny/ri/ct/tn or all)"
         default: "all"
 
 env:
@@ -247,3 +247,21 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx tsx scripts/ct/scrape-banner.ts
+
+  # ── Tennessee (TBR Banner SSB) ──────────────────────────────────────
+  # 13 TBR community colleges via shared Banner SSB endpoints (HTTP).
+  # Scraper auto-imports to Supabase on success.
+  scrape-tn:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'tn'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/tn/scrape-banner-ssb.ts

--- a/.github/workflows/scrape-courses-http.yml
+++ b/.github/workflows/scrape-courses-http.yml
@@ -264,4 +264,4 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npx tsx scripts/tn/scrape-banner-ssb.ts
+      - run: npx tsx scripts/tn/scrape-banner-ssb.ts --all


### PR DESCRIPTION
## Summary
TN has a working \`scripts/tn/scrape-banner-ssb.ts\` scraper (13 TBR community colleges via shared Banner SSB endpoints) but wasn't wired into the cron. This PR adds a \`scrape-tn\` job to \`scrape-courses-http.yml\` on the same Sun/Tue/Thu 6 AM UTC schedule as the rest of the HTTP scrapers.

## Changes
- \`.github/workflows/scrape-courses-http.yml\`: new \`scrape-tn\` job, 45 min timeout (13 colleges, one page each), passes \`--all\` to the script. Also updates the \`workflow_dispatch\` input description.

## Branch history note
This branch was originally cut before PR #17 (browserslist + scraper resilience) landed. Rebased onto latest main so the diff is scoped to only the workflow file.

## Test plan
- [x] yaml parses cleanly via \`js-yaml\`
- [x] \`npx tsc --noEmit\` clean
- [ ] After merge: trigger \`workflow_dispatch\` with \`state=tn\` to smoke-test — the TN scraper has been run manually before, so this should just confirm the cron wiring works

🤖 Generated with [Claude Code](https://claude.com/claude-code)