### PR TITLE
perf: defer ScheduleBuilder + audit modal components on college page

### DIFF
--- a/app/[state]/college/[id]/CollegeDetailClient.tsx
+++ b/app/[state]/college/[id]/CollegeDetailClient.tsx
@@ -1,11 +1,46 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import dynamic from "next/dynamic";
 import CourseTable from "@/components/CourseTableDynamic";
-import AuditInstructions from "@/components/AuditInstructions";
-import PrintInstructions from "@/components/PrintInstructions";
-import ScheduleBuilder from "@/components/ScheduleBuilder";
 import type { Institution, CourseSection } from "@/lib/types";
+
+// Dynamic imports keep the heavy interactive components out of the college
+// page's initial JS bundle. Lighthouse mobile identified college as the
+// worst-performing page (TBT 1.1 s post-#15, score 59) because these three
+// client chunks load + parse + execute synchronously with first paint even
+// though they only become useful after user interaction:
+//
+//   - ScheduleBuilder (302 lines)  — used once the user pins ≥2 courses;
+//                                    below the course table on every render.
+//   - AuditInstructions (277 lines) — only shown inside the "How to audit"
+//                                    modal.
+//   - PrintInstructions (140 lines) — only shown inside the same modal.
+//
+// `ssr: false` because none of these contribute to SEO content; the
+// course table + static audit badges on the page handle that. The
+// placeholder is a 200 px skeleton that reserves the ScheduleBuilder's
+// layout slot so there's no CLS when it swaps in.
+
+const ScheduleBuilder = dynamic(
+  () => import("@/components/ScheduleBuilder"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="mt-6 h-[200px] w-full animate-pulse rounded-lg bg-gray-100 dark:bg-slate-800" />
+    ),
+  }
+);
+
+const AuditInstructions = dynamic(
+  () => import("@/components/AuditInstructions"),
+  { ssr: false }
+);
+
+const PrintInstructions = dynamic(
+  () => import("@/components/PrintInstructions"),
+  { ssr: false }
+);
 
 type TransferLookup = Record<
   string,


### PR DESCRIPTION
## Summary
Residual TBT chase after PR #15. Lighthouse flagged \`/va/college/gcc\` at score 59 / TBT 1,100 ms (down from 51 / 3,240 ms before #15). The remaining 1.1 s of main-thread blocking comes from interactive client components that load + hydrate on every page render even though they're only useful after user interaction.

## Change
Moved three components from static imports to \`next/dynamic\` with \`ssr: false\` in \`CollegeDetailClient.tsx\`:

| Component | Lines | When it's needed |
|---|---:|---|
| \`ScheduleBuilder\` | 302 | After user pins ≥2 courses |
| \`AuditInstructions\` | 277 | Inside "How to audit" modal |
| \`PrintInstructions\` | 140 | Inside same modal |

ScheduleBuilder gets a 200 px skeleton to reserve its layout slot (no CLS). Audit/Print modals don't need one — their parent conditional already keeps them off the page until the modal opens.

## Measurements
Bundle on \`/va/college/gcc\` prerendered HTML:

|  | Eager JS (gzip) | Chunks |
|---|---:|---:|
| Before | 207 KB | 12 |
| After | 204 KB | 12 |
| Delta | **−3 KB** | = |

The bundle delta is modest, but the meaningful win should be in TBT — these components were running \`useEffect\` + time-grid math on hydration. Moving them out of the critical hydration pass should cut main-thread work more than the bundle size suggests. Will re-measure via Lighthouse after prod deploy.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] After merge: Lighthouse mobile on \`/va/college/gcc\`; target score 75+ / TBT < 700 ms
- [ ] Manual UX smoke: click "How to audit" on a course row → modal opens without lag; pin 2 courses → ScheduleBuilder renders below the table with no layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)