### PR TITLE
data: CT prereq scraper (CT State acalog, 573 courses)

### DIFF
--- a/data/ct/prereqs.json
+++ b/data/ct/prereqs.json
@@ -1,0 +1,3491 @@
+{
+  "ACCT 1098": {
+    "text": "ACCT 1130 and ACCT 1170 or permission of instructor",
+    "courses": [
+      "ACCT 1130",
+      "ACCT 1170"
+    ]
+  },
+  "ACCT 1130": {
+    "text": "MATH 0900I /MATH 0900 with a grade of D- or higher OR placement using multiple measures",
+    "courses": [
+      "MATH 0900",
+      "MATH 0900I"
+    ]
+  },
+  "ACCT 1170": {
+    "text": "Completion of ACCT 1130 with a C or higher",
+    "courses": [
+      "ACCT 1130"
+    ]
+  },
+  "ACCT 1230": {
+    "text": "ACCT 1170",
+    "courses": [
+      "ACCT 1170"
+    ]
+  },
+  "ACCT 1234": {
+    "text": "ACCT 1130 with a C or higher",
+    "courses": [
+      "ACCT 1130"
+    ]
+  },
+  "ACCT 1250": {
+    "text": "Completion of ACCT 1130 with a C or higher",
+    "courses": [
+      "ACCT 1130"
+    ]
+  },
+  "ACCT 1700": {
+    "text": "Completion of ACCT 1130 with a C or higher",
+    "courses": [
+      "ACCT 1130"
+    ]
+  },
+  "ACCT 2095": {
+    "text": "15 completed credit hours in the Accounting program/certificate including ACCT 1130 , ACCT 1170 , and ACCT 2710",
+    "courses": [
+      "ACCT 1130",
+      "ACCT 1170",
+      "ACCT 2710"
+    ]
+  },
+  "ACCT 2330": {
+    "text": "ACCT 1170 with a grade of C or higher",
+    "courses": [
+      "ACCT 1170"
+    ]
+  },
+  "ACCT 2410": {
+    "text": "Completion of ACCT 1130 with a C or higher",
+    "courses": [
+      "ACCT 1130"
+    ]
+  },
+  "ACCT 2710": {
+    "text": "ACCT 1170 with a C or higher",
+    "courses": [
+      "ACCT 1170"
+    ]
+  },
+  "ACCT 2720": {
+    "text": "ACCT 2710 with a C or higher",
+    "courses": [
+      "ACCT 2710"
+    ]
+  },
+  "ARCH 1010": {
+    "text": "Placement in MATH 1010 or higher",
+    "courses": [
+      "MATH 1010"
+    ]
+  },
+  "ARCH 2005": {
+    "text": "ARCH 1005",
+    "courses": [
+      "ARCH 1005"
+    ]
+  },
+  "ARCH 2010": {
+    "text": "ARCH 1005",
+    "courses": [
+      "ARCH 1005"
+    ]
+  },
+  "ARCH 2015": {
+    "text": "ARCH 1005 or with Program Coordinator’s permission",
+    "courses": [
+      "ARCH 1005"
+    ]
+  },
+  "ARCH 2020": {
+    "text": "ARCH 1002 or ARTH 1013 , and ARCH 1005 , or with Program Coordinator’s permission",
+    "courses": [
+      "ARCH 1002",
+      "ARCH 1005",
+      "ARTH 1013"
+    ]
+  },
+  "ARCH 2025": {
+    "text": "ARCH 2020",
+    "courses": [
+      "ARCH 2020"
+    ]
+  },
+  "ARCH 2029": {
+    "text": "ARCH 1008 and MATH 1600 or with Program Coordinator’s permission",
+    "courses": [
+      "ARCH 1008",
+      "MATH 1600"
+    ]
+  },
+  "ARCH 2030": {
+    "text": "ARCH 1005 and ARCH 1008 or with Program Coordinator’s permission",
+    "courses": [
+      "ARCH 1005",
+      "ARCH 1008"
+    ]
+  },
+  "ARCH 2040": {
+    "text": "ARCH 1008",
+    "courses": [
+      "ARCH 1008"
+    ]
+  },
+  "ARCH 2229": {
+    "text": "MATH 1010 or higher",
+    "courses": [
+      "MATH 1010"
+    ]
+  },
+  "ART 1000": {
+    "text": "Eligibility for ENG 1010 or permission of instructor or advisor",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "ART 1060": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "ART 1120": {
+    "text": "Grade of C or higher in ART 1110",
+    "courses": [
+      "ART 1110"
+    ]
+  },
+  "ART 1130": {
+    "text": "ART 1110 or permission of Instructor",
+    "courses": [
+      "ART 1110"
+    ]
+  },
+  "ART 1420": {
+    "text": "ART 1410",
+    "courses": [
+      "ART 1410"
+    ]
+  },
+  "ART 1460": {
+    "text": "ART 1450",
+    "courses": [
+      "ART 1450"
+    ]
+  },
+  "ART 1520": {
+    "text": "ART 1510",
+    "courses": [
+      "ART 1510"
+    ]
+  },
+  "ART 1620": {
+    "text": "C or higher in ART 1610",
+    "courses": [
+      "ART 1610"
+    ]
+  },
+  "ART 1770": {
+    "text": "Eligibility for ENG 0960",
+    "courses": [
+      "ENG 0960"
+    ]
+  },
+  "ART 1880": {
+    "text": "ART 1110 or permission of Instructor",
+    "courses": [
+      "ART 1110"
+    ]
+  },
+  "ART 2090": {
+    "text": "Second-year status, matriculation in an art curriculum and permission of the Art Program Coordinator",
+    "courses": []
+  },
+  "ART 2094": {
+    "text": "To be eligible for the internship course a student must be in the final term of his/her art degree program having completed 15 credits in their field and have a GPA of 3.0 or greater. Permission to take this course must be granted by the program coordinator",
+    "courses": []
+  },
+  "ART 2095": {
+    "text": "Second-year status and permission of the Art Program Coordinator",
+    "courses": []
+  },
+  "ART 2098": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "ART 2099": {
+    "text": "Permission of the Supervising faculty required. All independent projects must be arranged in the semester prior to registration, with advance approval and with the supervision of one of the full-time Art faculty members",
+    "courses": []
+  },
+  "ART 2110": {
+    "text": "ART 1110 - Drawing I and ART 1120 - Drawing II with grade of C or higher",
+    "courses": [
+      "ART 1110",
+      "ART 1120"
+    ]
+  },
+  "ART 2190": {
+    "text": "ART 2090 - Portfolio Preparation I , second-year status, matriculation in an art curriculum and permission of the Art Program Coordinator",
+    "courses": [
+      "ART 2090"
+    ]
+  },
+  "ART 2202": {
+    "text": "ART 2201 or GRA 2201",
+    "courses": [
+      "ART 2201",
+      "GRA 2201"
+    ]
+  },
+  "ART 2420": {
+    "text": "C- or higher in ART 1420",
+    "courses": [
+      "ART 1420"
+    ]
+  },
+  "ART 2430": {
+    "text": "C- or higher in ART 1410",
+    "courses": [
+      "ART 1410"
+    ]
+  },
+  "ART 2470": {
+    "text": "C- or higher in ART 1410 and ART 2430",
+    "courses": [
+      "ART 1410",
+      "ART 2430"
+    ]
+  },
+  "ART 2510": {
+    "text": "ART 1510 , ART 1520",
+    "courses": [
+      "ART 1510",
+      "ART 1520"
+    ]
+  },
+  "ART 2520": {
+    "text": "ART 1510 , ART 1520 , ART 2510",
+    "courses": [
+      "ART 1510",
+      "ART 1520",
+      "ART 2510"
+    ]
+  },
+  "ARTH 1012": {
+    "text": "Eligibility for ENG 1010 OR permission of the graphic design coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "AUTO 1037": {
+    "text": "AUTO 1033 or with permission of the coordinator",
+    "courses": [
+      "AUTO 1033"
+    ]
+  },
+  "AUTO 1115": {
+    "text": "AUTO 1101 and AUTO 1101L or AUTO 1030",
+    "courses": [
+      "AUTO 1030",
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "AUTO 1115L": {
+    "text": "AUTO 1101 and AUTO 1101L or AUTO 1030",
+    "courses": [
+      "AUTO 1030",
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "AUTO 1195A": {
+    "text": "Permission of General Motors (GM) Automotive Service Education Program (ASEP) Program Coordinator",
+    "courses": []
+  },
+  "AUTO 1195B": {
+    "text": "Permission of General Motors (GM) Automotive Service Education Program (ASEP) Program Coordinator",
+    "courses": []
+  },
+  "AUTO 1195C": {
+    "text": "Program Coordinator permission is required for this course",
+    "courses": []
+  },
+  "AUTO 1295": {
+    "text": "Program Coordinator permission is required to participate in this course",
+    "courses": []
+  },
+  "AUTO 1595": {
+    "text": "AUTO 1101 and AUTO 1101L",
+    "courses": [
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "AUTO 2001": {
+    "text": "AUTO 1010 , AUTO 1016",
+    "courses": [
+      "AUTO 1010",
+      "AUTO 1016"
+    ]
+  },
+  "AUTO 2005": {
+    "text": "AUTO 2001",
+    "courses": [
+      "AUTO 2001"
+    ]
+  },
+  "AUTO 2007": {
+    "text": "AUTO 1010 , AUTO 1016",
+    "courses": [
+      "AUTO 1010",
+      "AUTO 1016"
+    ]
+  },
+  "AUTO 2038": {
+    "text": "AUTO 1037 or with permission of the Coordinator",
+    "courses": [
+      "AUTO 1037"
+    ]
+  },
+  "AUTO 2090": {
+    "text": "AUTO 1101 and AUTO 1101L or AUTO 1030",
+    "courses": [
+      "AUTO 1030",
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "AUTO 2101L": {
+    "text": "AUTO 1110L",
+    "courses": [
+      "AUTO 1110L"
+    ]
+  },
+  "AUTO 2105L": {
+    "text": "AUTO 1101",
+    "courses": [
+      "AUTO 1101"
+    ]
+  },
+  "AUTO 2110": {
+    "text": "AUTO 1110 and AUTO 1110L or AUTO 1033",
+    "courses": [
+      "AUTO 1033",
+      "AUTO 1110",
+      "AUTO 1110L"
+    ]
+  },
+  "AUTO 2110L": {
+    "text": "AUTO 1110 and AUTO 1110L or AUTO 1033",
+    "courses": [
+      "AUTO 1033",
+      "AUTO 1110",
+      "AUTO 1110L"
+    ]
+  },
+  "AUTO 2115L": {
+    "text": "AUTO 1101",
+    "courses": [
+      "AUTO 1101"
+    ]
+  },
+  "AUTO 2120": {
+    "text": "AUTO 1110 and AUTO 1110L or AUTO 1033",
+    "courses": [
+      "AUTO 1033",
+      "AUTO 1110",
+      "AUTO 1110L"
+    ]
+  },
+  "AUTO 2120L": {
+    "text": "AUTO 1110 and AUTO 1110L or AUTO 1033",
+    "courses": [
+      "AUTO 1033",
+      "AUTO 1110",
+      "AUTO 1110L"
+    ]
+  },
+  "AUTO 2294": {
+    "text": "Co-op I and a minimum of 40 credits of course work completed or in progress and a 2.0 GPA, or with permission of Coordinator",
+    "courses": []
+  },
+  "AUTO 2394": {
+    "text": "Co-op II and a minimum of 40 credits of course work completed or in progress and a 2.0 GPA, or with permission of Coordinator",
+    "courses": []
+  },
+  "AUTO 2395A": {
+    "text": "Program Coordinator permission is required to participate in this course",
+    "courses": []
+  },
+  "AUTO 2395B": {
+    "text": "Program Coordinator permission is required to attend this course",
+    "courses": []
+  },
+  "AUTO 2395C": {
+    "text": "Program Coordinator permission is required to attend this course",
+    "courses": []
+  },
+  "AUTO 2495": {
+    "text": "Program Coordinator permission is required to attend this course",
+    "courses": []
+  },
+  "AUTO 2595": {
+    "text": "AUTO 1101 , AUTO 1101L",
+    "courses": [
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "AUTO 2695": {
+    "text": "AUTO 1101 , AUTO 1101L",
+    "courses": [
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "AUTO 2795": {
+    "text": "AUTO 1101 , AUTO 1101L",
+    "courses": [
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "AUTO 2895": {
+    "text": "AUTO 1101 , AUTO 1101L",
+    "courses": [
+      "AUTO 1101",
+      "AUTO 1101L"
+    ]
+  },
+  "BENT 2098": {
+    "text": "BENT 2180 or permission of the instructor and ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "BENT 2180",
+      "ENG 1010"
+    ]
+  },
+  "BENT 2300": {
+    "text": "BENT 2180 and ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "BENT 2180",
+      "ENG 1010"
+    ]
+  },
+  "BFIN 2100": {
+    "text": "A grade of C - or higher in all of the following courses: ACCT 1130 , ECON 1002",
+    "courses": [
+      "ACCT 1130",
+      "ECON 1002"
+    ]
+  },
+  "BFIN 2110": {
+    "text": "BFIN 2100 or ECON 1001 , either course with a Grade of “C” or higher",
+    "courses": [
+      "BFIN 2100",
+      "ECON 1001"
+    ]
+  },
+  "BFIN 2113": {
+    "text": "ECON 1001 , ECON 1002 , ACCT 1130 and ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ACCT 1130",
+      "ECON 1001",
+      "ECON 1002",
+      "ENG 1010"
+    ]
+  },
+  "BFIN 2300": {
+    "text": "BFIN 2100 with a grade of “C” or higher or permission of instructor",
+    "courses": [
+      "BFIN 2100"
+    ]
+  },
+  "BFIN 2350": {
+    "text": "BFIN 2100",
+    "courses": [
+      "BFIN 2100"
+    ]
+  },
+  "BMGT 2020": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMGT 2040": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMGT 2100": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMGT 2200": {
+    "text": "ENG 1010 , BMGT 2020",
+    "courses": [
+      "BMGT 2020",
+      "ENG 1010"
+    ]
+  },
+  "BMGT 2260": {
+    "text": "BMGT 2020",
+    "courses": [
+      "BMGT 2020"
+    ]
+  },
+  "BMGT 2416": {
+    "text": "Completion of ENG 1010 with C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMGT 2419": {
+    "text": "Completion of ENG 1010 with C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMGT 2421": {
+    "text": "Completion of ENG 1010 with C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMKT 2070": {
+    "text": "BMKT 2010 with a grade of C- or higher",
+    "courses": [
+      "BMKT 2010"
+    ]
+  },
+  "BMKT 2080": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMKT 2098": {
+    "text": "24 credits or permission of instructor",
+    "courses": []
+  },
+  "BMKT 2102": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMKT 2140": {
+    "text": "BMKT 2010 with a grade of C- or higher",
+    "courses": [
+      "BMKT 2010"
+    ]
+  },
+  "BMKT 2160": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMKT 2195": {
+    "text": "GPA 2.5 or above and instructor’s permission",
+    "courses": []
+  },
+  "BMKT 2200": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMKT 2210": {
+    "text": "BMKT 2010 with a grade of C- or higher",
+    "courses": [
+      "BMKT 2010"
+    ]
+  },
+  "BMKT 2295": {
+    "text": "BMKT 2195 , overall GPA of 2.5 or higher, or instructor’s permission",
+    "courses": [
+      "BMKT 2195"
+    ]
+  },
+  "BMKT 2350": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BMKT 2410": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BOT 1102": {
+    "text": "BOT 1101",
+    "courses": [
+      "BOT 1101"
+    ]
+  },
+  "BOT 2095": {
+    "text": "Permission of Program Coordinator",
+    "courses": []
+  },
+  "BOT 2109": {
+    "text": "C or higher in BOT 1101",
+    "courses": [
+      "BOT 1101"
+    ]
+  },
+  "BOT 2195": {
+    "text": "Permission of Program Coordinator",
+    "courses": []
+  },
+  "BOT 2200": {
+    "text": "Eligibility for ENG 0930",
+    "courses": [
+      "ENG 0930"
+    ]
+  },
+  "BOT 2702": {
+    "text": "BOT 1101 and BOT 2701 , or permission of instructor",
+    "courses": [
+      "BOT 1101",
+      "BOT 2701"
+    ]
+  },
+  "BUSN 2090": {
+    "text": "Completion of 15 business credits and permission of instructor",
+    "courses": []
+  },
+  "BUSN 2095": {
+    "text": "Permission of the Program Coordinator. Prior to taking this course students must have completed 12 business core or program option credits with a grade of C -or higher AND have completed at least 40 credits towards their Associate degree",
+    "courses": []
+  },
+  "BUSN 2098": {
+    "text": "24 credits or permission of instructor",
+    "courses": []
+  },
+  "BUSN 2101": {
+    "text": "BUSN 2100 AND ENG 1010 with a C-or higher",
+    "courses": [
+      "BUSN 2100",
+      "ENG 1010"
+    ]
+  },
+  "BUSN 2150": {
+    "text": "Completion of ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BUSN 2195": {
+    "text": "15 completed credit hours in Business Administration, Accounting, Computer Information Systems or Marketing programs, a GPA of over 2.5. and permission of instructor",
+    "courses": []
+  },
+  "BUSN 2250": {
+    "text": "ENG 1010 with a C-or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BUSN 2310": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BUSN 2320": {
+    "text": "BUSN 2310",
+    "courses": [
+      "BUSN 2310"
+    ]
+  },
+  "BUSN 2340": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "BUSN 2400": {
+    "text": "ENG 1010 with a grade of C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CAD 2204": {
+    "text": "CAD 1140 with a C- or higher",
+    "courses": [
+      "CAD 1140"
+    ]
+  },
+  "CAD 2210": {
+    "text": "CAD 2200 or permission of instructor",
+    "courses": [
+      "CAD 2200"
+    ]
+  },
+  "CAD 2300": {
+    "text": "CAD 1330 or permission of instructor",
+    "courses": [
+      "CAD 1330"
+    ]
+  },
+  "CAD 2520": {
+    "text": "CAD 2204 with C- or higher",
+    "courses": [
+      "CAD 2204"
+    ]
+  },
+  "CENT 1010": {
+    "text": "CENT 1016 and MATH 1001 or higher",
+    "courses": [
+      "CENT 1016",
+      "MATH 1001"
+    ]
+  },
+  "CENT 1024": {
+    "text": "CENT 1016",
+    "courses": [
+      "CENT 1016"
+    ]
+  },
+  "CENT 1026": {
+    "text": "CENT 1016",
+    "courses": [
+      "CENT 1016"
+    ]
+  },
+  "CENT 1036": {
+    "text": "CENT 1010 and MATH 1001 or higher",
+    "courses": [
+      "CENT 1010",
+      "MATH 1001"
+    ]
+  },
+  "CENT 2052": {
+    "text": "Eligibility for MATH 1610",
+    "courses": [
+      "MATH 1610"
+    ]
+  },
+  "CENT 2095": {
+    "text": "CENT 2010",
+    "courses": [
+      "CENT 2010"
+    ]
+  },
+  "CIS 1141": {
+    "text": "eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CIS 2131": {
+    "text": "CIS 1001",
+    "courses": [
+      "CIS 1001"
+    ]
+  },
+  "CIS 2144": {
+    "text": "Any Programming Language",
+    "courses": []
+  },
+  "CIS 2232": {
+    "text": "CIS 1001",
+    "courses": [
+      "CIS 1001"
+    ]
+  },
+  "CIS 2990": {
+    "text": "permission of instructor",
+    "courses": []
+  },
+  "CIS 2994": {
+    "text": "permission of instructor",
+    "courses": []
+  },
+  "CJS 1010": {
+    "text": "Eligible for ENG 0930 or higher",
+    "courses": [
+      "ENG 0930"
+    ]
+  },
+  "CJS 1020": {
+    "text": "Eligible for ENG 0930 or higher",
+    "courses": [
+      "ENG 0930"
+    ]
+  },
+  "CJS 1030": {
+    "text": "Eligible for ENG 0930 or higher",
+    "courses": [
+      "ENG 0930"
+    ]
+  },
+  "CJS 1050": {
+    "text": "Eligible for ENG 0930 or higher",
+    "courses": [
+      "ENG 0930"
+    ]
+  },
+  "CJS 1060": {
+    "text": "Eligible for ENG 0930 or higher",
+    "courses": [
+      "ENG 0930"
+    ]
+  },
+  "CJS 1200": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 1390": {
+    "text": "CJS 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010"
+    ]
+  },
+  "CJS 1520": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 1550": {
+    "text": "CJS 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010"
+    ]
+  },
+  "CJS 1600": {
+    "text": "CJS 1010 and ENG 1010 eligibility",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 1720": {
+    "text": "Eligible for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CJS 2010": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CJS 2020": {
+    "text": "CJS 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010"
+    ]
+  },
+  "CJS 2030": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2090": {
+    "text": "CJS 2500 with C- or higher",
+    "courses": [
+      "CJS 2500"
+    ]
+  },
+  "CJS 2095": {
+    "text": "Enrollment in the criminal justice program and the permission of the program coordinator. Prior to taking this course students must have completed 12 Criminal Justice core or program option credits with a grade of C- or higher AND must have completed at least 30 credits towards their associate degree. Students must have a 2.0 GPA and may not have any disciplinary record for violations of the CT state student code of conduct",
+    "courses": []
+  },
+  "CJS 2098": {
+    "text": "varies",
+    "courses": []
+  },
+  "CJS 2099": {
+    "text": "Criminal Justice Program Coordinator approval",
+    "courses": []
+  },
+  "CJS 2100": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2110": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2120": {
+    "text": "CJS 2110 with a “C-” or higher",
+    "courses": [
+      "CJS 2110"
+    ]
+  },
+  "CJS 2130": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2200": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2210": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2220": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2240": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2260": {
+    "text": "ENG 1010 with a C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CJS 2270": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2300": {
+    "text": "CJS 1010 with a C- or higher and CJS 1030 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "CJS 1030"
+    ]
+  },
+  "CJS 2350": {
+    "text": "ENG 1010 with a C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CJS 2370": {
+    "text": "CJS 2200 with a C- or higher",
+    "courses": [
+      "CJS 2200"
+    ]
+  },
+  "CJS 2380": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2400": {
+    "text": "CJS 1020 with a C- or higher",
+    "courses": [
+      "CJS 1020"
+    ]
+  },
+  "CJS 2410": {
+    "text": "CJS 1020 with a C- or higher",
+    "courses": [
+      "CJS 1020"
+    ]
+  },
+  "CJS 2430": {
+    "text": "CJS 1020 with a C- or higher",
+    "courses": [
+      "CJS 1020"
+    ]
+  },
+  "CJS 2440": {
+    "text": "CJS 1020",
+    "courses": [
+      "CJS 1020"
+    ]
+  },
+  "CJS 2450": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2470": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher and CJS 1050 or CJS 1200 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "CJS 1050",
+      "CJS 1200",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2480": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2500": {
+    "text": "CJS 1010 with a C- or higher or ENG 1010 with a C- or higher and CJS 1050 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "CJS 1050",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2530": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2550": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2570": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2580": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2610": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2720": {
+    "text": "CJS 1010 and C- or higher or PSY 1011 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010",
+      "PSY 1011"
+    ]
+  },
+  "CJS 2800": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2810": {
+    "text": "CJS 1580 with a C- or higher",
+    "courses": [
+      "CJS 1580"
+    ]
+  },
+  "CJS 2820": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2850": {
+    "text": "ENG 1010 with a C- or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CJS 2880": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CJS 2940": {
+    "text": "CJS 1010 with a C- or higher and ENG 1010 with a C- or higher",
+    "courses": [
+      "CJS 1010",
+      "ENG 1010"
+    ]
+  },
+  "CMGT 1150": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CMGT 1160": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CMGT 2150": {
+    "text": "CMGT 1110 , CMGT 1150",
+    "courses": [
+      "CMGT 1110",
+      "CMGT 1150"
+    ]
+  },
+  "CMGT 2160": {
+    "text": "CMGT 1110 , CMGT 1160",
+    "courses": [
+      "CMGT 1110",
+      "CMGT 1160"
+    ]
+  },
+  "CMGT 2230": {
+    "text": "CMGT 1150 , CMGT 1160",
+    "courses": [
+      "CMGT 1150",
+      "CMGT 1160"
+    ]
+  },
+  "CMGT 2275": {
+    "text": "CMGT 2150 , CMGT 2160",
+    "courses": [
+      "CMGT 2150",
+      "CMGT 2160"
+    ]
+  },
+  "CMGT 2285": {
+    "text": "CMGT 1150 , CMGT 1160",
+    "courses": [
+      "CMGT 1150",
+      "CMGT 1160"
+    ]
+  },
+  "CMGT 2500": {
+    "text": "ACCT 1130 , CMGT 2285",
+    "courses": [
+      "ACCT 1130",
+      "CMGT 2285"
+    ]
+  },
+  "COMM 1000": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1010": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1201": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1301": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1302": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1303": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1304": {
+    "text": "ENG 1010 and basic computer literacy",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1305": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1306": {
+    "text": "Eligibility for ENG 1010 or permission of instructor",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1401": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1402": {
+    "text": "One of the following introductory courses in Photography: ART 1410 , ART 1450 . Students are also encouraged to enroll in COMM 1401",
+    "courses": [
+      "ART 1410",
+      "ART 1450",
+      "COMM 1401"
+    ]
+  },
+  "COMM 1502": {
+    "text": "Eligible for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 1511": {
+    "text": "COMM 1401 or permission of Instructor",
+    "courses": [
+      "COMM 1401"
+    ]
+  },
+  "COMM 2202": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 2203": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 2302": {
+    "text": "COMM 1301",
+    "courses": [
+      "COMM 1301"
+    ]
+  },
+  "COMM 2303": {
+    "text": "ENG 1010 and COMM 1301",
+    "courses": [
+      "COMM 1301",
+      "ENG 1010"
+    ]
+  },
+  "COMM 2401": {
+    "text": "ENG 1010 and basic computer literacy, or permission of instructor",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 2402": {
+    "text": "COMM 2401",
+    "courses": [
+      "COMM 2401"
+    ]
+  },
+  "COMM 2501": {
+    "text": "ENG 1010 and COMM 1010",
+    "courses": [
+      "COMM 1010",
+      "ENG 1010"
+    ]
+  },
+  "COMM 2502": {
+    "text": "Eligible for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 2512": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 2513": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "COMM 2601": {
+    "text": "COMM 1604 or COMM 1601",
+    "courses": [
+      "COMM 1601",
+      "COMM 1604"
+    ]
+  },
+  "COMM 2611": {
+    "text": "COMM 1612",
+    "courses": [
+      "COMM 1612"
+    ]
+  },
+  "COMM 2695": {
+    "text": "Permission of instructor",
+    "courses": []
+  },
+  "COMM 2995": {
+    "text": "Permission of instructor",
+    "courses": []
+  },
+  "CSA 2113": {
+    "text": "CIS 1001 or CSA 1110",
+    "courses": [
+      "CIS 1001",
+      "CSA 1110"
+    ]
+  },
+  "CSC 1201": {
+    "text": "Eligibility for MATH 1600 or higher",
+    "courses": [
+      "MATH 1600"
+    ]
+  },
+  "CSC 1211": {
+    "text": "Eligible for MATH 1600",
+    "courses": [
+      "MATH 1600"
+    ]
+  },
+  "CSC 1231": {
+    "text": "eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CSC 1271": {
+    "text": "eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CSC 2212": {
+    "text": "CSC 1211",
+    "courses": [
+      "CSC 1211"
+    ]
+  },
+  "CSC 2213": {
+    "text": "CSC 1201",
+    "courses": [
+      "CSC 1201"
+    ]
+  },
+  "CSC 2214": {
+    "text": "Any programming class or permission of instructor",
+    "courses": []
+  },
+  "CSC 2215": {
+    "text": "any programming course or permission of instructor",
+    "courses": []
+  },
+  "CSC 2216": {
+    "text": "CSC 2213",
+    "courses": [
+      "CSC 2213"
+    ]
+  },
+  "CSC 2217": {
+    "text": "eligibility for MATH 1610",
+    "courses": [
+      "MATH 1610"
+    ]
+  },
+  "CSC 2218": {
+    "text": "CSC 2213 or CSC 2252 or CSC 2272",
+    "courses": [
+      "CSC 2213",
+      "CSC 2252",
+      "CSC 2272"
+    ]
+  },
+  "CSC 2219": {
+    "text": "CSC 1201 and MATH 1600 or higher",
+    "courses": [
+      "CSC 1201",
+      "MATH 1600"
+    ]
+  },
+  "CSC 2232": {
+    "text": "CSC 1231",
+    "courses": [
+      "CSC 1231"
+    ]
+  },
+  "CSC 2233": {
+    "text": "CSC 2232",
+    "courses": [
+      "CSC 2232"
+    ]
+  },
+  "CSC 2235": {
+    "text": "Any 1000 level programming course or higher",
+    "courses": []
+  },
+  "CSC 2251": {
+    "text": "Elective CPL or instructor permission",
+    "courses": []
+  },
+  "CSC 2252": {
+    "text": "CSC 1201",
+    "courses": [
+      "CSC 1201"
+    ]
+  },
+  "CSC 2253": {
+    "text": "CSC 1201",
+    "courses": [
+      "CSC 1201"
+    ]
+  },
+  "CSC 2272": {
+    "text": "CSC 1271",
+    "courses": [
+      "CSC 1271"
+    ]
+  },
+  "CSC 2274": {
+    "text": "Any 1000 level programming course or higher",
+    "courses": []
+  },
+  "CSC 2275": {
+    "text": "CSC 2213",
+    "courses": [
+      "CSC 2213"
+    ]
+  },
+  "CSC 2276": {
+    "text": "CSC 1201 or CSC 2272",
+    "courses": [
+      "CSC 1201",
+      "CSC 2272"
+    ]
+  },
+  "CST 2124": {
+    "text": "CST 1221 - Networking I or instructor permission (the former course, CST 1121 Networking I - 3 credits, will also fulfill this prerequisite)",
+    "courses": [
+      "CST 1121",
+      "CST 1221"
+    ]
+  },
+  "CST 2125": {
+    "text": "CST 1221 - Networking I or instructor permission (the former course, CST 1121 Networking I - 3 credits, will also fulfill this prerequisite)",
+    "courses": [
+      "CST 1121",
+      "CST 1221"
+    ]
+  },
+  "CST 2142": {
+    "text": "CST 1221 - Networking I or instructor permission (the former course, CST 1121 Networking I - 3 credits, will also fulfill this prerequisite)",
+    "courses": [
+      "CST 1121",
+      "CST 1221"
+    ]
+  },
+  "CST 2161": {
+    "text": "CST 1221 - Networking I or instructor permission (the former course, CST 1121 Networking I - 3 credits, will also fulfill this prerequisite)",
+    "courses": [
+      "CST 1121",
+      "CST 1221"
+    ]
+  },
+  "CST 2222": {
+    "text": "CST 1221 - Networking I or instructor permission (the former course, CST 1121 Networking I - 3 credits, will also fulfill this prerequisite)",
+    "courses": [
+      "CST 1121",
+      "CST 1221"
+    ]
+  },
+  "CST 2223": {
+    "text": "CST 2222 - Networking II or instructor permission (the former course, CST 2122 Networking II - 3 credits, will also fulfill this prerequisite)",
+    "courses": [
+      "CST 2122",
+      "CST 2222"
+    ]
+  },
+  "CTC 1006": {
+    "text": "C- or higher in ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "CYS 2111": {
+    "text": "CST 1221 or instructor permission The former course, CST 1121 Networking I -3 credits, also fulfills this pre-requisite",
+    "courses": [
+      "CST 1121",
+      "CST 1221"
+    ]
+  },
+  "CYS 2121": {
+    "text": "CYS 2111",
+    "courses": [
+      "CYS 2111"
+    ]
+  },
+  "CYS 2131": {
+    "text": "CYS 2111",
+    "courses": [
+      "CYS 2111"
+    ]
+  },
+  "CYS 2141": {
+    "text": "CYS 2111",
+    "courses": [
+      "CYS 2111"
+    ]
+  },
+  "CYS 2151": {
+    "text": "CYS 2111",
+    "courses": [
+      "CYS 2111"
+    ]
+  },
+  "CYS 2152": {
+    "text": "CYS 2151",
+    "courses": [
+      "CYS 2151"
+    ]
+  },
+  "CYS 2161": {
+    "text": "CYS 2111",
+    "courses": [
+      "CYS 2111"
+    ]
+  },
+  "CYS 2171": {
+    "text": "CYS 2111",
+    "courses": [
+      "CYS 2111"
+    ]
+  },
+  "DANC 2002": {
+    "text": "DANC 1002",
+    "courses": [
+      "DANC 1002"
+    ]
+  },
+  "DANC 2009": {
+    "text": "DANC 1009 or permission of instructor",
+    "courses": [
+      "DANC 1009"
+    ]
+  },
+  "DANC 2013": {
+    "text": "DANC 1013 or permission of instructor",
+    "courses": [
+      "DANC 1013"
+    ]
+  },
+  "DANC 2021": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "DANC 2022": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "DANC 2121": {
+    "text": "DANC 2021 and Permission of Instructor",
+    "courses": [
+      "DANC 2021"
+    ]
+  },
+  "DANC 2122": {
+    "text": "DANC 2022 and Permission of Instructor",
+    "courses": [
+      "DANC 2022"
+    ]
+  },
+  "DANC 2161": {
+    "text": "DANC 1061 or Permission of Instructor",
+    "courses": [
+      "DANC 1061"
+    ]
+  },
+  "DAT 1001": {
+    "text": "CSA 1110 or equivalent experience",
+    "courses": [
+      "CSA 1110"
+    ]
+  },
+  "DAT 1111": {
+    "text": "DAT 1001",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 1125": {
+    "text": "DAT 1111 or DAT 1221",
+    "courses": [
+      "DAT 1111",
+      "DAT 1221"
+    ]
+  },
+  "DAT 1211": {
+    "text": "DAT 1001",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 1221": {
+    "text": "DAT 1001",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 1311": {
+    "text": "B or higher in DAT 1001",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 1321": {
+    "text": "B or higher in DAT 1001",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 1411": {
+    "text": "DAT 1001",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 1511": {
+    "text": "DAT 1001 or instructor permission",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 1525": {
+    "text": "DAT 1001 or instructor permission",
+    "courses": [
+      "DAT 1001"
+    ]
+  },
+  "DAT 2131": {
+    "text": "DAT 1111",
+    "courses": [
+      "DAT 1111"
+    ]
+  },
+  "DAT 2145": {
+    "text": "DAT 1111 or any programming language",
+    "courses": [
+      "DAT 1111"
+    ]
+  },
+  "DAT 2211": {
+    "text": "DAT 1211",
+    "courses": [
+      "DAT 1211"
+    ]
+  },
+  "DAT 2221": {
+    "text": "DAT 1211",
+    "courses": [
+      "DAT 1211"
+    ]
+  },
+  "DAT 2321": {
+    "text": "DAT 1321",
+    "courses": [
+      "DAT 1321"
+    ]
+  },
+  "DAT 2411": {
+    "text": "DAT 1411",
+    "courses": [
+      "DAT 1411"
+    ]
+  },
+  "DAT 2421": {
+    "text": "DAT 1411",
+    "courses": [
+      "DAT 1411"
+    ]
+  },
+  "DAT 2511": {
+    "text": "DAT 1511",
+    "courses": [
+      "DAT 1511"
+    ]
+  },
+  "DAT 2535": {
+    "text": "DAT 1511 or DAT 1525",
+    "courses": [
+      "DAT 1511",
+      "DAT 1525"
+    ]
+  },
+  "DAT 2990": {
+    "text": "One of: DAT 1525 , DAT 2131 , DAT 2145 , DAT 2211 , DAT 2221 , DAT 2321 , DAT 2411 , DAT 2421 , DAT 2535 or instructor permission",
+    "courses": [
+      "DAT 1525",
+      "DAT 2131",
+      "DAT 2145",
+      "DAT 2211",
+      "DAT 2221",
+      "DAT 2321",
+      "DAT 2411",
+      "DAT 2421",
+      "DAT 2535"
+    ]
+  },
+  "DTS 2201": {
+    "text": "MATH 1200",
+    "courses": [
+      "MATH 1200"
+    ]
+  },
+  "DTS 2203": {
+    "text": "MATH 1200",
+    "courses": [
+      "MATH 1200"
+    ]
+  },
+  "DTS 2215": {
+    "text": "Eligibility for ENG 0910",
+    "courses": [
+      "ENG 0910"
+    ]
+  },
+  "DTS 2220": {
+    "text": "DTS 2201 OR DTS 2203",
+    "courses": [
+      "DTS 2201",
+      "DTS 2203"
+    ]
+  },
+  "DTS 2230": {
+    "text": "DTS 2220",
+    "courses": [
+      "DTS 2220"
+    ]
+  },
+  "DTS 2240": {
+    "text": "DTS 2220",
+    "courses": [
+      "DTS 2220"
+    ]
+  },
+  "DTS 2258": {
+    "text": "ENG 1010 , MATH 1200",
+    "courses": [
+      "ENG 1010",
+      "MATH 1200"
+    ]
+  },
+  "DTS 2274": {
+    "text": "CSC 1201",
+    "courses": [
+      "CSC 1201"
+    ]
+  },
+  "DTS 2290": {
+    "text": "Permission by instructor",
+    "courses": []
+  },
+  "ECED 1142": {
+    "text": "ECED 1104 or ECED 1002",
+    "courses": [
+      "ECED 1002",
+      "ECED 1104"
+    ]
+  },
+  "ECED 1143": {
+    "text": "ECED 1104 and ECED 1002 or PSY 2004",
+    "courses": [
+      "ECED 1002",
+      "ECED 1104",
+      "PSY 2004"
+    ]
+  },
+  "ECED 1377": {
+    "text": "PSY 2004 or ECED 1002",
+    "courses": [
+      "ECED 1002",
+      "PSY 2004"
+    ]
+  },
+  "ECED 1800": {
+    "text": "ECED 1001 , ECED 1002",
+    "courses": [
+      "ECED 1001",
+      "ECED 1002"
+    ]
+  },
+  "ECED 1801": {
+    "text": "ECED 1001 , ECED 1002",
+    "courses": [
+      "ECED 1001",
+      "ECED 1002"
+    ]
+  },
+  "ECED 2307": {
+    "text": "ECED 1001 or permission of program coordinator",
+    "courses": [
+      "ECED 1001"
+    ]
+  },
+  "ECED 2322": {
+    "text": "ECED 2410 and Home Campus Program Coordinator Approval",
+    "courses": [
+      "ECED 2410"
+    ]
+  },
+  "ECED 2331": {
+    "text": "ECED 1001 or ECED 1142 and ECED 1002 or ECED 1104 or PSY 2004",
+    "courses": [
+      "ECED 1001",
+      "ECED 1002",
+      "ECED 1104",
+      "ECED 1142",
+      "PSY 2004"
+    ]
+  },
+  "ECED 2410": {
+    "text": "ECED 1001 , ENG 1010 , and ECED 1002 & Home Campus Program Coordinator Approval",
+    "courses": [
+      "ECED 1001",
+      "ECED 1002",
+      "ENG 1010"
+    ]
+  },
+  "ECED 2515": {
+    "text": "ECED 1001 and PSY 2004 or ECED 1002 or permission of program coordinator, or bachelor’s degree in education or related discipline",
+    "courses": [
+      "ECED 1001",
+      "ECED 1002",
+      "PSY 2004"
+    ]
+  },
+  "ECED 2552": {
+    "text": "ECED 1001 or permission of program coordinator",
+    "courses": [
+      "ECED 1001"
+    ]
+  },
+  "ECED 2690": {
+    "text": "All core ECED courses with a grade of C- or higher and permission of program coordinator",
+    "courses": []
+  },
+  "ECED 2692": {
+    "text": "ECED 2690 with a grade of C- or higher, within 9 credits of graduation, and permission of program coordinator",
+    "courses": [
+      "ECED 2690"
+    ]
+  },
+  "ECED 2695": {
+    "text": "All ECED courses with a grade of C- or higher, within 9 credits of graduation, and permission of program coordinator",
+    "courses": []
+  },
+  "ECED 2706": {
+    "text": "Permission of program coordinator",
+    "courses": []
+  },
+  "ECED 2712": {
+    "text": "ECED 2706 and permission of program coordinator",
+    "courses": [
+      "ECED 2706"
+    ]
+  },
+  "ECED 2713": {
+    "text": "ECED 2706",
+    "courses": [
+      "ECED 2706"
+    ]
+  },
+  "ECED 2825": {
+    "text": "Eligibility for ENG 1010 or permission of program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "ECED 2875": {
+    "text": "Eligibility for ENG 1010 or permission of program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "EDUC 2010": {
+    "text": "Eligible for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "EDUC 2020": {
+    "text": "PSY 1011 or ECED 1002",
+    "courses": [
+      "ECED 1002",
+      "PSY 1011"
+    ]
+  },
+  "EDUC 2202": {
+    "text": "Permission of program coordinator",
+    "courses": []
+  },
+  "EDUC 2870": {
+    "text": "Permission of ECE Coordinator",
+    "courses": []
+  },
+  "EET 1044": {
+    "text": "MATH 1610",
+    "courses": [
+      "MATH 1610"
+    ]
+  },
+  "EET 1045": {
+    "text": "MATH 1610",
+    "courses": [
+      "MATH 1610"
+    ]
+  },
+  "EETA 1002": {
+    "text": "MATH 1600 or MATH 1610",
+    "courses": [
+      "MATH 1600",
+      "MATH 1610"
+    ]
+  },
+  "EETA 1014": {
+    "text": "EETA 1010",
+    "courses": [
+      "EETA 1010"
+    ]
+  },
+  "EETA 1036": {
+    "text": "EETA 1010",
+    "courses": [
+      "EETA 1010"
+    ]
+  },
+  "EETA 2008": {
+    "text": "EETA 1014 AND EETA 1026",
+    "courses": [
+      "EETA 1014",
+      "EETA 1026"
+    ]
+  },
+  "EETA 2032": {
+    "text": "EETA 1036 and MATH 1610",
+    "courses": [
+      "EETA 1036",
+      "MATH 1610"
+    ]
+  },
+  "EETA 2051": {
+    "text": "EETA 1026 and EETA 1014",
+    "courses": [
+      "EETA 1014",
+      "EETA 1026"
+    ]
+  },
+  "EETA 2052": {
+    "text": "(EETA 1010 or EGR 2221 ) and (MATH 1600 or MATH 1610 )",
+    "courses": [
+      "EETA 1010",
+      "EGR 2221",
+      "MATH 1600",
+      "MATH 1610"
+    ]
+  },
+  "EETA 2053": {
+    "text": "EETA 2052",
+    "courses": [
+      "EETA 2052"
+    ]
+  },
+  "EETA 2056": {
+    "text": "EETA 2052 and MATH 1610",
+    "courses": [
+      "EETA 2052",
+      "MATH 1610"
+    ]
+  },
+  "EETA 2062": {
+    "text": "EETA 1014 , EETA 1036 , and MATH 1610",
+    "courses": [
+      "EETA 1014",
+      "EETA 1036",
+      "MATH 1610"
+    ]
+  },
+  "EETA 2068": {
+    "text": "EETA 1014 and EETA 2032 and EETA 2052",
+    "courses": [
+      "EETA 1014",
+      "EETA 2032",
+      "EETA 2052"
+    ]
+  },
+  "EETA 2072": {
+    "text": "EETA 2032",
+    "courses": [
+      "EETA 2032"
+    ]
+  },
+  "EETA 2090": {
+    "text": "EETA 1004 and EETA 1014 and EETA 2032 and EETA 2051 and EETA 2052",
+    "courses": [
+      "EETA 1004",
+      "EETA 1014",
+      "EETA 2032",
+      "EETA 2051",
+      "EETA 2052"
+    ]
+  },
+  "EGR 1115": {
+    "text": "C or higher in MATH 1010",
+    "courses": [
+      "MATH 1010"
+    ]
+  },
+  "EGR 1118": {
+    "text": "MATH 1010 placement or completion of MATH 1010 concurrent",
+    "courses": [
+      "MATH 1010"
+    ]
+  },
+  "EGR 2098": {
+    "text": "Varies based on the internship placement",
+    "courses": []
+  },
+  "EGR 2201": {
+    "text": "C or higher in MATH 1610",
+    "courses": [
+      "MATH 1610"
+    ]
+  },
+  "EGR 2211": {
+    "text": "“C” or higher in MATH 2610 , or taking MATH 2610 concurrently",
+    "courses": [
+      "MATH 2610"
+    ]
+  },
+  "EGR 2212": {
+    "text": "C or higher in EGR 2211",
+    "courses": [
+      "EGR 2211"
+    ]
+  },
+  "EGR 2215": {
+    "text": "CHEM 1210 , MATH 2600 , and PHYS 2201",
+    "courses": [
+      "CHEM 1210",
+      "MATH 2600",
+      "PHYS 2201"
+    ]
+  },
+  "FTAD 1000": {
+    "text": "M.D. Physical & Clearance to participate in physical fitness activities",
+    "courses": []
+  },
+  "FTAD 1001": {
+    "text": "Acceptance into the CT State CC Firefighting I & II Certification Academy - Gateway Campus; M.D. physical and clearance to participate in physical activities, lifting, bending, and carrying up to 30 lbs",
+    "courses": []
+  },
+  "FTAD 1002": {
+    "text": "FTAD 1001",
+    "courses": [
+      "FTAD 1001"
+    ]
+  },
+  "FTAD 1010": {
+    "text": "FTAD 1001",
+    "courses": [
+      "FTAD 1001"
+    ]
+  },
+  "FTAD 1018": {
+    "text": "FTAD 1012",
+    "courses": [
+      "FTAD 1012"
+    ]
+  },
+  "FTAD 1022": {
+    "text": "FTAD 1012",
+    "courses": [
+      "FTAD 1012"
+    ]
+  },
+  "FTAD 1026": {
+    "text": "FTAD 1012",
+    "courses": [
+      "FTAD 1012"
+    ]
+  },
+  "FTAD 1101": {
+    "text": "FTAD 1001",
+    "courses": [
+      "FTAD 1001"
+    ]
+  },
+  "FTAD 2010": {
+    "text": "FTAD 1012 and MATH 1002 or higher",
+    "courses": [
+      "FTAD 1012",
+      "MATH 1002"
+    ]
+  },
+  "FTAD 2012": {
+    "text": "FTAD 1012",
+    "courses": [
+      "FTAD 1012"
+    ]
+  },
+  "FTAD 2016": {
+    "text": "FTAD 1012",
+    "courses": [
+      "FTAD 1012"
+    ]
+  },
+  "FTAD 2017": {
+    "text": "FTAD 1012",
+    "courses": [
+      "FTAD 1012"
+    ]
+  },
+  "FTAD 2109": {
+    "text": "CHEM 1110 and FTAD 1016",
+    "courses": [
+      "CHEM 1110",
+      "FTAD 1016"
+    ]
+  },
+  "FTAD 2207": {
+    "text": "FTAD 2010",
+    "courses": [
+      "FTAD 2010"
+    ]
+  },
+  "FTAD 2209": {
+    "text": "FTAD 2109",
+    "courses": [
+      "FTAD 2109"
+    ]
+  },
+  "FTAD 2300": {
+    "text": "FTAD 1012",
+    "courses": [
+      "FTAD 1012"
+    ]
+  },
+  "GAMD 2001": {
+    "text": "ENG 1010 with a C or higher",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "GAMD 2020": {
+    "text": "GAMD 1013 with a C or higher",
+    "courses": [
+      "GAMD 1013"
+    ]
+  },
+  "GAMD 2024": {
+    "text": "GAMD 1013 with a C or higher",
+    "courses": [
+      "GAMD 1013"
+    ]
+  },
+  "GAMD 2063": {
+    "text": "GAMD 1013 with a C or higher",
+    "courses": [
+      "GAMD 1013"
+    ]
+  },
+  "GAMD 2071": {
+    "text": "GAMD 1013 with a C or higher",
+    "courses": [
+      "GAMD 1013"
+    ]
+  },
+  "GAMD 2072": {
+    "text": "GAMD 2071 with a C or higher",
+    "courses": [
+      "GAMD 2071"
+    ]
+  },
+  "GAMD 2075": {
+    "text": "GAMD 1009 with a C or higher",
+    "courses": [
+      "GAMD 1009"
+    ]
+  },
+  "GAMD 2090": {
+    "text": "Permission of the instructor",
+    "courses": []
+  },
+  "GAMD 2167": {
+    "text": "GAMD 2063 with a C or higher",
+    "courses": [
+      "GAMD 2063"
+    ]
+  },
+  "GAMD 2176": {
+    "text": "GAMD 2071 with a C or higher",
+    "courses": [
+      "GAMD 2071"
+    ]
+  },
+  "GAMD 2177": {
+    "text": "GAMD 2075 with a C or higher",
+    "courses": [
+      "GAMD 2075"
+    ]
+  },
+  "GRA 2001": {
+    "text": "C- or higher in GRA 1501",
+    "courses": [
+      "GRA 1501"
+    ]
+  },
+  "GRA 2090": {
+    "text": "GRA 2502 or permission of the graphic design program coordinator",
+    "courses": [
+      "GRA 2502"
+    ]
+  },
+  "GRA 2095": {
+    "text": "Student must have a minimum of 15 program credits and permission of coordinator/chair",
+    "courses": []
+  },
+  "GRA 2098": {
+    "text": "GRA 1501 or GRA 1101 or permission of the Coordinator",
+    "courses": [
+      "GRA 1101",
+      "GRA 1501"
+    ]
+  },
+  "GRA 2099": {
+    "text": "Permission of the supervising faculty and coordinator. All independent projects must be arranged in the semester prior to registration, with advance approval and with the supervision of one of the full-time Graphic Design faculty members",
+    "courses": []
+  },
+  "GRA 2101": {
+    "text": "GRA 1101 or GRA 2300",
+    "courses": [
+      "GRA 1101",
+      "GRA 2300"
+    ]
+  },
+  "GRA 2202": {
+    "text": "GRA 2201",
+    "courses": [
+      "GRA 2201"
+    ]
+  },
+  "GRA 2207": {
+    "text": "GRA 2502 or by permission of the instructor",
+    "courses": [
+      "GRA 2502"
+    ]
+  },
+  "GRA 2300": {
+    "text": "Eligible for ENG 1010 or permission of the Graphic Design program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "GRA 2301": {
+    "text": "GRA 1501 or GRA 2300 or GRA 1101 or permission of the Graphic Design program coordinator or department chair",
+    "courses": [
+      "GRA 1101",
+      "GRA 1501",
+      "GRA 2300"
+    ]
+  },
+  "GRA 2306": {
+    "text": "GRA 1101 or GRA 1501 , or ART 1110 , ART 1210 or permission of graphic design coordinator",
+    "courses": [
+      "ART 1110",
+      "ART 1210",
+      "GRA 1101",
+      "GRA 1501"
+    ]
+  },
+  "GRA 2401": {
+    "text": "GRA 1101 or ART 1210 or permission of instructor",
+    "courses": [
+      "ART 1210",
+      "GRA 1101"
+    ]
+  },
+  "GRA 2502": {
+    "text": "GRA 1501 or GRA 1101",
+    "courses": [
+      "GRA 1101",
+      "GRA 1501"
+    ]
+  },
+  "GRA 2503": {
+    "text": "GRA 2502 - Graphic Design II (grade C or higher) and GRA 2401 - Digital Page Design or Permission from the Program Coordinator",
+    "courses": [
+      "GRA 2401",
+      "GRA 2502"
+    ]
+  },
+  "GRA 2507": {
+    "text": "GRA 1101 or COMM 1604",
+    "courses": [
+      "COMM 1604",
+      "GRA 1101"
+    ]
+  },
+  "GRA 2508": {
+    "text": "GRA 1101 or permission of the instructor",
+    "courses": [
+      "GRA 1101"
+    ]
+  },
+  "GRA 2600": {
+    "text": "GRA 1101 or CSC 1271 or permission of the graphic design program coordinator/chair",
+    "courses": [
+      "CSC 1271",
+      "GRA 1101"
+    ]
+  },
+  "GRA 2601": {
+    "text": "GRA 2600 or permission of the graphic design program coordinator/chair",
+    "courses": [
+      "GRA 2600"
+    ]
+  },
+  "GRA 2705": {
+    "text": "GRA 1101 or permission of the graphic design program coordinator",
+    "courses": [
+      "GRA 1101"
+    ]
+  },
+  "GRA 2890": {
+    "text": "Second-year status, and/or permission from the Graphic Design Program Coordinator",
+    "courses": []
+  },
+  "INTD 1001": {
+    "text": "ARCH 1005 or permission of Interior Design Coordinator",
+    "courses": [
+      "ARCH 1005"
+    ]
+  },
+  "INTD 1021": {
+    "text": "INTD 1020",
+    "courses": [
+      "INTD 1020"
+    ]
+  },
+  "INTD 2001": {
+    "text": "INTD 1001 or Permission of Interior Design Coordinator",
+    "courses": [
+      "INTD 1001"
+    ]
+  },
+  "INTD 2002": {
+    "text": "INTD 2001 or Permission of Interior Design Coordinator",
+    "courses": [
+      "INTD 2001"
+    ]
+  },
+  "INTD 2090": {
+    "text": "Completion of 30 credits in Interior Design AND Permission of Interior Design Coordinator",
+    "courses": []
+  },
+  "LGL 1001": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 1002": {
+    "text": "Eligibility for ENG 1010 and one of the following: POLS 1020 , LGL 1001 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010",
+      "LGL 1001",
+      "POLS 1020"
+    ]
+  },
+  "LGL 1004": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2003": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2004": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2006": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2008": {
+    "text": "Eligibility for ENG 1010 and one of the following: POLS 1020 , LGL 1001 or permission of the instructor",
+    "courses": [
+      "ENG 1010",
+      "LGL 1001",
+      "POLS 1020"
+    ]
+  },
+  "LGL 2009": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2010": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2011": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2012": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2013": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2016": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2020": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2090": {
+    "text": "Eligibility for ENG 1010 or permission of the program coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "LGL 2095": {
+    "text": "For Paralegal A.S. students - A minimum overall GPA of 2.0, 12 completed credit hours in the Paralegal program, completion of LGL 2008 , and permission of the Program Coordinator. , and permission of the Program Coordinator",
+    "courses": [
+      "LGL 2008"
+    ]
+  },
+  "LGL 2190": {
+    "text": "LGL 2012 or permission of the program coordinator",
+    "courses": [
+      "LGL 2012"
+    ]
+  },
+  "LGL 2195": {
+    "text": "Permission of the program coordinator",
+    "courses": []
+  },
+  "MECH 1014": {
+    "text": "MATH 1610 or higher and PHYS 1201",
+    "courses": [
+      "MATH 1610",
+      "PHYS 1201"
+    ]
+  },
+  "MECH 2034": {
+    "text": "MATH 1001 or higher",
+    "courses": [
+      "MATH 1001"
+    ]
+  },
+  "MECH 2038": {
+    "text": "MATH 2600 or higher and MECH 1014",
+    "courses": [
+      "MATH 2600",
+      "MECH 1014"
+    ]
+  },
+  "MECH 2040": {
+    "text": "MATH 1610 or higher",
+    "courses": [
+      "MATH 1610"
+    ]
+  },
+  "MECH 2051": {
+    "text": "MECH 1014",
+    "courses": [
+      "MECH 1014"
+    ]
+  },
+  "MECH 2071": {
+    "text": "MATH 1610 or higher",
+    "courses": [
+      "MATH 1610"
+    ]
+  },
+  "MECH 2072": {
+    "text": "PHYS 1105",
+    "courses": [
+      "PHYS 1105"
+    ]
+  },
+  "MECH 2074": {
+    "text": "MATH 2600 , MECH 2072 , PHYS 1105",
+    "courses": [
+      "MATH 2600",
+      "MECH 2072",
+      "PHYS 1105"
+    ]
+  },
+  "MFG 1225": {
+    "text": "MFG 1220 with a C- or higher",
+    "courses": [
+      "MFG 1220"
+    ]
+  },
+  "MFG 1240": {
+    "text": "MFG 1330 , MFG 1337 , MFG 1338",
+    "courses": [
+      "MFG 1330",
+      "MFG 1337",
+      "MFG 1338"
+    ]
+  },
+  "MFG 1245": {
+    "text": "MFG 1220",
+    "courses": [
+      "MFG 1220"
+    ]
+  },
+  "MFG 1330": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1337": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1338": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1340": {
+    "text": "MFG 1338 , MFG 1343 , MFG 1346",
+    "courses": [
+      "MFG 1338",
+      "MFG 1343",
+      "MFG 1346"
+    ]
+  },
+  "MFG 1342": {
+    "text": "Placement into MATH 0900I or permission by instructor",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1343": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1344": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1345": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1346": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1359": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1362": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1400": {
+    "text": "MFG 1420 and MFG 1424",
+    "courses": [
+      "MFG 1420",
+      "MFG 1424"
+    ]
+  },
+  "MFG 1405": {
+    "text": "MFG 0905 OR placement into MFG 1405",
+    "courses": [
+      "MFG 0905"
+    ]
+  },
+  "MFG 1409": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 1411": {
+    "text": "MATH 1010 (may be taken concurrently) or permission of instructor",
+    "courses": [
+      "MATH 1010"
+    ]
+  },
+  "MFG 1425": {
+    "text": "MFG 1424 or EGR 1120 with a C- or higher",
+    "courses": [
+      "EGR 1120",
+      "MFG 1424"
+    ]
+  },
+  "MFG 1467": {
+    "text": "Placement into MATH 0900I or instructor permission",
+    "courses": [
+      "MATH 0900I"
+    ]
+  },
+  "MFG 2050": {
+    "text": "A grade of C- or higher in MFG 1050",
+    "courses": [
+      "MFG 1050"
+    ]
+  },
+  "MFG 2080": {
+    "text": "A grade of C- or higher in MFG 1020 and MFG 1049 and MFG 1028",
+    "courses": [
+      "MFG 1020",
+      "MFG 1028",
+      "MFG 1049"
+    ]
+  },
+  "MFG 2081": {
+    "text": "A grade of C- or higher in MFG 1020 and MFG 1050",
+    "courses": [
+      "MFG 1020",
+      "MFG 1050"
+    ]
+  },
+  "MFG 2439": {
+    "text": "A grade of C- or higher in MFG 1424 or EGR 1120 (or permission of instructor)",
+    "courses": [
+      "EGR 1120",
+      "MFG 1424"
+    ]
+  },
+  "MFG 2445": {
+    "text": "MFG 2444",
+    "courses": [
+      "MFG 2444"
+    ]
+  },
+  "MFG 2456": {
+    "text": "A grade of C- or higher in MFG 1478 or permission of instructor",
+    "courses": [
+      "MFG 1478"
+    ]
+  },
+  "MFG 2477": {
+    "text": "A grade of C- or higher in MFG 1477 or instructor permission",
+    "courses": [
+      "MFG 1477"
+    ]
+  },
+  "MUS 1000": {
+    "text": "eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1001": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1002": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1004": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1007": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1008": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1009": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1011": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1101": {
+    "text": "A very basic understanding of notation before beginning this class is highly recommended. Successful completion of MUS 1100 is recommended, but not required",
+    "courses": [
+      "MUS 1100"
+    ]
+  },
+  "MUS 1102": {
+    "text": "MUS 1101 with a “C’ or higher; or by permission of the instructor",
+    "courses": [
+      "MUS 1101"
+    ]
+  },
+  "MUS 1201": {
+    "text": "A basic understanding of notation before beginning this class is highly recommended. Successful completion of MUS 1100 is recommended before taking this course, but not required",
+    "courses": [
+      "MUS 1100"
+    ]
+  },
+  "MUS 1202": {
+    "text": "MUS 1201 with a “C” or higher, or by permission of the instructor",
+    "courses": [
+      "MUS 1201"
+    ]
+  },
+  "MUS 1301": {
+    "text": "Permission by the instructor. Basic understanding of MUS 1101 con-currently",
+    "courses": [
+      "MUS 1101"
+    ]
+  },
+  "MUS 1302": {
+    "text": "MUS 1301 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 1301"
+    ]
+  },
+  "MUS 1303": {
+    "text": "MUS 1300",
+    "courses": [
+      "MUS 1300"
+    ]
+  },
+  "MUS 1405": {
+    "text": "By permission of the music program coordinator /department chair",
+    "courses": []
+  },
+  "MUS 1406": {
+    "text": "MUS 1405 with a “C” or above, or permission of instructor",
+    "courses": [
+      "MUS 1405"
+    ]
+  },
+  "MUS 1501": {
+    "text": "Permission by the instructor required (students who take this class must be able to sing and reproduce tones (i.e., “match pitch”)",
+    "courses": []
+  },
+  "MUS 1502": {
+    "text": "MUS 1501 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 1501"
+    ]
+  },
+  "MUS 1511": {
+    "text": "Audition is required and instructor approval",
+    "courses": []
+  },
+  "MUS 1512": {
+    "text": "MUS 1511 with ‘C’ or above, or permission by the instructor (audition required)",
+    "courses": [
+      "MUS 1511"
+    ]
+  },
+  "MUS 1521": {
+    "text": "MUS 1406 with a “C” or above, or permission of instructor",
+    "courses": [
+      "MUS 1406"
+    ]
+  },
+  "MUS 1522": {
+    "text": "Students have completed audition process into the program and demonstrate some facility with their musical instrument, or permission by the instructor",
+    "courses": []
+  },
+  "MUS 1530": {
+    "text": "Must have some rudimentary facility with a musical instrument",
+    "courses": []
+  },
+  "MUS 1531": {
+    "text": "Completion of MUS 1522 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 1522"
+    ]
+  },
+  "MUS 1532": {
+    "text": "MUS 1521 with a “C” or above; or permission by the instructor",
+    "courses": [
+      "MUS 1521"
+    ]
+  },
+  "MUS 1602": {
+    "text": "MUS 1301 with a “C” or above; or permission by the instructor",
+    "courses": [
+      "MUS 1301"
+    ]
+  },
+  "MUS 1701": {
+    "text": "Eligibility for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1702": {
+    "text": "ENG 1010 or permission from the Music Program Coordinator",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "MUS 1802": {
+    "text": "MUS 1801 or permission of instructor",
+    "courses": [
+      "MUS 1801"
+    ]
+  },
+  "MUS 1812": {
+    "text": "MUS 1811 with a “C” or above; or instructor’s permission",
+    "courses": [
+      "MUS 1811"
+    ]
+  },
+  "MUS 1821": {
+    "text": "A very basic understanding of notation before beginning this class is highly recommended. Successful completion of MUS 1100 is recommended",
+    "courses": [
+      "MUS 1100"
+    ]
+  },
+  "MUS 1831": {
+    "text": "Completion of MUS 1301 , MUS 1102 , MUS 1202 , AND either MUS 1501 or MUS 1521 , all with a grade of “C” or higher; or by permission of the instructor",
+    "courses": [
+      "MUS 1102",
+      "MUS 1202",
+      "MUS 1301",
+      "MUS 1501",
+      "MUS 1521"
+    ]
+  },
+  "MUS 2095": {
+    "text": "Approval of Music Program Coordinator",
+    "courses": []
+  },
+  "MUS 2098": {
+    "text": "MUS 1202 with a “C” or above, or instructor’s permission",
+    "courses": [
+      "MUS 1202"
+    ]
+  },
+  "MUS 2103": {
+    "text": "MUS 1202 with a “C’ or higher; or by permission of the instructor",
+    "courses": [
+      "MUS 1202"
+    ]
+  },
+  "MUS 2104": {
+    "text": "MUS 2201 with a “C’ or higher; or by permission of the instructor",
+    "courses": [
+      "MUS 2201"
+    ]
+  },
+  "MUS 2201": {
+    "text": "MUS 1102 with a “C” or higher, or by permission of the instructor",
+    "courses": [
+      "MUS 1102"
+    ]
+  },
+  "MUS 2202": {
+    "text": "MUS 2103 with a “C” or higher, or by permission of the instructor",
+    "courses": [
+      "MUS 2103"
+    ]
+  },
+  "MUS 2303": {
+    "text": "MUS 1302 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 1302"
+    ]
+  },
+  "MUS 2304": {
+    "text": "MUS 2303 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 2303"
+    ]
+  },
+  "MUS 2405": {
+    "text": "MUS 1406 with a “C” or above, or permission of instructor",
+    "courses": [
+      "MUS 1406"
+    ]
+  },
+  "MUS 2406": {
+    "text": "MUS 1406 with a “C” or above, or permission of instructor",
+    "courses": [
+      "MUS 1406"
+    ]
+  },
+  "MUS 2503": {
+    "text": "MUS 1502 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 1502"
+    ]
+  },
+  "MUS 2504": {
+    "text": "MUS 2503 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 2503"
+    ]
+  },
+  "MUS 2513": {
+    "text": "MUS 1512 with ‘C’ or above, or permission by the instructor",
+    "courses": [
+      "MUS 1512"
+    ]
+  },
+  "MUS 2514": {
+    "text": "MUS 2513 with ‘C’ or above, or permission by the instructor",
+    "courses": [
+      "MUS 2513"
+    ]
+  },
+  "MUS 2523": {
+    "text": "MUS 1532 with a “C” or above; or permission by the instructor",
+    "courses": [
+      "MUS 1532"
+    ]
+  },
+  "MUS 2524": {
+    "text": "MUS 2523 with a “C” or above; or permission by the instructor",
+    "courses": [
+      "MUS 2523"
+    ]
+  },
+  "MUS 2533": {
+    "text": "MUS 1531 with a “C” or higher; or permission by the instructor",
+    "courses": [
+      "MUS 1531"
+    ]
+  },
+  "MUS 2534": {
+    "text": "MUS 2533 with a “C” or higher; or permission of the instructor",
+    "courses": [
+      "MUS 2533"
+    ]
+  },
+  "MUS 2603": {
+    "text": "MUS 1602 with a “C” or above; or by permission of the instructor",
+    "courses": [
+      "MUS 1602"
+    ]
+  },
+  "MUS 2604": {
+    "text": "MUS 2603",
+    "courses": [
+      "MUS 2603"
+    ]
+  },
+  "MUS 2605": {
+    "text": "MUS 2603",
+    "courses": [
+      "MUS 2603"
+    ]
+  },
+  "MUS 2606": {
+    "text": "MUS 2603 or by Music Program Coordinator’s approval. Demonstrated knowledge and success in music theory, rudimentary acoustic composition, as well as digital music software programs are highly recommended",
+    "courses": [
+      "MUS 2603"
+    ]
+  },
+  "MUSX 1102": {
+    "text": "MUSX 1101 with a “C’ or higher; or by permission of the instructor",
+    "courses": [
+      "MUSX 1101"
+    ]
+  },
+  "MUSX 1201": {
+    "text": "Successful completion of MUSX 1100 is recommended before taking this course, but not required",
+    "courses": [
+      "MUSX 1100"
+    ]
+  },
+  "MUSX 1202": {
+    "text": "MUSX 1201 with a “C” or higher, or by permission of the instructor",
+    "courses": [
+      "MUSX 1201"
+    ]
+  },
+  "MUSX 1302": {
+    "text": "MUSX 1301 with a ‘C’ or higher or permission by Instructor",
+    "courses": [
+      "MUSX 1301"
+    ]
+  },
+  "MUSX 1405": {
+    "text": "By permission of the music program coordinator, or department chair, or discipline instructor",
+    "courses": []
+  },
+  "MUSX 1406": {
+    "text": "By permission of the music program coordinator, or department chair, or discipline instructor",
+    "courses": []
+  },
+  "MUSX 1502": {
+    "text": "MUSX 1501 or permission by instructor",
+    "courses": [
+      "MUSX 1501"
+    ]
+  },
+  "MUSX 1521": {
+    "text": "Permission from the Music Program Coordinator or Ensemble Director",
+    "courses": []
+  },
+  "MUSX 1531": {
+    "text": "MUSX 1522 or permission by Instructor",
+    "courses": [
+      "MUSX 1522"
+    ]
+  },
+  "MUSX 1532": {
+    "text": "MUSX 1521 or Permission from the Music Program Coordinator or Ensemble Director",
+    "courses": [
+      "MUSX 1521"
+    ]
+  },
+  "MUSX 1602": {
+    "text": "MUS 1600 Intro to Music Production or permission by Instructor",
+    "courses": [
+      "MUS 1600"
+    ]
+  },
+  "MUSX 2103": {
+    "text": "MUSX 1102 with a “C’ or higher; or by permission of the instructor",
+    "courses": [
+      "MUSX 1102"
+    ]
+  },
+  "MUSX 2104": {
+    "text": "MUSX 2103 with a ‘C’ or higher; or by permission of the instructor",
+    "courses": [
+      "MUSX 2103"
+    ]
+  },
+  "MUSX 2201": {
+    "text": "MUSX 1202 with a “C” or higher, or by permission of the instructor",
+    "courses": [
+      "MUSX 1202"
+    ]
+  },
+  "MUSX 2202": {
+    "text": "MUSX 2201 with a “C” or higher, or by permission of the instructor",
+    "courses": [
+      "MUSX 2201"
+    ]
+  },
+  "MUSX 2303": {
+    "text": "MUSX 1302 with a ‘C’ or higher or permission by Instructor",
+    "courses": [
+      "MUSX 1302"
+    ]
+  },
+  "MUSX 2304": {
+    "text": "MUSX 2303 with a ‘C’ or higher or permission by Instructor",
+    "courses": [
+      "MUSX 2303"
+    ]
+  },
+  "MUSX 2405": {
+    "text": "By permission of the music program coordinator, or department chair, or discipline instructor",
+    "courses": []
+  },
+  "MUSX 2406": {
+    "text": "By permission of the music program coordinator, or department chair, or discipline instructor",
+    "courses": []
+  },
+  "MUSX 2503": {
+    "text": "MUSX 1502 or permission by Instructor",
+    "courses": [
+      "MUSX 1502"
+    ]
+  },
+  "MUSX 2504": {
+    "text": "MUSX 2503 or permission by Instructor",
+    "courses": [
+      "MUSX 2503"
+    ]
+  },
+  "MUSX 2523": {
+    "text": "MUSX 1532 or Permission from the Music Program Coordinator or Ensemble Director",
+    "courses": [
+      "MUSX 1532"
+    ]
+  },
+  "MUSX 2524": {
+    "text": "MUSX 2523 or Permission from the Music Program Coordinator or Ensemble Director",
+    "courses": [
+      "MUSX 2523"
+    ]
+  },
+  "MUSX 2533": {
+    "text": "MUSX 1531 or permission by Instructor",
+    "courses": [
+      "MUSX 1531"
+    ]
+  },
+  "MUSX 2534": {
+    "text": "MUSX 2533 or permission by Instructor",
+    "courses": [
+      "MUSX 2533"
+    ]
+  },
+  "MUSX 2603": {
+    "text": "MUSX 1602 Electronic Music Composition I or permission by Instructor",
+    "courses": [
+      "MUSX 1602"
+    ]
+  },
+  "MUSX 2604": {
+    "text": "MUSX 2603 Electronic Music Composition II or permission by Instructor",
+    "courses": [
+      "MUSX 2603"
+    ]
+  },
+  "MUSX 2605": {
+    "text": "MUS 1600 - Introduction to Music Production or permission by Instructor",
+    "courses": [
+      "MUS 1600"
+    ]
+  },
+  "MUSX 2606": {
+    "text": "MUSX 2603 - Electronic Music Composition II or permission by Instructor",
+    "courses": [
+      "MUSX 2603"
+    ]
+  },
+  "NMP 1001": {
+    "text": "Computer experience highly recommended",
+    "courses": []
+  },
+  "NMP 1025": {
+    "text": "previous computer experience highly recommended",
+    "courses": []
+  },
+  "NMP 1047": {
+    "text": "COMM 1601",
+    "courses": [
+      "COMM 1601"
+    ]
+  },
+  "NMP 1053": {
+    "text": "COMM 1601",
+    "courses": [
+      "COMM 1601"
+    ]
+  },
+  "NMP 1110": {
+    "text": "previous computer experience highly recommended",
+    "courses": []
+  },
+  "NMP 1120": {
+    "text": "NMP 1001 or NMP 1110",
+    "courses": [
+      "NMP 1001",
+      "NMP 1110"
+    ]
+  },
+  "NMP 1130": {
+    "text": "NMP 1001 or NMP 1110",
+    "courses": [
+      "NMP 1001",
+      "NMP 1110"
+    ]
+  },
+  "NMP 1140": {
+    "text": "NMP 1001 or NMP 1110",
+    "courses": [
+      "NMP 1001",
+      "NMP 1110"
+    ]
+  },
+  "NMP 2003": {
+    "text": "Eligible for ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "NMP 2020": {
+    "text": "COMM 1601",
+    "courses": [
+      "COMM 1601"
+    ]
+  },
+  "NMP 2028": {
+    "text": "NMP 2020",
+    "courses": [
+      "NMP 2020"
+    ]
+  },
+  "NMP 2064": {
+    "text": "COMM 1601",
+    "courses": [
+      "COMM 1601"
+    ]
+  },
+  "NMP 2090": {
+    "text": "Must be a sophomore-level student in a New Media Production AAS degree, one of the NMP certificate programs or a student the Communication Studies AA who has completed at least three production courses, or permission of instructor",
+    "courses": []
+  },
+  "NMP 2095": {
+    "text": "By permission of instructor or program coordinator. Previous media production experience required. Enrollment is limited to 10 students",
+    "courses": []
+  },
+  "NMP 2100": {
+    "text": "NMP 1001 or NMP 1110",
+    "courses": [
+      "NMP 1001",
+      "NMP 1110"
+    ]
+  },
+  "NMP 2110": {
+    "text": "NMP 1001 or NMP 1110",
+    "courses": [
+      "NMP 1001",
+      "NMP 1110"
+    ]
+  },
+  "NMP 2120": {
+    "text": "NMP 1001 or NMP 1110",
+    "courses": [
+      "NMP 1001",
+      "NMP 1110"
+    ]
+  },
+  "NMP 2195": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "NMP 2200": {
+    "text": "NMP 1001",
+    "courses": [
+      "NMP 1001"
+    ]
+  },
+  "NMP 2210": {
+    "text": "NMP 1001 or NMP 1110",
+    "courses": [
+      "NMP 1001",
+      "NMP 1110"
+    ]
+  },
+  "NMP 2220": {
+    "text": "NMP 2210",
+    "courses": [
+      "NMP 2210"
+    ]
+  },
+  "NMP 2295": {
+    "text": "Permission of Instructor",
+    "courses": []
+  },
+  "NRG 1122": {
+    "text": "PHYS 1201 and NRG 1123 , both with C- or higher",
+    "courses": [
+      "NRG 1123",
+      "PHYS 1201"
+    ]
+  },
+  "NRG 1123": {
+    "text": "NRG 1101 with a C- or higher",
+    "courses": [
+      "NRG 1101"
+    ]
+  },
+  "NRG 1130": {
+    "text": "PHYS 1201 and NRG 1123 , both with C- or higher",
+    "courses": [
+      "NRG 1123",
+      "PHYS 1201"
+    ]
+  },
+  "NRG 1132": {
+    "text": "NRG 1123 with a C- or higher",
+    "courses": [
+      "NRG 1123"
+    ]
+  },
+  "NRG 2241": {
+    "text": "NRG 1123 with a C- or higher",
+    "courses": [
+      "NRG 1123"
+    ]
+  },
+  "SPED 1012": {
+    "text": "ENG 1010 and PSY 2004 or ECED 1002",
+    "courses": [
+      "ECED 1002",
+      "ENG 1010",
+      "PSY 2004"
+    ]
+  },
+  "SPED 2307": {
+    "text": "BS or BA in Education, Special Education, or related discipline, or SPED 1012 or ECED 2515 , or permission of program coordinator",
+    "courses": [
+      "ECED 2515",
+      "SPED 1012"
+    ]
+  },
+  "SPED 2695": {
+    "text": "Permission of the program coordinator, within 9 credits of graduation, ECED or SPED courses with a grade of C- or higher",
+    "courses": []
+  },
+  "SPED 2749": {
+    "text": "PSY 2004",
+    "courses": [
+      "PSY 2004"
+    ]
+  },
+  "THR 2210": {
+    "text": "THR 1110 or permission of the instructor",
+    "courses": [
+      "THR 1110"
+    ]
+  },
+  "THR 2216": {
+    "text": "THR 1110 or permission of the instructor",
+    "courses": [
+      "THR 1110"
+    ]
+  },
+  "THR 2217": {
+    "text": "THR 2216",
+    "courses": [
+      "THR 2216"
+    ]
+  },
+  "THR 2219": {
+    "text": "THR 1110 or permission of the instructor",
+    "courses": [
+      "THR 1110"
+    ]
+  },
+  "THR 2229": {
+    "text": "THR 1120 or permission of program coordinator",
+    "courses": [
+      "THR 1120"
+    ]
+  },
+  "THR 2230": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "THR 2232": {
+    "text": "ENG 1010",
+    "courses": [
+      "ENG 1010"
+    ]
+  },
+  "THR 2295": {
+    "text": "THR 1195",
+    "courses": [
+      "THR 1195"
+    ]
+  },
+  "THR 2298": {
+    "text": "ENG 1020",
+    "courses": [
+      "ENG 1020"
+    ]
+  },
+  "THR 2299": {
+    "text": "Permission of faculty",
+    "courses": []
+  }
+}

