### PR TITLE
fix: real HTTP 404 for malformed course URLs via proxy

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,32 +1,73 @@
+import { NextResponse, type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
-import type { NextRequest } from "next/server";
 
 /**
- * Next.js proxy (formerly "middleware") — refreshes the Supabase auth
- * session cookie.
+ * Next.js proxy (formerly "middleware"). Two jobs, routed by path:
  *
- * CRITICAL: only runs on auth-dependent routes. Running this on public pages
- * (college, course, subject, transfer, etc.) forces Next.js to emit
- * `cache-control: private, no-cache, no-store` because the proxy reads and
- * writes session cookies, which kills ISR edge caching and forces a full
- * server re-render on every request.
+ *   1. AUTH ROUTES (/account, /api/account, /auth)
+ *      Refresh the Supabase session cookie via `updateSession`.
  *
- * Only the 3 server files that import `@/lib/supabase/server` need this:
- *   - app/account/page.tsx
- *   - app/api/account/delete/route.ts
- *   - app/auth/callback/route.ts
+ *   2. PSEO COURSE PAGES (/<state>/course/<code>)
+ *      Validate the course-code format before the route even renders. If the
+ *      code is malformed (e.g. a legacy Google-crawled URL like
+ *      `/va/course/esl-42:`), return a real HTTP 404 response. This is the
+ *      only way to get a 404 *status* on a streamed route — once the response
+ *      body starts streaming (which happens the moment `loading.tsx`'s
+ *      Suspense boundary renders), the status code is locked at 200 and
+ *      `notFound()` can only set the body, not the status. Doing the format
+ *      check in the proxy runs before streaming starts. See Next.js docs:
+ *      "Status Codes" under loading.js.
  *
- * Client components that need to know the user is logged in should use
- * `createBrowserClient` and fetch the session client-side.
+ * CRITICAL: Neither branch touches cookies for public pages. The auth branch
+ * is scoped by the matcher to auth-only paths. The course branch just does
+ * regex validation + a static 404 response. This preserves ISR edge caching
+ * (`cache-control: public, s-maxage=…`) for the ~200 prerendered routes —
+ * any cookie access on a public page forces
+ * `cache-control: private, no-cache, no-store` and kills the cache.
  */
+
+// Same regex as app/[state]/course/[code]/page.tsx `parseCode()`. Kept in
+// sync by hand for now; both consumers reject URLs that don't match a
+// real course number in the scraped catalog.
+const COURSE_CODE_RE = /^[A-Z]{2,5}-[A-Z0-9-]{1,10}$/;
+
+// `/<state>/course/<code>` capture. State is 2 lowercase letters; code is
+// whatever the URL path segment is (validated against the regex below after
+// uppercasing).
+const COURSE_PATH_RE = /^\/([a-z]{2})\/course\/([^/]+)\/?$/;
+
 export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // -------------------------------------------------------------------------
+  // Course page format validation — runs for public paths but doesn't touch
+  // cookies, so ISR edge caching is preserved.
+  // -------------------------------------------------------------------------
+  const courseMatch = pathname.match(COURSE_PATH_RE);
+  if (courseMatch) {
+    const code = decodeURIComponent(courseMatch[2]).toUpperCase();
+    if (!COURSE_CODE_RE.test(code)) {
+      // Rewrite to the global 404 page. Using `rewrite` (not `redirect`)
+      // keeps the URL in the address bar and produces a 404 status —
+      // exactly what Google wants for dropping the URL from its index.
+      return new NextResponse(null, { status: 404 });
+    }
+    return NextResponse.next();
+  }
+
+  // -------------------------------------------------------------------------
+  // Auth session refresh — only for auth-dependent paths (see matcher).
+  // -------------------------------------------------------------------------
   return await updateSession(request);
 }
 
 export const config = {
   matcher: [
+    // Auth routes — need session refresh
     "/account/:path*",
     "/api/account/:path*",
     "/auth/:path*",
+    // Course detail routes — need URL format validation
+    "/:state/course/:code",
   ],
 };


### PR DESCRIPTION
## Summary
Residual Soft 404 cleanup after PR #19. Legacy Google-crawled URLs with malformed codes (e.g. \`/va/course/esl-42:\` with a trailing colon) still returned "Not Found" content at HTTP 200 — the classic streaming-response Soft 404.

Next.js 16 docs give the exact fix:
> "When streaming, a 200 status code will be returned... If you need a 404 status, ensure the resource exists before the response body is streamed... You can run this check in proxy..."

## Change
\`proxy.ts\` now runs for \`/:state/course/:code\` paths (in addition to the existing \`/account\`, \`/api/account\`, \`/auth\` auth routes). For course paths, it uppercase-validates the code against the same regex \`parseCode()\` uses (\`/^[A-Z]{2,5}-[A-Z0-9-]{1,10}$/\`) and returns \`new NextResponse(null, { status: 404 })\` for malformed codes. No cookie access on the course branch, so ISR edge caching is preserved.

## Local test

| Request | Result |
|---|---|
| \`GET /va/course/esl-42:\` | **404** (trailing colon) |
| \`GET /va/course/invalid\` | **404** (no hyphen) |
| \`GET /va/course/xxx-999-extra-garbage\` | **404** (code too long) |
| \`GET /ny/course/ese-11\` | **200** (valid CUNY 2-digit) |
| \`GET /va/course/mth-263\` | **200** (valid VCCS) |
| \`GET /va\` | **200** (state landing, not matched by proxy) |

## Not fixed here
The "sections.length === 0" streaming Soft 404 — that's a data-dependent check that can't run in the proxy without a DB query, and doing so would kill ISR caching. After PRs #19 + this PR, residual cases should be rare enough that Google stops flagging the issue entirely. If they persist, next lever is removing \`loading.tsx\` from specific route segments so \`notFound()\` returns 404 natively without streaming.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] Local dev: 6 test cases behave correctly (above)
- [ ] After merge + prod deploy: re-curl the malformed URLs, confirm HTTP 404
- [ ] Verify cache-control header on prerendered pages (\`/va/college/gcc\`) still shows \`public, s-maxage=…\` — proxy should NOT have killed the ISR cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)