### PR TITLE
fix: bundle data/*/prereqs.json into serverless functions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,18 @@ import createMDX from "@next/mdx";
 
 const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+  // Explicitly bundle every state's prereqs.json into the serverless
+  // functions that read them (prereqs/chain, prereqs/courses, and the state
+  // layout's `fs.existsSync` check). Next's auto-tracing picked up the
+  // original 8 states (va/nc/sc/ga/dc/md/de/tn) on earlier deploys but
+  // silently stopped detecting new state subfolders added later — VT/CT/RI
+  // shipped prereq data in PRs #22-#24 yet the files weren't bundled, so
+  // the routes 404'd on prod. Globbing all states here future-proofs every
+  // new prereq scraper.
+  outputFileTracingIncludes: {
+    "/api/[state]/prereqs/**": ["./data/*/prereqs.json"],
+    "/[state]/**": ["./data/*/prereqs.json"],
+  },
   async redirects() {
     // Backward-compatible redirects from old routes to /va/ prefixed routes
     return [


### PR DESCRIPTION
## Summary
Prereqs PRs #22/#23/#24 shipped data but the /api/<state>/prereqs/* endpoints return 404 on prod for the 3 new states. Cause: Next.js auto-tracing only bundled the 8 original state folders; new folders don't get detected.

Fix: \`outputFileTracingIncludes\` in \`next.config.ts\` explicitly globs \`./data/*/prereqs.json\` for every route that reads them.

Verified:
- \`curl /api/va/prereqs/courses\` on prod returns 292 courses (existing, working)
- \`curl /api/vt/prereqs/courses\` on prod returns **0 courses + 404** (broken)
- Local \`npm run build\` clean after the patch

After this deploy, all 11 states (VA/NC/SC/GA/DC/MD/DE/TN + VT/CT/RI) should return real prereq data on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)