--- a/scripts/ct/scrape-catalog-prereqs.ts
+++ b/scripts/ct/scrape-catalog-prereqs.ts
@@ -1,0 +1,310 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Scrapes CT State Community College's Modern Campus / acalog catalog at
+ * https://catalog.ctstate.edu to extract prerequisite text for every
+ * active course. CT State is Connecticut's unified community-college
+ * system (merged from 12 former colleges in 2023); the primary course
+ * scraper (scripts/ct/scrape-banner.ts) doesn't extract prereqs from
+ * Banner SSB so this catalog scrape fills that gap.
+ *
+ * Same two-pass Acalog engine as scripts/vt/scrape-catalog-prereqs.ts:
+ *
+ *   Pass 1: paginate the course list, collect coids, fetch every detail
+ *           page once, and build a `coid → "PREFIX NUMBER"` index.
+ *   Pass 2: re-scan each detail page's prereq block; resolve any anchor
+ *           `coid=X` references to canonical course codes via the index.
+ *
+ * Output: data/ct/prereqs.json keyed by "${PREFIX} ${NUMBER}".
+ *
+ * The catalog year rolls over every summer. Re-run once CT State
+ * publishes the new catoid. Update CATOID below when that happens.
+ *
+ * Usage:
+ *   npx tsx scripts/ct/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/ct/scrape-catalog-prereqs.ts --limit=50   # smoke test
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const BASE = "https://catalog.ctstate.edu";
+const CATOID = 24;     // CT State 2026-2027 catalog id
+const NAVOID = 2805;   // "Course Descriptions" nav entry
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 8;
+const DELAY_MS = 50;
+// CT State has ~19 pages of 100 courses each — give headroom.
+const MAX_PAGES = 25;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+interface CourseDetail {
+  coid: string;
+  prefix: string;
+  number: string;
+  html: string;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return ""; // 404 — course probably delisted; skip silently
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Catalog endpoints
+// ---------------------------------------------------------------------------
+
+function listUrl(cpage: number): string {
+  return (
+    `${BASE}/content.php?catoid=${CATOID}` +
+    `&catoid=${CATOID}` +
+    `&navoid=${NAVOID}` +
+    `&filter%5Bitem_type%5D=3` +
+    `&filter%5Bonly_active%5D=1` +
+    `&filter%5B3%5D=1` +
+    `&filter%5Bcpage%5D=${cpage}`
+  );
+}
+
+function detailUrl(coid: string): string {
+  return `${BASE}/preview_course_nopop.php?catoid=${CATOID}&coid=${coid}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function extractCoids(html: string): string[] {
+  const matches = html.match(/preview_course_nopop\.php\?catoid=\d+&(?:amp;)?coid=(\d+)/g) || [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+/**
+ * Extract the course code (prefix + number) from the detail page's H1.
+ * Returns null for non-course pages (general-education descriptors, etc.)
+ * which appear at the start of acalog's list and don't have a PREFIX NUMBER
+ * header.
+ */
+function extractCourseCode(html: string): { prefix: string; number: string } | null {
+  const m = html.match(/<h1[^>]*>\s*([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\s*-/);
+  if (!m) return null;
+  return { prefix: m[1].toUpperCase(), number: m[2] };
+}
+
+/**
+ * Extract the raw prereq HTML block (before tag stripping) so we can
+ * pull out `<a href="...coid=X">` links for resolution via the coid index.
+ */
+function extractPrereqBlock(html: string): string | null {
+  // Match "Prerequisites:" (with optional <strong> wrapper) up to the next
+  // <br><br>, </p>, or stock "Click here for course offerings" link.
+  const m = html.match(
+    /(?:<strong>\s*)?Prerequisites?(?:\(s\))?\s*:\s*(?:<\/strong>)?\s*([\s\S]*?)(?:<br\s*\/?>\s*<br|<\/p>|<strong>|<a\s+href=["']https:)/i,
+  );
+  return m ? m[1] : null;
+}
+
+/** Strip HTML tags + decode common entities to plain text. */
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,]\s*$/, "")
+    .trim();
+}
+
+/** Extract coid references from a block of HTML. Used to resolve prereq anchors. */
+function extractAnchorCoids(htmlBlock: string): string[] {
+  const matches = htmlBlock.match(/coid=(\d+)/g) || [];
+  const ids = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/coid=(\d+)/);
+    if (mm) ids.add(mm[1]);
+  }
+  return Array.from(ids);
+}
+
+// Stock phrases that indicate "no actual prereq" — filtered out to keep the
+// output clean. CCV's boilerplate comes in a few variants.
+const BOILERPLATE_RE =
+  /^(students must meet basic skills policy requirements\.?\s*no other (course\s+)?prerequisites? required|none|not applicable|n\/a)\s*\.?\s*$/i;
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limit = parseInt(args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0", 10);
+
+  console.log("CT State catalog prereq scraper");
+  console.log(`  Base: ${BASE}`);
+  console.log(`  catoid=${CATOID} navoid=${NAVOID}`);
+
+  // --- Phase 1: paginate list, collect coids ---
+  console.log("\n[1/3] Paginating course list...");
+  const allCoids = new Set<string>();
+  for (let cpage = 1; cpage <= MAX_PAGES; cpage++) {
+    const html = await retryFetch(listUrl(cpage), `list(cpage=${cpage})`);
+    const coids = extractCoids(html);
+    console.log(`  cpage=${cpage}: ${coids.length} coids`);
+    if (coids.length === 0) break;
+    for (const c of coids) allCoids.add(c);
+    await sleep(100);
+  }
+  let coidList = Array.from(allCoids);
+  console.log(`  Total unique coids: ${coidList.length}`);
+
+  if (limit > 0) {
+    coidList = coidList.slice(0, limit);
+    console.log(`  Limited to first ${limit} for smoke test`);
+  }
+
+  // --- Phase 2: fetch every detail page, build coid → code index ---
+  console.log("\n[2/3] Fetching detail pages + building coid index...");
+  const details: CourseDetail[] = [];
+  const codeByCoid = new Map<string, string>();
+  await pmap(coidList, CONCURRENCY, async (coid) => {
+    const html = await retryFetch(detailUrl(coid), `detail(${coid})`);
+    if (!html) return;
+    const code = extractCourseCode(html);
+    if (!code) return; // non-course page (gen-ed descriptor, etc.)
+    details.push({ coid, prefix: code.prefix, number: code.number, html });
+    codeByCoid.set(coid, `${code.prefix} ${code.number}`);
+  });
+  console.log(
+    `  Fetched ${details.length} real course pages (${coidList.length - details.length} non-course descriptors skipped)`,
+  );
+
+  // --- Phase 3: parse prereq blocks, resolve anchor coids to codes ---
+  console.log("\n[3/3] Parsing prereqs + resolving anchor refs...");
+  const prereqs: Record<string, PrereqEntry> = {};
+  let withPrereqs = 0;
+  let resolvedAnchors = 0;
+  for (const d of details) {
+    const block = extractPrereqBlock(d.html);
+    if (!block) continue;
+
+    const text = htmlToText(block);
+    if (!text) continue;
+    if (BOILERPLATE_RE.test(text)) continue;
+
+    // Extract course codes from the text itself (handles "MTH 1010", "ENG 2120")
+    const courses = new Set<string>();
+    const codeRegex = /\b([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b/g;
+    let m: RegExpExecArray | null;
+    while ((m = codeRegex.exec(text)) !== null) {
+      const code = `${m[1]} ${m[2]}`;
+      if (code !== `${d.prefix} ${d.number}`) courses.add(code);
+    }
+
+    // Also resolve `<a href="...coid=X">` links in the raw block — CCV uses
+    // anchor text like "Human Anatomy & Physiology II" which doesn't contain
+    // the course code, so the text-only regex misses those.
+    for (const anchorCoid of extractAnchorCoids(block)) {
+      const resolved = codeByCoid.get(anchorCoid);
+      if (resolved && resolved !== `${d.prefix} ${d.number}`) {
+        courses.add(resolved);
+        resolvedAnchors++;
+      }
+    }
+
+    const key = `${d.prefix} ${d.number}`;
+    prereqs[key] = { text, courses: Array.from(courses).sort() };
+    withPrereqs++;
+  }
+  console.log(`  Extracted prereqs for ${withPrereqs} courses`);
+  console.log(`  Resolved ${resolvedAnchors} <a href> anchor references via coid index`);
+
+  // Sort keys alphabetically for deterministic output
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(prereqs).sort()) {
+    sorted[key] = prereqs[key];
+  }
+
+  // --- Write ---
+  const outDir = path.join(process.cwd(), "data", "ct");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
CT State Community College was missing prereq data. The Banner course scraper doesn't extract prereqs, so this catalog scrape fills the gap — reusing the exact two-pass engine from PR #22 (VT) with different URL constants.

Source: https://catalog.ctstate.edu (Modern Campus / acalog, catoid=24, navoid=2805, ~1,889 entries across 19 pagination pages).

## Delta from PR #22
Purely constants + output path:
- `BASE = "https://catalog.ctstate.edu"`
- `CATOID = 24`
- `NAVOID = 2805`
- `MAX_PAGES = 25` (CT has 19 pages; VT had 4)
- Output: `data/ct/prereqs.json`

## Results

| Metric | VT (PR #22) | CT (this PR) |
|---|---:|---:|
| Real courses | 351 | 823 |
| With prereqs | 101 | 573 |
| With >=1 resolved code | 91 | 501 |
| Coverage | 29% | 70% |

CT's catalog has much richer prereq text (e.g. "ACCT 1130 and ACCT 1170 or permission of instructor") vs CCV's sparse anchor-text-only descriptions.

## End-to-end verification
`GET /api/ct/prereqs/chain?course=ACCT 1230` resolves to a 4-level chain: ACCT 1230 -> ACCT 1170 -> ACCT 1130 -> [MATH 0900 OR MATH 0900I] with AND-of-OR groups rendered correctly.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full scrape completes in ~3 min, writes 573 entries
- [x] `/api/ct/prereqs/courses` + `/api/ct/prereqs/chain` verified on dev
- [ ] After merge: spot-check a CT course page on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)
