### PR TITLE
data: VT prereq scraper (CCV acalog)

### DIFF
--- a/data/vt/prereqs.json
+++ b/data/vt/prereqs.json
@@ -1,0 +1,625 @@
+{
+  "ACC 1010": {
+    "text": "Financial Accounting",
+    "courses": [
+      "ACC 2121"
+    ]
+  },
+  "ACC 1030": {
+    "text": "Financial Accounting",
+    "courses": [
+      "ACC 2121"
+    ]
+  },
+  "ACC 2122": {
+    "text": "Financial Accounting",
+    "courses": [
+      "ACC 2121"
+    ]
+  },
+  "ACC 2201": {
+    "text": "Managerial Accounting",
+    "courses": [
+      "ACC 2122"
+    ]
+  },
+  "ACC 2202": {
+    "text": "Intermediate Accounting I",
+    "courses": [
+      "ACC 2201"
+    ]
+  },
+  "ACC 2210": {
+    "text": "Managerial Accounting",
+    "courses": [
+      "ACC 2122"
+    ]
+  },
+  "ACC 2230": {
+    "text": "Financial Accounting",
+    "courses": [
+      "ACC 2121"
+    ]
+  },
+  "AHS 1810": {
+    "text": "Administrative Medical Assisting",
+    "courses": [
+      "AHS 2200"
+    ]
+  },
+  "AHS 2070": {
+    "text": "Human Biology , Medical Terminology , or equivalent knowledge, and a criminal background check",
+    "courses": [
+      "AHS 1205",
+      "BIO 1140"
+    ]
+  },
+  "AHS 2121": {
+    "text": "Medical Terminology and Introduction to Health Information Systems",
+    "courses": [
+      "AHS 1015",
+      "AHS 1205"
+    ]
+  },
+  "AHS 2122": {
+    "text": "Medical Coding I",
+    "courses": [
+      "AHS 2121"
+    ]
+  },
+  "AHS 2165": {
+    "text": "Medical Terminology and Introduction to Health Information Systems",
+    "courses": [
+      "AHS 1015",
+      "AHS 1205"
+    ]
+  },
+  "AHS 2200": {
+    "text": "Medical Terminology , and a criminal background check",
+    "courses": [
+      "AHS 1205"
+    ]
+  },
+  "AHS 2470": {
+    "text": "Human Biology and Medical Terminology",
+    "courses": [
+      "AHS 1205",
+      "BIO 1140"
+    ]
+  },
+  "AHS 2820": {
+    "text": "Human Biology , Medical Terminology , Introduction to Phlebotomy , Fundamentals of Pharmacology , Clinical Medical Assisting , Basic Life Support for Healthcare Providers, and a criminal background check",
+    "courses": [
+      "AHS 1205",
+      "AHS 1410",
+      "AHS 2070",
+      "AHS 2470",
+      "BIO 1140"
+    ]
+  },
+  "ART 1111": {
+    "text": "Introduction to Adobe Creative Cloud",
+    "courses": [
+      "ART 1210"
+    ]
+  },
+  "ART 1112": {
+    "text": "Graphic Design I",
+    "courses": [
+      "ART 1111"
+    ]
+  },
+  "ART 1160": {
+    "text": "Drawing I or Introduction to Studio Art",
+    "courses": [
+      "ART 1011",
+      "ART 1020"
+    ]
+  },
+  "ART 1310": {
+    "text": "Basic computer skills are required",
+    "courses": []
+  },
+  "ART 1350": {
+    "text": "Introduction to Adobe Creative Cloud",
+    "courses": [
+      "ART 1210"
+    ]
+  },
+  "ART 2012": {
+    "text": "Drawing I",
+    "courses": [
+      "ART 1011"
+    ]
+  },
+  "ART 2031": {
+    "text": "Drawing I",
+    "courses": [
+      "ART 1011"
+    ]
+  },
+  "ART 2090": {
+    "text": "Introduction to Adobe Creative Cloud or equivalent skills",
+    "courses": [
+      "ART 1210"
+    ]
+  },
+  "ART 2170": {
+    "text": "Minimum of 30 college-level credits or advisor permission",
+    "courses": []
+  },
+  "ART 2211": {
+    "text": "Recommended prior learning: Drawing I or Introduction to Studio Art",
+    "courses": [
+      "ART 1011",
+      "ART 1020"
+    ]
+  },
+  "ART 2212": {
+    "text": "Painting I or similar experience",
+    "courses": [
+      "ART 2211"
+    ]
+  },
+  "ART 2232": {
+    "text": "Ceramics I",
+    "courses": [
+      "ART 1231"
+    ]
+  },
+  "ART 2315": {
+    "text": "Digital Photography I",
+    "courses": [
+      "ART 1310"
+    ]
+  },
+  "ART 2440": {
+    "text": "Digital Animation",
+    "courses": [
+      "ART 1420"
+    ]
+  },
+  "BIO 2012": {
+    "text": "Human Anatomy & Physiology I",
+    "courses": [
+      "BIO 2011"
+    ]
+  },
+  "BIO 2120": {
+    "text": "Prior successful completion of Human Anatomy & Physiology II is recommended",
+    "courses": [
+      "BIO 2012"
+    ]
+  },
+  "BIO 2260": {
+    "text": "Intermediate Algebra or equivalent",
+    "courses": [
+      "MAT 1020"
+    ]
+  },
+  "BIO 2340": {
+    "text": "Introduction to Biology or Introduction to Biology: Ecology & Evolution",
+    "courses": [
+      "BIO 1210",
+      "BIO 1211"
+    ]
+  },
+  "BUS 2245": {
+    "text": "Prerequisite: Introduction to Digital Marketing or equivalent skills",
+    "courses": []
+  },
+  "BUS 2445": {
+    "text": "Prerequisite: Human Resource Management",
+    "courses": []
+  },
+  "BUS 2740": {
+    "text": "Introduction to Business , Financial Accounting , Principles of Management or Small Business Management , and Principles of Marketing or Small Business Marketing",
+    "courses": [
+      "ACC 2121",
+      "BUS 1010",
+      "BUS 2020",
+      "BUS 2210",
+      "BUS 2230",
+      "BUS 2430"
+    ]
+  },
+  "CED 0211": {
+    "text": "Recommended near completion of the Cybersecurity and Networking Certificate + or focus area in the Information Technology (A.S.) +",
+    "courses": []
+  },
+  "CED 0221": {
+    "text": "Recommended near completion of the Cybersecurity and Networking Certificate + or focus area in the Information Technology (A.S.) +",
+    "courses": []
+  },
+  "CHE 1031": {
+    "text": "Intermediate Algebra or above",
+    "courses": [
+      "MAT 1020"
+    ]
+  },
+  "CHE 1032": {
+    "text": "General Chemistry I",
+    "courses": [
+      "CHE 1031"
+    ]
+  },
+  "CHE 2041": {
+    "text": "General Chemistry II",
+    "courses": [
+      "CHE 1032"
+    ]
+  },
+  "CHE 2042": {
+    "text": "Organic Chemistry I",
+    "courses": [
+      "CHE 2041"
+    ]
+  },
+  "CIS 1152": {
+    "text": "Website Development . Recommended prior or concurrent learning: JavaScript for Web Development",
+    "courses": [
+      "CIS 1151"
+    ]
+  },
+  "CIS 1170": {
+    "text": "Website Development or Introduction to Computer Science",
+    "courses": [
+      "CIS 1100",
+      "CIS 1151"
+    ]
+  },
+  "CIS 1350": {
+    "text": "Recommended prior or concurrent learning: Introduction to Computer Science or equivalent skills",
+    "courses": [
+      "CIS 1100"
+    ]
+  },
+  "CIS 1450": {
+    "text": "Prerequisite: Introduction to Computer Science or equivalent technology skills. Recommended prior or concurrent learning: Operating Systems",
+    "courses": [
+      "CIS 1100",
+      "CIS 1350"
+    ]
+  },
+  "CIS 2080": {
+    "text": "Website Development",
+    "courses": [
+      "CIS 1151"
+    ]
+  },
+  "CIS 2120": {
+    "text": "Recommended prior or concurrent learning: Operating Systems",
+    "courses": [
+      "CIS 1350"
+    ]
+  },
+  "CIS 2140": {
+    "text": "Website Development",
+    "courses": [
+      "CIS 1151"
+    ]
+  },
+  "CIS 2145": {
+    "text": "Programming I",
+    "courses": [
+      "CIS 1145"
+    ]
+  },
+  "CIS 2212": {
+    "text": "Python Programming or equivalent skills",
+    "courses": [
+      "CIS 2210"
+    ]
+  },
+  "CIS 2230": {
+    "text": "Desktop Operating Systems . Recommended prior or concurrent learning: Network and Security Foundations",
+    "courses": [
+      "CIS 1350",
+      "CIS 2120"
+    ]
+  },
+  "CIS 2235": {
+    "text": "System Administration",
+    "courses": [
+      "CIS 2230"
+    ]
+  },
+  "CIS 2245": {
+    "text": "Recommended prior or concurrent learning: Networking Foundations and Operating Systems",
+    "courses": [
+      "CIS 1350",
+      "CIS 2120"
+    ]
+  },
+  "CIS 2265": {
+    "text": "System Administration",
+    "courses": [
+      "CIS 2230"
+    ]
+  },
+  "CIS 2295": {
+    "text": "Recommended prior or concurrent learning: Python Programming or Programming I",
+    "courses": [
+      "CIS 1145",
+      "CIS 2210"
+    ]
+  },
+  "CIS 2300": {
+    "text": "Recommended prior or concurrent learning: Introduction to Computer Science , Networking Foundations , or equivalent experience",
+    "courses": [
+      "CIS 1100",
+      "CIS 2120"
+    ]
+  },
+  "CIS 2330": {
+    "text": "Introduction to Computer Science",
+    "courses": [
+      "CIS 1100"
+    ]
+  },
+  "CIS 2350": {
+    "text": "Foundations of Cloud Computing , Concepts of Computer Security , and Desktop Operating Systems",
+    "courses": [
+      "CIS 1350",
+      "CIS 1450",
+      "CIS 2245"
+    ]
+  },
+  "CIS 2360": {
+    "text": "Operating Systems",
+    "courses": [
+      "CIS 1350"
+    ]
+  },
+  "CIS 2380": {
+    "text": "Recommended prior or concurrent learning: Introduction to Artificial Intelligence (AI) , Introduction to Computer Science , and/or Python Programming",
+    "courses": [
+      "CIS 1100",
+      "CIS 1270",
+      "CIS 2210"
+    ]
+  },
+  "CIS 2420": {
+    "text": "Introduction to Computer Science",
+    "courses": [
+      "CIS 1100"
+    ]
+  },
+  "CIS 2460": {
+    "text": "Foundations of Cloud Computing , Concepts of Computer Security , and Desktop Operating Systems",
+    "courses": [
+      "CIS 1350",
+      "CIS 1450",
+      "CIS 2245"
+    ]
+  },
+  "COM 2180": {
+    "text": "Introduction to Adobe Creative Cloud",
+    "courses": [
+      "ART 1210"
+    ]
+  },
+  "CRJ 2010": {
+    "text": "Introduction to Criminal Justice",
+    "courses": [
+      "CRJ 1010"
+    ]
+  },
+  "CRJ 2020": {
+    "text": "Introduction to Criminal Justice",
+    "courses": [
+      "CRJ 1010"
+    ]
+  },
+  "CRJ 2080": {
+    "text": "Introduction to Criminal Justice",
+    "courses": [
+      "CRJ 1010"
+    ]
+  },
+  "CRJ 2510": {
+    "text": "American Judicial Process or advisor permission",
+    "courses": [
+      "CRJ 2020"
+    ]
+  },
+  "EDU 1270": {
+    "text": "a child development course. This course introduces concepts that are aligned with the National Association for the Education of Young Children (NAEYC) Professional Standards for Early Childhood Educators: Standards 1-6",
+    "courses": []
+  },
+  "EDU 1430": {
+    "text": "Recommended prior or concurrent learning: Perspectives on Development , Child Development , or a course focused on child development",
+    "courses": [
+      "EDU 2365",
+      "PSY 2010"
+    ]
+  },
+  "EDU 2045": {
+    "text": "Recommended Prior Learning: a course in child development",
+    "courses": []
+  },
+  "EDU 2145": {
+    "text": "Afterschool Education & Development of the School-Aged Child or Child Development",
+    "courses": [
+      "EDU 2065",
+      "PSY 2010"
+    ]
+  },
+  "EDU 2470": {
+    "text": "Recommended prior or concurrent learning: Perspectives on Development , Child Development , or a course focused on child development",
+    "courses": [
+      "EDU 2365",
+      "PSY 2010"
+    ]
+  },
+  "ENG 1020": {
+    "text": "English Composition",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "ENG 1062": {
+    "text": "English Composition",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "ENG 1310": {
+    "text": "English Composition",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "ENG 2050": {
+    "text": "English Composition",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "ENG 2101": {
+    "text": "English Composition",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "ENG 2135": {
+    "text": "English Composition",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "FLM 2060": {
+    "text": "Digital Filmmaking I",
+    "courses": [
+      "FLM 1050"
+    ]
+  },
+  "FRE 1112": {
+    "text": "French I or equivalent skills",
+    "courses": [
+      "FRE 1111"
+    ]
+  },
+  "HUM 2010": {
+    "text": "English Composition and a Research & Writing Intensive course, or equivalent skills",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "INT 2860": {
+    "text": "Degree students must successfully complete English Composition and a minimum of 30 prior college credits or advisor permission. Certificate seeking students generally enroll during the final semester of their program with advisor assistance. and a minimum of 30 prior college credits or advisor permission",
+    "courses": [
+      "ENG 1061"
+    ]
+  },
+  "MAT 1020": {
+    "text": "Math and Algebra for College or equivalent skills",
+    "courses": [
+      "MAT 0310"
+    ]
+  },
+  "MAT 1030": {
+    "text": "Math and Algebra for College or equivalent skills",
+    "courses": [
+      "MAT 0310"
+    ]
+  },
+  "MAT 1221": {
+    "text": "Math & Algebra for College or equivalent skills",
+    "courses": [
+      "MAT 0310"
+    ]
+  },
+  "MAT 1230": {
+    "text": "Intermediate Algebra or equivalent skills",
+    "courses": [
+      "MAT 1020"
+    ]
+  },
+  "MAT 1330": {
+    "text": "College Algebra or equivalent skills",
+    "courses": [
+      "MAT 1230"
+    ]
+  },
+  "MAT 1531": {
+    "text": "Pre-Calculus Mathematics or equivalent skills",
+    "courses": [
+      "MAT 1330"
+    ]
+  },
+  "MAT 2021": {
+    "text": "Math and Algebra for College or equivalent skills",
+    "courses": [
+      "MAT 0310"
+    ]
+  },
+  "MAT 2532": {
+    "text": "Calculus I or equivalent transfer course",
+    "courses": [
+      "MAT 1531"
+    ]
+  },
+  "MEC 1320": {
+    "text": "Principles of Manufacturing or at least one year of manufacturing experience required",
+    "courses": [
+      "MEC 1310"
+    ]
+  },
+  "MET 1020": {
+    "text": "Basic algebra skills are required",
+    "courses": []
+  },
+  "PHY 1041": {
+    "text": "College Algebra . Pre-Calculus Mathematics is strongly recommended",
+    "courses": [
+      "MAT 1230",
+      "MAT 1330"
+    ]
+  },
+  "PHY 1042": {
+    "text": "Physics I",
+    "courses": [
+      "PHY 1041"
+    ]
+  },
+  "PHY 1110": {
+    "text": "Basic Algebra skills required",
+    "courses": []
+  },
+  "PSY 2060": {
+    "text": "Introduction to Psychology",
+    "courses": [
+      "PSY 1010"
+    ]
+  },
+  "SLS 1012": {
+    "text": "American Sign Language I",
+    "courses": [
+      "SLS 1011"
+    ]
+  },
+  "SPA 1012": {
+    "text": "Spanish I or equivalent skills",
+    "courses": [
+      "SPA 1011"
+    ]
+  },
+  "SWK 2020": {
+    "text": "Introduction to Psychology or Introduction to Sociology",
+    "courses": [
+      "PSY 1010",
+      "SOC 1010"
+    ]
+  },
+  "SWK 2070": {
+    "text": "Introduction to Research Methods and one of the following courses: Introduction to Criminal Justice or Introduction to Early Childhood Education or Introduction to Substance Use Disorders , Human Growth & Development , or Introduction to Human Services",
+    "courses": [
+      "CRJ 1010",
+      "EDU 1030",
+      "ENG 1020",
+      "PSY 1130",
+      "SWK 1010"
+    ]
+  }
+}

--- a/scripts/vt/scrape-catalog-prereqs.ts
+++ b/scripts/vt/scrape-catalog-prereqs.ts
@@ -1,0 +1,311 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Scrapes Community College of Vermont's acalog/Modern Campus catalog at
+ * https://catalog.ccv.edu to extract prerequisite text for every active
+ * CCV course. CCV is Vermont's only community college; the primary course
+ * scraper (scripts/vt/scrape-colleague.ts) doesn't extract prereqs from
+ * Colleague Self-Service so this catalog scrape fills that gap.
+ *
+ * Unlike the TN/Pellissippi scraper, CCV's acalog links prereq course
+ * references via `<a href="...coid=X">…course title…</a>` with the course
+ * TITLE as anchor text (not the code). So parsing requires a two-pass
+ * approach:
+ *
+ *   Pass 1: paginate the course list, collect coids, fetch every detail
+ *           page once, and build a `coid → "PREFIX NUMBER"` index.
+ *   Pass 2: re-scan each detail page's prereq block; resolve any anchor
+ *           `coid=X` references to canonical course codes via the index.
+ *
+ * Output: data/vt/prereqs.json keyed by "${PREFIX} ${NUMBER}".
+ *
+ * The catalog year rolls over every summer. Re-run once CCV publishes the
+ * new catoid. Update CATOID below when that happens.
+ *
+ * Usage:
+ *   npx tsx scripts/vt/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/vt/scrape-catalog-prereqs.ts --limit=50   # smoke test
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const BASE = "https://catalog.ccv.edu";
+const CATOID = 17;     // CCV 2026-2027 catalog id
+const NAVOID = 1662;   // "Courses" nav entry
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 8;
+const DELAY_MS = 50;
+const MAX_PAGES = 10;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+interface CourseDetail {
+  coid: string;
+  prefix: string;
+  number: string;
+  html: string;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return ""; // 404 — course probably delisted; skip silently
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Catalog endpoints
+// ---------------------------------------------------------------------------
+
+function listUrl(cpage: number): string {
+  return (
+    `${BASE}/content.php?catoid=${CATOID}` +
+    `&catoid=${CATOID}` +
+    `&navoid=${NAVOID}` +
+    `&filter%5Bitem_type%5D=3` +
+    `&filter%5Bonly_active%5D=1` +
+    `&filter%5B3%5D=1` +
+    `&filter%5Bcpage%5D=${cpage}`
+  );
+}
+
+function detailUrl(coid: string): string {
+  return `${BASE}/preview_course_nopop.php?catoid=${CATOID}&coid=${coid}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function extractCoids(html: string): string[] {
+  const matches = html.match(/preview_course_nopop\.php\?catoid=\d+&(?:amp;)?coid=(\d+)/g) || [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+/**
+ * Extract the course code (prefix + number) from the detail page's H1.
+ * Returns null for non-course pages (general-education descriptors, etc.)
+ * which appear at the start of acalog's list and don't have a PREFIX NUMBER
+ * header.
+ */
+function extractCourseCode(html: string): { prefix: string; number: string } | null {
+  const m = html.match(/<h1[^>]*>\s*([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\s*-/);
+  if (!m) return null;
+  return { prefix: m[1].toUpperCase(), number: m[2] };
+}
+
+/**
+ * Extract the raw prereq HTML block (before tag stripping) so we can
+ * pull out `<a href="...coid=X">` links for resolution via the coid index.
+ */
+function extractPrereqBlock(html: string): string | null {
+  // Match "Prerequisites:" (with optional <strong> wrapper) up to the next
+  // <br><br>, </p>, or stock "Click here for course offerings" link.
+  const m = html.match(
+    /(?:<strong>\s*)?Prerequisites?(?:\(s\))?\s*:\s*(?:<\/strong>)?\s*([\s\S]*?)(?:<br\s*\/?>\s*<br|<\/p>|<strong>|<a\s+href=["']https:)/i,
+  );
+  return m ? m[1] : null;
+}
+
+/** Strip HTML tags + decode common entities to plain text. */
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,]\s*$/, "")
+    .trim();
+}
+
+/** Extract coid references from a block of HTML. Used to resolve prereq anchors. */
+function extractAnchorCoids(htmlBlock: string): string[] {
+  const matches = htmlBlock.match(/coid=(\d+)/g) || [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+// Stock phrases that indicate "no actual prereq" — filtered out to keep the
+// output clean. CCV's boilerplate comes in a few variants.
+const BOILERPLATE_RE =
+  /^(students must meet basic skills policy requirements\.?\s*no other (course\s+)?prerequisites? required|none|not applicable|n\/a)\s*\.?\s*$/i;
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limit = parseInt(args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0", 10);
+
+  console.log("CCV catalog prereq scraper");
+  console.log(`  Base: ${BASE}`);
+  console.log(`  catoid=${CATOID} navoid=${NAVOID}`);
+
+  // --- Phase 1: paginate list, collect coids ---
+  console.log("\n[1/3] Paginating course list...");
+  const allCoids = new Set<string>();
+  for (let cpage = 1; cpage <= MAX_PAGES; cpage++) {
+    const html = await retryFetch(listUrl(cpage), `list(cpage=${cpage})`);
+    const coids = extractCoids(html);
+    console.log(`  cpage=${cpage}: ${coids.length} coids`);
+    if (coids.length === 0) break;
+    for (const c of coids) allCoids.add(c);
+    await sleep(100);
+  }
+  let coidList = Array.from(allCoids);
+  console.log(`  Total unique coids: ${coidList.length}`);
+
+  if (limit > 0) {
+    coidList = coidList.slice(0, limit);
+    console.log(`  Limited to first ${limit} for smoke test`);
+  }
+
+  // --- Phase 2: fetch every detail page, build coid → code index ---
+  console.log("\n[2/3] Fetching detail pages + building coid index...");
+  const details: CourseDetail[] = [];
+  const codeByCoid = new Map<string, string>();
+  await pmap(coidList, CONCURRENCY, async (coid) => {
+    const html = await retryFetch(detailUrl(coid), `detail(${coid})`);
+    if (!html) return;
+    const code = extractCourseCode(html);
+    if (!code) return; // non-course page (gen-ed descriptor, etc.)
+    details.push({ coid, prefix: code.prefix, number: code.number, html });
+    codeByCoid.set(coid, `${code.prefix} ${code.number}`);
+  });
+  console.log(
+    `  Fetched ${details.length} real course pages (${coidList.length - details.length} non-course descriptors skipped)`,
+  );
+
+  // --- Phase 3: parse prereq blocks, resolve anchor coids to codes ---
+  console.log("\n[3/3] Parsing prereqs + resolving anchor refs...");
+  const prereqs: Record<string, PrereqEntry> = {};
+  let withPrereqs = 0;
+  let resolvedAnchors = 0;
+  for (const d of details) {
+    const block = extractPrereqBlock(d.html);
+    if (!block) continue;
+
+    const text = htmlToText(block);
+    if (!text) continue;
+    if (BOILERPLATE_RE.test(text)) continue;
+
+    // Extract course codes from the text itself (handles "MTH 1010", "ENG 2120")
+    const courses = new Set<string>();
+    const codeRegex = /\b([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b/g;
+    let m: RegExpExecArray | null;
+    while ((m = codeRegex.exec(text)) !== null) {
+      const code = `${m[1]} ${m[2]}`;
+      if (code !== `${d.prefix} ${d.number}`) courses.add(code);
+    }
+
+    // Also resolve `<a href="...coid=X">` links in the raw block — CCV uses
+    // anchor text like "Human Anatomy & Physiology II" which doesn't contain
+    // the course code, so the text-only regex misses those.
+    for (const anchorCoid of extractAnchorCoids(block)) {
+      const resolved = codeByCoid.get(anchorCoid);
+      if (resolved && resolved !== `${d.prefix} ${d.number}`) {
+        courses.add(resolved);
+        resolvedAnchors++;
+      }
+    }
+
+    const key = `${d.prefix} ${d.number}`;
+    prereqs[key] = { text, courses: Array.from(courses).sort() };
+    withPrereqs++;
+  }
+  console.log(`  Extracted prereqs for ${withPrereqs} courses`);
+  console.log(`  Resolved ${resolvedAnchors} <a href> anchor references via coid index`);
+
+  // Sort keys alphabetically for deterministic output
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(prereqs).sort()) {
+    sorted[key] = prereqs[key];
+  }
+
+  // --- Write ---
+  const outDir = path.join(process.cwd(), "data", "vt");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
VT was one of 7 states missing prereq data. The primary CCV course scraper (\`scripts/vt/scrape-colleague.ts\`) doesn't extract prereqs from Colleague Self-Service, so this fills the gap via a catalog scrape — same pattern as the TN/Pellissippi and DE/DTCC scrapers.

**Source:** https://catalog.ccv.edu (Modern Campus / acalog, catoid=17, navoid=1662, ~362 courses).

## Why two-pass
CCV's acalog links prereq course references via \`<a href="…coid=X">Course Title</a>\` where the anchor text is the course TITLE (not the code). Regex-scanning the text for \`\\\\b[A-Z]{2,5}\\\\s*\\\\d{3,4}\\\\b\` misses them. The scraper therefore:

1. Paginates list, collects coids
2. Fetches every detail page once, builds \`coid → "PREFIX NUMBER"\` index
3. Re-scans each prereq block, resolves \`<a href="…coid=X">\` refs via the index to canonical course codes

## Smoke-test
  - Fetched 351 real course pages (11 gen-ed descriptors skipped)
  - Extracted prereqs for **101 courses**
  - Resolved **128 \`<a href>\` anchor refs** via the coid index
  - **91 of 101** have ≥1 resolved course code prereq

## Verified end-to-end
\`GET /api/vt/prereqs/chain?course=ACC 2201\` → ACC 2201 → ACC 2122 → ACC 2121 (3-level chain rendered correctly).

## Next
6 more states still missing prereqs: NY, RI, CT, ME, PA, NJ. CT and ME look like Modern Campus too and could reuse most of this code. RI has a custom catalog. NY and PA/NJ need research.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Full scrape completes in ~40 seconds, writes \`data/vt/prereqs.json\`
- [x] \`/api/vt/prereqs/courses\` returns 101 courses on dev
- [x] \`/api/vt/prereqs/chain\` builds correct 3-level chain
- [ ] After merge: spot-check a VT course page on prod to see the prereq badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)