### PR TITLE
data: RI prereq scraper (CCRI CourseLeaf, 507 courses)

### DIFF
--- a/data/ri/prereqs.json
+++ b/data/ri/prereqs.json
@@ -1,0 +1,3936 @@
+{
+  "AAAF 1202": {
+    "text": "AAAF 1201",
+    "courses": [
+      "AAAF 1201"
+    ]
+  },
+  "AAAF 1247": {
+    "text": "ENGL 1010 (may be taken concurrently)",
+    "courses": [
+      "ENGL 1010"
+    ]
+  },
+  "ACCT 1020": {
+    "text": "ACCT 1010",
+    "courses": [
+      "ACCT 1010"
+    ]
+  },
+  "ACCT 1030": {
+    "text": "ACCT 1010",
+    "courses": [
+      "ACCT 1010"
+    ]
+  },
+  "ACCT 2010": {
+    "text": "ACCT 1020",
+    "courses": [
+      "ACCT 1020"
+    ]
+  },
+  "ACCT 2020": {
+    "text": "ACCT 2010",
+    "courses": [
+      "ACCT 2010"
+    ]
+  },
+  "ADAS 2530": {
+    "text": "OFTD 1140",
+    "courses": [
+      "OFTD 1140"
+    ]
+  },
+  "AEES 1010": {
+    "text": "MATH 1179 (may be taken concurrently) or Math Placement",
+    "courses": [
+      "MATH 1179"
+    ]
+  },
+  "AEES 1020": {
+    "text": "ETEE 1050 (may be taken concurrently)",
+    "courses": [
+      "ETEE 1050"
+    ]
+  },
+  "AEES 1030": {
+    "text": "(MATH 0500 or MATH 0100 or Math Placement)",
+    "courses": [
+      "MATH 0100",
+      "MATH 0500"
+    ]
+  },
+  "AEES 1050": {
+    "text": "(MATH 0600 or MATH 0101 or Math Placement) and ( PHYS 1000 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0101",
+      "MATH 0600",
+      "PHYS 1000"
+    ]
+  },
+  "AEES 1070": {
+    "text": "ENGR 1020 and ENGR 1030",
+    "courses": [
+      "ENGR 1020",
+      "ENGR 1030"
+    ]
+  },
+  "AEES 2000": {
+    "text": "AEES 1020",
+    "courses": [
+      "AEES 1020"
+    ]
+  },
+  "AEES 2010": {
+    "text": "MATH 1179 and MATH 1181 and PHYS 1000",
+    "courses": [
+      "MATH 1179",
+      "MATH 1181",
+      "PHYS 1000"
+    ]
+  },
+  "AEES 2020": {
+    "text": "(ETME 1010 or AEES 1060 ) and (ETEE 1800 or AEES 1030 )",
+    "courses": [
+      "AEES 1030",
+      "AEES 1060",
+      "ETEE 1800",
+      "ETME 1010"
+    ]
+  },
+  "AEES 2030": {
+    "text": "PHYS 1000 and MATH 1181",
+    "courses": [
+      "MATH 1181",
+      "PHYS 1000"
+    ]
+  },
+  "AEES 2500": {
+    "text": "AEES 1050",
+    "courses": [
+      "AEES 1050"
+    ]
+  },
+  "AGIS 1500": {
+    "text": "AGIS 1000",
+    "courses": [
+      "AGIS 1000"
+    ]
+  },
+  "AGIS 2000": {
+    "text": "AGIS 1500",
+    "courses": [
+      "AGIS 1500"
+    ]
+  },
+  "ARTS 1050": {
+    "text": "ARTS 1010",
+    "courses": [
+      "ARTS 1010"
+    ]
+  },
+  "ARTS 1510": {
+    "text": "ENGL 1005 or ENGL 1005A or ENGL 1010 or ENGL 1010A or English Wrtg Course Placement",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ARTS 1520": {
+    "text": "ENGL 1005 or ENGL 1005A or ENGL 1010 (may be taken concurrently) or ENGL 1010A or English Wrtg Course Placement",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ARTS 1530": {
+    "text": "ENGL 1005 or ENGL 1005A or ENGL 1010 (may be taken concurrently) or ENGL 1010A or English Wrtg Course Placement",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ARTS 1550": {
+    "text": "ENGL 1005 (may be taken concurrently) or ENGL 1005A or ENGL 1010 (may be taken concurrently) or ENGL 1010A or English Wrtg Course Placement",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ARTS 1660": {
+    "text": "ARTS 1650",
+    "courses": [
+      "ARTS 1650"
+    ]
+  },
+  "ARTS 1720": {
+    "text": "ARTS 1710",
+    "courses": [
+      "ARTS 1710"
+    ]
+  },
+  "ARTS 1820": {
+    "text": "ARTS 1810",
+    "courses": [
+      "ARTS 1810"
+    ]
+  },
+  "ARTS 2010": {
+    "text": "ARTS 1010 or ARTS 1020",
+    "courses": [
+      "ARTS 1010",
+      "ARTS 1020"
+    ]
+  },
+  "ARTS 2020": {
+    "text": "ARTS 2010",
+    "courses": [
+      "ARTS 2010"
+    ]
+  },
+  "ARTS 2050": {
+    "text": "ARTS 1050",
+    "courses": [
+      "ARTS 1050"
+    ]
+  },
+  "ARTS 2360": {
+    "text": "ARTS 1030",
+    "courses": [
+      "ARTS 1030"
+    ]
+  },
+  "ARTS 2660": {
+    "text": "ARTS 1660",
+    "courses": [
+      "ARTS 1660"
+    ]
+  },
+  "ARTS 2820": {
+    "text": "ARTS 1820 or ARTS 2850",
+    "courses": [
+      "ARTS 1820",
+      "ARTS 2850"
+    ]
+  },
+  "ARTS 2845": {
+    "text": "ARTS 1845",
+    "courses": [
+      "ARTS 1845"
+    ]
+  },
+  "ARTS 2850": {
+    "text": "ARTS 1850",
+    "courses": [
+      "ARTS 1850"
+    ]
+  },
+  "ASLG 1020": {
+    "text": "ASLG 1010 or HMNS 1060",
+    "courses": [
+      "ASLG 1010",
+      "HMNS 1060"
+    ]
+  },
+  "ASLG 2010": {
+    "text": "(HMNS 1060 and HMNS 1070) or ( ASLG 1010 and ASLG 1020 )",
+    "courses": [
+      "ASLG 1010",
+      "ASLG 1020",
+      "HMNS 1060",
+      "HMNS 1070"
+    ]
+  },
+  "ASLG 2020": {
+    "text": "(HMNS 1060 and HMNS 1070 and HMNS 2010) or ( ASLG 1010 and ASLG 1020 and ASLG 2010 )",
+    "courses": [
+      "ASLG 1010",
+      "ASLG 1020",
+      "ASLG 2010",
+      "HMNS 1060",
+      "HMNS 1070",
+      "HMNS 2010"
+    ]
+  },
+  "BIOL 1000": {
+    "text": "(ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) and (Math Placement or MATH 0101 or MATH 1200 or MATH 1025 or MATH 1179 or MATH 2111 or MATH 2141 or MATH 2142 or MATH 2243 or MATH 2362 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0101",
+      "MATH 1025",
+      "MATH 1179",
+      "MATH 1200",
+      "MATH 2111",
+      "MATH 2141",
+      "MATH 2142",
+      "MATH 2243",
+      "MATH 2362"
+    ]
+  },
+  "BIOL 1001": {
+    "text": "(MATH 0500 or MATH 0099 or MATH 0100 or MATH 0600 or MATH 0101 or MATH 8055 or Math Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 1002": {
+    "text": "(MATH 0500 or MATH 0100 or MATH 0101 or MATH 0600 or MATH 8055 or MATH 0099 or Math Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 1005": {
+    "text": "(Reading Course Placement or ENGL 0700 ) and (Math Placement or MATH 0500 or MATH 0099 or MATH 8055 or MATH 0101 or MATH 0600 or MATH 0100 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0700",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 1006": {
+    "text": "(MATH 0500 or MATH 0095 or MATH 0099 ) and ENGL 0700",
+    "courses": [
+      "ENGL 0700",
+      "MATH 0095",
+      "MATH 0099",
+      "MATH 0500"
+    ]
+  },
+  "BIOL 1007": {
+    "text": "(MATH 0500 or MATH 0099 or MATH 0100 or MATH 0101 or MATH 8055 or Math Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 1050": {
+    "text": "ENGL 0700 or Reading Course Placement or Bachelor Degree or higher",
+    "courses": [
+      "ENGL 0700"
+    ]
+  },
+  "BIOL 1060": {
+    "text": "(MATH 0500 or MATH 0099 or MATH 0100 or MATH 0101 or MATH 8055 or Math Placement) and ( ENGL 0850 or ENGL 0890 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0850",
+      "ENGL 0890",
+      "ENGL 1002",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 1070": {
+    "text": "(Math Placement or MATH 0500 or MATH 0099 or MATH 0600 or MATH 8055 or MATH 0100 or MATH 0101 ) and (Reading Course Placement or ENGL 0700 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0700",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 1080": {
+    "text": "BIOL 1070 and (MATH 0500 or MATH 0099 or Math Placement or Bachelor Degree or higher) and ( ENGL 0700 or Reading Course Placement or Bachelor Degree or higher)",
+    "courses": [
+      "BIOL 1070",
+      "ENGL 0700",
+      "MATH 0099",
+      "MATH 0500"
+    ]
+  },
+  "BIOL 1110": {
+    "text": "( BIOL 1070 or BIOL 1020) and (MATH 0500 or MATH 0099 or Math Placement) and (ENGL 0890 or ENGL 1002 or Reading Course Placement)",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 1070",
+      "ENGL 0890",
+      "ENGL 1002",
+      "MATH 0099",
+      "MATH 0500"
+    ]
+  },
+  "BIOL 1200": {
+    "text": "(MATH 0500 or MATH 0099 or Math Placement or Bachelor Degree or higher) and ( ENGL 0700 or Reading Course Placement or Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0700",
+      "MATH 0099",
+      "MATH 0500"
+    ]
+  },
+  "BIOL 1300": {
+    "text": "(ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) and (MATH 0500 or MATH 0099 or MATH 0100 or MATH 0101 or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500"
+    ]
+  },
+  "BIOL 1310": {
+    "text": "( CHEM 1030 or CHMT 8000 or CHMT 1120 or CHMT 1121 (may be taken concurrently)) and (MATH 0600 or MATH 0101 or Math Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "CHEM 1030",
+      "CHMT 1120",
+      "CHMT 1121",
+      "CHMT 8000",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0101",
+      "MATH 0600"
+    ]
+  },
+  "BIOL 2025": {
+    "text": "(ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement or Bachelor Degree or higher) and ( MATH 0095 or MATH 0100 or MATH 0600 or MATH 0101 or MATH 8055 or Math Placement) and ( BIOL 1001 or BIOL 1002 or BIOL 1005 )",
+    "courses": [
+      "BIOL 1001",
+      "BIOL 1002",
+      "BIOL 1005",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 2040": {
+    "text": "ENGL 0700 or Reading Course Placement or Bachelor Degree or higher",
+    "courses": [
+      "ENGL 0700"
+    ]
+  },
+  "BIOL 2070": {
+    "text": "( BIOL 1001 or BIOL 1002 ) and ( MATH 1200 or MATH 1700 or MATH 1179 or Math Placement) and (ENGL 0890 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "BIOL 1001",
+      "BIOL 1002",
+      "ENGL 0890",
+      "ENGL 1002",
+      "MATH 1179",
+      "MATH 1200",
+      "MATH 1700"
+    ]
+  },
+  "BIOL 2090": {
+    "text": "( MATH 1200 or MATH 1700 or MATH 1179 or Math Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 1179",
+      "MATH 1200",
+      "MATH 1700"
+    ]
+  },
+  "BIOL 2130": {
+    "text": "ENGL 1005 or ENGL 0890",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 1005"
+    ]
+  },
+  "BIOL 2150": {
+    "text": "ENGL 0700 or Accuplacer Rdg Test Score and BIOL 2090 or (Bachelor Degree or higher)",
+    "courses": [
+      "BIOL 2090",
+      "ENGL 0700"
+    ]
+  },
+  "BIOL 2201": {
+    "text": "(MATH 0500 or MATH 0095 or MATH 8055 or MATH 0099 or MATH 0100 or MATH 0101 or Math Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0095",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 2202": {
+    "text": "BIOL 2201",
+    "courses": [
+      "BIOL 2201"
+    ]
+  },
+  "BIOL 2210": {
+    "text": "BIOL 1020 or BIOL 2202",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 2202"
+    ]
+  },
+  "BIOL 2220": {
+    "text": "BIOL 1010 and BIOL 1020",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1020"
+    ]
+  },
+  "BIOL 2262": {
+    "text": "BIOL 2001",
+    "courses": [
+      "BIOL 2001"
+    ]
+  },
+  "BIOL 2410": {
+    "text": "( ENGL 0950 or ENGL 0890 or ENGL 1002 or Reading Course Placement or Bachelor Degree or higher) and (MATH 0500 or MATH 0095 or MATH 8055 or MATH 0100 or MATH 0101 or Math Placement)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "BIOL 2420": {
+    "text": "(ENGL 0890 or ENGL 1002 or Reading Course Placement) and ( MATH 0099 or Math Placement)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 1002",
+      "MATH 0099"
+    ]
+  },
+  "BIOL 2480": {
+    "text": "( BIOL 1000 or BIOL 1001 or BIOL 1002 ) and ( CHMT 1121 or CHMT 1120 or CHEM 1030 )",
+    "courses": [
+      "BIOL 1000",
+      "BIOL 1001",
+      "BIOL 1002",
+      "CHEM 1030",
+      "CHMT 1120",
+      "CHMT 1121"
+    ]
+  },
+  "BUSN 1175": {
+    "text": "ACCT 1020",
+    "courses": [
+      "ACCT 1020"
+    ]
+  },
+  "BUSN 1185": {
+    "text": "BUSN 1165",
+    "courses": [
+      "BUSN 1165"
+    ]
+  },
+  "BUSN 2050": {
+    "text": "BUSN 1010",
+    "courses": [
+      "BUSN 1010"
+    ]
+  },
+  "BUSN 2060": {
+    "text": "BUSN 1010",
+    "courses": [
+      "BUSN 1010"
+    ]
+  },
+  "BUSN 2070": {
+    "text": "ACCT 1010 and BUSN 2050 and BUSN 2060",
+    "courses": [
+      "ACCT 1010",
+      "BUSN 2050",
+      "BUSN 2060"
+    ]
+  },
+  "BUSN 2350": {
+    "text": "BUSN 1010 and BUSN 2050",
+    "courses": [
+      "BUSN 1010",
+      "BUSN 2050"
+    ]
+  },
+  "CHEM 1000": {
+    "text": "(MATH 0600 or MATH 0095 or MATH 0101 or MATH 0100 or Math Placement or MATH 1420 or MATH 1025 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 1025",
+      "MATH 1420"
+    ]
+  },
+  "CHEM 1010": {
+    "text": "( CHEM 1020 or Chemistry Placement Exam) and (MATH 0600 or MATH 0095 or MATH 0099 or MATH 0100 or MATH 0101 or Math Placement or MATH 1420 or MATH 1025 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "CHEM 1020",
+      "MATH 0095",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 1025",
+      "MATH 1420"
+    ]
+  },
+  "CHEM 1020": {
+    "text": "Chemistry Placement Exam and (MATH 0600 or MATH 0099 or MATH 0100 or MATH 0101 or Math Placement or MATH 1420 or MATH 1025 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 1025",
+      "MATH 1420"
+    ]
+  },
+  "CHEM 1030": {
+    "text": "( CHEM 1020 or Chemistry Placement Exam) and (MATH 0600 or MATH 0101 or MATH 1200 or MATH 1200C or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "CHEM 1020",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 1200",
+      "MATH 1200C"
+    ]
+  },
+  "CHEM 1060": {
+    "text": "CHEM 1000",
+    "courses": [
+      "CHEM 1000"
+    ]
+  },
+  "CHEM 1100": {
+    "text": "CHEM 1030",
+    "courses": [
+      "CHEM 1030"
+    ]
+  },
+  "CHEM 2250": {
+    "text": "CHEM 1100",
+    "courses": [
+      "CHEM 1100"
+    ]
+  },
+  "CHEM 2260": {
+    "text": "CHEM 2250",
+    "courses": [
+      "CHEM 2250"
+    ]
+  },
+  "CHEM 2270": {
+    "text": "CHEM 1100",
+    "courses": [
+      "CHEM 1100"
+    ]
+  },
+  "CHEM 2280": {
+    "text": "CHEM 2270",
+    "courses": [
+      "CHEM 2270"
+    ]
+  },
+  "CHIN 1040": {
+    "text": "CHIN 1030",
+    "courses": [
+      "CHIN 1030"
+    ]
+  },
+  "CHIN 1100": {
+    "text": "CHIN 1000",
+    "courses": [
+      "CHIN 1000"
+    ]
+  },
+  "CHMT 1220": {
+    "text": "CHMT 1120",
+    "courses": [
+      "CHMT 1120"
+    ]
+  },
+  "CHMT 2321": {
+    "text": "CHMT 1220",
+    "courses": [
+      "CHMT 1220"
+    ]
+  },
+  "CHMT 2322": {
+    "text": "CHMT 2321",
+    "courses": [
+      "CHMT 2321"
+    ]
+  },
+  "CHMT 2421": {
+    "text": "CHMT 2322",
+    "courses": [
+      "CHMT 2322"
+    ]
+  },
+  "CNVT 1820": {
+    "text": "CNVT 1810",
+    "courses": [
+      "CNVT 1810"
+    ]
+  },
+  "CNVT 1830": {
+    "text": "CNVT 1820",
+    "courses": [
+      "CNVT 1820"
+    ]
+  },
+  "CNVT 2030": {
+    "text": "CNVT 1830",
+    "courses": [
+      "CNVT 1830"
+    ]
+  },
+  "CNVT 2200": {
+    "text": "CNVT 1820",
+    "courses": [
+      "CNVT 1820"
+    ]
+  },
+  "CNVT 2410": {
+    "text": "CNVT 1830 (may be taken concurrently)",
+    "courses": [
+      "CNVT 1830"
+    ]
+  },
+  "COMI 1215": {
+    "text": "COMI 1150 or COMI 1225 or COMI 1510 or COMI 2040",
+    "courses": [
+      "COMI 1150",
+      "COMI 1225",
+      "COMI 1510",
+      "COMI 2040"
+    ]
+  },
+  "COMI 1225": {
+    "text": "COMI 1150 or COMI 1215 or COMI 1510 or COMI 2040",
+    "courses": [
+      "COMI 1150",
+      "COMI 1215",
+      "COMI 1510",
+      "COMI 2040"
+    ]
+  },
+  "COMI 1240": {
+    "text": "COMI 1150 or COMI 1215 or COMI 1225 or COMI 1510 or COMI 2040",
+    "courses": [
+      "COMI 1150",
+      "COMI 1215",
+      "COMI 1225",
+      "COMI 1510",
+      "COMI 2040"
+    ]
+  },
+  "COMI 1350": {
+    "text": "COMI 1150 or COMI 1300 or COMI 1260",
+    "courses": [
+      "COMI 1150",
+      "COMI 1260",
+      "COMI 1300"
+    ]
+  },
+  "COMI 1510": {
+    "text": "COMI 1150 or COMI 1215 or COMI 1225 or COMI 1240 or COMI 2040",
+    "courses": [
+      "COMI 1150",
+      "COMI 1215",
+      "COMI 1225",
+      "COMI 1240",
+      "COMI 2040"
+    ]
+  },
+  "COMI 1770": {
+    "text": "COMI 1750",
+    "courses": [
+      "COMI 1750"
+    ]
+  },
+  "COMI 2010": {
+    "text": "COMI 1150",
+    "courses": [
+      "COMI 1150"
+    ]
+  },
+  "COMI 2038": {
+    "text": "CNVT 1820 or COMI 1800 or COMI 2037",
+    "courses": [
+      "CNVT 1820",
+      "COMI 1800",
+      "COMI 2037"
+    ]
+  },
+  "COMI 2040": {
+    "text": "COMI 1150 or COMI 1215 or COMI 1225 or COMI 1510",
+    "courses": [
+      "COMI 1150",
+      "COMI 1215",
+      "COMI 1225",
+      "COMI 1510"
+    ]
+  },
+  "COMI 2225": {
+    "text": "COMI 1225",
+    "courses": [
+      "COMI 1225"
+    ]
+  },
+  "COMI 2510": {
+    "text": "COMI 1510",
+    "courses": [
+      "COMI 1510"
+    ]
+  },
+  "COMI 2520": {
+    "text": "COMI 2510 or COMI 2225",
+    "courses": [
+      "COMI 2225",
+      "COMI 2510"
+    ]
+  },
+  "COMI 2530": {
+    "text": "COMI 2510 (may be taken concurrently) or COMI 2225",
+    "courses": [
+      "COMI 2225",
+      "COMI 2510"
+    ]
+  },
+  "COMI 2900": {
+    "text": "COMI 1350 (may be taken concurrently)",
+    "courses": [
+      "COMI 1350"
+    ]
+  },
+  "COMM 1005": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1010": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 ) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1013": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1075": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1110": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1180": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1201": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1203": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1204": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1300": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1400": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "COMM 1600": {
+    "text": "COMM 1010 (may be taken concurrently)",
+    "courses": [
+      "COMM 1010"
+    ]
+  },
+  "COMM 2010": {
+    "text": "COMM 1010",
+    "courses": [
+      "COMM 1010"
+    ]
+  },
+  "COMM 2020": {
+    "text": "COMM 1010",
+    "courses": [
+      "COMM 1010"
+    ]
+  },
+  "COMM 2025": {
+    "text": "COMM 1010",
+    "courses": [
+      "COMM 1010"
+    ]
+  },
+  "COMM 2030": {
+    "text": "COMM 1010",
+    "courses": [
+      "COMM 1010"
+    ]
+  },
+  "COMP 2500": {
+    "text": "CNVT 1830 (may be taken concurrently) and COMI 2037",
+    "courses": [
+      "CNVT 1830",
+      "COMI 2037"
+    ]
+  },
+  "CRPT 1120": {
+    "text": "CRPT 1110",
+    "courses": [
+      "CRPT 1110"
+    ]
+  },
+  "CRPT 1140": {
+    "text": "CRPT 1130",
+    "courses": [
+      "CRPT 1130"
+    ]
+  },
+  "CRPT 1160": {
+    "text": "CRPT 1140",
+    "courses": [
+      "CRPT 1140"
+    ]
+  },
+  "CTIC 2010": {
+    "text": "CTIC 1010 and CTIC 1020 and CTIC 1030",
+    "courses": [
+      "CTIC 1010",
+      "CTIC 1020",
+      "CTIC 1030"
+    ]
+  },
+  "CULN 1015": {
+    "text": "Serve Safe Certification",
+    "courses": []
+  },
+  "CULN 1025": {
+    "text": "CULN 1015 (may be taken concurrently)",
+    "courses": [
+      "CULN 1015"
+    ]
+  },
+  "CULN 1035": {
+    "text": "CULN 1015",
+    "courses": [
+      "CULN 1015"
+    ]
+  },
+  "CULN 1040": {
+    "text": "CULN 1015",
+    "courses": [
+      "CULN 1015"
+    ]
+  },
+  "CULN 2010": {
+    "text": "CULN 1015 and CULN 1035",
+    "courses": [
+      "CULN 1015",
+      "CULN 1035"
+    ]
+  },
+  "CULN 2020": {
+    "text": "CULN 1015 and CULN 1025 and CULN 1035",
+    "courses": [
+      "CULN 1015",
+      "CULN 1025",
+      "CULN 1035"
+    ]
+  },
+  "CULN 2030": {
+    "text": "CULN 1015",
+    "courses": [
+      "CULN 1015"
+    ]
+  },
+  "CULN 2040": {
+    "text": "CULN 1015 and CULN 1040",
+    "courses": [
+      "CULN 1015",
+      "CULN 1040"
+    ]
+  },
+  "CYBR 1100": {
+    "text": "COMI 2037 and CNVT 1830",
+    "courses": [
+      "CNVT 1830",
+      "COMI 2037"
+    ]
+  },
+  "CYBR 1200": {
+    "text": "CNVT 1830 and COMI 2037",
+    "courses": [
+      "CNVT 1830",
+      "COMI 2037"
+    ]
+  },
+  "DAST 1040": {
+    "text": "DAST 1010",
+    "courses": [
+      "DAST 1010"
+    ]
+  },
+  "DAST 1050": {
+    "text": "( BIOL 1070 or BIOL 1020) or BIOL 2201",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 1070",
+      "BIOL 2201"
+    ]
+  },
+  "DAST 1060": {
+    "text": "DAST 1050 (may be taken concurrently)",
+    "courses": [
+      "DAST 1050"
+    ]
+  },
+  "DAST 1225": {
+    "text": "DENT 2225 (may be taken concurrently)",
+    "courses": [
+      "DENT 2225"
+    ]
+  },
+  "DENT 1000E": {
+    "text": "(English Wrtg Course Placement and Reading Course Placement or ENGL 0305 ) or (English Wrtg Course Placement and Reading Course Placement or ENGL 0305 )",
+    "courses": [
+      "ENGL 0305"
+    ]
+  },
+  "DENT 2225": {
+    "text": "DAST 1225 (may be taken concurrently)",
+    "courses": [
+      "DAST 1225"
+    ]
+  },
+  "DHYG 1030": {
+    "text": "DHYG 1020 (may be taken concurrently)",
+    "courses": [
+      "DHYG 1020"
+    ]
+  },
+  "DHYG 1050": {
+    "text": "DHYG 1020 and DHYG 1030",
+    "courses": [
+      "DHYG 1020",
+      "DHYG 1030"
+    ]
+  },
+  "DHYG 1060": {
+    "text": "DHYG 1030",
+    "courses": [
+      "DHYG 1030"
+    ]
+  },
+  "DHYG 2010": {
+    "text": "(BIOL 1020 or BIOL 2202 ) and DHYG 1040",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 2202",
+      "DHYG 1040"
+    ]
+  },
+  "DHYG 2020": {
+    "text": "DHYG 1050 and DHYG 1060",
+    "courses": [
+      "DHYG 1050",
+      "DHYG 1060"
+    ]
+  },
+  "DHYG 2030": {
+    "text": "DHYG 1030 and DHYG 1060 and DHYG 2090",
+    "courses": [
+      "DHYG 1030",
+      "DHYG 1060",
+      "DHYG 2090"
+    ]
+  },
+  "DHYG 2040": {
+    "text": "PSYC 2010 and DHYG 1060",
+    "courses": [
+      "DHYG 1060",
+      "PSYC 2010"
+    ]
+  },
+  "DHYG 2045": {
+    "text": "DHYG 1010 or DHYG 2020 or DHYG 2030",
+    "courses": [
+      "DHYG 1010",
+      "DHYG 2020",
+      "DHYG 2030"
+    ]
+  },
+  "DHYG 2050": {
+    "text": "BIOL 1020 or BIOL 2210",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 2210"
+    ]
+  },
+  "DHYG 2060": {
+    "text": "DHYG 2020 and DHYG 2030",
+    "courses": [
+      "DHYG 2020",
+      "DHYG 2030"
+    ]
+  },
+  "DHYG 2070": {
+    "text": "DHYG 1030 and DHYG 1060 and DHYG 2030",
+    "courses": [
+      "DHYG 1030",
+      "DHYG 1060",
+      "DHYG 2030"
+    ]
+  },
+  "DHYG 2090": {
+    "text": "(BIOL 1020 and DHYG 1020 ) or ( BIOL 2201 and BIOL 2202 and DHYG 1020 )",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 2201",
+      "BIOL 2202",
+      "DHYG 1020"
+    ]
+  },
+  "DMSD 2230": {
+    "text": "DMSD 2210 (may be taken concurrently) and DMSD 2220 and DMSD 2245",
+    "courses": [
+      "DMSD 2210",
+      "DMSD 2220",
+      "DMSD 2245"
+    ]
+  },
+  "DMSD 2235": {
+    "text": "DMSD 2230",
+    "courses": [
+      "DMSD 2230"
+    ]
+  },
+  "DMSD 2236": {
+    "text": "DMSD 2210",
+    "courses": [
+      "DMSD 2210"
+    ]
+  },
+  "DMSD 2240": {
+    "text": "DMSD 2235",
+    "courses": [
+      "DMSD 2235"
+    ]
+  },
+  "DMSD 2241": {
+    "text": "DMSD 2230",
+    "courses": [
+      "DMSD 2230"
+    ]
+  },
+  "DMSD 2242": {
+    "text": "DMSD 2241",
+    "courses": [
+      "DMSD 2241"
+    ]
+  },
+  "DMSD 2243": {
+    "text": "DMSD 2242",
+    "courses": [
+      "DMSD 2242"
+    ]
+  },
+  "DMSD 2250": {
+    "text": "DMSD 2210 and DMSD 2220 and DMSD 2245",
+    "courses": [
+      "DMSD 2210",
+      "DMSD 2220",
+      "DMSD 2245"
+    ]
+  },
+  "DMSD 2251": {
+    "text": "DMSD 2250",
+    "courses": [
+      "DMSD 2250"
+    ]
+  },
+  "DMSD 2252": {
+    "text": "DMSD 2251",
+    "courses": [
+      "DMSD 2251"
+    ]
+  },
+  "DMSD 2253": {
+    "text": "DMSD 2250",
+    "courses": [
+      "DMSD 2250"
+    ]
+  },
+  "DMSD 2254": {
+    "text": "DMSD 2251",
+    "courses": [
+      "DMSD 2251"
+    ]
+  },
+  "DMSD 2255": {
+    "text": "DMSD 2252",
+    "courses": [
+      "DMSD 2252"
+    ]
+  },
+  "DMSD 2260": {
+    "text": "DMSD 2210 and DMSD 2220 and DMSD 2245",
+    "courses": [
+      "DMSD 2210",
+      "DMSD 2220",
+      "DMSD 2245"
+    ]
+  },
+  "DMSD 2261": {
+    "text": "DMSD 2260",
+    "courses": [
+      "DMSD 2260"
+    ]
+  },
+  "DMSD 2262": {
+    "text": "DMSD 2261",
+    "courses": [
+      "DMSD 2261"
+    ]
+  },
+  "DMSD 2263": {
+    "text": "DMSD 2260",
+    "courses": [
+      "DMSD 2260"
+    ]
+  },
+  "DMSD 2264": {
+    "text": "DMSD 2263",
+    "courses": [
+      "DMSD 2263"
+    ]
+  },
+  "DMSD 2265": {
+    "text": "DMSD 2264",
+    "courses": [
+      "DMSD 2264"
+    ]
+  },
+  "DMSD 2500": {
+    "text": "DMSD 2240 or DMSD 2252 or DMSD 2262",
+    "courses": [
+      "DMSD 2240",
+      "DMSD 2252",
+      "DMSD 2262"
+    ]
+  },
+  "ECON 2030": {
+    "text": "(MATH 0600 or MATH 0100 (may be taken concurrently) or MATH 0101 (may be taken concurrently) or Math Placement)",
+    "courses": [
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600"
+    ]
+  },
+  "ECON 2040": {
+    "text": "(MATH 0600 or MATH 0101 (may be taken concurrently) or MATH 0100 (may be taken concurrently) or Math Placement)",
+    "courses": [
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600"
+    ]
+  },
+  "EMER 1030": {
+    "text": "EMER 1000",
+    "courses": [
+      "EMER 1000"
+    ]
+  },
+  "EMER 1040": {
+    "text": "ENGL 2100 or ENGL 1010 or ENGL 1010A",
+    "courses": [
+      "ENGL 1010",
+      "ENGL 1010A",
+      "ENGL 2100"
+    ]
+  },
+  "EMER 2010": {
+    "text": "EMER 1000",
+    "courses": [
+      "EMER 1000"
+    ]
+  },
+  "EMER 2020": {
+    "text": "EMER 1000",
+    "courses": [
+      "EMER 1000"
+    ]
+  },
+  "EMER 2030": {
+    "text": "EMER 1000",
+    "courses": [
+      "EMER 1000"
+    ]
+  },
+  "EMER 2500": {
+    "text": "EMER 1000 and EMER 1030 and EMER 2010 and EMER 2020",
+    "courses": [
+      "EMER 1000",
+      "EMER 1030",
+      "EMER 2010",
+      "EMER 2020"
+    ]
+  },
+  "ENGL 0250": {
+    "text": "(English Wrtg Course Placement and ENGL 0850 or ENGL 0890 or ENGL 1002 or ENGL 0700 (may be taken concurrently)) or (English Wrtg Course Placement and Reading Course Placement or Reading Course Placement or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0700",
+      "ENGL 0850",
+      "ENGL 0890",
+      "ENGL 1002"
+    ]
+  },
+  "ENGL 0305": {
+    "text": "Reading Course Placement",
+    "courses": []
+  },
+  "ENGL 0312": {
+    "text": "( ENGL 0305 and ENGL 1070 ) or (Reading Course Placement and ENGL 1070 ) or (Reading Course Placement and English Wrtg Course Placement) or (Reading Course Placement and English Wrtg Course Placement) or (Reading Course Placement and English Wrtg Course Placement) or (English Wrtg Course Placement and ENGL 0305 ) or ( ENGL 1080 and ENGL 0305 )",
+    "courses": [
+      "ENGL 0305",
+      "ENGL 1070",
+      "ENGL 1080"
+    ]
+  },
+  "ENGL 0500": {
+    "text": "(English Wrtg Course Placement or ENGL 0250 and ENGL 0850 (may be taken concurrently)) or (English Wrtg Course Placement and ENGL 0850 (may be taken concurrently)) or (English Wrtg Course Placement and Reading Course Placement or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0250",
+      "ENGL 0850"
+    ]
+  },
+  "ENGL 0700": {
+    "text": "Reading Course Placement or (Bachelor Degree or higher)",
+    "courses": []
+  },
+  "ENGL 0850": {
+    "text": "ENGL 0700 or Reading Course Placement or ENGL 8080 or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0700",
+      "ENGL 8080"
+    ]
+  },
+  "ENGL 0950": {
+    "text": "( ENGL 0250 or English Wrtg Course Placement) and (Reading Course Placement or ENGL 0700 ) or EVIDENCE-BASED READ/WRIT SCORE",
+    "courses": [
+      "ENGL 0250",
+      "ENGL 0700"
+    ]
+  },
+  "ENGL 1002": {
+    "text": "ENGL 0850 or Reading Course Placement or Bachelor Degree or higher",
+    "courses": [
+      "ENGL 0850"
+    ]
+  },
+  "ENGL 1005": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 8500 or ENGL 0890 (may be taken concurrently)) or (English Wrtg Course Placement and ENGL 0890 or ENGL 0950 or ENGL 1002 (may be taken concurrently)) or (English Wrtg Course Placement and Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 8500"
+    ]
+  },
+  "ENGL 1005A": {
+    "text": "( ENGL 0500 or ENGL 8500 or ENGL 0950 or English Wrtg Test Score or English Wrtg Course Placement) and (ENGL 0890 or ENGL 1002 or Reading Course Placement or ALP Writing Eligible) or (English Wrtg Test Score or English Wrtg Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 8500"
+    ]
+  },
+  "ENGL 1010": {
+    "text": "(English Wrtg Test Score or English Wrtg Course Placement or ENGL 1050 or ENGL 1005 or ENGL 1005A ) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1050"
+    ]
+  },
+  "ENGL 1010A": {
+    "text": "(English Wrtg Test Score or English Wrtg Course Placement or ENGL 1005A (may be taken concurrently)) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 1005A"
+    ]
+  },
+  "ENGL 1070": {
+    "text": "ESL Wrtg Test Score",
+    "courses": []
+  },
+  "ENGL 1080": {
+    "text": "ESL Wrtg Test Score or ENGL 1070",
+    "courses": [
+      "ENGL 1070"
+    ]
+  },
+  "ENGL 1081": {
+    "text": "( ENGL 0850 or ENGL 0950 or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0850",
+      "ENGL 0950"
+    ]
+  },
+  "ENGL 1082": {
+    "text": "( ENGL 1005 or ENGL 1005A or ENGL 1050) or English Wrtg Test Score",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1050"
+    ]
+  },
+  "ENGL 1090": {
+    "text": "ESL Wrtg Test Score or ENGL 1080",
+    "courses": [
+      "ENGL 1080"
+    ]
+  },
+  "ENGL 1120": {
+    "text": "ENGL 1070 or English Wrtg Course Placement",
+    "courses": [
+      "ENGL 1070"
+    ]
+  },
+  "ENGL 1130": {
+    "text": "( ENGL 1080 or ESL Wrtg Test Score)",
+    "courses": [
+      "ENGL 1080"
+    ]
+  },
+  "ENGL 1300": {
+    "text": "ESL Wrtg Test Score or ENGL 1090",
+    "courses": [
+      "ENGL 1090"
+    ]
+  },
+  "ENGL 1300E": {
+    "text": "(ESL Wrtg Test Score or ENGL 1090 )",
+    "courses": [
+      "ENGL 1090"
+    ]
+  },
+  "ENGL 1410": {
+    "text": "ENGL 1010 or ENGL 1010A",
+    "courses": [
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ENGL 1430": {
+    "text": "ENGL 1010 or ENGL 1010A",
+    "courses": [
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ENGL 2010": {
+    "text": "ENGL 1010 or ENGL 1010A",
+    "courses": [
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ENGL 2015": {
+    "text": "ENGL 1010 or ENGL 1010A",
+    "courses": [
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ENGL 2050": {
+    "text": "ENGL 1010",
+    "courses": [
+      "ENGL 1010"
+    ]
+  },
+  "ENGL 2100": {
+    "text": "(ENGL 1050 or ENGL 1005 or ENGL 1005A ) or (English Wrtg Test Score or ENGL 1010 or ENGL 1010A )",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1010",
+      "ENGL 1010A",
+      "ENGL 1050"
+    ]
+  },
+  "ENGL 2120": {
+    "text": "(English Wrtg Test Score or ENGL 1005 or ENGL 1005A )",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A"
+    ]
+  },
+  "ENGL 2240": {
+    "text": "English Wrtg Test Score or ENGL 1010",
+    "courses": [
+      "ENGL 1010"
+    ]
+  },
+  "ENGL 2310": {
+    "text": "ENGL 1005 or ENGL 1005A or ENGL 1010 or ENGL 1010A or English Wrtg Test Score",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "ENGR 1020": {
+    "text": "MATH 0600 (may be taken concurrently) or MATH 0095 or MATH 0101 (may be taken concurrently) or MATH 0100 or Math Placement or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600"
+    ]
+  },
+  "ENGR 1220": {
+    "text": "MATH 1200 or MATH 1200C or MATH 1179 or MATH 1750 or Math Placement",
+    "courses": [
+      "MATH 1179",
+      "MATH 1200",
+      "MATH 1200C",
+      "MATH 1750"
+    ]
+  },
+  "ENGR 2050": {
+    "text": "(MATH 1910 or MATH 2141 )",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141"
+    ]
+  },
+  "ENGR 2060": {
+    "text": "ENGR 2050 and (MATH 1920 or MATH 2142 )",
+    "courses": [
+      "ENGR 2050",
+      "MATH 1920",
+      "MATH 2142"
+    ]
+  },
+  "ENGR 2160": {
+    "text": "MATH 1910 (may be taken concurrently) or MATH 2141 (may be taken concurrently)",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141"
+    ]
+  },
+  "ENGR 2320": {
+    "text": "MATH 2141 (may be taken concurrently)",
+    "courses": [
+      "MATH 2141"
+    ]
+  },
+  "ENGR 2520": {
+    "text": "MATH 2141 (may be taken concurrently) or MATH 1910 (may be taken concurrently)",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141"
+    ]
+  },
+  "ENGR 2540": {
+    "text": "ENGR 2050",
+    "courses": [
+      "ENGR 2050"
+    ]
+  },
+  "ENGR 2620": {
+    "text": "(ENGR 2150 or PHYS 1500 ) and (MATH 2990 (may be taken concurrently) or MATH 2362 (may be taken concurrently))",
+    "courses": [
+      "ENGR 2150",
+      "MATH 2362",
+      "MATH 2990",
+      "PHYS 1500"
+    ]
+  },
+  "ENGR 2621": {
+    "text": "ENGR 2620 (may be taken concurrently)",
+    "courses": [
+      "ENGR 2620"
+    ]
+  },
+  "ENGT 2090": {
+    "text": "ENGR 1030",
+    "courses": [
+      "ENGR 1030"
+    ]
+  },
+  "ETCN 1200": {
+    "text": "ETCN 1100",
+    "courses": [
+      "ETCN 1100"
+    ]
+  },
+  "ETCN 1300": {
+    "text": "ENGR 1030 (may be taken concurrently) and ETME 1020 (may be taken concurrently) and ETCN 1100 (may be taken concurrently)",
+    "courses": [
+      "ENGR 1030",
+      "ETCN 1100",
+      "ETME 1020"
+    ]
+  },
+  "ETCN 2200": {
+    "text": "ETCN 1300 (may be taken concurrently) and ETCN 2100 (may be taken concurrently)",
+    "courses": [
+      "ETCN 1300",
+      "ETCN 2100"
+    ]
+  },
+  "ETCN 2300": {
+    "text": "ENGR 1030 (may be taken concurrently) and ENGT 2090 (may be taken concurrently)",
+    "courses": [
+      "ENGR 1030",
+      "ENGT 2090"
+    ]
+  },
+  "ETCN 2500": {
+    "text": "ETEE 1800 (may be taken concurrently) or ( ETCN 2100 (may be taken concurrently) and ETCN 2200 (may be taken concurrently) and ETCN 2300 (may be taken concurrently))",
+    "courses": [
+      "ETCN 2100",
+      "ETCN 2200",
+      "ETCN 2300",
+      "ETEE 1800"
+    ]
+  },
+  "FILM 1010": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "FILM 1020": {
+    "text": "FILM 1010 and COMM 1300",
+    "courses": [
+      "COMM 1300",
+      "FILM 1010"
+    ]
+  },
+  "FILM 1204": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "FILM 1205": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "FILM 2100": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "FILM 2110": {
+    "text": "FILM 1010",
+    "courses": [
+      "FILM 1010"
+    ]
+  },
+  "FILM 2150": {
+    "text": "FILM 1020 or COMM 1000",
+    "courses": [
+      "COMM 1000",
+      "FILM 1020"
+    ]
+  },
+  "FILM 2200": {
+    "text": "COMM 1000 or FILM 1020",
+    "courses": [
+      "COMM 1000",
+      "FILM 1020"
+    ]
+  },
+  "FILM 2210": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "FILM 2250": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "FILM 2300": {
+    "text": "COMM 1000 or FILM 1020",
+    "courses": [
+      "COMM 1000",
+      "FILM 1020"
+    ]
+  },
+  "FILM 2310": {
+    "text": "COMM 1000 or FILM 1020",
+    "courses": [
+      "COMM 1000",
+      "FILM 1020"
+    ]
+  },
+  "FILM 2350": {
+    "text": "COMM 1000 or FILM 1020",
+    "courses": [
+      "COMM 1000",
+      "FILM 1020"
+    ]
+  },
+  "FILM 2370": {
+    "text": "COMM 1000 (may be taken concurrently) or FILM 1020",
+    "courses": [
+      "COMM 1000",
+      "FILM 1020"
+    ]
+  },
+  "FILM 2400": {
+    "text": "(COMM 1000 or FILM 1020 )",
+    "courses": [
+      "COMM 1000",
+      "FILM 1020"
+    ]
+  },
+  "FIRE 1020": {
+    "text": "FIRE 1030",
+    "courses": [
+      "FIRE 1030"
+    ]
+  },
+  "FIRE 1040": {
+    "text": "FIRE 1030",
+    "courses": [
+      "FIRE 1030"
+    ]
+  },
+  "FIRE 1050": {
+    "text": "FIRE 1020",
+    "courses": [
+      "FIRE 1020"
+    ]
+  },
+  "FIRE 1070": {
+    "text": "FIRE 1020",
+    "courses": [
+      "FIRE 1020"
+    ]
+  },
+  "FIRE 1090": {
+    "text": "MATH 1420 or MATH 1700 or MATH 1025",
+    "courses": [
+      "MATH 1025",
+      "MATH 1420",
+      "MATH 1700"
+    ]
+  },
+  "FIRE 1100": {
+    "text": "FIRE 1030",
+    "courses": [
+      "FIRE 1030"
+    ]
+  },
+  "FREN 1040": {
+    "text": "FREN 1010 or FREN 1030",
+    "courses": [
+      "FREN 1010",
+      "FREN 1030"
+    ]
+  },
+  "FREN 2010": {
+    "text": "FREN 1020 or FREN 1040",
+    "courses": [
+      "FREN 1020",
+      "FREN 1040"
+    ]
+  },
+  "FREN 2020": {
+    "text": "FREN 2010",
+    "courses": [
+      "FREN 2010"
+    ]
+  },
+  "GERM 1040": {
+    "text": "GERM 1010 or GERM 1030",
+    "courses": [
+      "GERM 1010",
+      "GERM 1030"
+    ]
+  },
+  "GERM 2010": {
+    "text": "GERM 1020 or GERM 1040",
+    "courses": [
+      "GERM 1020",
+      "GERM 1040"
+    ]
+  },
+  "GERM 2020": {
+    "text": "GERM 2010",
+    "courses": [
+      "GERM 2010"
+    ]
+  },
+  "HEAL 1000": {
+    "text": "Accuplacer Rdg Test Score or NG-Accuplacer Rdg Test Score or ENGL 0890 or ENGL 1002 or Bachelor Degree or higher",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 1002"
+    ]
+  },
+  "HEAL 1055": {
+    "text": "BIOL 1010 and BIOL 1020",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1020"
+    ]
+  },
+  "HEAL 1060": {
+    "text": "MATH 0500 or MATH 0095 or MATH 0100 or MATH 0101 or MATH 8055 or MATH 0099 or Accu Arithmetic Test Score or NG-Accu Arithmetic Test Score or Bachelor Degree or higher",
+    "courses": [
+      "MATH 0095",
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "HEAL 1070": {
+    "text": "(BIOL 1010 and BIOL 1020) or ( BIOL 2201 and BIOL 2202 )",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1020",
+      "BIOL 2201",
+      "BIOL 2202"
+    ]
+  },
+  "HMNS 1140": {
+    "text": "HMNS 1130",
+    "courses": [
+      "HMNS 1130"
+    ]
+  },
+  "HMNS 1200": {
+    "text": "HMNS 1010 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 1210": {
+    "text": "HMNS 1010 and HMNS 2100",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2100"
+    ]
+  },
+  "HMNS 1220": {
+    "text": "HMNS 1010 and HMNS 2060 or HMNS 2070",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2060",
+      "HMNS 2070"
+    ]
+  },
+  "HMNS 2030": {
+    "text": "HMNS 2100 and HMNS 2120",
+    "courses": [
+      "HMNS 2100",
+      "HMNS 2120"
+    ]
+  },
+  "HMNS 2120": {
+    "text": "HMNS 2100",
+    "courses": [
+      "HMNS 2100"
+    ]
+  },
+  "HMNS 2130": {
+    "text": "HMNS 2200",
+    "courses": [
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2135": {
+    "text": "HMNS 1010 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2208": {
+    "text": "HMNS 1010 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2220": {
+    "text": "HMNS 2110",
+    "courses": [
+      "HMNS 2110"
+    ]
+  },
+  "HMNS 2230": {
+    "text": "HMNS 2110",
+    "courses": [
+      "HMNS 2110"
+    ]
+  },
+  "HMNS 2310": {
+    "text": "HMNS 1010 and HMNS 2100 and HMNS 1210 and HMNS 2120 (may be taken concurrently)",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1210",
+      "HMNS 2100",
+      "HMNS 2120"
+    ]
+  },
+  "HMNS 2320": {
+    "text": "HMNS 1010 and HMNS 1220 and HMNS 2060 or HMNS 2070",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1220",
+      "HMNS 2060",
+      "HMNS 2070"
+    ]
+  },
+  "HMNS 2340": {
+    "text": "HMNS 1010 and HMNS 1200 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1200",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2360": {
+    "text": "HMNS 1010 and HMNS 1200 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1200",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2410": {
+    "text": "HMNS 1010 and HMNS 1210 and HMNS 2100 and HMNS 2120 and HMNS 2310",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1210",
+      "HMNS 2100",
+      "HMNS 2120",
+      "HMNS 2310"
+    ]
+  },
+  "HMNS 2420": {
+    "text": "HMNS 1220 and HMNS 1010 and HMNS 2320 and HMNS 2060 or HMNS 2070",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1220",
+      "HMNS 2060",
+      "HMNS 2070",
+      "HMNS 2320"
+    ]
+  },
+  "HMNS 2440": {
+    "text": "HMNS 1010 and HMNS 1200 and HMNS 2200 and HMNS 2340",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1200",
+      "HMNS 2200",
+      "HMNS 2340"
+    ]
+  },
+  "HMNS 2460": {
+    "text": "HMNS 1010 and HMNS 1200 and HMNS 2200 and HMNS 2360",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1200",
+      "HMNS 2200",
+      "HMNS 2360"
+    ]
+  },
+  "HMNS 2515": {
+    "text": "HMNS 1010 and HMNS 1090",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1090"
+    ]
+  },
+  "HMNS 2520": {
+    "text": "HMNS 1010 and HMNS 2200 and HMNS 1090 (may be taken concurrently)",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 1090",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2530": {
+    "text": "HMNS 1010 and HMNS 2200 (may be taken concurrently)",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2540": {
+    "text": "HMNS 1010 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2560": {
+    "text": "HMNS 1010 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2590": {
+    "text": "HMNS 1010 and HMNS 2200",
+    "courses": [
+      "HMNS 1010",
+      "HMNS 2200"
+    ]
+  },
+  "HMNS 2900": {
+    "text": "( HMNS 1210 and HMNS 2310 and HMNS 2410 (may be taken concurrently)) or ( HMNS 1220 and HMNS 2320 and HMNS 2420 (may be taken concurrently)) or ( HMNS 1200 and HMNS 2340 and HMNS 2440 (may be taken concurrently)) or ( HMNS 1200 and HMNS 2360 and HMNS 2460 (may be taken concurrently))",
+    "courses": [
+      "HMNS 1200",
+      "HMNS 1210",
+      "HMNS 1220",
+      "HMNS 2310",
+      "HMNS 2320",
+      "HMNS 2340",
+      "HMNS 2360",
+      "HMNS 2410",
+      "HMNS 2420",
+      "HMNS 2440",
+      "HMNS 2460"
+    ]
+  },
+  "HSTO 1320": {
+    "text": "HSTO 1310",
+    "courses": [
+      "HSTO 1310"
+    ]
+  },
+  "HSTO 2310": {
+    "text": "HSTO 1320",
+    "courses": [
+      "HSTO 1320"
+    ]
+  },
+  "HSTO 2320": {
+    "text": "HSTO 2310",
+    "courses": [
+      "HSTO 2310"
+    ]
+  },
+  "HSTO 2330": {
+    "text": "HSTO 2310",
+    "courses": [
+      "HSTO 2310"
+    ]
+  },
+  "INTC 1400": {
+    "text": "( RHAB 1010 and High School Transcript rec'd and Oral Proficiency Spanish) and (ENGL 0890 or ENGL 1002 or Accuplacer Rdg Test Score)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 1002",
+      "RHAB 1010"
+    ]
+  },
+  "ITAL 1040": {
+    "text": "ITAL 1010 or ITAL 1030",
+    "courses": [
+      "ITAL 1010",
+      "ITAL 1030"
+    ]
+  },
+  "ITAL 2010": {
+    "text": "ITAL 1020 or ITAL 1040",
+    "courses": [
+      "ITAL 1020",
+      "ITAL 1040"
+    ]
+  },
+  "ITAL 2020": {
+    "text": "ITAL 2010",
+    "courses": [
+      "ITAL 2010"
+    ]
+  },
+  "ITAL 2210": {
+    "text": "ITAL 2020",
+    "courses": [
+      "ITAL 2020"
+    ]
+  },
+  "ITAL 2220": {
+    "text": "ITAL 2210",
+    "courses": [
+      "ITAL 2210"
+    ]
+  },
+  "JAPN 1100": {
+    "text": "JAPN 1000",
+    "courses": [
+      "JAPN 1000"
+    ]
+  },
+  "JOUR 1050": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "JOUR 1150": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 0890 or ENGL 0950 or ENGL 1002 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "JOUR 1200": {
+    "text": "(English Wrtg Course Placement or ENGL 0500 or ENGL 1005 or ENGL 1010 ) and (Reading Course Placement or ENGL 1002 or ENGL 0890 or ENGL 0950 )",
+    "courses": [
+      "ENGL 0500",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1010"
+    ]
+  },
+  "JOUR 2000": {
+    "text": "JOUR 1150",
+    "courses": [
+      "JOUR 1150"
+    ]
+  },
+  "JOUR 2050": {
+    "text": "JOUR 1150",
+    "courses": [
+      "JOUR 1150"
+    ]
+  },
+  "JOUR 2221": {
+    "text": "COMM 2000 (may be taken concurrently) or JOUR 2000 (may be taken concurrently)",
+    "courses": [
+      "COMM 2000",
+      "JOUR 2000"
+    ]
+  },
+  "LAWS 1040": {
+    "text": "LAWS 1030",
+    "courses": [
+      "LAWS 1030"
+    ]
+  },
+  "LAWS 2020": {
+    "text": "LAWS 1080",
+    "courses": [
+      "LAWS 1080"
+    ]
+  },
+  "LAWS 2090": {
+    "text": "ENGL 1010 and LAWS 1080",
+    "courses": [
+      "ENGL 1010",
+      "LAWS 1080"
+    ]
+  },
+  "LAWS 2095": {
+    "text": "LAWS 2090",
+    "courses": [
+      "LAWS 2090"
+    ]
+  },
+  "LAWS 2100": {
+    "text": "LAWS 1080",
+    "courses": [
+      "LAWS 1080"
+    ]
+  },
+  "LAWS 2500": {
+    "text": "LAWS 1010 and LAWS 1020 and LAWS 1030 and LAWS 2010 and LAWS 2030",
+    "courses": [
+      "LAWS 1010",
+      "LAWS 1020",
+      "LAWS 1030",
+      "LAWS 2010",
+      "LAWS 2030"
+    ]
+  },
+  "LIBA 1010": {
+    "text": "( ENGL 1005 or ENGL 1005A ) or ( ENGL 1010 or ENGL 1010A )",
+    "courses": [
+      "ENGL 1005",
+      "ENGL 1005A",
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "LIBA 1020": {
+    "text": "LIBA 1010",
+    "courses": [
+      "LIBA 1010"
+    ]
+  },
+  "LIBA 2030": {
+    "text": "ENGL 1010 or ENGL 1010A",
+    "courses": [
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "MAMC 2010": {
+    "text": "MAMC 1010 and MAMC 1020",
+    "courses": [
+      "MAMC 1010",
+      "MAMC 1020"
+    ]
+  },
+  "MAMC 2020": {
+    "text": "MAMC 1010 and MAMC 1020",
+    "courses": [
+      "MAMC 1010",
+      "MAMC 1020"
+    ]
+  },
+  "MATH 0095": {
+    "text": "( and ENGL 0850 (may be taken concurrently) or ENGL 0312 or ENGL 0950 (may be taken concurrently)) or ( and Reading Course Placement) or ( and Reading Course Placement)",
+    "courses": [
+      "ENGL 0312",
+      "ENGL 0850",
+      "ENGL 0950"
+    ]
+  },
+  "MATH 0099": {
+    "text": "MATH 0095 (may be taken concurrently)",
+    "courses": [
+      "MATH 0095"
+    ]
+  },
+  "MATH 0100": {
+    "text": "MATH 0095 (may be taken concurrently)",
+    "courses": [
+      "MATH 0095"
+    ]
+  },
+  "MATH 0101": {
+    "text": "MATH 0095 (may be taken concurrently)",
+    "courses": [
+      "MATH 0095"
+    ]
+  },
+  "MATH 0239C": {
+    "text": "MATH 1139C (may be taken concurrently)",
+    "courses": [
+      "MATH 1139C"
+    ]
+  },
+  "MATH 1005": {
+    "text": "( MATH 0099 or MATH 0500 or MATH 8055 or MATH 0100 or MATH 0101 or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1015": {
+    "text": "( MATH 0095 or MATH 0100 or MATH 0600 or MATH 0101 or MATH 8055 or MATH 1005 or MATH 1600 or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 1005",
+      "MATH 1600",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1025": {
+    "text": "( MATH 0099 or MATH 0500 or MATH 8055 or MATH 0100 or MATH 0101 or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1080": {
+    "text": "( MATH 0099 or Math Placement) and ( ENGL 0850 or Reading Course Placement or Reading Course Placement)",
+    "courses": [
+      "ENGL 0850",
+      "MATH 0099"
+    ]
+  },
+  "MATH 1139": {
+    "text": "( MATH 0095 or MATH 0100 or MATH 0101 or MATH 0600 or MATH 1025 or MATH 1420 or MATH 8055 or MATH 8025C or MATH 8225C or Math Placement)",
+    "courses": [
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 1025",
+      "MATH 1420",
+      "MATH 8025C",
+      "MATH 8055",
+      "MATH 8225C"
+    ]
+  },
+  "MATH 1139C": {
+    "text": "( MATH 0099 or MATH 0100 or MATH 0500 or MATH 0101 or MATH 8055 or Math Placement)",
+    "courses": [
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1143": {
+    "text": "MATH 0100 or MATH 0101 or Math Placement",
+    "courses": [
+      "MATH 0100",
+      "MATH 0101"
+    ]
+  },
+  "MATH 1144": {
+    "text": "( MATH 1143 or MATH 8143)",
+    "courses": [
+      "MATH 1143",
+      "MATH 8143"
+    ]
+  },
+  "MATH 1145": {
+    "text": "MATH 1139 or MATH 1430 or Math Placement",
+    "courses": [
+      "MATH 1139",
+      "MATH 1430"
+    ]
+  },
+  "MATH 1155": {
+    "text": "MATH 1139 or MATH 1430 or Math Placement",
+    "courses": [
+      "MATH 1139",
+      "MATH 1430"
+    ]
+  },
+  "MATH 1175": {
+    "text": "(MATH 0600 or MATH 0095 or MATH 8055 or MATH 1025 or MATH 1420 or MATH 0100 or MATH 0101 or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 1025",
+      "MATH 1420",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1175C": {
+    "text": "(Math Placement or MATH 0099 or MATH 0100 or MATH 0101 or MATH 0500 or MATH 0600 or MATH 8055) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0099",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0500",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1179": {
+    "text": "( MATH 0101 or MATH 0600 or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0101",
+      "MATH 0600"
+    ]
+  },
+  "MATH 1181": {
+    "text": "MATH 1179 or MATH 1750 or Math Placement",
+    "courses": [
+      "MATH 1179",
+      "MATH 1750"
+    ]
+  },
+  "MATH 1200": {
+    "text": "( MATH 0095 or MATH 0101 or MATH 0600 or MATH 8055 or Math Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0095",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1200C": {
+    "text": "(Math Placement or MATH 0095 or MATH 0100 or MATH 0101 or MATH 0600 or MATH 8055) or (Bachelor Degree or higher)",
+    "courses": [
+      "MATH 0095",
+      "MATH 0100",
+      "MATH 0101",
+      "MATH 0600",
+      "MATH 8055"
+    ]
+  },
+  "MATH 1240": {
+    "text": "MATH 1200 or MATH 1179 or MATH 1200C or MATH 1750 or Math Placement",
+    "courses": [
+      "MATH 1179",
+      "MATH 1200",
+      "MATH 1200C",
+      "MATH 1750"
+    ]
+  },
+  "MATH 1241": {
+    "text": "MATH 1240 or MATH 1550",
+    "courses": [
+      "MATH 1240",
+      "MATH 1550"
+    ]
+  },
+  "MATH 2077": {
+    "text": "MATH 1200 or MATH 1200C or Math Placement",
+    "courses": [
+      "MATH 1200",
+      "MATH 1200C"
+    ]
+  },
+  "MATH 2103": {
+    "text": "MATH 1200 or MATH 1200C or Math Placement",
+    "courses": [
+      "MATH 1200",
+      "MATH 1200C"
+    ]
+  },
+  "MATH 2110": {
+    "text": "MATH 1200 or MATH 1200C or Math Placement",
+    "courses": [
+      "MATH 1200",
+      "MATH 1200C"
+    ]
+  },
+  "MATH 2111": {
+    "text": "MATH 1210 or MATH 2110 or Math Placement",
+    "courses": [
+      "MATH 1210",
+      "MATH 2110"
+    ]
+  },
+  "MATH 2131": {
+    "text": "MATH 2103 or MATH 2111 or Math Placement",
+    "courses": [
+      "MATH 2103",
+      "MATH 2111"
+    ]
+  },
+  "MATH 2138": {
+    "text": "MATH 2077 or Math Placement or MATH 1670",
+    "courses": [
+      "MATH 1670",
+      "MATH 2077"
+    ]
+  },
+  "MATH 2141": {
+    "text": "MATH 2111 or Math Placement or MATH 1900",
+    "courses": [
+      "MATH 1900",
+      "MATH 2111"
+    ]
+  },
+  "MATH 2142": {
+    "text": "MATH 2141 or MATH 1910 or Math Dept. Course Placement",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141"
+    ]
+  },
+  "MATH 2180": {
+    "text": "MATH 1200 or MATH 1200C",
+    "courses": [
+      "MATH 1200",
+      "MATH 1200C"
+    ]
+  },
+  "MATH 2215": {
+    "text": "MATH 2141",
+    "courses": [
+      "MATH 2141"
+    ]
+  },
+  "MATH 2243": {
+    "text": "MATH 2142 or MATH 1920",
+    "courses": [
+      "MATH 1920",
+      "MATH 2142"
+    ]
+  },
+  "MATH 2362": {
+    "text": "Math Dept. Course Placement or MATH 2243 or MATH 2910",
+    "courses": [
+      "MATH 2243",
+      "MATH 2910"
+    ]
+  },
+  "MEDL 2390": {
+    "text": "MEDL 2350 (may be taken concurrently)",
+    "courses": [
+      "MEDL 2350"
+    ]
+  },
+  "MEDL 2410": {
+    "text": "MEDL 2390 (may be taken concurrently)",
+    "courses": [
+      "MEDL 2390"
+    ]
+  },
+  "MEDL 2420": {
+    "text": "MEDL 2390 (may be taken concurrently) and (MEDL 2400 (may be taken concurrently) or MEDL 2385 (may be taken concurrently))",
+    "courses": [
+      "MEDL 2385",
+      "MEDL 2390",
+      "MEDL 2400"
+    ]
+  },
+  "MLTC 1160": {
+    "text": "MLTC 1120",
+    "courses": [
+      "MLTC 1120"
+    ]
+  },
+  "MLTC 1930": {
+    "text": "MLTC 1130",
+    "courses": [
+      "MLTC 1130"
+    ]
+  },
+  "MLTC 1940": {
+    "text": "MLTC 1160 and MLTC 1161",
+    "courses": [
+      "MLTC 1160",
+      "MLTC 1161"
+    ]
+  },
+  "MLTC 1950": {
+    "text": "MLTC 1150",
+    "courses": [
+      "MLTC 1150"
+    ]
+  },
+  "MLTC 1970": {
+    "text": "COMI 1100",
+    "courses": [
+      "COMI 1100"
+    ]
+  },
+  "MLTC 2110": {
+    "text": "MLTC 1110",
+    "courses": [
+      "MLTC 1110"
+    ]
+  },
+  "MLTC 2190": {
+    "text": "MLTC 1190",
+    "courses": [
+      "MLTC 1190"
+    ]
+  },
+  "MLTC 2910": {
+    "text": "MLTC 2110",
+    "courses": [
+      "MLTC 2110"
+    ]
+  },
+  "MLTC 2920": {
+    "text": "MLTC 2120",
+    "courses": [
+      "MLTC 2120"
+    ]
+  },
+  "MLTC 2990": {
+    "text": "MLTC 2190",
+    "courses": [
+      "MLTC 2190"
+    ]
+  },
+  "MRIC 2280": {
+    "text": "MRIC 2270 and MRIC 2290 (may be taken concurrently)",
+    "courses": [
+      "MRIC 2270",
+      "MRIC 2290"
+    ]
+  },
+  "MRIC 2290": {
+    "text": "MRIC 2280 (may be taken concurrently)",
+    "courses": [
+      "MRIC 2280"
+    ]
+  },
+  "MUSC 1113": {
+    "text": "MUSC 1112",
+    "courses": [
+      "MUSC 1112"
+    ]
+  },
+  "MUSC 1130": {
+    "text": "MUSC 1010 or MUSC 1700",
+    "courses": [
+      "MUSC 1010",
+      "MUSC 1700"
+    ]
+  },
+  "MUSC 1135": {
+    "text": "MUSC 1130",
+    "courses": [
+      "MUSC 1130"
+    ]
+  },
+  "MUSC 1140": {
+    "text": "MUSC 1010 or MUSC 1700",
+    "courses": [
+      "MUSC 1010",
+      "MUSC 1700"
+    ]
+  },
+  "MUSC 1145": {
+    "text": "MUSC 1140",
+    "courses": [
+      "MUSC 1140"
+    ]
+  },
+  "MUSC 1800": {
+    "text": "MUSC 1700",
+    "courses": [
+      "MUSC 1700"
+    ]
+  },
+  "MUSC 1810": {
+    "text": "MUSC 1710",
+    "courses": [
+      "MUSC 1710"
+    ]
+  },
+  "MUSC 2040": {
+    "text": "MUSC 1800 and MUSC 1810",
+    "courses": [
+      "MUSC 1800",
+      "MUSC 1810"
+    ]
+  },
+  "MUSC 2070": {
+    "text": "MUSC 1800 and MUSC 1810",
+    "courses": [
+      "MUSC 1800",
+      "MUSC 1810"
+    ]
+  },
+  "MUSC 2080": {
+    "text": "MUSC 2070",
+    "courses": [
+      "MUSC 2070"
+    ]
+  },
+  "MUSC 2090": {
+    "text": "MUSC 1800 and MUSC 1810",
+    "courses": [
+      "MUSC 1800",
+      "MUSC 1810"
+    ]
+  },
+  "MUSC 2100": {
+    "text": "MUSC 2090",
+    "courses": [
+      "MUSC 2090"
+    ]
+  },
+  "MUSC 2700": {
+    "text": "MUSC 1800",
+    "courses": [
+      "MUSC 1800"
+    ]
+  },
+  "MUSC 2710": {
+    "text": "MUSC 1810",
+    "courses": [
+      "MUSC 1810"
+    ]
+  },
+  "MUSC 2720": {
+    "text": "( MUSC 2700 or MUSC 2070 ) and MUSC 1140",
+    "courses": [
+      "MUSC 1140",
+      "MUSC 2070",
+      "MUSC 2700"
+    ]
+  },
+  "MUSC 2721": {
+    "text": "MUSC 2720",
+    "courses": [
+      "MUSC 2720"
+    ]
+  },
+  "MUSC 2800": {
+    "text": "MUSC 2700",
+    "courses": [
+      "MUSC 2700"
+    ]
+  },
+  "MUSC 2810": {
+    "text": "MUSC 2710",
+    "courses": [
+      "MUSC 2710"
+    ]
+  },
+  "NURP 1010": {
+    "text": "BIOL 1070 (may be taken concurrently) or (BIOL 1010 and BIOL 1020) or ( BIOL 2201 and BIOL 2202 (may be taken concurrently)) and ( NURS 1015P (may be taken concurrently) or NURS 1015 (may be taken concurrently)) and ( NURS 1061P (may be taken concurrently) or NURS 1061 (may be taken concurrently))",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1020",
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1061",
+      "NURS 1061P"
+    ]
+  },
+  "NURP 1020": {
+    "text": "( NURP 1010 and PSYC 2010 (may be taken concurrently)) and ( NURS 1061P or NURS 1061 ) and ( NURS 1015P or NURS 1015 ) and ( NURS 1062P (may be taken concurrently) or NURS 1062 ) and ( BIOL 1070 or BIOL 2201 and BIOL 2202 )",
+    "courses": [
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURP 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P",
+      "PSYC 2010"
+    ]
+  },
+  "NURP 1030": {
+    "text": "BIOL 1070 or (BIOL 1010 and BIOL 1020) or ( BIOL 2201 and BIOL 2202 ) and NURP 1010 and NURP 1020 and ( NURS 1015P or NURS 1015 ) and ( NURS 1061 or NURS 1061P ) and ( NURS 1062 or NURS 1062P ) and NURP 2500 (may be taken concurrently)",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1020",
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURP 1010",
+      "NURP 1020",
+      "NURP 2500",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P"
+    ]
+  },
+  "NURP 2500": {
+    "text": "NURP 1010 and NURP 1020 and ( NURS 1015 or NURS 1015P ) and ( NURS 1062P or NURS 1062 ) and ( NURS 1061 or NURS 1061P ) and ( BIOL 1070 or BIOL 2201 and BIOL 2202 ) and NURP 1030 (may be taken concurrently)",
+    "courses": [
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURP 1010",
+      "NURP 1020",
+      "NURP 1030",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P"
+    ]
+  },
+  "NURS 1010": {
+    "text": "( NURS 1015 (may be taken concurrently) and NURS 1061 (may be taken concurrently)) or ( BIOL 2201 and BIOL 2202 (may be taken concurrently) or A & P I >= C and A & P II >= C)",
+    "courses": [
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURS 1015",
+      "NURS 1061"
+    ]
+  },
+  "NURS 1015": {
+    "text": "NURS 1010 (may be taken concurrently) and ( NURS 1061 (may be taken concurrently) or NURS 1061P ) and ( BIOL 2202 (may be taken concurrently) or A & P II >= C or BIOL 1020 or Biol 1020 >=C for Nursing)",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 2202",
+      "NURS 1010",
+      "NURS 1061",
+      "NURS 1061P"
+    ]
+  },
+  "NURS 1015P": {
+    "text": "NURP 1010 (may be taken concurrently) and ( NURS 1061 (may be taken concurrently) or NURS 1061P (may be taken concurrently)) and ( BIOL 1070 (may be taken concurrently) or BIOL 2201 (may be taken concurrently) and BIOL 2202 (may be taken concurrently))",
+    "courses": [
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURP 1010",
+      "NURS 1061",
+      "NURS 1061P"
+    ]
+  },
+  "NURS 1020": {
+    "text": "NURS 1010 and ( NURS 1015 or NURS 1015P ) and ( NURS 1061 or NURS 1061P ) and NURS 1062 (may be taken concurrently) and NURS 1023 (may be taken concurrently) and PSYC 2030 (may be taken concurrently) and ( BIOL 2202 or A & P II >= C)",
+    "courses": [
+      "BIOL 2202",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1023",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "PSYC 2030"
+    ]
+  },
+  "NURS 1023": {
+    "text": "NURS 1010 and ( NURS 1015 or NURS 1015P ) and ( NURS 1061 or NURS 1061P ) and ( BIOL 2202 or A & P II >= C) and NURS 1020 (may be taken concurrently) and NURS 1062 (may be taken concurrently) and PSYC 2030 (may be taken concurrently)",
+    "courses": [
+      "BIOL 2202",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1020",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "PSYC 2030"
+    ]
+  },
+  "NURS 1061": {
+    "text": "NURS 1010 (may be taken concurrently) and ( NURS 1015 (may be taken concurrently) or NURS 1015P ) and ( BIOL 2202 (may be taken concurrently) or A & P II >= C or BIOL 1020 or Biol 1020 >=C for Nursing)",
+    "courses": [
+      "BIOL 1020",
+      "BIOL 2202",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P"
+    ]
+  },
+  "NURS 1061P": {
+    "text": "( NURS 1010 (may be taken concurrently) or NURP 1010 (may be taken concurrently)) and ( NURS 1015P (may be taken concurrently) or NURS 1015 ) and ( BIOL 1070 (may be taken concurrently)) or ( BIOL 2201 (may be taken concurrently) and BIOL 2202 (may be taken concurrently)) or (A & P I >= C and A & P II >= C)",
+    "courses": [
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURP 1010",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P"
+    ]
+  },
+  "NURS 1062": {
+    "text": "( NURS 1010 or NURP 1010 ) and ( NURS 1015 or NURS 1015P ) and ( NURS 1061 or NURS 1061P ) and ( NURS 1020 (may be taken concurrently) or NURP 1020 (may be taken concurrently)) and ( BIOL 1070 or BIOL 2201 and BIOL 2202 )",
+    "courses": [
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURP 1010",
+      "NURP 1020",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1020",
+      "NURS 1061",
+      "NURS 1061P"
+    ]
+  },
+  "NURS 1062P": {
+    "text": "( NURS 1010 (may be taken concurrently) or NURP 1010 (may be taken concurrently)) and ( NURS 1015 (may be taken concurrently) or NURS 1015P (may be taken concurrently)) and ( NURS 1061 (may be taken concurrently) or NURS 1061P (may be taken concurrently)) and NURP 1020 (may be taken concurrently) and ( BIOL 1070 (may be taken concurrently) or BIOL 2201 (may be taken concurrently) and BIOL 2202 (may be taken concurrently))",
+    "courses": [
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202",
+      "NURP 1010",
+      "NURP 1020",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1061",
+      "NURS 1061P"
+    ]
+  },
+  "NURS 1063": {
+    "text": "NURS 1010 and ( NURS 1015 or NURS 1015P ) and ( NURS 1061 or NURS 1061P ) and BIOL 2202 and NURS 1020 and NURS 1023 and ( NURS 1062 or NURS 1062P ) and PSYC 2030 and NURS 2040 (may be taken concurrently) and NURS 2050 (may be taken concurrently)",
+    "courses": [
+      "BIOL 2202",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1020",
+      "NURS 1023",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P",
+      "NURS 2040",
+      "NURS 2050",
+      "PSYC 2030"
+    ]
+  },
+  "NURS 2030": {
+    "text": "( NURS 1062 (may be taken concurrently) or NURS 1062P (may be taken concurrently)) and NURS 1023 (may be taken concurrently)",
+    "courses": [
+      "NURS 1023",
+      "NURS 1062",
+      "NURS 1062P"
+    ]
+  },
+  "NURS 2040": {
+    "text": "NURS 1010 and ( NURS 1015 or NURS 1015P ) and ( NURS 1061 or NURS 1061P ) and NURS 1020 and NURS 1023 and ( NURS 1062 or NURS 1062P ) and ( BIOL 2202 or A & P II >= C) and PSYC 2030 and NURS 2050 (may be taken concurrently) and NURS 1063 (may be taken concurrently)",
+    "courses": [
+      "BIOL 2202",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1020",
+      "NURS 1023",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P",
+      "NURS 1063",
+      "NURS 2050",
+      "PSYC 2030"
+    ]
+  },
+  "NURS 2050": {
+    "text": "NURS 1010 and ( NURS 1015 or NURS 1015P ) and ( NURS 1061 or NURS 1061P ) and NURS 1020 and NURS 1023 and ( NURS 1062 or NURS 1062P ) and ( BIOL 2202 or A & P II >= C) and PSYC 2030 and NURS 2040 (may be taken concurrently)",
+    "courses": [
+      "BIOL 2202",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1020",
+      "NURS 1023",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P",
+      "NURS 2040",
+      "PSYC 2030"
+    ]
+  },
+  "NURS 2060": {
+    "text": "NURS 1010 and ( NURS 1015 or NURS 1015P ) and ( NURS 1061 or NURS 1061P ) and NURS 1020 and NURS 1023 and ( NURS 1062 or NURS 1062P ) and PSYC 2030 and NURS 2500 (may be taken concurrently) and BIOL 2210 (may be taken concurrently) and NURS 2040 and NURS 2050 and NURS 1063",
+    "courses": [
+      "BIOL 2210",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1020",
+      "NURS 1023",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P",
+      "NURS 1063",
+      "NURS 2040",
+      "NURS 2050",
+      "NURS 2500",
+      "PSYC 2030"
+    ]
+  },
+  "NURS 2500": {
+    "text": "NURS 1010 and NURS 1020 and ( NURS 1015 or NURS 1015P ) and NURS 1023 and ( NURS 1061 or NURS 1061P ) and ( NURS 1062 or NURS 1062P ) and NURS 1063 and NURS 2040 and NURS 2050 and NURS 2060 (may be taken concurrently) and PSYC 2030 and BIOL 2210 (may be taken concurrently)",
+    "courses": [
+      "BIOL 2210",
+      "NURS 1010",
+      "NURS 1015",
+      "NURS 1015P",
+      "NURS 1020",
+      "NURS 1023",
+      "NURS 1061",
+      "NURS 1061P",
+      "NURS 1062",
+      "NURS 1062P",
+      "NURS 1063",
+      "NURS 2040",
+      "NURS 2050",
+      "NURS 2060",
+      "PSYC 2030"
+    ]
+  },
+  "OCTA 1010": {
+    "text": "RHAB 1030 (may be taken concurrently)",
+    "courses": [
+      "RHAB 1030"
+    ]
+  },
+  "OCTA 1030": {
+    "text": "RHAB 1110 and OCTA 1010 and RHAB 1030 and OCTA 1070",
+    "courses": [
+      "OCTA 1010",
+      "OCTA 1070",
+      "RHAB 1030",
+      "RHAB 1110"
+    ]
+  },
+  "OCTA 1040": {
+    "text": "RHAB 1110 and OCTA 1010 and RHAB 1030 and OCTA 1070",
+    "courses": [
+      "OCTA 1010",
+      "OCTA 1070",
+      "RHAB 1030",
+      "RHAB 1110"
+    ]
+  },
+  "OCTA 1050": {
+    "text": "OCTA 1010 and OCTA 1030 and OCTA 1070 and OCTA 2010 and RHAB 1030",
+    "courses": [
+      "OCTA 1010",
+      "OCTA 1030",
+      "OCTA 1070",
+      "OCTA 2010",
+      "RHAB 1030"
+    ]
+  },
+  "OCTA 1060": {
+    "text": "RHAB 1110 and OCTA 1010 and RHAB 1030 and OCTA 1070",
+    "courses": [
+      "OCTA 1010",
+      "OCTA 1070",
+      "RHAB 1030",
+      "RHAB 1110"
+    ]
+  },
+  "OCTA 1070": {
+    "text": "RHAB 1030 (may be taken concurrently)",
+    "courses": [
+      "RHAB 1030"
+    ]
+  },
+  "OCTA 1080": {
+    "text": "OCTA 1030 and OCTA 1040 and OCTA 1060 and OCTA 2010",
+    "courses": [
+      "OCTA 1030",
+      "OCTA 1040",
+      "OCTA 1060",
+      "OCTA 2010"
+    ]
+  },
+  "OCTA 2010": {
+    "text": "RHAB 1030 and OCTA 1010",
+    "courses": [
+      "OCTA 1010",
+      "RHAB 1030"
+    ]
+  },
+  "OCTA 2020": {
+    "text": "OCTA 1030 and OCTA 1040 and OCTA 1060",
+    "courses": [
+      "OCTA 1030",
+      "OCTA 1040",
+      "OCTA 1060"
+    ]
+  },
+  "OCTA 2030": {
+    "text": "OCTA 2010 and OCTA 2020",
+    "courses": [
+      "OCTA 2010",
+      "OCTA 2020"
+    ]
+  },
+  "OCTA 2035": {
+    "text": "OCTA 2010 and OCTA 2020",
+    "courses": [
+      "OCTA 2010",
+      "OCTA 2020"
+    ]
+  },
+  "OCTA 2040": {
+    "text": "OCTA 2010 and OCTA 2020",
+    "courses": [
+      "OCTA 2010",
+      "OCTA 2020"
+    ]
+  },
+  "PHED 1420": {
+    "text": "PHED 1410",
+    "courses": [
+      "PHED 1410"
+    ]
+  },
+  "PHED 1620": {
+    "text": "PHED 1610",
+    "courses": [
+      "PHED 1610"
+    ]
+  },
+  "PHED 1800": {
+    "text": "BIOL 1070 and COMM 1010 and PHED 1610 and PHED 1630 and PSYC 2010",
+    "courses": [
+      "BIOL 1070",
+      "COMM 1010",
+      "PHED 1610",
+      "PHED 1630",
+      "PSYC 2010"
+    ]
+  },
+  "PHED 2010": {
+    "text": "PHED 1610 and PHED 1630 and COMM 1010 and BIOL 1070 and PSYC 2010",
+    "courses": [
+      "BIOL 1070",
+      "COMM 1010",
+      "PHED 1610",
+      "PHED 1630",
+      "PSYC 2010"
+    ]
+  },
+  "PHTA 1020": {
+    "text": "( RHAB 1110 or PHTA 1110) and PHTA 1010 and PHTA 1120",
+    "courses": [
+      "PHTA 1010",
+      "PHTA 1110",
+      "PHTA 1120",
+      "RHAB 1110"
+    ]
+  },
+  "PHTA 1220": {
+    "text": "PHTA 1110 or RHAB 1110",
+    "courses": [
+      "PHTA 1110",
+      "RHAB 1110"
+    ]
+  },
+  "PHTA 2010": {
+    "text": "( RHAB 1110 or PHTA 1110) and ( RHAB 1030 or PHTA 1030) and PHTA 1010 and PHTA 1120 and PHTA 1020",
+    "courses": [
+      "PHTA 1010",
+      "PHTA 1020",
+      "PHTA 1030",
+      "PHTA 1110",
+      "PHTA 1120",
+      "RHAB 1030",
+      "RHAB 1110"
+    ]
+  },
+  "PHTA 2020": {
+    "text": "( RHAB 1110 or PHTA 1110) and ( RHAB 1030 or PHTA 1030) and PHTA 1010 and PHTA 1020 and PHTA 1120 and PHTA 2010 and PHTA 2910",
+    "courses": [
+      "PHTA 1010",
+      "PHTA 1020",
+      "PHTA 1030",
+      "PHTA 1110",
+      "PHTA 1120",
+      "PHTA 2010",
+      "PHTA 2910",
+      "RHAB 1030",
+      "RHAB 1110"
+    ]
+  },
+  "PHTA 2030": {
+    "text": "PHTA 2010",
+    "courses": [
+      "PHTA 2010"
+    ]
+  },
+  "PHTA 2040": {
+    "text": "PHTA 2020 and PHTA 2930",
+    "courses": [
+      "PHTA 2020",
+      "PHTA 2930"
+    ]
+  },
+  "PHTA 2910": {
+    "text": "PHTA 1020 and RHAB 1030",
+    "courses": [
+      "PHTA 1020",
+      "RHAB 1030"
+    ]
+  },
+  "PHTA 2920": {
+    "text": "PHTA 2010 and RHAB 1030",
+    "courses": [
+      "PHTA 2010",
+      "RHAB 1030"
+    ]
+  },
+  "PHTA 2930": {
+    "text": "PHTA 2020",
+    "courses": [
+      "PHTA 2020"
+    ]
+  },
+  "PHYS 1040": {
+    "text": "PHYS 1030",
+    "courses": [
+      "PHYS 1030"
+    ]
+  },
+  "PHYS 1150": {
+    "text": "MATH 2141 (may be taken concurrently) or MATH 1910",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141"
+    ]
+  },
+  "PHYS 1151": {
+    "text": "PHYS 1150 (may be taken concurrently) and ( MATH 2141 (may be taken concurrently) or MATH 1910)",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141",
+      "PHYS 1150"
+    ]
+  },
+  "PHYS 1500": {
+    "text": "( MATH 2141 or MATH 1910) and ( PHYS 1150 )",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141",
+      "PHYS 1150"
+    ]
+  },
+  "PHYS 1501": {
+    "text": "( MATH 2141 or MATH 1910) and ( PHYS 1500 (may be taken concurrently))",
+    "courses": [
+      "MATH 1910",
+      "MATH 2141",
+      "PHYS 1500"
+    ]
+  },
+  "PHYS 2000": {
+    "text": "( MATH 2141 or MATH 1910) and ( MATH 2142 or MATH 1920) and ( PHYS 1150 )",
+    "courses": [
+      "MATH 1910",
+      "MATH 1920",
+      "MATH 2141",
+      "MATH 2142",
+      "PHYS 1150"
+    ]
+  },
+  "PHYS 2001": {
+    "text": "PHYS 2000 (may be taken concurrently)",
+    "courses": [
+      "PHYS 2000"
+    ]
+  },
+  "POLS 2040": {
+    "text": "POLS 1010",
+    "courses": [
+      "POLS 1010"
+    ]
+  },
+  "PORT 1040": {
+    "text": "PORT 1010 or PORT 1030",
+    "courses": [
+      "PORT 1010",
+      "PORT 1030"
+    ]
+  },
+  "PORT 2010": {
+    "text": "PORT 1020 or PORT 1040",
+    "courses": [
+      "PORT 1020",
+      "PORT 1040"
+    ]
+  },
+  "PORT 2020": {
+    "text": "PORT 2010",
+    "courses": [
+      "PORT 2010"
+    ]
+  },
+  "PSYC 2020": {
+    "text": "PSYC 2010",
+    "courses": [
+      "PSYC 2010"
+    ]
+  },
+  "PSYC 2030": {
+    "text": "PSYC 2010",
+    "courses": [
+      "PSYC 2010"
+    ]
+  },
+  "PSYC 2050": {
+    "text": "PSYC 2010",
+    "courses": [
+      "PSYC 2010"
+    ]
+  },
+  "PSYC 2090": {
+    "text": "PSYC 2010 and PSYC 2030",
+    "courses": [
+      "PSYC 2010",
+      "PSYC 2030"
+    ]
+  },
+  "PSYC 2100": {
+    "text": "PSYC 2010",
+    "courses": [
+      "PSYC 2010"
+    ]
+  },
+  "PSYC 2110": {
+    "text": "PSYC 2010",
+    "courses": [
+      "PSYC 2010"
+    ]
+  },
+  "PSYC 2120": {
+    "text": "PSYC 2010",
+    "courses": [
+      "PSYC 2010"
+    ]
+  },
+  "RENL 1020": {
+    "text": "RENL 1030 (may be taken concurrently)",
+    "courses": [
+      "RENL 1030"
+    ]
+  },
+  "RENL 1030": {
+    "text": "RENL 1020 (may be taken concurrently)",
+    "courses": [
+      "RENL 1020"
+    ]
+  },
+  "RESP 1100": {
+    "text": "RESP 1010",
+    "courses": [
+      "RESP 1010"
+    ]
+  },
+  "RESP 1800": {
+    "text": "RESP 1010",
+    "courses": [
+      "RESP 1010"
+    ]
+  },
+  "RESP 2030": {
+    "text": "RESP 2020",
+    "courses": [
+      "RESP 2020"
+    ]
+  },
+  "RESP 2120": {
+    "text": "RESP 1100",
+    "courses": [
+      "RESP 1100"
+    ]
+  },
+  "RESP 2130": {
+    "text": "RESP 2120",
+    "courses": [
+      "RESP 2120"
+    ]
+  },
+  "RHAB 1110": {
+    "text": "( BIOL 1070 or BIOL 1010) or ( BIOL 2201 and BIOL 2202 )",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1070",
+      "BIOL 2201",
+      "BIOL 2202"
+    ]
+  },
+  "ROTC 2070": {
+    "text": "ROTC 2050",
+    "courses": [
+      "ROTC 2050"
+    ]
+  },
+  "SOCM 1010": {
+    "text": "( ENGL 1005 or ENGL 1005A or English Wrtg Course Placement) and ( ENGL 0850 or ENGL 0890 or ENGL 1002 or Reading Course Placement)",
+    "courses": [
+      "ENGL 0850",
+      "ENGL 0890",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1005A"
+    ]
+  },
+  "SOCM 1020": {
+    "text": "( SOCM 1010 (may be taken concurrently)) and ( ENGL 1005 or ENGL 1005A or English Wrtg Course Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1005A",
+      "SOCM 1010"
+    ]
+  },
+  "SOCM 1030": {
+    "text": "( SOCM 1010 and SOCM 1020 (may be taken concurrently)) and ( ENGL 1005 or ENGL 1005A or English Wrtg Course Placement) and (ENGL 0890 or ENGL 0950 or ENGL 1002 or Reading Course Placement)",
+    "courses": [
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002",
+      "ENGL 1005",
+      "ENGL 1005A",
+      "SOCM 1010",
+      "SOCM 1020"
+    ]
+  },
+  "SOCM 2010": {
+    "text": "SOCM 1010 and SOCM 1020 and SOCM 1030",
+    "courses": [
+      "SOCM 1010",
+      "SOCM 1020",
+      "SOCM 1030"
+    ]
+  },
+  "SOCM 2020": {
+    "text": "SOCM 1010 and SOCM 1020 and SOCM 1030",
+    "courses": [
+      "SOCM 1010",
+      "SOCM 1020",
+      "SOCM 1030"
+    ]
+  },
+  "SOCM 2030": {
+    "text": "SOCM 1010 and SOCM 1020 and SOCM 1030",
+    "courses": [
+      "SOCM 1010",
+      "SOCM 1020",
+      "SOCM 1030"
+    ]
+  },
+  "SOCS 2040": {
+    "text": "( ENGL 0850 (may be taken concurrently) or ENGL 0890 (may be taken concurrently) or ENGL 0950 (may be taken concurrently) or ENGL 1002 (may be taken concurrently) or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0850",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002"
+    ]
+  },
+  "SOCS 2050": {
+    "text": "SOCS 1010",
+    "courses": [
+      "SOCS 1010"
+    ]
+  },
+  "SOCS 2240": {
+    "text": "( ENGL 0850 (may be taken concurrently) or ENGL 0890 (may be taken concurrently) or ENGL 0950 (may be taken concurrently) or ENGL 1002 (may be taken concurrently) or Reading Course Placement) or (Bachelor Degree or higher)",
+    "courses": [
+      "ENGL 0850",
+      "ENGL 0890",
+      "ENGL 0950",
+      "ENGL 1002"
+    ]
+  },
+  "SPAN 1040": {
+    "text": "SPAN 1010 or SPAN 1030",
+    "courses": [
+      "SPAN 1010",
+      "SPAN 1030"
+    ]
+  },
+  "SPAN 1100": {
+    "text": "SPAN 1000",
+    "courses": [
+      "SPAN 1000"
+    ]
+  },
+  "SPAN 2010": {
+    "text": "SPAN 1020 or SPAN 1040",
+    "courses": [
+      "SPAN 1020",
+      "SPAN 1040"
+    ]
+  },
+  "SPAN 2020": {
+    "text": "SPAN 2010",
+    "courses": [
+      "SPAN 2010"
+    ]
+  },
+  "SPAN 2210": {
+    "text": "SPAN 2020",
+    "courses": [
+      "SPAN 2020"
+    ]
+  },
+  "SPAN 2220": {
+    "text": "SPAN 2210",
+    "courses": [
+      "SPAN 2210"
+    ]
+  },
+  "SURG 1000": {
+    "text": "BIOL 2201",
+    "courses": [
+      "BIOL 2201"
+    ]
+  },
+  "SURG 1001": {
+    "text": "SURG 1000",
+    "courses": [
+      "SURG 1000"
+    ]
+  },
+  "SURG 1010": {
+    "text": "BIOL 2201 (may be taken concurrently) or (BIOL 1010 and BIOL 1020)",
+    "courses": [
+      "BIOL 1010",
+      "BIOL 1020",
+      "BIOL 2201"
+    ]
+  },
+  "SURG 1020": {
+    "text": "SURG 1010",
+    "courses": [
+      "SURG 1010"
+    ]
+  },
+  "SURG 2002": {
+    "text": "SURG 1001",
+    "courses": [
+      "SURG 1001"
+    ]
+  },
+  "SURG 2003": {
+    "text": "SURG 1001 and SURG 2002 (may be taken concurrently)",
+    "courses": [
+      "SURG 1001",
+      "SURG 2002"
+    ]
+  },
+  "SURG 2010": {
+    "text": "SURG 1020",
+    "courses": [
+      "SURG 1020"
+    ]
+  },
+  "SURG 2020": {
+    "text": "SURG 2010",
+    "courses": [
+      "SURG 2010"
+    ]
+  },
+  "THEA 2140": {
+    "text": "THEA 1140",
+    "courses": [
+      "THEA 1140"
+    ]
+  },
+  "THEA 2145": {
+    "text": "THEA 1140",
+    "courses": [
+      "THEA 1140"
+    ]
+  },
+  "THEA 2200": {
+    "text": "ENGT 1060 and ARTS 1010 and THEA 1080 or THEA 1120 or THEA 1180",
+    "courses": [
+      "ARTS 1010",
+      "ENGT 1060",
+      "THEA 1080",
+      "THEA 1120",
+      "THEA 1180"
+    ]
+  },
+  "TMSG 1020": {
+    "text": "BIOL 2201 and RHAB 1020 (may be taken concurrently)",
+    "courses": [
+      "BIOL 2201",
+      "RHAB 1020"
+    ]
+  },
+  "TMSG 1030": {
+    "text": "BIOL 2201 and TMSG 1000 and TMSG 1020 and RHAB 1020 and RHAB 1030 (may be taken concurrently)",
+    "courses": [
+      "BIOL 2201",
+      "RHAB 1020",
+      "RHAB 1030",
+      "TMSG 1000",
+      "TMSG 1020"
+    ]
+  },
+  "TMSG 1040": {
+    "text": "BIOL 1070 and RHAB 1010 and TMSG 1000 and ENGL 1010 and TMSG 1020 (may be taken concurrently)",
+    "courses": [
+      "BIOL 1070",
+      "ENGL 1010",
+      "RHAB 1010",
+      "TMSG 1000",
+      "TMSG 1020"
+    ]
+  },
+  "TMSG 1140": {
+    "text": "TMSG 1020 and TMSG 1040 and RHAB 1030",
+    "courses": [
+      "RHAB 1030",
+      "TMSG 1020",
+      "TMSG 1040"
+    ]
+  },
+  "TMSG 2010": {
+    "text": "RHAB 1030 and TMSG 1020 and TMSG 1030",
+    "courses": [
+      "RHAB 1030",
+      "TMSG 1020",
+      "TMSG 1030"
+    ]
+  },
+  "TMSG 2020": {
+    "text": "RHAB 1030 and TMSG 1000 and TMSG 1020 and TMSG 1030 and TMSG 2010 (may be taken concurrently)",
+    "courses": [
+      "RHAB 1030",
+      "TMSG 1000",
+      "TMSG 1020",
+      "TMSG 1030",
+      "TMSG 2010"
+    ]
+  },
+  "TMSG 2021": {
+    "text": "TMSG 1020 and TMSG 1030 (may be taken concurrently) and RHAB 1030 (may be taken concurrently)",
+    "courses": [
+      "RHAB 1030",
+      "TMSG 1020",
+      "TMSG 1030"
+    ]
+  },
+  "TMSG 2030": {
+    "text": "RHAB 1030 and TMSG 1020 and TMSG 1040 and TMSG 1030 and TMSG 2010 and TMSG 2020 and TMSG 2021 and TMSG 1140",
+    "courses": [
+      "RHAB 1030",
+      "TMSG 1020",
+      "TMSG 1030",
+      "TMSG 1040",
+      "TMSG 1140",
+      "TMSG 2010",
+      "TMSG 2020",
+      "TMSG 2021"
+    ]
+  },
+  "TMSG 2040": {
+    "text": "(PHTA 1110 or RHAB 1110 ) and (PHTA 1030 or RHAB 1030 ) and TMSG 1020 and TMSG 1030 and TMSG 2010 and TMSG 2020 and TMSG 2021",
+    "courses": [
+      "PHTA 1030",
+      "PHTA 1110",
+      "RHAB 1030",
+      "RHAB 1110",
+      "TMSG 1020",
+      "TMSG 1030",
+      "TMSG 2010",
+      "TMSG 2020",
+      "TMSG 2021"
+    ]
+  },
+  "TMSG 2110": {
+    "text": "RHAB 1030 and TMSG 1020 and TMSG 1030 and TMSG 2010",
+    "courses": [
+      "RHAB 1030",
+      "TMSG 1020",
+      "TMSG 1030",
+      "TMSG 2010"
+    ]
+  },
+  "TMSG 2130": {
+    "text": "RHAB 1030 and TMSG 1020 and TMSG 1030 and TMSG 1040 and TMSG 2010 and TMSG 2020 and TMSG 2021 and TMSG 2040 (may be taken concurrently) and TMSG 1140 and TMSG 2110 (may be taken concurrently)",
+    "courses": [
+      "RHAB 1030",
+      "TMSG 1020",
+      "TMSG 1030",
+      "TMSG 1040",
+      "TMSG 1140",
+      "TMSG 2010",
+      "TMSG 2020",
+      "TMSG 2021",
+      "TMSG 2040",
+      "TMSG 2110"
+    ]
+  },
+  "TMSG 2500": {
+    "text": "TMSG 1020 and TMSG 1030 and TMSG 2021",
+    "courses": [
+      "TMSG 1020",
+      "TMSG 1030",
+      "TMSG 2021"
+    ]
+  },
+  "XRAY 1000": {
+    "text": "ENGL 1010 (may be taken concurrently) or ENGL 1010A (may be taken concurrently)",
+    "courses": [
+      "ENGL 1010",
+      "ENGL 1010A"
+    ]
+  },
+  "XRAY 1010": {
+    "text": "XRAY 1000",
+    "courses": [
+      "XRAY 1000"
+    ]
+  },
+  "XRAY 1110": {
+    "text": "XRAY 1000",
+    "courses": [
+      "XRAY 1000"
+    ]
+  },
+  "XRAY 1130": {
+    "text": "XRAY 1010 and XRAY 1110",
+    "courses": [
+      "XRAY 1010",
+      "XRAY 1110"
+    ]
+  },
+  "XRAY 1220": {
+    "text": "XRAY 1110",
+    "courses": [
+      "XRAY 1110"
+    ]
+  },
+  "XRAY 1230": {
+    "text": "XRAY 1010",
+    "courses": [
+      "XRAY 1010"
+    ]
+  },
+  "XRAY 1910": {
+    "text": "XRAY 1010 and XRAY 1110",
+    "courses": [
+      "XRAY 1010",
+      "XRAY 1110"
+    ]
+  },
+  "XRAY 1920": {
+    "text": "XRAY 1910",
+    "courses": [
+      "XRAY 1910"
+    ]
+  },
+  "XRAY 1930": {
+    "text": "XRAY 1920",
+    "courses": [
+      "XRAY 1920"
+    ]
+  },
+  "XRAY 2410": {
+    "text": "PHYS 1110 and XRAY 1130",
+    "courses": [
+      "PHYS 1110",
+      "XRAY 1130"
+    ]
+  },
+  "XRAY 2430": {
+    "text": "XRAY 1130",
+    "courses": [
+      "XRAY 1130"
+    ]
+  },
+  "XRAY 2460": {
+    "text": "PHYS 1110 and XRAY 1930 and XRAY 1920 and XRAY 1220",
+    "courses": [
+      "PHYS 1110",
+      "XRAY 1220",
+      "XRAY 1920",
+      "XRAY 1930"
+    ]
+  },
+  "XRAY 2470": {
+    "text": "XRAY 1130 and XRAY 2340 and XRAY 2910 and XRAY 1930",
+    "courses": [
+      "XRAY 1130",
+      "XRAY 1930",
+      "XRAY 2340",
+      "XRAY 2910"
+    ]
+  },
+  "XRAY 2910": {
+    "text": "XRAY 1930",
+    "courses": [
+      "XRAY 1930"
+    ]
+  },
+  "XRAY 2920": {
+    "text": "XRAY 2910 and XRAY 2340 and XRAY 2460",
+    "courses": [
+      "XRAY 2340",
+      "XRAY 2460",
+      "XRAY 2910"
+    ]
+  }
+}

