### PR TITLE
data: PA prereq scraper (CCP Drupal, 567 courses)

### DIFF
--- a/data/pa/prereqs.json
+++ b/data/pa/prereqs.json
@@ -1,0 +1,3803 @@
+{
+  "ACCT 102": {
+    "text": "ACCT 101 with grade of \"C\" or better",
+    "courses": [
+      "ACCT 101"
+    ]
+  },
+  "ACCT 103": {
+    "text": "ACCT 101 with a grade of \"C\" or better",
+    "courses": [
+      "ACCT 101"
+    ]
+  },
+  "ACCT 201": {
+    "text": "ACCT 101",
+    "courses": [
+      "ACCT 101"
+    ]
+  },
+  "ACCT 202": {
+    "text": "ACCT 201",
+    "courses": [
+      "ACCT 201"
+    ]
+  },
+  "ACCT 203": {
+    "text": "ACCT 102",
+    "courses": [
+      "ACCT 102"
+    ]
+  },
+  "ACCT 206": {
+    "text": "ACCT 201",
+    "courses": [
+      "ACCT 201"
+    ]
+  },
+  "ACCT 209": {
+    "text": "ACCT 208",
+    "courses": [
+      "ACCT 208"
+    ]
+  },
+  "ACCT 215": {
+    "text": "ACCT 102 or ACCT 101 and departmental approval",
+    "courses": [
+      "ACCT 101",
+      "ACCT 102"
+    ]
+  },
+  "ACCT 250": {
+    "text": "ACCT 202",
+    "courses": [
+      "ACCT 202"
+    ]
+  },
+  "ADC 112": {
+    "text": "ADC 103 or ADC 109",
+    "courses": [
+      "ADC 103",
+      "ADC 109"
+    ]
+  },
+  "ADC 159": {
+    "text": "ADC 103 and ADC 109",
+    "courses": [
+      "ADC 103",
+      "ADC 109"
+    ]
+  },
+  "ADC 160": {
+    "text": "ADC 103",
+    "courses": [
+      "ADC 103"
+    ]
+  },
+  "ADC 163": {
+    "text": "ADC 103",
+    "courses": [
+      "ADC 103"
+    ]
+  },
+  "ADC 192": {
+    "text": "ADC 160 , which may be taken concurrently",
+    "courses": [
+      "ADC 160"
+    ]
+  },
+  "ADC 209": {
+    "text": "ADC 159 and ADC 160",
+    "courses": [
+      "ADC 159",
+      "ADC 160"
+    ]
+  },
+  "ADC 212": {
+    "text": "ADC 103 or ADC 109",
+    "courses": [
+      "ADC 103",
+      "ADC 109"
+    ]
+  },
+  "ADC 221": {
+    "text": "ENGL 101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ADC 222": {
+    "text": "ADC 221 and ENGL 102 , which may be taken concurrently",
+    "courses": [
+      "ADC 221",
+      "ENGL 102"
+    ]
+  },
+  "ADC 226": {
+    "text": "MATH 137 or higher",
+    "courses": [
+      "MATH 137"
+    ]
+  },
+  "ADC 236": {
+    "text": "ADC 112 and ADC 133 , which may be taken concurrently",
+    "courses": [
+      "ADC 112",
+      "ADC 133"
+    ]
+  },
+  "ADC 237": {
+    "text": "ADC 236 and ADC 212 , which may be taken concurrently",
+    "courses": [
+      "ADC 212",
+      "ADC 236"
+    ]
+  },
+  "ADC 246": {
+    "text": "ADC 101",
+    "courses": [
+      "ADC 101"
+    ]
+  },
+  "ADC 253": {
+    "text": "ADC 101 and ADC 103 or ADC 109",
+    "courses": [
+      "ADC 101",
+      "ADC 103",
+      "ADC 109"
+    ]
+  },
+  "ADC 254": {
+    "text": "ADC 101 and ADC 103 or ADC 109",
+    "courses": [
+      "ADC 101",
+      "ADC 103",
+      "ADC 109"
+    ]
+  },
+  "ADC 259": {
+    "text": "ADC 209",
+    "courses": [
+      "ADC 209"
+    ]
+  },
+  "ADC 260": {
+    "text": "ADC 160",
+    "courses": [
+      "ADC 160"
+    ]
+  },
+  "ADC 261": {
+    "text": "ADC 133",
+    "courses": [
+      "ADC 133"
+    ]
+  },
+  "ADC 263": {
+    "text": "ADC 103 or ART 150",
+    "courses": [
+      "ADC 103",
+      "ART 150"
+    ]
+  },
+  "ADC 273": {
+    "text": "ADC 163",
+    "courses": [
+      "ADC 163"
+    ]
+  },
+  "ADC 283": {
+    "text": "ADC 160",
+    "courses": [
+      "ADC 160"
+    ]
+  },
+  "AET 102": {
+    "text": "ENGL 098 , ENGL 098 ESL , ENGL 098 / 108 , ENGL 101 /109 (CLC) or higher placement. Open to students at FNMT 017 level or higher, however, if students are at FNMT 017 level they must take FNMT 017 concurrently",
+    "courses": [
+      "ENGL 098",
+      "ENGL 101",
+      "FNMT 017"
+    ]
+  },
+  "AET 130": {
+    "text": "FNMT 118 or higher MATH with a grade of \"C\" or better or placement in MATH 161 or higher MATH",
+    "courses": [
+      "FNMT 118",
+      "MATH 161"
+    ]
+  },
+  "AET 140": {
+    "text": "FNMT 017 or higher MATH with a grade of \"C\" or better or placement in FNMT 118 or higher MATH",
+    "courses": [
+      "FNMT 017",
+      "FNMT 118"
+    ]
+  },
+  "AET 150": {
+    "text": "ELEC 120 , FNMT 118 or higher MATH completed with a grade of \"C\" or better or placement in MATH 161 or higher",
+    "courses": [
+      "ELEC 120",
+      "FNMT 118",
+      "MATH 161"
+    ]
+  },
+  "AET 201": {
+    "text": "CHEM 110 and FNMT 118 or higher MATH with a grade of \"C\" or better or placement in MATH 161 or higher",
+    "courses": [
+      "CHEM 110",
+      "FNMT 118",
+      "MATH 161"
+    ]
+  },
+  "AH 113": {
+    "text": "AH 103 and BIOL 108 with a grade of \"C\" or better, or AH 103 and BIOL 109 and BIOL 110 , each with a grade of \"C\" or better",
+    "courses": [
+      "AH 103",
+      "BIOL 108",
+      "BIOL 109",
+      "BIOL 110"
+    ]
+  },
+  "AH 115": {
+    "text": "AH 113 with a grade of \"C\" or better, which may be taken concurrently",
+    "courses": [
+      "AH 113"
+    ]
+  },
+  "AH 118": {
+    "text": "AH 113 and AH 115 , all of which may be taken concurrently",
+    "courses": [
+      "AH 113",
+      "AH 115"
+    ]
+  },
+  "AH 120": {
+    "text": "AH 103 and ENGL 101",
+    "courses": [
+      "AH 103",
+      "ENGL 101"
+    ]
+  },
+  "AH 190": {
+    "text": "AH 103 and BIOL 108 or BIOL 109 all with a grade of \"C\" or better",
+    "courses": [
+      "AH 103",
+      "BIOL 108",
+      "BIOL 109"
+    ]
+  },
+  "AH 201": {
+    "text": "AH 103 with a grade of \"C\" or better, AH 120 with a grade of \"C\" or better, BIOL 108 with a grade of \"C\" or better or BIOL 109 and 110 both with a grade of \"C\" or better and AH 190 with a grade of \"C\" or better",
+    "courses": [
+      "AH 103",
+      "AH 120",
+      "AH 190",
+      "BIOL 108",
+      "BIOL 109"
+    ]
+  },
+  "AH 204": {
+    "text": "ENGL 101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "AH 220": {
+    "text": "CIS 103 with a grade of \"C\" or better",
+    "courses": [
+      "CIS 103"
+    ]
+  },
+  "AH 224": {
+    "text": "MATH 150 or MATH 251 with a grade of \"C\" or better",
+    "courses": [
+      "MATH 150",
+      "MATH 251"
+    ]
+  },
+  "AH 260": {
+    "text": "AH 204",
+    "courses": [
+      "AH 204"
+    ]
+  },
+  "ALTF 101": {
+    "text": "AT 121 or MHT 112 or suitable work experience",
+    "courses": [
+      "AT 121",
+      "MHT 112"
+    ]
+  },
+  "ALTF 102": {
+    "text": "AT 121 or MHT 112 or suitable documented industry experience",
+    "courses": [
+      "AT 121",
+      "MHT 112"
+    ]
+  },
+  "ALTF 110": {
+    "text": "AT 261 or suitable documented industry experience",
+    "courses": [
+      "AT 261"
+    ]
+  },
+  "ALTF 111": {
+    "text": "AT 261 or suitable documented industry experience",
+    "courses": [
+      "AT 261"
+    ]
+  },
+  "ANTH 202": {
+    "text": "ENGL 101 , plus one of the following: ANTH 101 , ANTH 112 or SOC 101",
+    "courses": [
+      "ANTH 101",
+      "ANTH 112",
+      "ENGL 101",
+      "SOC 101"
+    ]
+  },
+  "ANTH 211": {
+    "text": "Any social or behavioral science course",
+    "courses": []
+  },
+  "ANTH 215": {
+    "text": "Any social or behavioral science course",
+    "courses": []
+  },
+  "ARAB 102": {
+    "text": "ARAB 101 or equivalent",
+    "courses": [
+      "ARAB 101"
+    ]
+  },
+  "ARAB 201": {
+    "text": "ARAB 102",
+    "courses": [
+      "ARAB 102"
+    ]
+  },
+  "ART 101H": {
+    "text": "ENGL 101 , may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ART 105": {
+    "text": "ENGL 071 and ENGL 081 / ENGL 091 or higher placement",
+    "courses": [
+      "ENGL 071",
+      "ENGL 081",
+      "ENGL 091"
+    ]
+  },
+  "ART 106": {
+    "text": "ART 105 with a grade of \"C\" or better",
+    "courses": [
+      "ART 105"
+    ]
+  },
+  "ART 109": {
+    "text": "ENGL 071 and ENGL 081 / ENGL 091 or higher placement",
+    "courses": [
+      "ENGL 071",
+      "ENGL 081",
+      "ENGL 091"
+    ]
+  },
+  "ART 112": {
+    "text": "ART 111 with a grade of \"C\" or better",
+    "courses": [
+      "ART 111"
+    ]
+  },
+  "ART 126": {
+    "text": "ART 125 with a grade of \"C\" or better",
+    "courses": [
+      "ART 125"
+    ]
+  },
+  "ART 151": {
+    "text": "ART 150 with a grade of \"C\" or better",
+    "courses": [
+      "ART 150"
+    ]
+  },
+  "ART 205": {
+    "text": "ART 103 with a grade of \"C\" or better and ART 104 with a grade of \"C\" or better",
+    "courses": [
+      "ART 103",
+      "ART 104"
+    ]
+  },
+  "ART 207": {
+    "text": "ART 106 with a grade of \"C\" or better",
+    "courses": [
+      "ART 106"
+    ]
+  },
+  "ART 208": {
+    "text": "ART 207 with a grade of \"C\" or better",
+    "courses": [
+      "ART 207"
+    ]
+  },
+  "ART 209": {
+    "text": "ART 109 with a grade of \"C\" or better",
+    "courses": [
+      "ART 109"
+    ]
+  },
+  "ART 215": {
+    "text": "ART 115 with a grade of \"C\" or better",
+    "courses": [
+      "ART 115"
+    ]
+  },
+  "ART 251": {
+    "text": "ART 151 with a grade of \"C\" or better",
+    "courses": [
+      "ART 151"
+    ]
+  },
+  "ART 290": {
+    "text": "ART 106 with a grade of \"C\" or better, ART 125 with a grade of \"C\" or better, and ART 111 with a grade of \"C\" or better",
+    "courses": [
+      "ART 106",
+      "ART 111",
+      "ART 125"
+    ]
+  },
+  "ASL 102": {
+    "text": "ASL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ASL 101"
+    ]
+  },
+  "ASL 201": {
+    "text": "ASL 102 with a grade of \"C\" or better",
+    "courses": [
+      "ASL 102"
+    ]
+  },
+  "ASL 202": {
+    "text": "ASL 201 with a grade of \"C\" or better",
+    "courses": [
+      "ASL 201"
+    ]
+  },
+  "ASL 215": {
+    "text": "ASL 202 with a grade of \"B\" or better",
+    "courses": [
+      "ASL 202"
+    ]
+  },
+  "ASL 230": {
+    "text": "ASL 202 with a grade of \"C\" or better and ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ASL 202",
+      "ENGL 101"
+    ]
+  },
+  "ASL 231": {
+    "text": "ASL 202 with a grade of \"B\" or better",
+    "courses": [
+      "ASL 202"
+    ]
+  },
+  "ASL 232": {
+    "text": "ASL 231 with a grade of \"C\" or better",
+    "courses": [
+      "ASL 231"
+    ]
+  },
+  "AT 102": {
+    "text": "Note: Before enrolling in any course in the Advanced Automotive Repair Professional proficiency certificate, students must submit proof of current state vehicle safety or emissions license or ASE certification",
+    "courses": []
+  },
+  "AT 105": {
+    "text": "Note: Before enrolling in any course in the Advanced Automotive Repair Professional proficiency certificate, students must submit proof of current state vehicle safety or emissions license or ASE certification",
+    "courses": []
+  },
+  "AT 106": {
+    "text": "Note: Before enrolling in any course in the Advanced Automotive Repair Professional proficiency certificate, students must submit proof of current state vehicle safety or emissions license or ASE certification",
+    "courses": []
+  },
+  "AT 109": {
+    "text": "Note: Before enrolling in any course in the Advanced Automotive Repair Professional proficiency certificate, students must submit proof of current state vehicle safety or emissions license or ASE certification",
+    "courses": []
+  },
+  "AT 110": {
+    "text": "Note: Before enrolling in any course in the Advanced Automotive Repair Professional proficiency certificate, students must submit proof of current state vehicle safety or emissions license or ASE certification",
+    "courses": []
+  },
+  "AT 111": {
+    "text": "AT 100 , which may be taken concurrently",
+    "courses": [
+      "AT 100"
+    ]
+  },
+  "AT 121": {
+    "text": "AT 100 , which may be taken concurrently",
+    "courses": [
+      "AT 100"
+    ]
+  },
+  "AT 131": {
+    "text": "AT 100 , which may be taken concurrently",
+    "courses": [
+      "AT 100"
+    ]
+  },
+  "AT 150": {
+    "text": "AT 100 , which may be taken concurrently",
+    "courses": [
+      "AT 100"
+    ]
+  },
+  "AT 181": {
+    "text": "AT 100 , which may be taken concurrently",
+    "courses": [
+      "AT 100"
+    ]
+  },
+  "AT 210": {
+    "text": "AT 121",
+    "courses": [
+      "AT 121"
+    ]
+  },
+  "AT 221": {
+    "text": "AT 100 , which may be taken concurrently",
+    "courses": [
+      "AT 100"
+    ]
+  },
+  "AT 241": {
+    "text": "AT 121 and AT 131",
+    "courses": [
+      "AT 121",
+      "AT 131"
+    ]
+  },
+  "AT 250": {
+    "text": "AT 121 and AT 150",
+    "courses": [
+      "AT 121",
+      "AT 150"
+    ]
+  },
+  "AT 261": {
+    "text": "AT 221 , which may be taken concurrently",
+    "courses": [
+      "AT 221"
+    ]
+  },
+  "AT 271": {
+    "text": "AT 121",
+    "courses": [
+      "AT 121"
+    ]
+  },
+  "AT 281": {
+    "text": "AT 221 and AT 261",
+    "courses": [
+      "AT 221",
+      "AT 261"
+    ]
+  },
+  "ATEN 111": {
+    "text": "ATEN 101",
+    "courses": [
+      "ATEN 101"
+    ]
+  },
+  "ATEN 121": {
+    "text": "ATEN 101 , which may be taken concurrently",
+    "courses": [
+      "ATEN 101"
+    ]
+  },
+  "ATEN 131": {
+    "text": "ATEN 150",
+    "courses": [
+      "ATEN 150"
+    ]
+  },
+  "ATEN 150": {
+    "text": "ATEN 111",
+    "courses": [
+      "ATEN 111"
+    ]
+  },
+  "ATEN 181": {
+    "text": "ATEN 271",
+    "courses": [
+      "ATEN 271"
+    ]
+  },
+  "ATEN 221": {
+    "text": "ATEN 121 , FNMT 118",
+    "courses": [
+      "ATEN 121",
+      "FNMT 118"
+    ]
+  },
+  "ATEN 241": {
+    "text": "ATEN 131",
+    "courses": [
+      "ATEN 131"
+    ]
+  },
+  "ATEN 261": {
+    "text": "ATEN 181",
+    "courses": [
+      "ATEN 181"
+    ]
+  },
+  "ATEN 281": {
+    "text": "ATEN 261 , may be taken concurrently",
+    "courses": [
+      "ATEN 261"
+    ]
+  },
+  "ATEN 282": {
+    "text": "ATEN 281",
+    "courses": [
+      "ATEN 281"
+    ]
+  },
+  "ATEN 294": {
+    "text": "ATEN 101 , which may be taken concurrently",
+    "courses": [
+      "ATEN 101"
+    ]
+  },
+  "ATEN 295": {
+    "text": "ATEN 121",
+    "courses": [
+      "ATEN 121"
+    ]
+  },
+  "BHHS 103": {
+    "text": "ENGL 101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "BHHS 112": {
+    "text": "BHHS 101 , which may be taken concurrently",
+    "courses": [
+      "BHHS 101"
+    ]
+  },
+  "BHHS 191": {
+    "text": "BHHS Practicum Education Coordinator approval",
+    "courses": []
+  },
+  "BHHS 194": {
+    "text": "BHHS 112 , and ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "BHHS 112",
+      "ENGL 101"
+    ]
+  },
+  "BHHS 195": {
+    "text": "BHHS Practicum Education Coordinator approval",
+    "courses": []
+  },
+  "BHHS 205": {
+    "text": "BHHS 105 with grade of \"C\" or better",
+    "courses": [
+      "BHHS 105"
+    ]
+  },
+  "BHHS 212": {
+    "text": "BHHS 111 with a grade of \"C\" or better",
+    "courses": [
+      "BHHS 111"
+    ]
+  },
+  "BHHS 213": {
+    "text": "BHHS 195 with a grade of \"C\" or better",
+    "courses": [
+      "BHHS 195"
+    ]
+  },
+  "BHHS 220": {
+    "text": "BHHS 120 with a grade of \"C\" or better",
+    "courses": [
+      "BHHS 120"
+    ]
+  },
+  "BHHS 293": {
+    "text": "BHHS 111 with a grade of \"C\" or better",
+    "courses": [
+      "BHHS 111"
+    ]
+  },
+  "BHHS 299": {
+    "text": "BHHS Practicum Education Coordinator approval",
+    "courses": []
+  },
+  "BIOL 100": {
+    "text": "FNMT 017 or FNMT 019 , which may be taken concurrently or placement in FNMT 118 or higher",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "BIOL 104": {
+    "text": "FNMT 118 or MATH 118 (or higher) placement",
+    "courses": [
+      "FNMT 118",
+      "MATH 118"
+    ]
+  },
+  "BIOL 107": {
+    "text": "BIOL 106 with a \"C\" or better",
+    "courses": [
+      "BIOL 106"
+    ]
+  },
+  "BIOL 108": {
+    "text": "FNMT 118 or MATH 118 (or higher) placement",
+    "courses": [
+      "FNMT 118",
+      "MATH 118"
+    ]
+  },
+  "BIOL 110": {
+    "text": "BIOL 109 and FNMT 017 (or FNMT 118 ready)",
+    "courses": [
+      "BIOL 109",
+      "FNMT 017",
+      "FNMT 118"
+    ]
+  },
+  "BIOL 123": {
+    "text": "CHEM 121 or CHEM 110 with a \"C\" or better and high school biology or permission of the department head",
+    "courses": [
+      "CHEM 110",
+      "CHEM 121"
+    ]
+  },
+  "BIOL 124": {
+    "text": "BIOL 123 with a \"C\" or better",
+    "courses": [
+      "BIOL 123"
+    ]
+  },
+  "BIOL 156": {
+    "text": "BIOL 155 and FNMT 118 or higher",
+    "courses": [
+      "BIOL 155",
+      "FNMT 118"
+    ]
+  },
+  "BIOL 211": {
+    "text": "BIOL 106 or BIOL 108 or BIOL 109 or BIOL 123 with a \"C\" or better or permission of the department head",
+    "courses": [
+      "BIOL 106",
+      "BIOL 108",
+      "BIOL 109",
+      "BIOL 123"
+    ]
+  },
+  "BIOL 225": {
+    "text": "BIOL 107 or BIOL 124 with a grade of \"C\" or better in either",
+    "courses": [
+      "BIOL 107",
+      "BIOL 124"
+    ]
+  },
+  "BIOL 241": {
+    "text": "BIOL 106 or BIOL 108 or BIOL 109 or BIOL 123 with a \"C\" or better or permission of the department head",
+    "courses": [
+      "BIOL 106",
+      "BIOL 108",
+      "BIOL 109",
+      "BIOL 123"
+    ]
+  },
+  "BIOL 255": {
+    "text": "FNMT 118 or higher or MATH 161 , CHEM 110 or CHEM 121 , and BIOL 123 OR BIOL 156 OR Department Head approval of a Co-requisite BIOL Lab Experience",
+    "courses": [
+      "BIOL 123",
+      "BIOL 156",
+      "CHEM 110",
+      "CHEM 121",
+      "FNMT 118",
+      "MATH 161"
+    ]
+  },
+  "BIOL 256": {
+    "text": "BIOL 255 with a grade of \"C\" or better",
+    "courses": [
+      "BIOL 255"
+    ]
+  },
+  "BIOL 281": {
+    "text": "BIOL 123 with a \"C\" or better",
+    "courses": [
+      "BIOL 123"
+    ]
+  },
+  "BLAS 102": {
+    "text": "BLAS 101",
+    "courses": [
+      "BLAS 101"
+    ]
+  },
+  "BLAS 250": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "BLAS 290": {
+    "text": "BLAS 101 and ENGL 102",
+    "courses": [
+      "BLAS 101",
+      "ENGL 102"
+    ]
+  },
+  "BMET 101": {
+    "text": "BIOL 108 or BIOL 110 (either may be taken concurrently.)",
+    "courses": [
+      "BIOL 108",
+      "BIOL 110"
+    ]
+  },
+  "BMET 102": {
+    "text": "BMET 101 with a grade of \"C\" or better and EETP 101/101C, which may be taken concurrently",
+    "courses": [
+      "BMET 101",
+      "EETP 101"
+    ]
+  },
+  "BMET 103": {
+    "text": "BMET 102 with a grade of \"C\" or better and FNMT 118 or higher",
+    "courses": [
+      "BMET 102",
+      "FNMT 118"
+    ]
+  },
+  "BMET 201": {
+    "text": "BMET 103 with a grade of \"C\" or better",
+    "courses": [
+      "BMET 103"
+    ]
+  },
+  "BMET 202": {
+    "text": "BMET 201 ; ELEC 130 , which may be taken concurrently; CIS 105 ; and CIS 150 with a grade of \"C\" or better in all four courses",
+    "courses": [
+      "BMET 201",
+      "CIS 105",
+      "CIS 150",
+      "ELEC 130"
+    ]
+  },
+  "BMET 203": {
+    "text": "BMET 102 with a \"C\" or better, FNMT 118 or higher",
+    "courses": [
+      "BMET 102",
+      "FNMT 118"
+    ]
+  },
+  "BTT 101": {
+    "text": "Permission of the Biomedical Training academic coordinator and completion of the Orientation to Biomedical Technology",
+    "courses": []
+  },
+  "BUSL 125": {
+    "text": "BUSL 101 , which may be taken concurrently, or ENTR 101",
+    "courses": [
+      "BUSL 101",
+      "ENTR 101"
+    ]
+  },
+  "BUSL 180": {
+    "text": "BUSL 101",
+    "courses": [
+      "BUSL 101"
+    ]
+  },
+  "BUSL 215": {
+    "text": "BUSL 125 or ( PJMT 110 and PJMT 130 )",
+    "courses": [
+      "BUSL 125",
+      "PJMT 110",
+      "PJMT 130"
+    ]
+  },
+  "CHEM 102": {
+    "text": "CHEM 101 or CHEM 110 with a grade of \"C\" or better",
+    "courses": [
+      "CHEM 101",
+      "CHEM 110"
+    ]
+  },
+  "CHEM 104": {
+    "text": "CHEM 103 or CHEM 101 or CHEM 110 , with a grade of \"C\" or better",
+    "courses": [
+      "CHEM 101",
+      "CHEM 103",
+      "CHEM 110"
+    ]
+  },
+  "CHEM 105": {
+    "text": "ENGL 101 ready",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CHEM 110": {
+    "text": "FNMT 118 or MATH 118 placement and ENGL 101 ready",
+    "courses": [
+      "ENGL 101",
+      "FNMT 118",
+      "MATH 118"
+    ]
+  },
+  "CHEM 118": {
+    "text": "CHEM 101 , CHEM 110 or CHEM 121 with a grade of \"C\" or better",
+    "courses": [
+      "CHEM 101",
+      "CHEM 110",
+      "CHEM 121"
+    ]
+  },
+  "CHEM 120": {
+    "text": "CHEM 103 or CHEM 104 with a grade of \"C\" or better, or a CHEM lecture course from a transfer institution with a grade of \"C\" or better; permission of the department head",
+    "courses": [
+      "CHEM 103",
+      "CHEM 104"
+    ]
+  },
+  "CHEM 121": {
+    "text": "CHEM 110 with a grade of \"C\" or better and FNMT 118 or MATH 118",
+    "courses": [
+      "CHEM 110",
+      "FNMT 118",
+      "MATH 118"
+    ]
+  },
+  "CHEM 122": {
+    "text": "CHEM 121 with a grade of \"C\" or better",
+    "courses": [
+      "CHEM 121"
+    ]
+  },
+  "CHEM 203": {
+    "text": "BIOL 108 or higher",
+    "courses": [
+      "BIOL 108"
+    ]
+  },
+  "CHEM 214": {
+    "text": "CHEM 122 with a grade of \"C\" or better and MATH 162 with a grade of \"C\" or better",
+    "courses": [
+      "CHEM 122",
+      "MATH 162"
+    ]
+  },
+  "CHEM 221": {
+    "text": "CHEM 122 with a grade of \"C\" or better",
+    "courses": [
+      "CHEM 122"
+    ]
+  },
+  "CHEM 222": {
+    "text": "CHEM 221 with a grade of \"C\" or better",
+    "courses": [
+      "CHEM 221"
+    ]
+  },
+  "CHIN 102": {
+    "text": "CHIN 101",
+    "courses": [
+      "CHIN 101"
+    ]
+  },
+  "CHIN 201": {
+    "text": "CHIN 102",
+    "courses": [
+      "CHIN 102"
+    ]
+  },
+  "CHIN 202": {
+    "text": "CHIN 201",
+    "courses": [
+      "CHIN 201"
+    ]
+  },
+  "CIS 130": {
+    "text": "CIS 103",
+    "courses": [
+      "CIS 103"
+    ]
+  },
+  "CIS 152": {
+    "text": "CIS 150 may be taken concurrently",
+    "courses": [
+      "CIS 150"
+    ]
+  },
+  "CIS 201": {
+    "text": "CIS 200",
+    "courses": [
+      "CIS 200"
+    ]
+  },
+  "CIS 204": {
+    "text": "CIS 105 or CIS 155",
+    "courses": [
+      "CIS 105",
+      "CIS 155"
+    ]
+  },
+  "CIS 205": {
+    "text": "CSCI 112 , which may be taken concurrently, or CIS 103 or CSCI 118",
+    "courses": [
+      "CIS 103",
+      "CSCI 112",
+      "CSCI 118"
+    ]
+  },
+  "CIS 211": {
+    "text": "CIS 106 or CIS 114 or CSCI 111",
+    "courses": [
+      "CIS 106",
+      "CIS 114",
+      "CSCI 111"
+    ]
+  },
+  "CIS 212": {
+    "text": "CIS 211",
+    "courses": [
+      "CIS 211"
+    ]
+  },
+  "CIS 228": {
+    "text": "CIS 114",
+    "courses": [
+      "CIS 114"
+    ]
+  },
+  "CIS 230": {
+    "text": "CIS 130",
+    "courses": [
+      "CIS 130"
+    ]
+  },
+  "CIS 244": {
+    "text": "CIS 114 and CIS 205 , which may be taken concurrently",
+    "courses": [
+      "CIS 114",
+      "CIS 205"
+    ]
+  },
+  "CIS 252": {
+    "text": "CIS 150",
+    "courses": [
+      "CIS 150"
+    ]
+  },
+  "CIS 256": {
+    "text": "CIS 150",
+    "courses": [
+      "CIS 150"
+    ]
+  },
+  "CIS 259": {
+    "text": "CIS 150 with a grade of \"C\" or better",
+    "courses": [
+      "CIS 150"
+    ]
+  },
+  "CIS 261": {
+    "text": "CIS 155",
+    "courses": [
+      "CIS 155"
+    ]
+  },
+  "CIS 270": {
+    "text": "CIS 205",
+    "courses": [
+      "CIS 205"
+    ]
+  },
+  "CIS 271": {
+    "text": "CIS 103 and FNMT 118 or higher",
+    "courses": [
+      "CIS 103",
+      "FNMT 118"
+    ]
+  },
+  "CIS 274": {
+    "text": "CIS 152 and CIS 259",
+    "courses": [
+      "CIS 152",
+      "CIS 259"
+    ]
+  },
+  "CIS 288": {
+    "text": "CIS 103",
+    "courses": [
+      "CIS 103"
+    ]
+  },
+  "CMS 107": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 115": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 116": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 117": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 118": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 119": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 122": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 180": {
+    "text": "ENGL 097 which may be taken concurrently or ENGL 101 ready",
+    "courses": [
+      "ENGL 097",
+      "ENGL 101"
+    ]
+  },
+  "CMS 214": {
+    "text": "CMS 107 with a grade of \"C\" or better",
+    "courses": [
+      "CMS 107"
+    ]
+  },
+  "CMS 216": {
+    "text": "ENGL 115 with a grade of \"C\" or better and CMS 107 or ENGL 116 with a grade of \"C\" or better",
+    "courses": [
+      "CMS 107",
+      "ENGL 115",
+      "ENGL 116"
+    ]
+  },
+  "CMS 219": {
+    "text": "ENGL 101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CMS 220": {
+    "text": "CMS 107 or CMS 180",
+    "courses": [
+      "CMS 107",
+      "CMS 180"
+    ]
+  },
+  "CMS 252": {
+    "text": "CMS 107 or CMS 114 or CMS 122",
+    "courses": [
+      "CMS 107",
+      "CMS 114",
+      "CMS 122"
+    ]
+  },
+  "CMS 254": {
+    "text": "CMS 122 or ENGL 122",
+    "courses": [
+      "CMS 122",
+      "ENGL 122"
+    ]
+  },
+  "CMS 255": {
+    "text": "CMS 122 or ENGL 122",
+    "courses": [
+      "CMS 122",
+      "ENGL 122"
+    ]
+  },
+  "CMS 270": {
+    "text": "CMS 107 or CMS 180",
+    "courses": [
+      "CMS 107",
+      "CMS 180"
+    ]
+  },
+  "CMS 280": {
+    "text": "CMS 114",
+    "courses": [
+      "CMS 114"
+    ]
+  },
+  "CMS 290": {
+    "text": "CMS 114 and CMS 122",
+    "courses": [
+      "CMS 114",
+      "CMS 122"
+    ]
+  },
+  "COUN 101": {
+    "text": "ENGL 101 placement",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "CSCI 111": {
+    "text": "FNMT 118 or MATH 118 or higher; (or MATH 161 placement)",
+    "courses": [
+      "FNMT 118",
+      "MATH 118",
+      "MATH 161"
+    ]
+  },
+  "CSCI 112": {
+    "text": "CSCI 111 with a grade of \"C\" or better",
+    "courses": [
+      "CSCI 111"
+    ]
+  },
+  "CSCI 118": {
+    "text": "FNMT 118 completed with a grade of \"C\" or better (or placement in MATH 161 or higher) and either CSCI 111 , which may be taken concurrently or CIS 106 , which may be taken concurrently",
+    "courses": [
+      "CIS 106",
+      "CSCI 111",
+      "FNMT 118",
+      "MATH 161"
+    ]
+  },
+  "CSCI 211": {
+    "text": "CSCI 112 with a grade of \"C\" or better",
+    "courses": [
+      "CSCI 112"
+    ]
+  },
+  "CSCI 213": {
+    "text": "MATH 163 , which may be taken concurrently, and CSCI 111 with a grade of \"C\" or better",
+    "courses": [
+      "CSCI 111",
+      "MATH 163"
+    ]
+  },
+  "CSCI 215": {
+    "text": "CSCI 111 with a grade of \"C\" or better",
+    "courses": [
+      "CSCI 111"
+    ]
+  },
+  "CSCI 218": {
+    "text": "MATH 161 with a grade of \"C\" or better (or higher placement) and either CSCI 111 with a grade of \"C\" or better or CSCI 118 with a grade of \"C\" or better",
+    "courses": [
+      "CSCI 111",
+      "CSCI 118",
+      "MATH 161"
+    ]
+  },
+  "CSCI 221": {
+    "text": "CSCI 118 with a grade of \"C\" or better or CSCI 218 with a grade of \"C\" or better",
+    "courses": [
+      "CSCI 118",
+      "CSCI 218"
+    ]
+  },
+  "CTR 201": {
+    "text": "CTR 101",
+    "courses": [
+      "CTR 101"
+    ]
+  },
+  "CULA 171": {
+    "text": "CULA 170",
+    "courses": [
+      "CULA 170"
+    ]
+  },
+  "CULA 210": {
+    "text": "CULA 151 , and CULA 171",
+    "courses": [
+      "CULA 151",
+      "CULA 171"
+    ]
+  },
+  "CULA 211": {
+    "text": "CULA 151 and CULA 171",
+    "courses": [
+      "CULA 151",
+      "CULA 171"
+    ]
+  },
+  "CULA 220": {
+    "text": "CULA 171",
+    "courses": [
+      "CULA 171"
+    ]
+  },
+  "CULA 240": {
+    "text": "CULA 210 & CULA 211 and ENGL 101",
+    "courses": [
+      "CULA 210",
+      "CULA 211",
+      "ENGL 101"
+    ]
+  },
+  "CULA 270": {
+    "text": "CULA 210 and CULA 211",
+    "courses": [
+      "CULA 210",
+      "CULA 211"
+    ]
+  },
+  "CULA 271": {
+    "text": "CULA 210 and CULA 211",
+    "courses": [
+      "CULA 210",
+      "CULA 211"
+    ]
+  },
+  "CULA 288": {
+    "text": "CULA 220 and ENGL 101",
+    "courses": [
+      "CULA 220",
+      "ENGL 101"
+    ]
+  },
+  "DF 101": {
+    "text": "JUS 101 or PLS 101",
+    "courses": [
+      "JUS 101",
+      "PLS 101"
+    ]
+  },
+  "DF 201": {
+    "text": "DF 101",
+    "courses": [
+      "DF 101"
+    ]
+  },
+  "DF 203": {
+    "text": "DF 101 and CIS 150",
+    "courses": [
+      "CIS 150",
+      "DF 101"
+    ]
+  },
+  "DF 220": {
+    "text": "DF 101 and CIS 150",
+    "courses": [
+      "CIS 150",
+      "DF 101"
+    ]
+  },
+  "DF 250": {
+    "text": "DF 201",
+    "courses": [
+      "DF 201"
+    ]
+  },
+  "DH 115": {
+    "text": "ENGL 101 and CIS 103",
+    "courses": [
+      "CIS 103",
+      "ENGL 101"
+    ]
+  },
+  "DH 121": {
+    "text": "DH 115 , DH 135 , DH 150 , DH 191 and BIOL 109",
+    "courses": [
+      "BIOL 109",
+      "DH 115",
+      "DH 135",
+      "DH 150",
+      "DH 191"
+    ]
+  },
+  "DH 135": {
+    "text": "ENGL 101 and CIS 103",
+    "courses": [
+      "CIS 103",
+      "ENGL 101"
+    ]
+  },
+  "DH 150": {
+    "text": "ENGL 101 and CIS 103",
+    "courses": [
+      "CIS 103",
+      "ENGL 101"
+    ]
+  },
+  "DH 165": {
+    "text": "DH 115 , DH 135 , DH 150 , DH 191 and BIOL 109",
+    "courses": [
+      "BIOL 109",
+      "DH 115",
+      "DH 135",
+      "DH 150",
+      "DH 191"
+    ]
+  },
+  "DH 191": {
+    "text": "ENGL 101 CIS 103 and CPR certification",
+    "courses": [
+      "CIS 103",
+      "ENGL 101"
+    ]
+  },
+  "DH 192": {
+    "text": "DH 115 , DH 135 , DH 150 , DH 191 and BIOL 109",
+    "courses": [
+      "BIOL 109",
+      "DH 115",
+      "DH 135",
+      "DH 150",
+      "DH 191"
+    ]
+  },
+  "DH 210": {
+    "text": "DH 121 , DH 165 , DH 192 and BIOL 110",
+    "courses": [
+      "BIOL 110",
+      "DH 121",
+      "DH 165",
+      "DH 192"
+    ]
+  },
+  "DH 241": {
+    "text": "ENGL 102 , BIOL 110 , DH 165 , DH 192 , and DH 121",
+    "courses": [
+      "BIOL 110",
+      "DH 121",
+      "DH 165",
+      "DH 192",
+      "ENGL 102"
+    ]
+  },
+  "DH 245": {
+    "text": "ENGL 102 , BIOL 110 , DH 165 , DH 192 , and DH 121",
+    "courses": [
+      "BIOL 110",
+      "DH 121",
+      "DH 165",
+      "DH 192",
+      "ENGL 102"
+    ]
+  },
+  "DH 247": {
+    "text": "ENGL 102 , BIOL 110 , DH 121 , DH 192 , and DH 165",
+    "courses": [
+      "BIOL 110",
+      "DH 121",
+      "DH 165",
+      "DH 192",
+      "ENGL 102"
+    ]
+  },
+  "DH 271": {
+    "text": "DH 241 , DH 245 , DH 247 , DH 293 , and BIOL 241",
+    "courses": [
+      "BIOL 241",
+      "DH 241",
+      "DH 245",
+      "DH 247",
+      "DH 293"
+    ]
+  },
+  "DH 293": {
+    "text": "BIOL 110 , ENGL 102 , DH 165 , DH 121 , and DH 192",
+    "courses": [
+      "BIOL 110",
+      "DH 121",
+      "DH 165",
+      "DH 192",
+      "ENGL 102"
+    ]
+  },
+  "DH 294": {
+    "text": "DH 241 , DH 245 , DH 247 , DH 293 , and BIOL 241",
+    "courses": [
+      "BIOL 241",
+      "DH 241",
+      "DH 245",
+      "DH 247",
+      "DH 293"
+    ]
+  },
+  "DH 295": {
+    "text": "DH 271 , DH 294 , and ENGL 115",
+    "courses": [
+      "DH 271",
+      "DH 294",
+      "ENGL 115"
+    ]
+  },
+  "DMI 105": {
+    "text": "FNMT 118 with a grade of \"C\" or better, or placement in MATH 161 and DMI 101 with a grade of \"C\" or better",
+    "courses": [
+      "DMI 101",
+      "FNMT 118",
+      "MATH 161"
+    ]
+  },
+  "DMI 106": {
+    "text": "DMI 105 with a grade of \"C\" or better",
+    "courses": [
+      "DMI 105"
+    ]
+  },
+  "DMI 131": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "DMI 132": {
+    "text": "BIOL 109 with a grade of \"C\" or better",
+    "courses": [
+      "BIOL 109"
+    ]
+  },
+  "DMI 198": {
+    "text": "DMI 106 , DMI 120 , DMI 132 , DMI 182 and DMI 197 all with a grade of \"C\" or better",
+    "courses": [
+      "DMI 106",
+      "DMI 120",
+      "DMI 132",
+      "DMI 182",
+      "DMI 197"
+    ]
+  },
+  "DMI 199": {
+    "text": "DMI 198 with a grade of \"C\" or better",
+    "courses": [
+      "DMI 198"
+    ]
+  },
+  "DMI 221": {
+    "text": "CIS 103 , DMI 199 , both with a grade of \"C\" or better",
+    "courses": [
+      "CIS 103",
+      "DMI 199"
+    ]
+  },
+  "DMI 222": {
+    "text": "DMI 221 , DMI 231 , DMI 261 and DMI 297 , all with a grade of \"C\" or better",
+    "courses": [
+      "DMI 221",
+      "DMI 231",
+      "DMI 261",
+      "DMI 297"
+    ]
+  },
+  "DMI 231": {
+    "text": "BIOL 110 , ENGL 102 , all with a grade of \"C\" or better",
+    "courses": [
+      "BIOL 110",
+      "ENGL 102"
+    ]
+  },
+  "DMI 299": {
+    "text": "DMI 222 , DMI 232 and DMI 298 all with a grade of \"C\" or better",
+    "courses": [
+      "DMI 222",
+      "DMI 232",
+      "DMI 298"
+    ]
+  },
+  "DVP 120": {
+    "text": "PHOT 104 with a B or better",
+    "courses": [
+      "PHOT 104"
+    ]
+  },
+  "DVP 130": {
+    "text": "PHOT 104 with a B or better",
+    "courses": [
+      "PHOT 104"
+    ]
+  },
+  "DVP 140": {
+    "text": "PHOT 104 with a grade of \"B\" or better",
+    "courses": [
+      "PHOT 104"
+    ]
+  },
+  "DVP 150": {
+    "text": "PHOT 104 with a grade of \"B\" or better",
+    "courses": [
+      "PHOT 104"
+    ]
+  },
+  "DVP 210": {
+    "text": "DVP 120 , DVP 130 , DVP 140 , and DVP 150",
+    "courses": [
+      "DVP 120",
+      "DVP 130",
+      "DVP 140",
+      "DVP 150"
+    ]
+  },
+  "DVP 220": {
+    "text": "DVP 120 , DVP 130 , DVP 140 , and DVP 150",
+    "courses": [
+      "DVP 120",
+      "DVP 130",
+      "DVP 140",
+      "DVP 150"
+    ]
+  },
+  "DVP 240": {
+    "text": "DVP 140",
+    "courses": [
+      "DVP 140"
+    ]
+  },
+  "DVP 250": {
+    "text": "PHOT 104",
+    "courses": [
+      "PHOT 104"
+    ]
+  },
+  "DVP 260": {
+    "text": "DVP 140 , and DVP 130 which may be taken concurrently",
+    "courses": [
+      "DVP 130",
+      "DVP 140"
+    ]
+  },
+  "ECON 112": {
+    "text": "FNMT 118 or MATH 118, or higher than FNMT 118 or MATH 118 on placement test",
+    "courses": [
+      "FNMT 118",
+      "MATH 118"
+    ]
+  },
+  "ECON 114": {
+    "text": "ECON 112 and CIS 103",
+    "courses": [
+      "CIS 103",
+      "ECON 112"
+    ]
+  },
+  "ECON 181": {
+    "text": "FNMT 118 or higher",
+    "courses": [
+      "FNMT 118"
+    ]
+  },
+  "ECON 182": {
+    "text": "FNMT 118 or higher",
+    "courses": [
+      "FNMT 118"
+    ]
+  },
+  "ED 201": {
+    "text": "ENGL 101 which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ED 204": {
+    "text": "ED 105 with a grade of \"C\" or better, ENGL 101 , and PSYC 101",
+    "courses": [
+      "ED 105",
+      "ENGL 101",
+      "PSYC 101"
+    ]
+  },
+  "ED 214": {
+    "text": "ED 105 or ED 201 either with a grade of \"C\" or better, PSYC 101 , may be taken concurrently, and ENGL 102 with a grade of \"C\" or better",
+    "courses": [
+      "ED 105",
+      "ED 201",
+      "ENGL 102",
+      "PSYC 101"
+    ]
+  },
+  "ED 222": {
+    "text": "PSYC 201 and ( ED 204 or ED 214 , either with a grade of \"C\" or better) and ENGL 102",
+    "courses": [
+      "ED 204",
+      "ED 214",
+      "ENGL 102",
+      "PSYC 201"
+    ]
+  },
+  "ED 224": {
+    "text": "FNMT 118 or higher with a grade of \"C\" or higher and EASC 111 or Lab Science course with a grade of \"C\" or higher",
+    "courses": [
+      "EASC 111",
+      "FNMT 118"
+    ]
+  },
+  "ED 227": {
+    "text": "ENGL 214 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 214"
+    ]
+  },
+  "ED 230": {
+    "text": "ED 105 with a grade of \"C\" or better and ENGL 101",
+    "courses": [
+      "ED 105",
+      "ENGL 101"
+    ]
+  },
+  "ED 245": {
+    "text": "( ED 204 or ED 214 , either with a grade of \"C\" or better) and PSYC 201",
+    "courses": [
+      "ED 204",
+      "ED 214",
+      "PSYC 201"
+    ]
+  },
+  "ED 246": {
+    "text": "ED 201 with a grade of \"C\" or better and ED 214 , may be taken concurrently",
+    "courses": [
+      "ED 201",
+      "ED 214"
+    ]
+  },
+  "ED 247": {
+    "text": "ED 214 , can be taken concurrently",
+    "courses": [
+      "ED 214"
+    ]
+  },
+  "ED 250": {
+    "text": "( ED 204 or ED 214 , either with a grade of \"C\" or better) and PSYC 201",
+    "courses": [
+      "ED 204",
+      "ED 214",
+      "PSYC 201"
+    ]
+  },
+  "ED 255": {
+    "text": "( ED 105 or ED 201 , either with a grade of \"C\" or better) and ( ED 204 or ED 214 , either with a grade of \"C\" or better) and ( ED 222 with a grade of \"C\" or better or PSYC 209 ) and ENGL 102",
+    "courses": [
+      "ED 105",
+      "ED 201",
+      "ED 204",
+      "ED 214",
+      "ED 222",
+      "ENGL 102",
+      "PSYC 209"
+    ]
+  },
+  "ED 265": {
+    "text": "( ED 105 or ED 201 , either with a grade of \"C\" or better) and ( ED 204 or ED 214 , either with a grade of \"C\" or better) and ( PSYC 201 or PSYC 209 or PSYC 215 )",
+    "courses": [
+      "ED 105",
+      "ED 201",
+      "ED 204",
+      "ED 214",
+      "PSYC 201",
+      "PSYC 209",
+      "PSYC 215"
+    ]
+  },
+  "ED 290": {
+    "text": "ED 222 , ED 245 , and ED 250 , all with a grade of \"C\" or better",
+    "courses": [
+      "ED 222",
+      "ED 245",
+      "ED 250"
+    ]
+  },
+  "ED 295": {
+    "text": "ED 246 or ED 247 or ED 271 which may be taken concurrently",
+    "courses": [
+      "ED 246",
+      "ED 247",
+      "ED 271"
+    ]
+  },
+  "EETP 101": {
+    "text": "EETP 101: FNMT 118 or 141 with a \"C\" or better, OR placement in MATH 161 or higher. EETP 101C: MATH 161 with a \"C\" or better, or placement in MATH 171",
+    "courses": [
+      "EETP 101C",
+      "FNMT 118",
+      "MATH 161",
+      "MATH 171"
+    ]
+  },
+  "EETP 101C": {
+    "text": "MATH 161 with a \"C\" or better, or placement in MATH 171",
+    "courses": [
+      "MATH 161",
+      "MATH 171"
+    ]
+  },
+  "EETP 102": {
+    "text": "EETP 101 with a grade of \"C\" better",
+    "courses": [
+      "EETP 101"
+    ]
+  },
+  "EETP 102C": {
+    "text": "EETP 101C with a grade of \"C\" or better",
+    "courses": [
+      "EETP 101C"
+    ]
+  },
+  "EETP 205": {
+    "text": "FNMT 118 with a grade of \"C\" or better or FNMT 141 with a grade of \"C\" or better",
+    "courses": [
+      "FNMT 118",
+      "FNMT 141"
+    ]
+  },
+  "EETP 205C": {
+    "text": "MATH 162 with a grade of \"C\" or better",
+    "courses": [
+      "MATH 162"
+    ]
+  },
+  "EETP 206": {
+    "text": "EETP 101/ 101C and FNMT 118 or FNMT 141",
+    "courses": [
+      "EETP 101",
+      "FNMT 118",
+      "FNMT 141"
+    ]
+  },
+  "EETP 206C": {
+    "text": "ELEC 120 or EETP 101C and MATH 171",
+    "courses": [
+      "EETP 101C",
+      "ELEC 120",
+      "MATH 171"
+    ]
+  },
+  "EETP 250": {
+    "text": "FNMT 118 with a grade of \"C\" or better, or FNMT 141 with a grade of \"C\" or better, or MATH 162 with a grade of \"C\" or better",
+    "courses": [
+      "FNMT 118",
+      "FNMT 141",
+      "MATH 162"
+    ]
+  },
+  "ENGL 071": {
+    "text": "placement",
+    "courses": []
+  },
+  "ENGL 072": {
+    "text": "\"Pass\" grade in ENGL 071 or ENGL 072 placement",
+    "courses": [
+      "ENGL 071"
+    ]
+  },
+  "ENGL 073": {
+    "text": "ENGL 072 or ENGL 073 placement and ENGL 082 / 092 placement or pass grade in ENGL 081 / 091",
+    "courses": [
+      "ENGL 072",
+      "ENGL 081",
+      "ENGL 082"
+    ]
+  },
+  "ENGL 081": {
+    "text": "Placement",
+    "courses": []
+  },
+  "ENGL 082": {
+    "text": "\"Pass\" grade in ENGL 081 and ENGL 091 or placement",
+    "courses": [
+      "ENGL 081",
+      "ENGL 091"
+    ]
+  },
+  "ENGL 083": {
+    "text": "ENGL 082 / ENGL 092 or placement",
+    "courses": [
+      "ENGL 082",
+      "ENGL 092"
+    ]
+  },
+  "ENGL 091": {
+    "text": "Placement",
+    "courses": []
+  },
+  "ENGL 092": {
+    "text": "\"Pass\" grade in ENGL 081 and ENGL 091 or placement",
+    "courses": [
+      "ENGL 081",
+      "ENGL 091"
+    ]
+  },
+  "ENGL 093": {
+    "text": "ENGL 082 / ENGL 092 or placement",
+    "courses": [
+      "ENGL 082",
+      "ENGL 092"
+    ]
+  },
+  "ENGL 098": {
+    "text": "Successful completion of ENGL 097 with a grade of MP or better",
+    "courses": [
+      "ENGL 097"
+    ]
+  },
+  "ENGL 099": {
+    "text": "ENGL 093 or ENGL 097 placement",
+    "courses": [
+      "ENGL 093",
+      "ENGL 097"
+    ]
+  },
+  "ENGL 102": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 102H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "ENGL 107": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 112": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 131": {
+    "text": "ENGL 073 and ENGL 083 / ENGL 093 or higher placement",
+    "courses": [
+      "ENGL 073",
+      "ENGL 083",
+      "ENGL 093"
+    ]
+  },
+  "ENGL 132": {
+    "text": "ENGL 131 or permission of the department head",
+    "courses": [
+      "ENGL 131"
+    ]
+  },
+  "ENGL 135": {
+    "text": "ENGL 073 and ENGL 083 / ENGL 093 or higher placement",
+    "courses": [
+      "ENGL 073",
+      "ENGL 083",
+      "ENGL 093"
+    ]
+  },
+  "ENGL 136": {
+    "text": "ENGL 135 or permission of the department head",
+    "courses": [
+      "ENGL 135"
+    ]
+  },
+  "ENGL 142": {
+    "text": "ENGL 132",
+    "courses": [
+      "ENGL 132"
+    ]
+  },
+  "ENGL 190": {
+    "text": "ENGL 101 , may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 195H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "ENGL 196H": {
+    "text": "ENGL 195H",
+    "courses": [
+      "ENGL 195H"
+    ]
+  },
+  "ENGL 211": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 212": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 221": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 222": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 230": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 232": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 241": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 245": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 246": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 250": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 251": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 256": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 260": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 265": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 271": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 272": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 280": {
+    "text": "ENGL 205",
+    "courses": [
+      "ENGL 205"
+    ]
+  },
+  "ENGL 281": {
+    "text": "ENGL 205",
+    "courses": [
+      "ENGL 205"
+    ]
+  },
+  "ENGL 282": {
+    "text": "ENGL 205",
+    "courses": [
+      "ENGL 205"
+    ]
+  },
+  "ENGL 283": {
+    "text": "ENGL 102 or ENGL 205",
+    "courses": [
+      "ENGL 102",
+      "ENGL 205"
+    ]
+  },
+  "ENGL 285": {
+    "text": "Enrollment in the certificate program in Creative Writing and ENGL 280 , ENGL 281 , ENGL 282 or ENGL 283",
+    "courses": [
+      "ENGL 280",
+      "ENGL 281",
+      "ENGL 282",
+      "ENGL 283"
+    ]
+  },
+  "ENGL 297H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "ENGL 298H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "ENGR 102": {
+    "text": "MATH 162 or a higher-level Mathematics course",
+    "courses": [
+      "MATH 162"
+    ]
+  },
+  "ENGR 202": {
+    "text": "ENGR 102",
+    "courses": [
+      "ENGR 102"
+    ]
+  },
+  "ENGR 205": {
+    "text": "PHYS 241 and MATH 172",
+    "courses": [
+      "MATH 172",
+      "PHYS 241"
+    ]
+  },
+  "ENGR 221": {
+    "text": "PHYS 140 and MATH 172",
+    "courses": [
+      "MATH 172",
+      "PHYS 140"
+    ]
+  },
+  "ENGR 222": {
+    "text": "ENGR 221 and MATH 271",
+    "courses": [
+      "ENGR 221",
+      "MATH 271"
+    ]
+  },
+  "ENTR 140": {
+    "text": "ENTR 110",
+    "courses": [
+      "ENTR 110"
+    ]
+  },
+  "ENTR 210": {
+    "text": "ENTR 101 and ENTR 170",
+    "courses": [
+      "ENTR 101",
+      "ENTR 170"
+    ]
+  },
+  "ENTR 250": {
+    "text": "ENTR 210 , which may be taken concurrently",
+    "courses": [
+      "ENTR 210"
+    ]
+  },
+  "FIN 155": {
+    "text": "FIN 151 , which may be taken concurrently",
+    "courses": [
+      "FIN 151"
+    ]
+  },
+  "FIN 160": {
+    "text": "FIN 151 , which may be taken concurrently",
+    "courses": [
+      "FIN 151"
+    ]
+  },
+  "FIN 165": {
+    "text": "FIN 151 , which may be taken concurrently",
+    "courses": [
+      "FIN 151"
+    ]
+  },
+  "FMM 110": {
+    "text": "FMM 101 , which may be taken concurrently",
+    "courses": [
+      "FMM 101"
+    ]
+  },
+  "FMM 112": {
+    "text": "FMM 110",
+    "courses": [
+      "FMM 110"
+    ]
+  },
+  "FMM 115": {
+    "text": "FMM 101",
+    "courses": [
+      "FMM 101"
+    ]
+  },
+  "FMM 120": {
+    "text": "FMM 101",
+    "courses": [
+      "FMM 101"
+    ]
+  },
+  "FMM 125": {
+    "text": "FMM 101",
+    "courses": [
+      "FMM 101"
+    ]
+  },
+  "FMM 130": {
+    "text": "FMM 110",
+    "courses": [
+      "FMM 110"
+    ]
+  },
+  "FMM 135": {
+    "text": "FMM 115 , with a grade of \"C\" or better OR THM 170 , which may be taken concurrently OR CMS 114 , with a grade of \"C\" or better",
+    "courses": [
+      "CMS 114",
+      "FMM 115",
+      "THM 170"
+    ]
+  },
+  "FMM 140": {
+    "text": "FMM 105 , FMM 115 , FMM 125 , FNMT 121 or FNMT 118 or higher MATH, and CIS 103",
+    "courses": [
+      "CIS 103",
+      "FMM 105",
+      "FMM 115",
+      "FMM 125",
+      "FNMT 118",
+      "FNMT 121"
+    ]
+  },
+  "FMM 145": {
+    "text": "FMM 110 and FMM 130",
+    "courses": [
+      "FMM 110",
+      "FMM 130"
+    ]
+  },
+  "FMM 150": {
+    "text": "FMM 105",
+    "courses": [
+      "FMM 105"
+    ]
+  },
+  "FMM 155": {
+    "text": "FMM 135 , FMM 140 , ECON 181 (may be taken concurrently) , and PHOT 105 (may be taken concurrently)",
+    "courses": [
+      "ECON 181",
+      "FMM 135",
+      "FMM 140",
+      "PHOT 105"
+    ]
+  },
+  "FMM 160": {
+    "text": "FMM 101 , FMM 130 , and FMM 145",
+    "courses": [
+      "FMM 101",
+      "FMM 130",
+      "FMM 145"
+    ]
+  },
+  "FNMT 017": {
+    "text": "\"Pass\" grade in FNMT 016 or satisfactory score on mathematics placement test",
+    "courses": [
+      "FNMT 016"
+    ]
+  },
+  "FNMT 020": {
+    "text": "FNMT 019 , which may be taken concurrently",
+    "courses": [
+      "FNMT 019"
+    ]
+  },
+  "FNMT 101": {
+    "text": "FNMT 017 or FNMT 019 completed or FNMT 118 ready placement",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "FNMT 118": {
+    "text": "FNMT 017 or FNMT 019 completed or FNMT 118 (or higher) placement",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019"
+    ]
+  },
+  "FNMT 121": {
+    "text": "FNMT 017 or FNMT 019 completed or FNMT 118 (or higher) placement",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "FNMT 141": {
+    "text": "FNMT 017 or FNMT 019 or FNMT 118 placement",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "FREN 102": {
+    "text": "FREN 101",
+    "courses": [
+      "FREN 101"
+    ]
+  },
+  "FREN 201": {
+    "text": "FREN 102",
+    "courses": [
+      "FREN 102"
+    ]
+  },
+  "FREN 202": {
+    "text": "FREN 201",
+    "courses": [
+      "FREN 201"
+    ]
+  },
+  "GEOG 222": {
+    "text": "GEOG 101 or GEOG 103",
+    "courses": [
+      "GEOG 101",
+      "GEOG 103"
+    ]
+  },
+  "GLS 102": {
+    "text": "GLS 101",
+    "courses": [
+      "GLS 101"
+    ]
+  },
+  "HEBR 102": {
+    "text": "HEBR 101",
+    "courses": [
+      "HEBR 101"
+    ]
+  },
+  "HIST 297H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "HIST 298H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "HUM 101": {
+    "text": "ENGL 101 may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HUM 102": {
+    "text": "ENGL 101 may be taken currently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HUM 120": {
+    "text": "ENGL 101 may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HUM 130": {
+    "text": "ENGL 101 may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HUM 150": {
+    "text": "ENGL 101 may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HUM 170": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HUM 180": {
+    "text": "ENGL 101 may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "IDS 297H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "IDS 298H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "INT 106": {
+    "text": "INT 105 with a grade of \"C\" or better",
+    "courses": [
+      "INT 105"
+    ]
+  },
+  "INT 240": {
+    "text": "ASL 230 , ASL 231 , and INT 105 with a grade of \"C\" or better",
+    "courses": [
+      "ASL 230",
+      "ASL 231",
+      "INT 105"
+    ]
+  },
+  "INT 242": {
+    "text": "ASL 230 and ASL 231 with a grade of \"C\" or better",
+    "courses": [
+      "ASL 230",
+      "ASL 231"
+    ]
+  },
+  "INT 251": {
+    "text": "ASL 232 , INT 240 , INT 242 with a grade of \"C\" or better",
+    "courses": [
+      "ASL 232",
+      "INT 240",
+      "INT 242"
+    ]
+  },
+  "INT 252": {
+    "text": "INT 251 with a grade of \"C\" or better",
+    "courses": [
+      "INT 251"
+    ]
+  },
+  "INT 255": {
+    "text": "INT 251 with a grade of \"C\" or better",
+    "courses": [
+      "INT 251"
+    ]
+  },
+  "INT 260": {
+    "text": "INT 240 with a grade of \"C\" or better",
+    "courses": [
+      "INT 240"
+    ]
+  },
+  "INT 297": {
+    "text": "INT 252 and INT 255 with a grade of \"C\" or better",
+    "courses": [
+      "INT 252",
+      "INT 255"
+    ]
+  },
+  "ITAL 102": {
+    "text": "ITAL 101",
+    "courses": [
+      "ITAL 101"
+    ]
+  },
+  "ITAL 201": {
+    "text": "ITAL 102",
+    "courses": [
+      "ITAL 102"
+    ]
+  },
+  "ITAL 202": {
+    "text": "ITAL 201",
+    "courses": [
+      "ITAL 201"
+    ]
+  },
+  "JAPN 102": {
+    "text": "JAPN 101",
+    "courses": [
+      "JAPN 101"
+    ]
+  },
+  "JAPN 201": {
+    "text": "JAPN 102",
+    "courses": [
+      "JAPN 102"
+    ]
+  },
+  "JAPN 202": {
+    "text": "JAPN 201",
+    "courses": [
+      "JAPN 201"
+    ]
+  },
+  "JUS 105": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 121": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 151": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 181": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 191": {
+    "text": "JUS 101 , which may be taken concurrently",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 201": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 221": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 235": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 237": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 241": {
+    "text": "JUS 101 or PLS 101",
+    "courses": [
+      "JUS 101",
+      "PLS 101"
+    ]
+  },
+  "JUS 251": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 261": {
+    "text": "JUS 101",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 281": {
+    "text": "JUS 101 or permission of the department head",
+    "courses": [
+      "JUS 101"
+    ]
+  },
+  "JUS 291": {
+    "text": "JUS 241",
+    "courses": [
+      "JUS 241"
+    ]
+  },
+  "JUS 298": {
+    "text": "JUS 241 and permission of the Department Head",
+    "courses": [
+      "JUS 241"
+    ]
+  },
+  "JUSR 201": {
+    "text": "JUSR 101 with a grade of \"C\" or better",
+    "courses": [
+      "JUSR 101"
+    ]
+  },
+  "JUSR 295": {
+    "text": "JUSR 201 with a grade of \"C\" or better",
+    "courses": [
+      "JUSR 201"
+    ]
+  },
+  "LATN 102": {
+    "text": "LATN 101 with a grade of \"C\" or better",
+    "courses": [
+      "LATN 101"
+    ]
+  },
+  "MATH 121": {
+    "text": "FNMT 017 or FNMT 019 completed or placement in FNMT 118 or higher",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "MATH 123": {
+    "text": "FNMT 017 or FNMT 019 completed or placement in FNMT 118 or higher",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "MATH 133": {
+    "text": "MATH 123 with a grade of \"C\" or better",
+    "courses": [
+      "MATH 123"
+    ]
+  },
+  "MATH 137": {
+    "text": "FNMT 017 or FNMT 019 completed or placement in FNMT 118 or higher",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "MATH 149": {
+    "text": "FNMT 016 or placement in FNMT 017 or FNMT 019",
+    "courses": [
+      "FNMT 016",
+      "FNMT 017",
+      "FNMT 019"
+    ]
+  },
+  "MATH 150": {
+    "text": "FNMT 017 or FNMT 019 completed or placement in FNMT 118 or higher",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019",
+      "FNMT 118"
+    ]
+  },
+  "MATH 151": {
+    "text": "FNMT 118 with a grade of \"C\" or better or FNMT 141 with a grade of \"C\" or better",
+    "courses": [
+      "FNMT 118",
+      "FNMT 141"
+    ]
+  },
+  "MATH 161": {
+    "text": "FNMT 118 with a grade of \"C\" or better or FNMT 141 with a grade of \"C\" or better",
+    "courses": [
+      "FNMT 118",
+      "FNMT 141"
+    ]
+  },
+  "MATH 162": {
+    "text": "MATH 161 with a grade of \"C\" or better, or placement in MATH 162 or higher",
+    "courses": [
+      "MATH 161"
+    ]
+  },
+  "MATH 163": {
+    "text": "MATH 161 with a grade of \"C\" or better, or placement in MATH 162 or higher",
+    "courses": [
+      "MATH 161",
+      "MATH 162"
+    ]
+  },
+  "MATH 171": {
+    "text": "MATH 162 with a grade of \"C\" or better, or placement in MATH 171 or higher",
+    "courses": [
+      "MATH 162"
+    ]
+  },
+  "MATH 172": {
+    "text": "MATH 171 with a grade of \"C\" or better, or placement in MATH 172 or higher",
+    "courses": [
+      "MATH 171"
+    ]
+  },
+  "MATH 251": {
+    "text": "FNMT 118 with a grade of \"C\" or better, or FNMT 141 with a grade of \"C\" or better, or MATH 150 with a grade of \"C\" or better",
+    "courses": [
+      "FNMT 118",
+      "FNMT 141",
+      "MATH 150"
+    ]
+  },
+  "MATH 263": {
+    "text": "MATH 163 with a grade of \"C\" or better",
+    "courses": [
+      "MATH 163"
+    ]
+  },
+  "MATH 270": {
+    "text": "MATH 171 with a grade of \"C\" or better and MATH 172 with a grade of \"C\" or better ( MATH 172 may be taken concurrently)",
+    "courses": [
+      "MATH 171",
+      "MATH 172"
+    ]
+  },
+  "MATH 271": {
+    "text": "MATH 172 with a grade of \"C\" or better and MATH 270 with a grade of \"C\" or better",
+    "courses": [
+      "MATH 172",
+      "MATH 270"
+    ]
+  },
+  "MATH 272": {
+    "text": "MATH 172 with a grade of \"C\" or better and MATH 270 with a grade of \"C\" or better",
+    "courses": [
+      "MATH 172",
+      "MATH 270"
+    ]
+  },
+  "MHT 112": {
+    "text": "MHT 101 , which may be taken concurrently",
+    "courses": [
+      "MHT 101"
+    ]
+  },
+  "MHT 120": {
+    "text": "MHT 112 , which may be taken concurrently",
+    "courses": [
+      "MHT 112"
+    ]
+  },
+  "MHT 125": {
+    "text": "MHT 112 , which may be taken concurrently",
+    "courses": [
+      "MHT 112"
+    ]
+  },
+  "MHT 180": {
+    "text": "MHT 101 and MHT 112 , which may be taken concurrently",
+    "courses": [
+      "MHT 101",
+      "MHT 112"
+    ]
+  },
+  "MHT 212": {
+    "text": "MHT 112",
+    "courses": [
+      "MHT 112"
+    ]
+  },
+  "MHT 241": {
+    "text": "MHT 112",
+    "courses": [
+      "MHT 112"
+    ]
+  },
+  "MHT 280": {
+    "text": "FNMT 118 , MHT 112 , and MHT 180",
+    "courses": [
+      "FNMT 118",
+      "MHT 112",
+      "MHT 180"
+    ]
+  },
+  "MHT 281": {
+    "text": "FNMT 118 and MHT 112",
+    "courses": [
+      "FNMT 118",
+      "MHT 112"
+    ]
+  },
+  "MKTG 131": {
+    "text": "MNGT 121 may be taken concurrently",
+    "courses": [
+      "MNGT 121"
+    ]
+  },
+  "MLT 102": {
+    "text": "English Level V; FNMT 019 or FNMT 017 placement or higher and approval of department head or MLT curriculum coordinator. Applicants must be 18 years of age on or before the first day of the semester",
+    "courses": [
+      "FNMT 017",
+      "FNMT 019"
+    ]
+  },
+  "MLT 155": {
+    "text": "BIOL 108 or BIOL 110 which may be taken concurrently and MLT 102 , which may be taken concurrently",
+    "courses": [
+      "BIOL 108",
+      "BIOL 110",
+      "MLT 102"
+    ]
+  },
+  "MLT 205": {
+    "text": "MLT 155 with a grade of \"C\" or better",
+    "courses": [
+      "MLT 155"
+    ]
+  },
+  "MLT 225": {
+    "text": "CHEM 110 and CHEM 118 or CHEM 121 and CHEM 122 , BIOL 108 or BIOL 109 + BIOL 110 , FNMT 118 or MATH 118, MLT 205",
+    "courses": [
+      "BIOL 108",
+      "BIOL 109",
+      "BIOL 110",
+      "CHEM 110",
+      "CHEM 118",
+      "CHEM 121",
+      "CHEM 122",
+      "FNMT 118",
+      "MATH 118",
+      "MLT 205"
+    ]
+  },
+  "MLT 245": {
+    "text": "BIOL 241 , MLT 205 , CHEM 110 and CHEM 118 or CHEM 121 and CHEM 122 all with a grade of \"C\" or better",
+    "courses": [
+      "BIOL 241",
+      "CHEM 110",
+      "CHEM 118",
+      "CHEM 121",
+      "CHEM 122",
+      "MLT 205"
+    ]
+  },
+  "MLT 265": {
+    "text": "MLT 225 and MLT 245 both with a grade of \"C\" or better",
+    "courses": [
+      "MLT 225",
+      "MLT 245"
+    ]
+  },
+  "MLT 295": {
+    "text": "MLT 225 and MLT 245 with a grade \"C\" or better. MLT 155 and MLT 265 must be taken concurrently",
+    "courses": [
+      "MLT 155",
+      "MLT 225",
+      "MLT 245",
+      "MLT 265"
+    ]
+  },
+  "MNGT 141": {
+    "text": "MNGT 121 may be taken concurrently",
+    "courses": [
+      "MNGT 121"
+    ]
+  },
+  "MNGT 142": {
+    "text": "MNGT 121",
+    "courses": [
+      "MNGT 121"
+    ]
+  },
+  "MUS 101": {
+    "text": "ENGL 071 and ENGL 081 / ENGL 091 or higher placement",
+    "courses": [
+      "ENGL 071",
+      "ENGL 081",
+      "ENGL 091"
+    ]
+  },
+  "MUS 102": {
+    "text": "MUS 101 , ENGL 071 and ENGL 081 / ENGL 091 or higher placement",
+    "courses": [
+      "ENGL 071",
+      "ENGL 081",
+      "ENGL 091",
+      "MUS 101"
+    ]
+  },
+  "MUS 108": {
+    "text": "ENGL 071 and ENGL 081 / ENGL 091 or higher placement",
+    "courses": [
+      "ENGL 071",
+      "ENGL 081",
+      "ENGL 091"
+    ]
+  },
+  "MUS 109": {
+    "text": "MUS 108 , ENGL 071 and ENGL 081 / ENGL 091 or higher placement",
+    "courses": [
+      "ENGL 071",
+      "ENGL 081",
+      "ENGL 091",
+      "MUS 108"
+    ]
+  },
+  "MUS 116": {
+    "text": "MUS 100",
+    "courses": [
+      "MUS 100"
+    ]
+  },
+  "MUS 118": {
+    "text": "MUS 116",
+    "courses": [
+      "MUS 116"
+    ]
+  },
+  "MUS 142": {
+    "text": "Student must satisfy the Music Performance major audition requirements, be accepted, and enroll in the program. Student must see department chair prior to enrolling. Students may not audit Applied Music courses and no Applied Music course can be repeated if the student earns a grade of \"C\" or better in the course",
+    "courses": []
+  },
+  "MUS 143": {
+    "text": "Student must satisfy the Music Performance major audition requirements, be accepted, and enroll in the program. Student must see department chair prior to enrolling. Students may not audit Applied Music courses and no Applied Music course can be repeated if the student earns a grade of \"C\" or better in the course",
+    "courses": []
+  },
+  "MUS 144": {
+    "text": "Student must satisfy the Music Performance major audition requirements, be accepted, and enroll in the program. Student must see department chair prior to enrolling. Students may not audit Applied Music courses and no Applied Music course can be repeated if the student earns a grade of \"C\" or higher in the course",
+    "courses": []
+  },
+  "MUS 215": {
+    "text": "MUS 115",
+    "courses": [
+      "MUS 115"
+    ]
+  },
+  "MUS 216": {
+    "text": "MUS 118",
+    "courses": [
+      "MUS 118"
+    ]
+  },
+  "MUS 220": {
+    "text": "MUS 115",
+    "courses": [
+      "MUS 115"
+    ]
+  },
+  "MUS 241": {
+    "text": "Student must satisfy the Music Performance major audition requirements, be accepted, and enroll in the program. Student must see department chair prior to enrolling. Students may not audit Applied Music courses and no Applied Music course can be repeated if the student earns a grade of \"C\" or better in the course",
+    "courses": []
+  },
+  "MUS 242": {
+    "text": "Student must satisfy the Music Performance major audition requirements, be accepted, and enroll in the program. Student must see department chair prior to enrolling. Students may not audit Applied Music courses and no Applied Music course can be repeated if the student earns a grade of \"C\" or better in the course",
+    "courses": []
+  },
+  "MUS 243": {
+    "text": "Student must satisfy the Music Performance major audition requirements, be accepted, and enroll in the program. Student must see department chair prior to enrolling. Students may not audit Applied Music courses and no Applied Music course can be repeated if the student earns a grade of \"C\" or better in the course",
+    "courses": []
+  },
+  "MUS 244": {
+    "text": "Student must satisfy the Music Performance major audition requirements, be accepted, and enroll in the program. Student must see department chair prior to enrolling. Students may not audit Applied Music courses and no Applied Music course can be repeated if the student earns a grade of \"C\" or better in the course",
+    "courses": []
+  },
+  "MUS 260": {
+    "text": "MUS 215",
+    "courses": [
+      "MUS 215"
+    ]
+  },
+  "MUS 280": {
+    "text": "MUS 180",
+    "courses": [
+      "MUS 180"
+    ]
+  },
+  "MUS 290": {
+    "text": "MUS 180 and MUS 260 , which may be taken concurrently",
+    "courses": [
+      "MUS 180",
+      "MUS 260"
+    ]
+  },
+  "NURS 101": {
+    "text": "BIOL 109 , NUTR 111 , and ENGL 101 , which may be taken concurrently, all with a grade of \"C\" or better",
+    "courses": [
+      "BIOL 109",
+      "ENGL 101",
+      "NUTR 111"
+    ]
+  },
+  "NURS 132": {
+    "text": "NURS 101",
+    "courses": [
+      "NURS 101"
+    ]
+  },
+  "NURS 231": {
+    "text": "NURS 132",
+    "courses": [
+      "NURS 132"
+    ]
+  },
+  "NURS 232": {
+    "text": "NURS 231",
+    "courses": [
+      "NURS 231"
+    ]
+  },
+  "NUTR 111": {
+    "text": "ENGL 101 and BIOL 109 with a \"C\" or higher",
+    "courses": [
+      "BIOL 109",
+      "ENGL 101"
+    ]
+  },
+  "PEH 220": {
+    "text": "PEH 120 with a grade of \"C\" or better",
+    "courses": [
+      "PEH 120"
+    ]
+  },
+  "PEH 230": {
+    "text": "BIOL 108 or BIOL 109 and BIOL 110 with a \"C\" or better",
+    "courses": [
+      "BIOL 108",
+      "BIOL 109",
+      "BIOL 110"
+    ]
+  },
+  "PEH 240": {
+    "text": "BIOL 108 or BIOL 109 and BIOL 110 ; each with a grade of \"C\" or better",
+    "courses": [
+      "BIOL 108",
+      "BIOL 109",
+      "BIOL 110"
+    ]
+  },
+  "PEH 250": {
+    "text": "PEH 240 with a grade of \"C\" or better",
+    "courses": [
+      "PEH 240"
+    ]
+  },
+  "PEH 260": {
+    "text": "PEH 240 with a grade of \"C\" or better",
+    "courses": [
+      "PEH 240"
+    ]
+  },
+  "PH 102": {
+    "text": "PH 101",
+    "courses": [
+      "PH 101"
+    ]
+  },
+  "PH 222": {
+    "text": "AH 204 with a grade of \"C\" or better",
+    "courses": [
+      "AH 204"
+    ]
+  },
+  "PH 226": {
+    "text": "PH 102 , SOC 231 or SOC 233 , FNMT 118 or MATH 251",
+    "courses": [
+      "FNMT 118",
+      "MATH 251",
+      "PH 102",
+      "SOC 231",
+      "SOC 233"
+    ]
+  },
+  "PHIL 101H": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "PHIL 297H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "PHIL 298H": {
+    "text": "ENGL 101 or ENGL 101H",
+    "courses": [
+      "ENGL 101",
+      "ENGL 101H"
+    ]
+  },
+  "PHOT 100": {
+    "text": "ENGL 072 and ENGL 082 / ENGL 092 or higher placement",
+    "courses": [
+      "ENGL 072",
+      "ENGL 082",
+      "ENGL 092"
+    ]
+  },
+  "PHOT 101": {
+    "text": "ENGL 073 and ENGL 083 / ENGL 093 or higher placement",
+    "courses": [
+      "ENGL 073",
+      "ENGL 083",
+      "ENGL 093"
+    ]
+  },
+  "PHOT 103": {
+    "text": "PHOT 101 or PHOT 105 with a grade of \"C\" or better or permission of the department head",
+    "courses": [
+      "PHOT 101",
+      "PHOT 105"
+    ]
+  },
+  "PHOT 152": {
+    "text": "PHOT 151 , which may be taken concurrently",
+    "courses": [
+      "PHOT 151"
+    ]
+  },
+  "PHOT 201": {
+    "text": "PHOT 101 or PHOT 105 ; PHOT 151 , which may be taken concurrently; and PHOT 152 , which may be taken concurrently",
+    "courses": [
+      "PHOT 101",
+      "PHOT 105",
+      "PHOT 151",
+      "PHOT 152"
+    ]
+  },
+  "PHOT 202": {
+    "text": "PHOT 152 , which may be taken concurrently",
+    "courses": [
+      "PHOT 152"
+    ]
+  },
+  "PHOT 205": {
+    "text": "PHOT 152 and PHOT 201",
+    "courses": [
+      "PHOT 152",
+      "PHOT 201"
+    ]
+  },
+  "PHOT 211": {
+    "text": "PHOT 104",
+    "courses": [
+      "PHOT 104"
+    ]
+  },
+  "PHOT 217": {
+    "text": "PHOT 104 , PHOT 151 , PHOT 152 , which may be taken concurrently",
+    "courses": [
+      "PHOT 104",
+      "PHOT 151",
+      "PHOT 152"
+    ]
+  },
+  "PHOT 250": {
+    "text": "PHOT 101 or PHOT 105 and PHOT 201",
+    "courses": [
+      "PHOT 101",
+      "PHOT 105",
+      "PHOT 201"
+    ]
+  },
+  "PHOT 251": {
+    "text": "PHOT 151",
+    "courses": [
+      "PHOT 151"
+    ]
+  },
+  "PHOT 260": {
+    "text": "PHOT 101 or PHOT 105 , PHOT 104",
+    "courses": [
+      "PHOT 101",
+      "PHOT 104",
+      "PHOT 105"
+    ]
+  },
+  "PHOT 290": {
+    "text": "PHOT 101 or PHOT 105",
+    "courses": [
+      "PHOT 101",
+      "PHOT 105"
+    ]
+  },
+  "PHOT 291": {
+    "text": "PHOT 152 and PHOT 201 or PHOT 202 , with a GPA of at least 3.0 in Photographic Imaging courses or DVP 150 and DVP 210 with a GPA of at least 3.0 in Digital Video Production courses",
+    "courses": [
+      "DVP 150",
+      "DVP 210",
+      "PHOT 152",
+      "PHOT 201",
+      "PHOT 202"
+    ]
+  },
+  "PHOT 297": {
+    "text": "PHOT 101 or PHOT 105 , PHOT 104",
+    "courses": [
+      "PHOT 101",
+      "PHOT 104",
+      "PHOT 105"
+    ]
+  },
+  "PHOT 298": {
+    "text": "PHOT 104 and PHOT 201",
+    "courses": [
+      "PHOT 104",
+      "PHOT 201"
+    ]
+  },
+  "PHOT 299": {
+    "text": "PHOT 201 (Photography students) or DVP 120 , DVP 130 , DVP 140 , DVP 150 must be taken prior to this course. DVP 210 and DVP 240 may be taken concurrently with this course (Digital Video Production students)",
+    "courses": [
+      "DVP 120",
+      "DVP 130",
+      "DVP 140",
+      "DVP 150",
+      "DVP 210",
+      "DVP 240",
+      "PHOT 201"
+    ]
+  },
+  "PHYS 105": {
+    "text": "FNMT 118 (or higher) placement or a passing grade in FNMT 017 (or higher) are required",
+    "courses": [
+      "FNMT 017",
+      "FNMT 118"
+    ]
+  },
+  "PHYS 106": {
+    "text": "PHYS 105 or permission of the department head",
+    "courses": [
+      "PHYS 105"
+    ]
+  },
+  "PHYS 111": {
+    "text": "MATH 162 or MATH 171 or MATH 171 placement",
+    "courses": [
+      "MATH 162",
+      "MATH 171"
+    ]
+  },
+  "PHYS 112": {
+    "text": "PHYS 111 or permission of the department head",
+    "courses": [
+      "PHYS 111"
+    ]
+  },
+  "PHYS 140": {
+    "text": "MATH 171 . (It is suggested that students who have never had a physics course take PHYS 111 before PHYS 140 .)",
+    "courses": [
+      "MATH 171",
+      "PHYS 111"
+    ]
+  },
+  "PHYS 241": {
+    "text": "PHYS 140 , MATH 172 or permission of the department head",
+    "courses": [
+      "MATH 172",
+      "PHYS 140"
+    ]
+  },
+  "PHYS 242": {
+    "text": "PHYS 241",
+    "courses": [
+      "PHYS 241"
+    ]
+  },
+  "PLS 111": {
+    "text": "PLS 101 , which may be taken concurrently",
+    "courses": [
+      "PLS 101"
+    ]
+  },
+  "PLS 115": {
+    "text": "PLS 101 , which may be taken concurrently",
+    "courses": [
+      "PLS 101"
+    ]
+  },
+  "PLS 121": {
+    "text": "PLS 101 , which may be taken concurrently",
+    "courses": [
+      "PLS 101"
+    ]
+  },
+  "PLS 211": {
+    "text": "PLS 111 and ENGL 102",
+    "courses": [
+      "ENGL 102",
+      "PLS 111"
+    ]
+  },
+  "PLS 215": {
+    "text": "PLS 121",
+    "courses": [
+      "PLS 121"
+    ]
+  },
+  "PLS 221": {
+    "text": "PLS 101 and PLS 121",
+    "courses": [
+      "PLS 101",
+      "PLS 121"
+    ]
+  },
+  "PLS 231": {
+    "text": "PLS 111 and PLS 121",
+    "courses": [
+      "PLS 111",
+      "PLS 121"
+    ]
+  },
+  "PLS 241": {
+    "text": "PLS 121",
+    "courses": [
+      "PLS 121"
+    ]
+  },
+  "PLS 251": {
+    "text": "PLS 111",
+    "courses": [
+      "PLS 111"
+    ]
+  },
+  "PLS 255": {
+    "text": "ENGL 101 and PLS 111",
+    "courses": [
+      "ENGL 101",
+      "PLS 111"
+    ]
+  },
+  "PLS 261": {
+    "text": "PLS 111",
+    "courses": [
+      "PLS 111"
+    ]
+  },
+  "PLS 265": {
+    "text": "PLS 111",
+    "courses": [
+      "PLS 111"
+    ]
+  },
+  "PLS 271": {
+    "text": "PLS 121",
+    "courses": [
+      "PLS 121"
+    ]
+  },
+  "PLS 275": {
+    "text": "PLS 111",
+    "courses": [
+      "PLS 111"
+    ]
+  },
+  "PLS 281": {
+    "text": "PLS 111",
+    "courses": [
+      "PLS 111"
+    ]
+  },
+  "PLS 285": {
+    "text": "PLS 121",
+    "courses": [
+      "PLS 121"
+    ]
+  },
+  "PLS 295": {
+    "text": "Completion of PLS 101 , PLS 111 and PLS 121 and a grade point average of 2.5 or better",
+    "courses": [
+      "PLS 101",
+      "PLS 111",
+      "PLS 121"
+    ]
+  },
+  "POLS 111H": {
+    "text": "ENGL 101 , which may be taken concurrently",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "PSYC 167": {
+    "text": "MATH 150",
+    "courses": [
+      "MATH 150"
+    ]
+  },
+  "PSYC 201": {
+    "text": "PSYC 101",
+    "courses": [
+      "PSYC 101"
+    ]
+  },
+  "PSYC 202": {
+    "text": "PSYC 101",
+    "courses": [
+      "PSYC 101"
+    ]
+  },
+  "PSYC 205": {
+    "text": "PSYC 101",
+    "courses": [
+      "PSYC 101"
+    ]
+  },
+  "PSYC 209": {
+    "text": "PSYC 101",
+    "courses": [
+      "PSYC 101"
+    ]
+  },
+  "PSYC 210": {
+    "text": "ENGL 101 , PSYC 101 , PSYC 110 , PSYC 167",
+    "courses": [
+      "ENGL 101",
+      "PSYC 101",
+      "PSYC 110",
+      "PSYC 167"
+    ]
+  },
+  "PSYC 211": {
+    "text": "PSYC 101",
+    "courses": [
+      "PSYC 101"
+    ]
+  },
+  "PSYC 215": {
+    "text": "PSYC 101 or BIOL 109",
+    "courses": [
+      "BIOL 109",
+      "PSYC 101"
+    ]
+  },
+  "PSYC 215H": {
+    "text": "PSYC 101 or BIOL 109 or PSYC 101H",
+    "courses": [
+      "BIOL 109",
+      "PSYC 101",
+      "PSYC 101H"
+    ]
+  },
+  "PSYC 220": {
+    "text": "ENGL 101 with a grade of \"C\" or better and PSYC 101",
+    "courses": [
+      "ENGL 101",
+      "PSYC 101"
+    ]
+  },
+  "PSYC 221": {
+    "text": "PSYC 101",
+    "courses": [
+      "PSYC 101"
+    ]
+  },
+  "PSYC 222": {
+    "text": "PSYC 101 or JUS 101 and ENGL 101",
+    "courses": [
+      "ENGL 101",
+      "JUS 101",
+      "PSYC 101"
+    ]
+  },
+  "PSYC 230": {
+    "text": "ENGL 101 with a grade of \"C\" or better and PSYC 101",
+    "courses": [
+      "ENGL 101",
+      "PSYC 101"
+    ]
+  },
+  "PSYC 232": {
+    "text": "ENGL 101 and PSYC 101",
+    "courses": [
+      "ENGL 101",
+      "PSYC 101"
+    ]
+  },
+  "RE 105": {
+    "text": "RE 101 , which may be taken concurrently",
+    "courses": [
+      "RE 101"
+    ]
+  },
+  "RESP 100": {
+    "text": "RESP 101 which must be taken concurrently",
+    "courses": [
+      "RESP 101"
+    ]
+  },
+  "RESP 101": {
+    "text": "RESP 100 , which must be taken concurrently",
+    "courses": [
+      "RESP 100"
+    ]
+  },
+  "RESP 102": {
+    "text": "RESP 100 and RESP 101",
+    "courses": [
+      "RESP 100",
+      "RESP 101"
+    ]
+  },
+  "RESP 103": {
+    "text": "RESP 102",
+    "courses": [
+      "RESP 102"
+    ]
+  },
+  "RESP 104": {
+    "text": "RESP 103",
+    "courses": [
+      "RESP 103"
+    ]
+  },
+  "RESP 210": {
+    "text": "BIOL 110 with a grade of \"C\" or better, CHEM 110 or CHEM 101 with a grade of \"C\" or better, CIS 103 , ENGL 102 , and RESP 104 ; and RESP 220 which must be taken concurrently",
+    "courses": [
+      "BIOL 110",
+      "CHEM 101",
+      "CHEM 110",
+      "CIS 103",
+      "ENGL 102",
+      "RESP 104",
+      "RESP 220"
+    ]
+  },
+  "RESP 211": {
+    "text": "BIOL 241 & with a grade of \"C\" or better, RESP 210 , and RESP 221 which must be taken concurrently",
+    "courses": [
+      "BIOL 241",
+      "RESP 210",
+      "RESP 221"
+    ]
+  },
+  "RESP 220": {
+    "text": "RESP 104 , and RESP 210 , which must be taken concurrently",
+    "courses": [
+      "RESP 104",
+      "RESP 210"
+    ]
+  },
+  "RESP 221": {
+    "text": "RESP 220 ; and RESP 211 , which must be taken concurrently",
+    "courses": [
+      "RESP 211",
+      "RESP 220"
+    ]
+  },
+  "RESP 299": {
+    "text": "RESP 211 and RESP 221",
+    "courses": [
+      "RESP 211",
+      "RESP 221"
+    ]
+  },
+  "SOC 115": {
+    "text": "ENGL 101 with a grade of \"C\" or better",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "SOC 212": {
+    "text": "SOC 101 or ANTH 112",
+    "courses": [
+      "ANTH 112",
+      "SOC 101"
+    ]
+  },
+  "SOC 215": {
+    "text": "SOC 101 or ANTH 112",
+    "courses": [
+      "ANTH 112",
+      "SOC 101"
+    ]
+  },
+  "SOC 231": {
+    "text": "SOC 101 or ANTH 112",
+    "courses": [
+      "ANTH 112",
+      "SOC 101"
+    ]
+  },
+  "SOC 233": {
+    "text": "SOC 101 or ANTH 112",
+    "courses": [
+      "ANTH 112",
+      "SOC 101"
+    ]
+  },
+  "SPAN 102": {
+    "text": "SPAN 101",
+    "courses": [
+      "SPAN 101"
+    ]
+  },
+  "SPAN 112": {
+    "text": "SPAN 111 , although students who have successfully completed Spanish 101 may take Spanish 112 with permission of the department head",
+    "courses": [
+      "SPAN 111"
+    ]
+  },
+  "SPAN 201": {
+    "text": "SPAN 102 or permission of the department head",
+    "courses": [
+      "SPAN 102"
+    ]
+  },
+  "SPAN 202": {
+    "text": "SPAN 201 or permission of the department head",
+    "courses": [
+      "SPAN 201"
+    ]
+  },
+  "SPAN 205": {
+    "text": "SPAN 202 or demonstrated proficiency in Spanish, as determined by department head",
+    "courses": [
+      "SPAN 202"
+    ]
+  },
+  "SRA 210": {
+    "text": "SRA 101 with a grade of \"C\" or better",
+    "courses": [
+      "SRA 101"
+    ]
+  },
+  "SRA 270": {
+    "text": "SRA 210 with a grade of \"C\" or better and PSYC 167 with a grade of \"C\" or better",
+    "courses": [
+      "PSYC 167",
+      "SRA 210"
+    ]
+  },
+  "STS 101": {
+    "text": "MATH 118 or FNMT 118 or higher placement",
+    "courses": [
+      "FNMT 118",
+      "MATH 118"
+    ]
+  },
+  "SWAH 101": {
+    "text": "ENGL 073 and ENGL 083/093 or higher placement",
+    "courses": [
+      "ENGL 073",
+      "ENGL 083"
+    ]
+  },
+  "SWAH 102": {
+    "text": "SWAH 101",
+    "courses": [
+      "SWAH 101"
+    ]
+  },
+  "SWAH 201": {
+    "text": "SWAH 102",
+    "courses": [
+      "SWAH 102"
+    ]
+  },
+  "SWAH 202": {
+    "text": "SWAH 201",
+    "courses": [
+      "SWAH 201"
+    ]
+  },
+  "THM 130": {
+    "text": "THM 110 , which may be taken concurrently",
+    "courses": [
+      "THM 110"
+    ]
+  },
+  "THM 140": {
+    "text": "THM 110 with a grade of \"C\" or better",
+    "courses": [
+      "THM 110"
+    ]
+  },
+  "THM 160": {
+    "text": "THM 110 , must be taken before, and THM 112 , may be taken concurrently",
+    "courses": [
+      "THM 110",
+      "THM 112"
+    ]
+  },
+  "THM 170": {
+    "text": "THM 278 , which may be taken concurrently, CIS 103 or CMS 140",
+    "courses": [
+      "CIS 103",
+      "CMS 140",
+      "THM 278"
+    ]
+  },
+  "THM 180": {
+    "text": "THM 110",
+    "courses": [
+      "THM 110"
+    ]
+  },
+  "THM 266": {
+    "text": "THM 110 and ENGL 101",
+    "courses": [
+      "ENGL 101",
+      "THM 110"
+    ]
+  },
+  "THM 270": {
+    "text": "THM 170 with a grade of \"C\" or better, and THM 278 with a grade of \"C\" or better or FMM 135 with a grade of \"C\" or better",
+    "courses": [
+      "FMM 135",
+      "THM 170",
+      "THM 278"
+    ]
+  },
+  "THM 276": {
+    "text": "THM 110 with a grade of \"C\" or better",
+    "courses": [
+      "THM 110"
+    ]
+  },
+  "THM 278": {
+    "text": "FMM 115 , with a grade of \"C\" or better OR THM 170 , which may be taken concurrently OR CMS 114 , with a grade of \"C\" or better",
+    "courses": [
+      "CMS 114",
+      "FMM 115",
+      "THM 170"
+    ]
+  },
+  "THM 285": {
+    "text": "THM 276 , with a grade of \"C\" or better, or CULA 171 and THM 110 , must be completed before",
+    "courses": [
+      "CULA 171",
+      "THM 110",
+      "THM 276"
+    ]
+  },
+  "THM 290": {
+    "text": "THM 180 and THM 285 with a grade of \"C\" or better",
+    "courses": [
+      "THM 180",
+      "THM 285"
+    ]
+  }
+}

--- a/scripts/pa/scrape-catalog-prereqs.ts
+++ b/scripts/pa/scrape-catalog-prereqs.ts
@@ -1,0 +1,265 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Scrapes Community College of Philadelphia's Drupal-based catalog at
+ * https://www.ccp.edu/college-catalog/course-offerings to extract
+ * prerequisite data. CCP is the largest community college in PA (~20k
+ * students) and PA has no course data at all today (data/pa/courses is
+ * empty), so this scraper gives PA its first prereq source.
+ *
+ * CCP uses a custom Drupal site — neither acalog nor CourseLeaf nor
+ * Coursedog — so this is a new parser. Structure (verified against the
+ * Accounting subject page):
+ *
+ *   <div class="views-row">
+ *     <h2><span>ACCT 102 - Financial Accounting</span></h2>
+ *     ...
+ *     <h3 class="h2">Prerequisite</h3>
+ *     <p><a href="/node/2610">ACCT 101</a> with grade of "C" or better.</p>
+ *     ...
+ *   </div>
+ *
+ * Course code is the H2's span text ("PREFIX NUMBER - Title"). Prereqs
+ * appear as inline text in the <p> after the <h3>; course references are
+ * usually wrapped in `<a class="colorbox-load">` with the course code as
+ * anchor text, so the extraction is single-pass (no coid-indirection like
+ * VT/CT).
+ *
+ * Output: data/pa/prereqs.json keyed by "${PREFIX} ${NUMBER}".
+ *
+ * Usage:
+ *   npx tsx scripts/pa/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/pa/scrape-catalog-prereqs.ts --limit-subjects=3   # smoke test
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const BASE = "https://www.ccp.edu";
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 6;
+const DELAY_MS = 100;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, label: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return "";
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/** Extract subject URLs from the course-offerings root page. */
+function extractSubjectUrls(html: string): string[] {
+  const matches = html.match(/\/college-catalog\/course-offerings\/[^"'?#]+/g) || [];
+  const slugs = new Set<string>();
+  for (const m of matches) {
+    // Skip the index itself
+    if (m === "/college-catalog/course-offerings/") continue;
+    if (m === "/college-catalog/course-offerings") continue;
+    slugs.add(m);
+  }
+  return Array.from(slugs).sort();
+}
+
+/** Split a subject page into <div class="views-row"> course segments. */
+function extractCourseBlocks(subjectHtml: string): string[] {
+  const parts = subjectHtml.split(/<div[^>]*class="[^"]*views-row[^"]*"/);
+  return parts.slice(1);
+}
+
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.;,]\s*$/, "")
+    .trim();
+}
+
+const BOILERPLATE_RE =
+  /^(none|n\/a|not applicable|see course description)\s*\.?\s*$/i;
+
+function parseCourseBlock(block: string): {
+  prefix: string;
+  number: string;
+  text: string;
+  courses: string[];
+} | null {
+  // --- Code: <h2><span>ACCT 102 - Financial Accounting</span></h2> ---
+  const codeMatch = block.match(
+    /<h2[^>]*>[\s\S]*?<span[^>]*>\s*([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\s*-/,
+  );
+  if (!codeMatch) return null;
+  const prefix = codeMatch[1].toUpperCase();
+  const number = codeMatch[2];
+
+  // --- Prereq block: <h3>Prerequisite(s)?</h3><p>...</p> ---
+  // CCP's structure is the H3 followed by exactly one <p> with the prereq
+  // text. Any <p> after that (e.g. "Course Offered Online: Yes") is a
+  // different metadata field, so stop at the first </p>.
+  const prereqMatch = block.match(
+    /<h3[^>]*>\s*Prerequisites?\s*<\/h3>\s*<p[^>]*>([\s\S]*?)<\/p>/i,
+  );
+  if (!prereqMatch) return null;
+
+  const text = htmlToText(prereqMatch[1]);
+  if (!text) return null;
+  if (BOILERPLATE_RE.test(text)) return null;
+
+  // Extract course codes from the text. CCP's prereq text is plain prose
+  // with codes like "ACCT 101" (typically wrapped in <a class="colorbox-load">
+  // in the HTML, but htmlToText strips the tags).
+  const courses = new Set<string>();
+  const codeRegex = /\b([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = codeRegex.exec(text)) !== null) {
+    const code = `${m[1]} ${m[2]}`;
+    if (code !== `${prefix} ${number}`) courses.add(code);
+  }
+
+  return { prefix, number, text, courses: Array.from(courses).sort() };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const limitSubjects = parseInt(
+    args.find((a) => a.startsWith("--limit-subjects="))?.split("=")[1] || "0",
+    10,
+  );
+
+  console.log("CCP (PA) catalog prereq scraper");
+  console.log(`  Base: ${BASE}`);
+
+  // --- Phase 1: enumerate subjects ---
+  console.log("\n[1/2] Enumerating subjects from /college-catalog/course-offerings ...");
+  const indexHtml = await retryFetch(
+    `${BASE}/college-catalog/course-offerings`,
+    "index",
+  );
+  let subjects = extractSubjectUrls(indexHtml);
+  console.log(`  Found ${subjects.length} subject URLs`);
+
+  if (limitSubjects > 0) {
+    subjects = subjects.slice(0, limitSubjects);
+    console.log(`  Limited to first ${limitSubjects} for smoke test`);
+  }
+
+  // --- Phase 2: fetch each subject page + parse all course blocks ---
+  console.log("\n[2/2] Fetching subject pages...");
+  const prereqs: Record<string, PrereqEntry> = {};
+  let totalBlocks = 0;
+  let withPrereqs = 0;
+
+  await pmap(subjects, CONCURRENCY, async (subjPath) => {
+    const html = await retryFetch(`${BASE}${subjPath}`, `subject(${subjPath})`);
+    if (!html) return;
+    const blocks = extractCourseBlocks(html);
+    totalBlocks += blocks.length;
+
+    for (const block of blocks) {
+      const parsed = parseCourseBlock(block);
+      if (!parsed) continue;
+      const key = `${parsed.prefix} ${parsed.number}`;
+      if (prereqs[key]) continue;
+      prereqs[key] = { text: parsed.text, courses: parsed.courses };
+      withPrereqs++;
+    }
+  });
+
+  console.log(
+    `  Parsed ${totalBlocks} course blocks across ${subjects.length} subjects`,
+  );
+  console.log(`  Extracted prereqs for ${withPrereqs} courses`);
+
+  // Sort keys alphabetically for deterministic output
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(prereqs).sort()) {
+    sorted[key] = prereqs[key];
+  }
+
+  // --- Write ---
+  const outDir = path.join(process.cwd(), "data", "pa");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+  console.log(`\n✓ Wrote ${Object.keys(sorted).length} prereqs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Fourth state in the prereq-scraper series, first PA data of any kind. CCP (Community College of Philadelphia — largest PA CC) uses custom Drupal, so this is a new parser engine.

**Source:** `https://www.ccp.edu/college-catalog/course-offerings` — 78 subject pages, single-pass.

## Engine matrix so far

| Engine | States | Platform |
|---|---|---|
| Acalog two-pass | VT (#22), CT (#23) | Modern Campus |
| CourseLeaf single-pass | RI (#24) | CourseLeaf |
| **Drupal single-pass** | **PA (this PR)** | Custom `views-row` + `<h3>Prerequisite</h3>` |

## Results

| State | Engine | Courses | With prereqs | Resolve rate |
|---|---|---:|---:|---:|
| VT | acalog | 351 | 101 | 29% |
| CT | acalog | 823 | 573 | 70% |
| RI | CourseLeaf | 1,028 | 507 | 99% |
| **PA (CCP)** | **Drupal** | **851** | **567** | **96%** |

251 of PA's 567 entries have multi-course prereq text like `"ACCT 102 or ACCT 101 and departmental approval"` — the chain API's AND-of-OR parser handles these cleanly.

## End-to-end verification
`GET /api/pa/prereqs/chain?course=ACCT 215` returns a 2-level chain: ACCT 215 → [ACCT 101 OR ACCT 102] → ACCT 101. AND-of-OR groups rendered correctly.

## Note on PA course data
PA has NO course-section data today (`data/pa/courses/` is empty — no PA course scraper exists). The prereq data will appear when users visit `/pa/course/<code>` pages but those pages don't serve content yet. A CCP course-section scraper is a separate future PR.

## Remaining prereq gaps after this PR
- NY — Coursedog, deferred
- ME — PDF-only
- NJ — mixed Coursedog + CourseLeaf variants

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full scrape: 567 entries in ~90 seconds
- [x] `/api/pa/prereqs/chain` tested on dev with multi-level chain
- [ ] After merge: spot-check via a CCP course that has prereq data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
