### PR TITLE
fix: Soft 404s — relax course code regex + sanitize DB artifacts

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -22,7 +22,18 @@ type PageProps = {
 // ---------------------------------------------------------------------------
 
 function parseCode(code: string): { prefix: string; number: string } | null {
-  const match = code.toUpperCase().match(/^([A-Z]{2,5})-(\d{3,5}[A-Z]{0,3})$/);
+  // Loose match so every real course number in the dataset round-trips:
+  //   - VA/NC/SC/GA/TN/ME 3-5 digit, optional 1-3 letter suffix (`MTH-263`,
+  //     `BIO-101L`)
+  //   - NY (CUNY) 2-digit (`ESE-11`)
+  //   - DE letter-first (`IDT-G01`)
+  //   - DC law-school style (`LAW-L204`)
+  //   - MD alpha-only (`MATH-A`, `ESOL-LA`)
+  //   - VT hyphenated (`EDU-GTEW1`)
+  // The prior strict `/^([A-Z]{2,5})-(\d{3,5}[A-Z]{0,3})$/` regex rejected
+  // 455 valid course codes, causing `notFound()` to fire on URLs that
+  // Google had indexed — a Soft 404 flood in Search Console.
+  const match = code.toUpperCase().match(/^([A-Z]{2,5})-([A-Z0-9-]{1,10})$/);
   if (!match) return null;
   return { prefix: match[1], number: match[2] };
 }

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -451,10 +451,12 @@ export async function getSitemapCourseIndex(
         .range(start, start + PAGE_SIZE - 1);
       if (error || !rows || rows.length === 0) break;
       for (const r of rows) {
-        const key = `${r.course_prefix}-${r.course_number}`;
+        const cleanNum = sanitizeCourseNumber(r.course_number);
+        if (!cleanNum) continue; // drop rows whose number becomes empty after strip
+        const key = `${r.course_prefix}-${cleanNum}`;
         if (!seen.has(key)) {
           seen.add(key);
-          codes.push({ prefix: r.course_prefix, number: r.course_number });
+          codes.push({ prefix: r.course_prefix, number: cleanNum });
         }
         subjectSectionCounts.set(
           r.course_prefix,
@@ -518,9 +520,12 @@ export async function getDistinctCourseCodes(
     });
 
     if (!error && data) {
-      return (data as { course_prefix: string; course_number: string }[]).map(
-        (r) => ({ prefix: r.course_prefix, number: r.course_number })
-      );
+      return (data as { course_prefix: string; course_number: string }[])
+        .map((r) => ({
+          prefix: r.course_prefix,
+          number: sanitizeCourseNumber(r.course_number),
+        }))
+        .filter((r) => r.number);
     }
 
     // Fallback: select only the two columns we need (cheaper than select *)
@@ -539,10 +544,12 @@ export async function getDistinctCourseCodes(
         .range(start, start + PAGE_SIZE - 1);
       if (pageErr || !rows || rows.length === 0) break;
       for (const r of rows) {
-        const key = `${r.course_prefix}-${r.course_number}`;
+        const cleanNum = sanitizeCourseNumber(r.course_number);
+        if (!cleanNum) continue;
+        const key = `${r.course_prefix}-${cleanNum}`;
         if (!seen.has(key)) {
           seen.add(key);
-          out.push({ prefix: r.course_prefix, number: r.course_number });
+          out.push({ prefix: r.course_prefix, number: cleanNum });
         }
       }
       if (rows.length < PAGE_SIZE) break;
@@ -560,13 +567,26 @@ export async function getDistinctCourseCodes(
  * Map a Supabase row to a CourseSection object.
  * Handles field name mapping and type coercion.
  */
+/**
+ * Strip stray punctuation from `course_number` at read time. A handful of
+ * legacy VA rows (28 at last count — e.g. `CHM-5:`, `ESL-21:`, `DNH-95:`)
+ * came out of the VCCS PDF scrape with a trailing `:`. Rather than run a
+ * Supabase migration to rewrite the stored values, we normalize on read
+ * so every downstream consumer (page render, sitemap URL, prereq lookup)
+ * sees the same clean identifier.
+ */
+function sanitizeCourseNumber(raw: string): string {
+  if (!raw) return raw;
+  return raw.replace(/[^A-Za-z0-9-]/g, "").trim();
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function mapRow(row: any): CourseSection {
   return {
     college_code: row.college_code,
     term: row.term,
     course_prefix: row.course_prefix,
-    course_number: row.course_number,
+    course_number: sanitizeCourseNumber(row.course_number),
     course_title: row.course_title,
     credits: Number(row.credits) || 0,
     crn: row.crn,


### PR DESCRIPTION
## Summary

Google Search Console flagged **351 pages as Soft 404** — page bodies render as "Not Found" with noindex but return HTTP 200. Full catalog scan (27,346 rows) traced the root cause to two data-shape mismatches between the scraper output and the \`/[state]/course/[code]\` page router.

## Root cause

### 1. \`parseCode\` regex was too strict

The course detail page rejected **455 valid course codes** — they fell through \`parseCode\` and triggered \`notFound()\`:

| Count | Format | Source state(s) | Examples |
|---:|---|---|---|
| **333** | 1-2 digit numbers | NY (CUNY) | \`ESE-11\`, \`ACS-25\`, \`PHY-11\` |
| **78** | Letter-first numbers | DE, DC | \`IDT-G01\`, \`LAW-L204\` |
| **28** | Trailing colon (scraper bug) | VA | \`CHM-5:\`, \`DNH-95:\` |
| **10** | Other | various | mixed formats |
| **6** | Alpha-only | MD, VT | \`MATH-A\`, \`CNX-SND\` |

Fix: loosened \`/^([A-Z]{2,5})-(\\\\d{3,5}[A-Z]{0,3})$/\` → \`/^([A-Z]{2,5})-([A-Z0-9-]{1,10})$/\`.

### 2. 28 VA rows have \`course_number\` stored with trailing \`:\`

A VCCS PDF-scrape artifact. Added \`sanitizeCourseNumber()\` at read sites in \`lib/courses.ts\` (\`mapRow\`, \`getSitemapCourseIndex\`, \`getDistinctCourseCodes\`) — normalizes on read so every consumer sees clean identifiers.

## Verified

5 URLs from the Search Console report that previously returned "Not Found" now render real titles on local dev:

| URL | Title |
|---|---|
| \`/ny/course/ese-11\` | ESE 11: Earth Sys Science: Earth |
| \`/ny/course/phy-11\` | PHY 11: College Physics I |
| \`/ny/course/acs-25\` | ACS 25: Automatic/Manual Transmission |
| \`/de/course/idt-g01\` | IDT G01: Intro to Teaching a Dist Ed Cr |
| \`/md/course/math-a\` | MATH A: Instruction with Algebra |

## Out of scope

The residual **\`notFound()\` = HTTP 200 quirk** in Next 16 App Router ISR is not fixed here — doing so requires \`dynamic = 'force-dynamic'\` which loses ISR caching across ~19,650 course pages. After this PR, the 455 flagged URLs start serving real content (200 status + real content = normal indexable page), so Google will re-index rather than keep flagging Soft 404. Any remaining truly-invalid URLs will be a small residual that Google drops naturally over time.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] Local dev server: 5 flagged URLs render real titles (above)
- [ ] After merge + prod deploy: re-curl the same URLs, confirm real HTML
- [ ] Google Search Console: hit "Validate fix" on the Soft 404 issue; expect the 351 count to drop to near-zero over the following crawl cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)