--- a/scripts/ri/scrape-catalog-prereqs.ts
+++ b/scripts/ri/scrape-catalog-prereqs.ts
@@ -1,0 +1,294 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Scrapes Community College of Rhode Island's CourseLeaf catalog at
+ * https://catalog.ccri.edu to extract prerequisite text for every active
+ * CCRI course. CCRI is RI's only community college; the primary course
+ * scraper (scripts/ri/scrape-banner8.ts) doesn't extract prereqs from
+ * Banner 8's legacy HTML forms, so this catalog scrape fills the gap.
+ *
+ * CCRI uses CourseLeaf, not acalog — a different engine than VT/TN/CT.
+ * Courses are grouped by subject prefix: each subject has its own page at
+ * `/course-descriptions/{subj}/` (e.g. `/course-descriptions/acct/`) with
+ * all that subject's courses rendered inline as `<div class="courseblock">`
+ * blocks. Prereqs live in `<span class="text detail-prereqs">` with course
+ * codes as the anchor text inside `<a class="bubblelink code">` links —
+ * much cleaner than acalog's coid-indirected links.
+ *
+ * Flow:
+ *   1. GET /course-descriptions/ to enumerate subject slugs
+ *   2. For each subject page, split on `<div class="courseblock">` and
+ *      parse each block for { code, prereq text, prereq course codes }
+ *   3. Write data/ri/prereqs.json keyed by "${PREFIX} ${NUMBER}"
+ *
+ * Usage:
+ *   npx tsx scripts/ri/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/ri/scrape-catalog-prereqs.ts --limit-subjects=3   # smoke test
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const BASE = "https://catalog.ccri.edu";
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 6;
+const DELAY_MS = 100;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return ""; // 404 — skip
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/** Extract subject slugs from the top-level course-descriptions index page. */
+function extractSubjectSlugs(html: string): string[] {
+  const matches = html.match(/\/course-descriptions\/([a-z]{2,6})\//g) || [];
+  const slugs = new Set<string>();
+  for (const m of matches) {
+    const mm = m.match(/\/course-descriptions\/([a-z]{2,6})\//);
+    if (mm) slugs.add(mm[1]);
+  }
+  return Array.from(slugs).sort();
+}
+
+/** Decode common HTML entities + strip tags → plain text, single-spaced. */
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,]\s*$/, "")
+    .trim();
+}
+
+const BOILERPLATE_RE =
+  /^(none|n\/a|not applicable|see course description|placement by|placement test)\s*\.?\s*$/i;
+
+/**
+ * Parse one CourseLeaf course block. Returns { prefix, number, text, courses }
+ * or null if the block has no prereq or doesn't parse.
+ *
+ * HTML structure (verified against CCRI ACCT 1030):
+ *   <div class="courseblock">
+ *     <div class="cols noindent">
+ *       <span class="... detail-code ...">
+ *         <strong>ACCT 1030</strong>
+ *       </span>
+ *       <span class="... detail-title ...">
+ *         <strong>- Computerized Accounting</strong>
+ *       </span>
+ *     </div>
+ *     ...
+ *     <span class="text detail-prereqs">
+ *       <strong>Prerequisite(s): </strong>
+ *       <a ... class="bubblelink code" ...>ACCT 1010</a>
+ *       <br/>
+ *     </span>
+ *     ...
+ *   </div>
+ */
+function parseCourseBlock(block: string): {
+  prefix: string;
+  number: string;
+  text: string;
+  courses: string[];
+} | null {
+  // --- Course code ---
+  // The code appears as `<strong>PREFIX NUMBER</strong>` inside detail-code.
+  const codeMatch = block.match(
+    /detail-code[^>]*>\s*<strong>\s*([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\s*<\/strong>/,
+  );
+  if (!codeMatch) return null;
+  const prefix = codeMatch[1].toUpperCase();
+  const number = codeMatch[2];
+
+  // --- Prereq span ---
+  const prereqMatch = block.match(
+    /<span[^>]*detail-prereqs[^>]*>([\s\S]*?)<\/span>/,
+  );
+  if (!prereqMatch) return null;
+
+  // Extract plain text (for the `text` field)
+  const text = htmlToText(
+    // Strip the "Prerequisite(s): " header label — we don't want to repeat it
+    prereqMatch[1].replace(
+      /<strong>\s*Prerequisites?(?:\(s\))?\s*:\s*<\/strong>/i,
+      "",
+    ),
+  );
+  if (!text) return null;
+  if (BOILERPLATE_RE.test(text)) return null;
+
+  // Extract all bubble-link course codes from the prereq span. CourseLeaf
+  // emits `class="bubblelink code"` on every course-to-course link, which
+  // gives us a reliable extraction even when the surrounding text has AND/OR
+  // prose. Exclude the course's own code.
+  const courses = new Set<string>();
+  const linkRegex = /class="[^"]*bubblelink\s+code[^"]*"[^>]*>\s*([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\s*</g;
+  let m: RegExpExecArray | null;
+  while ((m = linkRegex.exec(prereqMatch[1])) !== null) {
+    const code = `${m[1]} ${m[2]}`;
+    if (code !== `${prefix} ${number}`) courses.add(code);
+  }
+
+  // Fallback: also match any inline `PREFIX NUMBER` in the text itself.
+  // Handles cases where CourseLeaf didn't wrap a reference in a bubblelink.
+  const fallbackRegex = /\b([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b/g;
+  while ((m = fallbackRegex.exec(text)) !== null) {
+    const code = `${m[1]} ${m[2]}`;
+    if (code !== `${prefix} ${number}`) courses.add(code);
+  }
+
+  return { prefix, number, text, courses: Array.from(courses).sort() };
+}
+
+/** Split a subject page into `<div class="courseblock">` segments. */
+function extractCourseBlocks(subjectHtml: string): string[] {
+  // Split on the opening tag; the first fragment is pre-blocks boilerplate.
+  const parts = subjectHtml.split(/<div[^>]*class="[^"]*courseblock[^"]*"/);
+  return parts.slice(1); // drop the pre-block preamble
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limitSubjects = parseInt(
+    args.find((a) => a.startsWith("--limit-subjects="))?.split("=")[1] || "0",
+    10,
+  );
+
+  console.log("CCRI catalog prereq scraper");
+  console.log(`  Base: ${BASE}`);
+
+  // --- Phase 1: enumerate subjects ---
+  console.log("\n[1/2] Enumerating subjects from /course-descriptions/ ...");
+  const indexHtml = await retryFetch(`${BASE}/course-descriptions/`, "index");
+  let subjects = extractSubjectSlugs(indexHtml);
+  console.log(`  Found ${subjects.length} subject slugs`);
+
+  if (limitSubjects > 0) {
+    subjects = subjects.slice(0, limitSubjects);
+    console.log(`  Limited to first ${limitSubjects} for smoke test`);
+  }
+
+  // --- Phase 2: fetch each subject page + parse all course blocks ---
+  console.log("\n[2/2] Fetching subject pages...");
+  const prereqs: Record<string, PrereqEntry> = {};
+  let totalBlocks = 0;
+  let withPrereqs = 0;
+
+  await pmap(subjects, CONCURRENCY, async (subj) => {
+    const html = await retryFetch(
+      `${BASE}/course-descriptions/${subj}/`,
+      `subject(${subj})`,
+    );
+    if (!html) return;
+    const blocks = extractCourseBlocks(html);
+    totalBlocks += blocks.length;
+
+    for (const block of blocks) {
+      const parsed = parseCourseBlock(block);
+      if (!parsed) continue;
+      const key = `${parsed.prefix} ${parsed.number}`;
+      if (prereqs[key]) continue;
+      prereqs[key] = { text: parsed.text, courses: parsed.courses };
+      withPrereqs++;
+    }
+  });
+
+  console.log(`  Parsed ${totalBlocks} course blocks across ${subjects.length} subjects`);
+  console.log(`  Extracted prereqs for ${withPrereqs} courses`);
+
+  // Sort keys alphabetically for deterministic output
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(prereqs).sort()) {
+    sorted[key] = prereqs[key];
+  }
+
+  // --- Write ---
+  const outDir = path.join(process.cwd(), "data", "ri");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Third of 7 missing-prereq states shipped. CCRI uses CourseLeaf (different platform than VT/CT's acalog) — separate single-pass scraper.

**Source:** https://catalog.ccri.edu (CourseLeaf).

## Engine differences

| Engine | States | Platform | Lookup pattern |
|---|---|---|---|
| Acalog two-pass | VT (PR #22), CT (PR #23) | Modern Campus | coid-indirected `<a href>` links; need coid-to-code index |
| **CourseLeaf single-pass** | **RI (this PR)** | CourseLeaf | `<a class="bubblelink code">PREFIX NUMBER</a>` — code is the anchor text directly |

## Results

| State | Engine | Real courses | With prereqs | Coverage |
|---|---|---:|---:|---:|
| VT | acalog | 351 | 101 | 29% |
| CT | acalog | 823 | 573 | 70% |
| **RI** | **CourseLeaf** | **1,028 blocks** | **507** | **99% resolve-rate** |

CourseLeaf's explicit `bubblelink code` class makes code extraction deterministic — almost no false negatives.

## End-to-end verification
`GET /api/ri/prereqs/chain?course=AEES 1030` resolves to a multi-level chain with AND-of-OR groups rendered correctly.

## Reusable for NJ
The CourseLeaf engine here is the same as Essex CC, Ocean CC, and Bergen CC in NJ. A future PR can lift the parsing helpers into a shared module + wire 3-4 NJ schools in one go.

## Remaining 4 states
NY (Coursedog), ME (PDF-only), PA (CCP custom Drupal + Northampton Coursedog), NJ (Brookdale Coursedog + Essex/Ocean CourseLeaf)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full scrape completes in ~2 min, 507 entries
- [x] `/api/ri/prereqs/chain` tested on dev — multi-level chain works
- [ ] After merge: spot-check a CCRI course page on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)
