### PR TITLE
Add NY prereqs + weekly freshness cron for all prereq data

### DIFF
--- a/.github/workflows/scrape-prereqs.yml
+++ b/.github/workflows/scrape-prereqs.yml
@@ -1,0 +1,166 @@
+name: Scrape Prereqs
+
+# Refresh community college prerequisite data weekly and commit the
+# resulting data/<state>/prereqs.json back to the repo so Next.js can
+# serve the new data on the next deploy. Each state runs in its own job
+# so one flaky upstream catalog doesn't block the others.
+#
+# Two kinds of jobs:
+#   1. Dedicated catalog scrapers (ct/de/ny/pa/ri/vt) — each writes
+#      data/<state>/prereqs.json directly.
+#   2. Aggregate-from-courses (va/nc/sc/ga/dc) — reads the most recent
+#      data/<state>/courses/**.json (produced by scrape-courses-*.yml)
+#      and flattens the prerequisite_text field into prereqs.json.
+#
+# Each job runs the regression check BEFORE committing. If the new file
+# has <80% of the committed entry count (or is empty / malformed), the
+# job fails without committing — GitHub emails the actor on failure.
+
+on:
+  schedule:
+    - cron: "0 7 * * 0" # Sundays 7 AM UTC (2 AM EST)
+  workflow_dispatch:
+    inputs:
+      state:
+        description: "State to scrape (ct/de/ny/pa/ri/vt/aggregate or all)"
+        default: "all"
+
+permissions:
+  contents: write # required for auto-commit
+
+env:
+  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+jobs:
+  # ── Catalog scrapers (one per state) ─────────────────────────────────
+  scrape-catalog:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'ct' || inputs.state == 'de' ||
+      inputs.state == 'ny' || inputs.state == 'pa' || inputs.state == 'ri' ||
+      inputs.state == 'vt'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      # Only run states the user actually selected (or all for schedule).
+      # The `include` block pins per-state extras (Playwright-heavy states).
+      matrix:
+        state: [ct, de, ny, pa, ri, vt]
+    concurrency:
+      # Serialize jobs that push to the same branch.
+      group: scrape-prereqs-${{ matrix.state }}
+      cancel-in-progress: false
+    steps:
+      # Skip matrix entries the user didn't select when dispatching manually.
+      # (Can't filter matrix with `if` alone — GitHub evaluates matrix before
+      # job-level if, so we short-circuit at the step level here.)
+      - name: Filter by dispatch input
+        id: filter
+        run: |
+          want='${{ inputs.state }}'
+          this='${{ matrix.state }}'
+          if [ "${{ github.event_name }}" = "schedule" ] || [ -z "$want" ] || [ "$want" = "all" ] || [ "$want" = "$this" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping $this (dispatch selected $want)"
+          fi
+
+      - if: steps.filter.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - if: steps.filter.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - if: steps.filter.outputs.run == 'true'
+        run: npm ci
+
+      # NY uses Playwright (CUNY Coursedog needs a real browser session).
+      # The other states' scrapers are pure HTTP. Installing chromium only
+      # when needed saves ~30s per non-NY job.
+      - if: steps.filter.outputs.run == 'true' && matrix.state == 'ny'
+        run: npx playwright install chromium --with-deps
+
+      - if: steps.filter.outputs.run == 'true'
+        name: Scrape ${{ matrix.state }} prereqs
+        run: npx tsx scripts/${{ matrix.state }}/scrape-catalog-prereqs.ts
+
+      - if: steps.filter.outputs.run == 'true'
+        name: Regression check
+        run: npx tsx scripts/lib/check-prereq-regression.ts ${{ matrix.state }}
+
+      - if: steps.filter.outputs.run == 'true'
+        name: Commit updated prereqs
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          # Scope the commit strictly to the one file this job owns — prevents
+          # accidental commits of anything else a scraper might touch.
+          file_pattern: data/${{ matrix.state }}/prereqs.json
+          commit_message: "chore(${{ matrix.state }}): refresh prereqs.json [skip ci]"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
+
+  # ── Aggregate-from-courses (VA/NC/SC/GA/DC) ──────────────────────────
+  # These states' course scrapers embed prerequisite_text on each section;
+  # aggregate-prereqs.ts flattens the latest courses/*.json into a single
+  # prereqs.json. Runs off whatever's currently committed in
+  # data/<state>/courses/ — scrape-courses-*.yml handles that refresh
+  # separately on its own cron.
+  aggregate:
+    if: >-
+      github.event_name == 'schedule' ||
+      inputs.state == 'all' || inputs.state == 'aggregate' ||
+      inputs.state == 'va' || inputs.state == 'nc' || inputs.state == 'sc' ||
+      inputs.state == 'ga' || inputs.state == 'dc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        state: [va, nc, sc, ga, dc]
+    concurrency:
+      group: scrape-prereqs-${{ matrix.state }}
+      cancel-in-progress: false
+    steps:
+      - name: Filter by dispatch input
+        id: filter
+        run: |
+          want='${{ inputs.state }}'
+          this='${{ matrix.state }}'
+          if [ "${{ github.event_name }}" = "schedule" ] || [ -z "$want" ] || [ "$want" = "all" ] || [ "$want" = "aggregate" ] || [ "$want" = "$this" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - if: steps.filter.outputs.run == 'true'
+        uses: actions/checkout@v4
+      - if: steps.filter.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - if: steps.filter.outputs.run == 'true'
+        run: npm ci
+
+      - if: steps.filter.outputs.run == 'true'
+        name: Aggregate ${{ matrix.state }} prereqs
+        run: npx tsx scripts/lib/aggregate-prereqs.ts ${{ matrix.state }}
+
+      - if: steps.filter.outputs.run == 'true'
+        name: Regression check
+        run: npx tsx scripts/lib/check-prereq-regression.ts ${{ matrix.state }}
+
+      - if: steps.filter.outputs.run == 'true'
+        name: Commit updated prereqs
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          file_pattern: data/${{ matrix.state }}/prereqs.json
+          commit_message: "chore(${{ matrix.state }}): refresh prereqs.json (aggregate) [skip ci]"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"

--- a/data/ny/prereqs.json
+++ b/data/ny/prereqs.json
@@ -1,0 +1,5614 @@
+{
+  "ACC 1100": {
+    "text": "<p><u>Explanation</u>: The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5jChangeinPrereq-ACC1100-FundamentalsofAccountingI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5jChangeinPrereq-ACC1100-FundamentalsofAccountingI.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024"
+    ]
+  },
+  "ACC 360": {
+    "text": "<p>This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite for the Government &amp; Not-for-Profit Accounting course content. </p>",
+    "courses": [
+      "ACC 122",
+      "ACC 222"
+    ]
+  },
+  "ACC 370": {
+    "text": "<p>This revision lowers the prerequisite for this course from ACC 222 to ACC 122. ACC 122 is an appropriate prerequisite for the Forensic Accounting &amp; Fraud Analysis course content. </p>",
+    "courses": [
+      "ACC 122",
+      "ACC 222"
+    ]
+  },
+  "ACCT 223": {
+    "text": "<p>5/31/24 - Per Central, even if the Pre-Requisites / Co-Requisites is in CD. The Enrollment Requirement Group needs to be inputted in CD because this field maps with CUNYfirst. Requirement was approved on March'23 AUR.</p>",
+    "courses": []
+  },
+  "ACL 215": {
+    "text": "<p>This change is prerequisite will make sure that students are more adequately prepared for the writing required for this course. </p>",
+    "courses": []
+  },
+  "ACL 225": {
+    "text": "(ENG 101 or Equivalent) or ACL 125 or Departmental Approval",
+    "courses": [
+      "ACL 125",
+      "ENG 101"
+    ]
+  },
+  "ACL 275": {
+    "text": "ACL 125 or (ENG 101 or Equivalent) or Department Approval",
+    "courses": [
+      "ACL 125",
+      "ENG 101"
+    ]
+  },
+  "ACS 55": {
+    "text": "ACS 24",
+    "courses": [
+      "ACS 24"
+    ]
+  },
+  "ACS 56": {
+    "text": "ACS 24, ACS 55",
+    "courses": [
+      "ACS 24",
+      "ACS 55"
+    ]
+  },
+  "ACS 57": {
+    "text": "ACS 55, ACS 56",
+    "courses": [
+      "ACS 55",
+      "ACS 56"
+    ]
+  },
+  "AMST 203": {
+    "text": "<p>Updated eff term, hrs., pre-requisite, department, workload hrs.</p><p>6/25/25:1st time- change made for registration purposes.&nbsp;</p>",
+    "courses": []
+  },
+  "ANI 301": {
+    "text": "VAT 161 or VAT 171 or MMA 100 or MMP 100",
+    "courses": [
+      "MMA 100",
+      "MMP 100",
+      "VAT 161",
+      "VAT 171"
+    ]
+  },
+  "ANI 411": {
+    "text": "ANI 401",
+    "courses": [
+      "ANI 401"
+    ]
+  },
+  "ANI 412": {
+    "text": "ANI 411",
+    "courses": [
+      "ANI 411"
+    ]
+  },
+  "ANTH 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ANTH 140": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ANTH 150": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ANTH 160": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ANTH 170": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ARB 221": {
+    "text": "ARB 106, or ARB 121, or departmental permission based on Language Level Assessment",
+    "courses": [
+      "ARB 106",
+      "ARB 121"
+    ]
+  },
+  "ARCH 111": {
+    "text": "COREQ: ARCH119",
+    "courses": [
+      "ARCH 119"
+    ]
+  },
+  "ARCH 119": {
+    "text": "COREQ: ARCH111 OR CONM111",
+    "courses": [
+      "ARCH 111",
+      "CONM 111"
+    ]
+  },
+  "ARCH 121": {
+    "text": "ARCH111 WITH GRADE OF C OR BETTER COREQ: ARCH129",
+    "courses": [
+      "ARCH 111",
+      "ARCH 129"
+    ]
+  },
+  "ARCH 123": {
+    "text": "ARCH113 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "ARCH 113"
+    ]
+  },
+  "ARCH 125": {
+    "text": "MA114 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "MA 114"
+    ]
+  },
+  "ARCH 129": {
+    "text": "ARCH119 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "ARCH 119"
+    ]
+  },
+  "ARCH 231": {
+    "text": "ARCH 121 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "ARCH 121"
+    ]
+  },
+  "ARCH 237": {
+    "text": "COREQ: ARCH123",
+    "courses": [
+      "ARCH 123"
+    ]
+  },
+  "ARCH 241": {
+    "text": "ARCH231 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "ARCH 231"
+    ]
+  },
+  "ARCH 248": {
+    "text": "COREQ: MT345",
+    "courses": [
+      "MT 345"
+    ]
+  },
+  "ART 233": {
+    "text": "<p>This revision removes ART 101 from the list of prerequisites, as it is not an appropriate prerequisite for a photography course. </p>",
+    "courses": [
+      "ART 101"
+    ]
+  },
+  "ART 238": {
+    "text": "ART 133 or ART 236 or departmental permission",
+    "courses": [
+      "ART 133",
+      "ART 236"
+    ]
+  },
+  "ARTH 100": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ARTH 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTH 115": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTH 116": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTH 117": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTH 120": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTH 126": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTH 128": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTH 202": {
+    "text": "ARTH100 OR ARTH101",
+    "courses": [
+      "ARTH 100",
+      "ARTH 101"
+    ]
+  },
+  "ARTH 251": {
+    "text": "ARTH150",
+    "courses": [
+      "ARTH 150"
+    ]
+  },
+  "ARTH 252": {
+    "text": "ARTH150",
+    "courses": [
+      "ARTH 150"
+    ]
+  },
+  "ARTH 380": {
+    "text": "OPEN ONLY TO MATRICULATED STUDENTS WHO HAVE COMPLETED 24 CREDITS WITH AT LEAST 5 CREDITS IN ART, AND ARE RECOMMENDED BY THE DEPARTMENT. INTERESTED STUDENTS SHOULD CONTACT THE DEPARTMENT DURING THE SEMESTER PRIOR TO REGISTRATION. THEY MAY REGISTER FOR ONE COURSE PER SEMESTER (ARTH-380 OR ARTH-381) AND MAY TAKE A MAXIMUM TOTAL OF 4 CREDITS IN THE GALLERY INTERNSHIP. DEPARTMENTAL PERMISSION REQUIRED",
+    "courses": [
+      "ARTH 381"
+    ]
+  },
+  "ARTH 381": {
+    "text": "OPEN ONLY TO MATRICULATED STUDENTS WHO HAVE COMPLETED 24 CREDITS WITH AT LEAST 5 CREDITS IN ART, AND ARE RECOMMENDED BY THE DEPARTMENT. INTERESTED STUDENTS SHOULD CONTACT THE DEPARTMENT DURING THE SEMESTER PRIOR TO REGISTRATION. THEY MAY REGISTER FOR ONE COURSE PER SEMESTER (ARTH-380 OR ARTH-381) AND MAY TAKE A MAXIMUM TOTAL OF 4 CREDITS IN THE GALLERY INTERNSHIP. DEPARTMENTAL PERMISSION REQUIRED",
+    "courses": [
+      "ARTH 380"
+    ]
+  },
+  "ARTS 132": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ARTS 182": {
+    "text": "ARTS 122(AR122)",
+    "courses": [
+      "AR 122",
+      "ARTS 122"
+    ]
+  },
+  "ARTS 192": {
+    "text": "ARTS 290 or ARTS 291",
+    "courses": [
+      "ARTS 290",
+      "ARTS 291"
+    ]
+  },
+  "ARTS 221": {
+    "text": "ARTS121 (AR121)",
+    "courses": [
+      "AR 121",
+      "ARTS 121"
+    ]
+  },
+  "ARTS 242": {
+    "text": "ARTS141(AR461), OR PERMISSION OF THE DEPARTMENT ON REVIEW OF PORTFOLIO",
+    "courses": [
+      "AR 461",
+      "ARTS 141"
+    ]
+  },
+  "ARTS 243": {
+    "text": "<p>This elective course will be popular with students in Digital Art (DAD) and Art AS programs. Since DAD only has only 5 elective credits, removing the burden of a prerequisite will allow students to take the course and fit it into their schedules.</p>",
+    "courses": []
+  },
+  "ARTS 252": {
+    "text": "ARTS151 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "ARTS 151"
+    ]
+  },
+  "ARTS 253": {
+    "text": "ARTS151 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "ARTS 151"
+    ]
+  },
+  "ARTS 262": {
+    "text": "ARTS121 (AR121) and ARTS161 (AR261)",
+    "courses": [
+      "AR 121",
+      "AR 261",
+      "ARTS 121",
+      "ARTS 161"
+    ]
+  },
+  "ARTS 263": {
+    "text": "ARTS 262 (AR262) OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "AR 262",
+      "ARTS 262"
+    ]
+  },
+  "ARTS 270": {
+    "text": "ARTS121 OR ARTS151 OR ARTS161",
+    "courses": [
+      "ARTS 121",
+      "ARTS 151",
+      "ARTS 161"
+    ]
+  },
+  "ARTS 271": {
+    "text": "ARTS121 OR ARTS151 OR ARTS161",
+    "courses": [
+      "ARTS 121",
+      "ARTS 151",
+      "ARTS 161"
+    ]
+  },
+  "ARTS 272": {
+    "text": "ARTS270 (AR510)",
+    "courses": [
+      "AR 510",
+      "ARTS 270"
+    ]
+  },
+  "ARTS 286": {
+    "text": "ARTS186 (AR231)",
+    "courses": [
+      "AR 231",
+      "ARTS 186"
+    ]
+  },
+  "ARTS 290": {
+    "text": "ARTS121 ( AR121)",
+    "courses": [
+      "AR 121",
+      "ARTS 121"
+    ]
+  },
+  "ARTS 291": {
+    "text": "ARTS121 ( AR121)",
+    "courses": [
+      "AR 121",
+      "ARTS 121"
+    ]
+  },
+  "ARTS 292": {
+    "text": "ARTS290 (AR541)",
+    "courses": [
+      "AR 541",
+      "ARTS 290"
+    ]
+  },
+  "ARTS 293": {
+    "text": "ARTS 192",
+    "courses": [
+      "ARTS 192"
+    ]
+  },
+  "ARTS 380": {
+    "text": "OPEN ONLY TO MATRICULATED STUDENTS WHO HAVE COMPLETED 24 CREDITS, INCLUDING AT LEAST 5 CREDITS IN ART, AND ARE RECOMMENDED BY THE DEPARTMENT. STUDENTS INTERESTED IN THE PROGRAM SHOULD CONTACT THE DEPARTMENT DURING THE SEMESTER PRIOR TO REGISTRATION. STUDENTS MAY REGISTER FOR ONE COURSE PER SEMESTER (ARTS-380 OR ARTS-381) AND MAY TAKE UP TO A TOTAL MAXIMUM OF 4 CREDITS IN THE ARTIST APPRENTICE INTERNSHIP. DEPARTMENTAL PERMISSION REQUIRED",
+    "courses": [
+      "ARTS 381"
+    ]
+  },
+  "ARTS 381": {
+    "text": "OPEN ONLY TO MATRICULATED STUDENTS WHO HAVE COMPLETED 24 CREDITS, INCLUDING AT LEAST 5 CREDITS IN ART, AND ARE RECOMMENDED BY THE DEPARTMENT. STUDENTS INTERESTED IN THE PROGRAM SHOULD CONTACT THE DEPARTMENT DURING THE SEMESTER PRIOR TO REGISTRATION. STUDENTS MAY REGISTER FOR ONE COURSE PER SEMESTER (ARTS-380 OR ARTS-381) AND MAY TAKE UP TO A TOTAL MAXIMUM OF 4 CREDITS IN THE ARTIST APPRENTICE INTERNSHIP. DEPARTMENTAL PERMISSION REQUIRED",
+    "courses": [
+      "ARTS 380"
+    ]
+  },
+  "ARTS 382": {
+    "text": "6 CREDITS IN ELECTED ART DISCIPLINE (OTHER THAN ART HISTORY) AND APPROVAL OF DEPARTMENT",
+    "courses": []
+  },
+  "ARTS 383": {
+    "text": "6 CREDITS IN ELECTED ART DISCIPLINE (OTHER THAN ART HISTORY) AND APPROVAL OF DEPARTMENT",
+    "courses": []
+  },
+  "ARTS 390": {
+    "text": "15 credits in Studio Arts, ARTH 100 (formerly AR-310) or ARTH 101 (formerly AR-311), and at least one Art History elective",
+    "courses": [
+      "AR 310",
+      "AR 311",
+      "ARTH 100",
+      "ARTH 101"
+    ]
+  },
+  "ARTS 392": {
+    "text": "ARTS 192",
+    "courses": [
+      "ARTS 192"
+    ]
+  },
+  "BI 131": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 132": {
+    "text": "COREQ: BI-131",
+    "courses": [
+      "BI 131"
+    ]
+  },
+  "BI 140": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 160": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 170": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 171": {
+    "text": "PREREQ OR COREQ: BI170",
+    "courses": [
+      "BI 170"
+    ]
+  },
+  "BI 201": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 202": {
+    "text": "BI201",
+    "courses": [
+      "BI 201"
+    ]
+  },
+  "BI 203": {
+    "text": "BI201",
+    "courses": [
+      "BI 201"
+    ]
+  },
+  "BI 260": {
+    "text": "BI150",
+    "courses": [
+      "BI 150"
+    ]
+  },
+  "BI 301": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 302": {
+    "text": "BI301",
+    "courses": [
+      "BI 301"
+    ]
+  },
+  "BI 311": {
+    "text": "BI202 OR BI302, MAY NOT BE TAKEN BY THOSE STUDENTS WHO HAVE COMPLETED BI461",
+    "courses": [
+      "BI 202",
+      "BI 302",
+      "BI 461"
+    ]
+  },
+  "BI 325": {
+    "text": "(BI301 AND BI302) OR (BI 235 AND BI421)",
+    "courses": [
+      "BI 235",
+      "BI 301",
+      "BI 302",
+      "BI 421"
+    ]
+  },
+  "BI 330": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE COREQ: BI301. NOTE: PRIORITY IS GIVEN TO STUDENTS IN THE MASSAGE THERAPY PROGRAM. STUDENTS MUST OBTAIN LIABILITY INSURANCE",
+    "courses": [
+      "BI 301"
+    ]
+  },
+  "BI 331": {
+    "text": "BI330 OR PERMISSION OF INSTRUCTOR. PRIORITY IS GIVEN TO STUDENTS IN THE MASSAGE THERAPY PROGRAM. STUDENTS MUST OBTAIN LIABILITY INSURANCE",
+    "courses": [
+      "BI 330"
+    ]
+  },
+  "BI 340": {
+    "text": "BI-520 for students in the Medical Office Assistant A.A.S. Program. (Students not enrolled in the Medical Office Assistant A.A.S Program may substitute BI-111, BI-140, BI-201, BI-301, or the equivalent.) Not open to students in the Medical Laboratory Technology Program who are required to take BI-401 and BI-407",
+    "courses": [
+      "BI 111",
+      "BI 140",
+      "BI 201",
+      "BI 301",
+      "BI 401",
+      "BI 407",
+      "BI 520"
+    ]
+  },
+  "BI 341": {
+    "text": "BI-111 (Students not in the Medical Office Assistant Certificate or Medical Assistant AAS Program may substitute BI-140, BI-201, BI-301, or the equivalent.)",
+    "courses": [
+      "BI 111",
+      "BI 140",
+      "BI 201",
+      "BI 301"
+    ]
+  },
+  "BI 425": {
+    "text": "BI302 OR BI421",
+    "courses": [
+      "BI 302",
+      "BI 421"
+    ]
+  },
+  "BI 451": {
+    "text": "BI111 FOR STUDENTS IN THE MEDICAL OFFICE ASSISTANT AAS PROGRAM AND OTHER STUDENTS MAY SUBSTITUTE NU-102, OR THE EQUIVALENT",
+    "courses": [
+      "BI 111",
+      "NU 102"
+    ]
+  },
+  "BI 452": {
+    "text": "BI341 OR NU102",
+    "courses": [
+      "BI 341",
+      "NU 102"
+    ]
+  },
+  "BI 453": {
+    "text": "BI201",
+    "courses": [
+      "BI 201"
+    ]
+  },
+  "BI 456": {
+    "text": "BI201 & COREQUISITE BI202 AND PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "BI 201",
+      "BI 202"
+    ]
+  },
+  "BI 457": {
+    "text": "BI201 OR CH151 OR BI140",
+    "courses": [
+      "BI 140",
+      "BI 201",
+      "CH 151"
+    ]
+  },
+  "BI 461": {
+    "text": "BI201",
+    "courses": [
+      "BI 201"
+    ]
+  },
+  "BI 480": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 503": {
+    "text": "BI-201 OR BI-301 OR BI-520",
+    "courses": [
+      "BI 201",
+      "BI 301",
+      "BI 520"
+    ]
+  },
+  "BI 520": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BI 521": {
+    "text": "BI201",
+    "courses": [
+      "BI 201"
+    ]
+  },
+  "BI 522": {
+    "text": "MUST COMPLETE MA 336, Statistics",
+    "courses": [
+      "MA 336"
+    ]
+  },
+  "BI 554": {
+    "text": "BI201 AND PERMSSION OF THE INSTRUCTOR",
+    "courses": [
+      "BI 201"
+    ]
+  },
+  "BI 961": {
+    "text": "BI451 AND PERMISSION OF THE INSTRUCTOR PRIOR TO REGISTRATION",
+    "courses": [
+      "BI 451"
+    ]
+  },
+  "BIO 110": {
+    "text": "CUNY English proficiency; or ENG 100 or 110, if required; and CUNY Math Proficiency or MTH 23.5 or MTH 28.5, if required",
+    "courses": [
+      "ENG 100",
+      "MTH 23",
+      "MTH 28"
+    ]
+  },
+  "BIO 120": {
+    "text": "CUNY English proficiency or ENG 100 or 110, if required; and CUNY Math proficiency or MTH 23.5 or MTH 28.5, if required",
+    "courses": [
+      "ENG 100",
+      "MTH 23",
+      "MTH 28"
+    ]
+  },
+  "BIO 299": {
+    "text": "BIO 220 and CHE 220",
+    "courses": [
+      "BIO 220",
+      "CHE 220"
+    ]
+  },
+  "BIO 46": {
+    "text": "<p><strong>This minor change to the prerequisite is designed to allow students in the newly modified AAS in Medical Office Assistant to enroll in this required course.&nbsp; Additionally BIO 18, which has not been offered for several years, has been proposed by the Department of Biological Sciences for withdrawal. This course has been removed from the prerequisite requirements.</strong></p><p>&nbsp;</p>",
+    "courses": [
+      "BIO 18"
+    ]
+  },
+  "BIO 47": {
+    "text": "<p><strong>This change to the prerequisite is designed to allow students in the newly modified AAS in Medical Office Assistant to enroll in this required course.&nbsp; Additionally BIO 18, which has not been offered for several years, has been proposed by the Department of Biological Sciences for withdrawal. This course has been removed from the prerequisite requirements.</strong></p>",
+    "courses": [
+      "BIO 18"
+    ]
+  },
+  "BIOL 211": {
+    "text": "<p>11/7/24 - Added Pre-requisite &amp; Co-requisite in the correct fields as it was only showing in the enrollment group. It looks like when the rollover of the systems from Cf to CD was done, this was not rollover correctly. The pre &amp; co requisites took effect Fall 2023. Approved in AUR of Jan/Feb 2023.</p><table><tbody><tr><td><p>8/16/24 - Repeat fields changed back to original settings. </p><p></p></td></tr></tbody></table><p>8/27/24: change made for registration purposes</p><p>8/27/24: change made to reflect original set up after the registration.</p><p>1/21/25: change made for registration purposes</p>",
+    "courses": []
+  },
+  "BIS 13": {
+    "text": "<table><tbody><tr><td><p><strong>Rationale: This moves the KEY 10 prerequisite to become a corequisite and to create a uniform verbiage for all new and revised courses in the Department.</strong></p></td></tr></tbody></table>",
+    "courses": [
+      "KEY 10"
+    ]
+  },
+  "BIS 23": {
+    "text": "<p><strong>Rationale: This change to the prerequisite is designed to eliminate unnecessary and redundant prerequisites from prior courses in the degree and to create a uniform verbiage for all new and revised courses in the Department.</strong></p>",
+    "courses": []
+  },
+  "BIS 31": {
+    "text": "<p><strong> This change to the prerequisite is designed to update for currently offered courses and to create a uniform verbiage for all new and revised courses in the Department.</strong></p>",
+    "courses": []
+  },
+  "BLS 130": {
+    "text": "Pre-requisite ENG 100 or higher",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "BLS 150W": {
+    "text": "<p>Writing-Intensive iteration.</p><p>Minimum English Pre/Co-Requisite of ENG 100 added.</p>",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "BTP 214": {
+    "text": "BTP101",
+    "courses": [
+      "BTP 101"
+    ]
+  },
+  "BU 102": {
+    "text": "BU101 WITH A GRADE OF C- OR BETTER",
+    "courses": [
+      "BU 101"
+    ]
+  },
+  "BU 103": {
+    "text": "BU102 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "BU 102"
+    ]
+  },
+  "BU 104": {
+    "text": "BU103",
+    "courses": [
+      "BU 103"
+    ]
+  },
+  "BU 108": {
+    "text": "BU102",
+    "courses": [
+      "BU 102"
+    ]
+  },
+  "BU 110": {
+    "text": "BU102 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "BU 102"
+    ]
+  },
+  "BU 111": {
+    "text": "CIS101 (BU500) & BU102 C, both with the minimum grade of C, or permission of the Department",
+    "courses": [
+      "BU 102",
+      "BU 500",
+      "CIS 101"
+    ]
+  },
+  "BU 203": {
+    "text": "MA-114 or MA-119 or MA-321 (Students who have taken MA-240, which is no longer offered, have satisfied the mathematics pre-requisite for BU-203",
+    "courses": [
+      "MA 114",
+      "MA 119",
+      "MA 240",
+      "MA 321"
+    ]
+  },
+  "BU 301": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "BU 401": {
+    "text": "BU201",
+    "courses": [
+      "BU 201"
+    ]
+  },
+  "BU 402": {
+    "text": "BU401",
+    "courses": [
+      "BU 401"
+    ]
+  },
+  "BU 403": {
+    "text": "BU401",
+    "courses": [
+      "BU 401"
+    ]
+  },
+  "BU 404": {
+    "text": "BU401 OR SOCY275 (SS375)",
+    "courses": [
+      "BU 401",
+      "SOCY 275",
+      "SS 375"
+    ]
+  },
+  "BU 405": {
+    "text": "BU401",
+    "courses": [
+      "BU 401"
+    ]
+  },
+  "BU 408": {
+    "text": "BU-401",
+    "courses": [
+      "BU 401"
+    ]
+  },
+  "BU 701": {
+    "text": "ECON101(SS211) OR ECON102(SS212)",
+    "courses": [
+      "ECON 101",
+      "ECON 102",
+      "SS 211",
+      "SS 212"
+    ]
+  },
+  "BU 906": {
+    "text": "CIS101",
+    "courses": [
+      "CIS 101"
+    ]
+  },
+  "BU 918": {
+    "text": "BU916",
+    "courses": [
+      "BU 916"
+    ]
+  },
+  "BUS 100": {
+    "text": "MAT 10 or higher or equivalent placement on CUNY proficiency index PRE/Co-requisite: ESL 30 or ENG 100 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 30",
+      "MAT 10"
+    ]
+  },
+  "BUS 203": {
+    "text": "Pre/Co-requisite: ENG 110 or equivalent",
+    "courses": [
+      "ENG 110"
+    ]
+  },
+  "BUS 21": {
+    "text": "<p>The Department of Business and Information Systems is proposing a revision and restoration of BUS 21, Small Business Management, to its current offerings.&nbsp; The importance of small businesses and entrepreneurship in our global and national economies cannot be overstated.&nbsp; The restoration of BUS 21 will provide students with valuable academic and practical knowledge.&nbsp; This knowledge can serve to help them in the transfer to a senior college or if they desire to pursue a small business career after completing their associate degree.&nbsp; The revision of the course prerequisites will allow students in their second semester to enroll in BUS 21.&nbsp; This revised course is separately proposed for inclusion in the Business Administration AS degree in the Management and Marketing options.</p>",
+    "courses": []
+  },
+  "BUS 219": {
+    "text": "MAT 150 or MAT 209 Corequisite: CIS 100 or CIS 140",
+    "courses": [
+      "CIS 100",
+      "CIS 140",
+      "MAT 150",
+      "MAT 209"
+    ]
+  },
+  "BUS 222": {
+    "text": "BUS 104 for business majors; Second semester standing for non-business majors",
+    "courses": [
+      "BUS 104"
+    ]
+  },
+  "BUS 54": {
+    "text": "<p>The prerequisite for BUS 54 is being modified to allow students in the new AAS degree in Entrepreneurship and Small Business Management to enroll in this course.&nbsp; The description is being modified to provide students with a clearer understanding of Entrepreneurship and what will be covered in this class.&nbsp; This change will not affect the transferability of this course to any other CUNY senior college.&nbsp;</p>",
+    "courses": []
+  },
+  "BUSI 212": {
+    "text": "ENGL 103/A, BUSI 102",
+    "courses": [
+      "BUSI 102",
+      "ENGL 103"
+    ]
+  },
+  "CAP 203": {
+    "text": "ENG 110 , 40 credits Co-requisites: MAT 100 or higher",
+    "courses": [
+      "ENG 110",
+      "MAT 100"
+    ]
+  },
+  "CH 101": {
+    "text": "Co-Requisite: CH-102",
+    "courses": [
+      "CH 102"
+    ]
+  },
+  "CH 102": {
+    "text": "COREQ: CH101",
+    "courses": [
+      "CH 101"
+    ]
+  },
+  "CH 110": {
+    "text": "None Co-Requisite: CH-111",
+    "courses": [
+      "CH 111"
+    ]
+  },
+  "CH 111": {
+    "text": "COREQ: CH110",
+    "courses": [
+      "CH 110"
+    ]
+  },
+  "CH 128": {
+    "text": "CH120, OR CH127 OR CH151. NOT OPEN TO STUDENTS WHO HAVE COMPLETED CH 251",
+    "courses": [
+      "CH 120",
+      "CH 127",
+      "CH 151",
+      "CH 251"
+    ]
+  },
+  "CH 151": {
+    "text": "(MA-119 and MA-121) OR MA120 OR MA 114 OR SATISFACTORY SCORE ON THE MATHEMATICS PLACEMENT TEST, MA 440 OR MA 441 OR MA 442 MAY SATISFY THE PRE-REQ MATH REQUIREMENT",
+    "courses": [
+      "MA 114",
+      "MA 119",
+      "MA 120",
+      "MA 121",
+      "MA 440",
+      "MA 441",
+      "MA 442"
+    ]
+  },
+  "CH 152": {
+    "text": "CH151",
+    "courses": [
+      "CH 151"
+    ]
+  },
+  "CH 251": {
+    "text": "COREQ: CH152, OR BY PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "CH 152"
+    ]
+  },
+  "CH 252": {
+    "text": "CH251",
+    "courses": [
+      "CH 251"
+    ]
+  },
+  "CH 900": {
+    "text": "<p>The course description is outdated, and it has been updated to provide more details. Additionally, requiring a full year of chemistry as a prerequisite is not necessary for most co-op sponsors we have worked with. Also, permitting students to participate only after taking General Chemistry II may prevent strong students from participating in available internship opportunities before they graduate.</p>",
+    "courses": []
+  },
+  "CH 901": {
+    "text": "CH152 FOR CH 900/901. ONLY OPEN TO MATRICULATED STUDENTS WHO HAVE COMPLETED CH152 WITH A GRADE POIN AVERAGE OF AT LEAST 2.5 IN CHEMISTRY COURSES AND WHO HAVE BEEN RECOMMENDED BY THE CHEMISTRY DEPARTMENT",
+    "courses": [
+      "CH 152",
+      "CH 900"
+    ]
+  },
+  "CH 911": {
+    "text": "CH120 OR CH127 OR CH151",
+    "courses": [
+      "CH 120",
+      "CH 127",
+      "CH 151"
+    ]
+  },
+  "CH 912": {
+    "text": "CH911",
+    "courses": [
+      "CH 911"
+    ]
+  },
+  "CH 913": {
+    "text": "CH151 AND CH912",
+    "courses": [
+      "CH 151",
+      "CH 912"
+    ]
+  },
+  "CH 914": {
+    "text": "CH151 & 913",
+    "courses": [
+      "CH 151"
+    ]
+  },
+  "CHE 299": {
+    "text": "BIO 220 and CHE 220",
+    "courses": [
+      "BIO 220",
+      "CHE 220"
+    ]
+  },
+  "CHEM 120": {
+    "text": "<p>Correct description format and removed pre-requisites as they were approved in Jan/Feb 2023 CAPPR. This was changed on 4/5/23 in Cf, but somehow did not reflect in Cf or CD when posted in April.</p>",
+    "courses": []
+  },
+  "CHEM 211": {
+    "text": "<p>Added Pre-requisite &amp; Co-requisite in the correct fields as it was only showing in the enrollment group. It looks like when the rollover of the systems from Cf to CD was done, this was not rollover correctly. The pre &amp; co requisites took effect Fall 2023. Approved in AUR of Jan/Feb 2023.</p>",
+    "courses": []
+  },
+  "CHM 11": {
+    "text": "<p><strong>Per the CUNY-required elimination of stand-alone remediation, CHM 02 will no longer be offered, effective Fall 2023. Therefore, we propose removing the CHM 02 / placement exam as a prerequisite to CHM 11. In an attempt to compensate somewhat for the loss of CHM 02, we propose adding one hour of instruction to CHM 11, consistent with the structure at Hostos, BMCC, Queensborough and Guttman. Note that the prerequisite math requirement for CHM 11 was increased last year from MTH 05 to MTH 06/28/28.5, which is consistent with peer CUNY community colleges. This change should result in mathematically better-prepared students in CHM 11.</strong></p>",
+    "courses": [
+      "CHM 02",
+      "MTH 05",
+      "MTH 06"
+    ]
+  },
+  "CHM 17": {
+    "text": "<p><strong>Per the CUNY-required elimination of stand-alone remediation, CHM 02 will no longer be offered, effective Fall 2023. Therefore, we propose removing the CHM 02 / placement exam as a prerequisite to CHM 17. In an attempt to compensate somewhat for the loss of CHM 02, the course has been revised to dedicate slightly more time to basic topics during lecture and lab hours.</strong></p>",
+    "courses": [
+      "CHM 02"
+    ]
+  },
+  "CIS 1200": {
+    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required. </p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5l.%20Change%20in%20Prereq%20-%20CIS%201200%20-Introduction%20to%20Operating%20Systems.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5l. Change in Prereq - CIS 1200 -Introduction to Operating Systems</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5lChangeinPrereq-CIS1200-IntroductiontoOperatingSystems.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5lChangeinPrereq-CIS1200-IntroductiontoOperatingSystems.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "courses": [
+      "CP 500",
+      "FALL 2024",
+      "FEB 2025"
+    ]
+  },
+  "CIS 152": {
+    "text": "CIS102 (FORMERLY BU502)",
+    "courses": [
+      "BU 502",
+      "CIS 102"
+    ]
+  },
+  "CIS 153": {
+    "text": "CIS101",
+    "courses": [
+      "CIS 101"
+    ]
+  },
+  "CIS 155": {
+    "text": "CIS 101 and CIS 102",
+    "courses": [
+      "CIS 101",
+      "CIS 102"
+    ]
+  },
+  "CIS 156": {
+    "text": "CIS-101",
+    "courses": [
+      "CIS 101"
+    ]
+  },
+  "CIS 201": {
+    "text": "CIS153 (FORMERLY BU532)",
+    "courses": [
+      "BU 532",
+      "CIS 153"
+    ]
+  },
+  "CIS 204": {
+    "text": "CIS-102 and MA-010 or satisfactory score on the Mathematics Placement Test",
+    "courses": [
+      "CIS 102",
+      "MA 010"
+    ]
+  },
+  "CIS 206": {
+    "text": "CIS 101 (BU500) AND MA-010 OR SATISFACTORY SCORE ON THE MATHEMATICS PLACEMENT TEST",
+    "courses": [
+      "BU 500",
+      "CIS 101",
+      "MA 010"
+    ]
+  },
+  "CIS 208": {
+    "text": "CIS101",
+    "courses": [
+      "CIS 101"
+    ]
+  },
+  "CIS 210": {
+    "text": "CIS-101 and BU-401",
+    "courses": [
+      "BU 401",
+      "CIS 101"
+    ]
+  },
+  "CIS 2100": {
+    "text": "<p><u>5/19/2025:</u> Requisite from JAN 2025 attached to course.</p><p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5m.%20Change%20in%20Prereq%20-%20CIS%202100%20-%20Introduction%20to%20Web%20Page%20Development.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5m. Change in Prereq - CIS 2100 - Introduction to Web Page Development</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5mChangeinPrereq-CIS2100-IntroductiontoWebPageDevelopment.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5mChangeinPrereq-CIS2100-IntroductiontoWebPageDevelopment.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "courses": [
+      "CP 500",
+      "FALL 2024",
+      "FEB 2025",
+      "JAN 2025"
+    ]
+  },
+  "CIS 211": {
+    "text": "CIS-155",
+    "courses": [
+      "CIS 155"
+    ]
+  },
+  "CIS 220": {
+    "text": "Pre/ Co Requisites: BUS 100, MAT 120",
+    "courses": [
+      "BUS 100",
+      "MAT 120"
+    ]
+  },
+  "CIS 251": {
+    "text": "CIS-152(BU520), CIS-153(BU532), CIS-208(BU508) and MA-10 or satisfactory score on the Mathematics Placement Test",
+    "courses": [
+      "BU 508",
+      "BU 520",
+      "BU 532",
+      "CIS 152",
+      "CIS 153",
+      "CIS 208",
+      "MA 10"
+    ]
+  },
+  "CIS 254": {
+    "text": "CIS-153 and MA-10 or satisfactory score on the Mathematics Placement Test or Permission of the Department. or MATH PROFICIENT MILESTONE",
+    "courses": [
+      "CIS 153",
+      "MA 10"
+    ]
+  },
+  "CIS 255": {
+    "text": "CIS-211",
+    "courses": [
+      "CIS 211"
+    ]
+  },
+  "CIS 272": {
+    "text": "CSC 101 or departmental approval",
+    "courses": [
+      "CSC 101"
+    ]
+  },
+  "CIS 3100": {
+    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5n.%20Change%20in%20Prereq%20-%20CIS%203100%20-%20Introduction%20to%20Database.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5n. Change in Prereq - CIS 3100 - Introduction to Database</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5nChangeinPrereq-CIS3100-IntroductiontoDatabase.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5nChangeinPrereq-CIS3100-IntroductiontoDatabase.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "courses": [
+      "CP 500",
+      "FALL 2024",
+      "FEB 2025"
+    ]
+  },
+  "CLE 11": {
+    "text": "<p>The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program.</p>",
+    "courses": [
+      "MTH 13",
+      "MTH 28",
+      "RAD 12",
+      "RAD 16"
+    ]
+  },
+  "CLE 51": {
+    "text": "<p>Change in Prerequisites</p>",
+    "courses": []
+  },
+  "COM 200W": {
+    "text": "ENG 110 or higher Pre/Co-Requisite: COM 110",
+    "courses": [
+      "COM 110",
+      "ENG 110"
+    ]
+  },
+  "COM 31": {
+    "text": "<p><strong>Rationale:</strong> The prerequisites, description and content of COM 31 are being modified to bring this course into equivalence with Baruch’s COM 2020 and allow students to receive transfer credit at Baruch.&nbsp; This change will not affect the transferability of this course to any other CUNY senior college.&nbsp;</p>",
+    "courses": [
+      "COM 2020"
+    ]
+  },
+  "CONM 241": {
+    "text": "COREQ: ECON101, INTRODUCTION TO MACROECONOMICS",
+    "courses": [
+      "ECON 101"
+    ]
+  },
+  "CONM 248": {
+    "text": "MT341 APPLIED MECHANICS",
+    "courses": [
+      "MT 341"
+    ]
+  },
+  "COOP 102": {
+    "text": "COOP 101",
+    "courses": [
+      "COOP 101"
+    ]
+  },
+  "CP 2100": {
+    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5o.%20Change%20in%20Prereq%20-%20CP%202100%20-%20C%2B%2B%20Programming%201.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5o. Change in Prereq - CP 2100 - C++ Programming 1</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5oChangeinPrereq-CP2100-CplusplusProgramming1.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5oChangeinPrereq-CP2100-CplusplusProgramming1.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p><p>Amanda Kalin7/27 10:32 AM&nbsp;</p><table><tbody><tr><td><p><strong>Listed in Course Dog &amp; CUNYFirst</strong></p></td><td><p><strong>Correction</strong></p></td></tr><tr><td><p>CP 2100 - C Programming I</p></td><td><p>CP 2100 - C<strong>++ </strong>Programming I</p></td></tr><tr><td><p>CP 2200 - &nbsp;C Programming II</p></td><td><p>CP 2200 - &nbsp;C<strong>++</strong> Programming II</p></td></tr><tr><td><p>ACC 1100 - Fundamentals of Accounting&nbsp;</p></td><td><p>ACC 1100 - Fundamentals of Accounting <strong>I</strong></p></td></tr></tbody></table>",
+    "courses": [
+      "ACC 1100",
+      "CP 2200",
+      "CP 500",
+      "FALL 2024",
+      "FEB 2025"
+    ]
+  },
+  "CP 500": {
+    "text": "<p><u>Explanation</u>: The change in prerequisite and pre-/co-requisite reflect the introduction of the ACCUPLACER mathematics exam and removal of MAT R300, which is no longer offered. </p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5j.%20Change%20in%20Pre%20and%20Pre-Co%20Req%20-%20CP%20500%20-%20Introduction%20to%20Computer%20Programming.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5j. Change in Pre and Pre-Co Req - CP 500 - Introduction to Computer Programming</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5jChangeinPreandPre-CoReq-CP500-IntroductiontoComputerProgramming.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5jChangeinPreandPre-CoReq-CP500-IntroductiontoComputerProgramming.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "courses": [
+      "FALL 2024",
+      "FEB 2025"
+    ]
+  },
+  "CP 6200": {
+    "text": "<p><u>Explanation</u>: Decision of faculty committee has determined that a passing grade in CP 500 is required.</p><p>CURRICULUM COMMITTEE FALL 2024 FOR JAN/FEB 2025 AUR</p><p><a href=\"https://coursedog-static-public.s3.us-east-2.amazonaws.com/kcc01/5p.%20Change%20in%20Prereq%20-%20CP%206200%20-%20Java%20Programming%202.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">5p. Change in Prereq - CP 6200 - Java Programming 2</a></p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5pChangeinPrereq-CP6200-JavaProgramming2.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2024/5pChangeinPrereq-CP6200-JavaProgramming2.pdf</a></p><p>11/11/2024: Requisite Change Submitted to College Council 11/19/2024 Agenda as Informational Item (no vote needed)</p>",
+    "courses": [
+      "CP 500",
+      "FALL 2024",
+      "FEB 2025"
+    ]
+  },
+  "CRIM 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "CRIM 106": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "CRIM 201": {
+    "text": "CRIM101 and CRIM106",
+    "courses": [
+      "CRIM 101",
+      "CRIM 106"
+    ]
+  },
+  "CRIM 202": {
+    "text": "CRIM101 and CRIM106",
+    "courses": [
+      "CRIM 101",
+      "CRIM 106"
+    ]
+  },
+  "CRIM 203": {
+    "text": "CRIM101 and CRIM106",
+    "courses": [
+      "CRIM 101",
+      "CRIM 106"
+    ]
+  },
+  "CRIM 204": {
+    "text": "CRIM101 and CRIM106",
+    "courses": [
+      "CRIM 101",
+      "CRIM 106"
+    ]
+  },
+  "CRIM 205": {
+    "text": "CRIM101 and CRIM106 for Criminal Justice Degree Program students. SOCY-101 for students who are not in the Criminal Justice Degree Program",
+    "courses": [
+      "CRIM 101",
+      "CRIM 106",
+      "SOCY 101"
+    ]
+  },
+  "CRJ 102": {
+    "text": "SOC 100",
+    "courses": [
+      "SOC 100"
+    ]
+  },
+  "CRJ 201": {
+    "text": "CRJ 101",
+    "courses": [
+      "CRJ 101"
+    ]
+  },
+  "CRJ 204": {
+    "text": "CRJ 101 and CRJ 102",
+    "courses": [
+      "CRJ 101",
+      "CRJ 102"
+    ]
+  },
+  "CRT 100": {
+    "text": "<p>Need to update prereq</p>",
+    "courses": []
+  },
+  "CRT 100.6": {
+    "text": "<p>ESL co-requisite courses are proficiency designating courses, and instead of tying the co-req to a specific course, we are proposing that it be referred to as “for ESL reading and writing proficiency” and to remove reference to a specific course in the description. This is in line with changes to remediation and ESL set by CUNY Central.</p>",
+    "courses": []
+  },
+  "CRT 200": {
+    "text": "ENG 100.5 or ENG 101 or department approval",
+    "courses": [
+      "ENG 100",
+      "ENG 101"
+    ]
+  },
+  "CRT 275": {
+    "text": "[(ENG 101 or Equivalent) AND (Any CRT or PHI course or equivalent)] or Departmental Approval",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "CS 100": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN MATHEMATICS (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "CS 101": {
+    "text": "COREQ: MA441",
+    "courses": [
+      "MA 441"
+    ]
+  },
+  "CS 201": {
+    "text": "MA441 AND CS101 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "CS 101",
+      "MA 441"
+    ]
+  },
+  "CS 203": {
+    "text": "MA441 AND CS101 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "CS 101",
+      "MA 441"
+    ]
+  },
+  "CS 204": {
+    "text": "MA441 AND CS101 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "CS 101",
+      "MA 441"
+    ]
+  },
+  "CS 3500": {
+    "text": "CS 1200 with a grade of \"C\" or higher and MAT 1500 with a grade of \"C+\" or higher",
+    "courses": [
+      "CS 1200",
+      "MAT 1500"
+    ]
+  },
+  "CS 3700": {
+    "text": "CS 13A0 with a grade of \"C\" or higher",
+    "courses": []
+  },
+  "CSC 203": {
+    "text": "<p>This change lowers the prerequisite to precalculus makes the course more accessible to a broader range of students, encouraging participation from those interested in data science but who may not have completed calculus yet. The course focuses on programming and data analysis concepts that rely more on algebraic reasoning and basic mathematical logic rather than advanced calculus, making precalculus a sufficient foundation. </p>",
+    "courses": []
+  },
+  "CSC 275": {
+    "text": "<table><tbody><tr><td><p>CSC 275 is a continuation of CSC 215. CSC 215 cannot be a corequisite course.</p></td></tr></tbody></table><p>Added the Major Gateway Course Attribute(s)</p>",
+    "courses": [
+      "CSC 215"
+    ]
+  },
+  "CSC 300": {
+    "text": "<p>Updating Prerequisite since CSC 275 is a continuation of CSC 215, and CSC 300 requires strong mathematical understanding.</p><p>Added the Major Gateway Course Attribute(s)</p>",
+    "courses": [
+      "CSC 215",
+      "CSC 275"
+    ]
+  },
+  "CSN 100": {
+    "text": "<p>Update prerequisites</p>",
+    "courses": []
+  },
+  "CST 140": {
+    "text": "ESL 86 – 88 or ESL 91 or higher, or ENG 100 or higher and CUNY Proficiency Index Co-requisites: MAT 150",
+    "courses": [
+      "ENG 100",
+      "ESL 86",
+      "ESL 91",
+      "MAT 150"
+    ]
+  },
+  "CST 150": {
+    "text": "CSC 140",
+    "courses": [
+      "CSC 140"
+    ]
+  },
+  "CST 160": {
+    "text": "CSC 140",
+    "courses": [
+      "CSC 140"
+    ]
+  },
+  "CST 220": {
+    "text": "CST 140",
+    "courses": [
+      "CST 140"
+    ]
+  },
+  "CST 230": {
+    "text": "CSC 140 / Co-requisite: CSC 215",
+    "courses": [
+      "CSC 140",
+      "CSC 215"
+    ]
+  },
+  "CST 240": {
+    "text": "CST 140 Pre/Co-requisite: CST 220",
+    "courses": [
+      "CST 140",
+      "CST 220"
+    ]
+  },
+  "CST 250": {
+    "text": "CST 140",
+    "courses": [
+      "CST 140"
+    ]
+  },
+  "CST 260": {
+    "text": "Pre or Co Requisite: CST 240",
+    "courses": [
+      "CST 240"
+    ]
+  },
+  "CWE 31": {
+    "text": "<p><strong>This minor change to the prerequisite is designed to create a uniform verbiage for all new and revised courses in the Department and to allow student in the newly approved AS in Accounting and AS in Marketing to enroll in this required course.</strong></p>",
+    "courses": []
+  },
+  "CWE 41": {
+    "text": "Students must be accepted into an apprenticeship opportunity, have departmental permission, and have earned a minimum of 30 degree credits completed towards their associate degree",
+    "courses": []
+  },
+  "CWE 42": {
+    "text": "Students must be accepted into an apprenticeship opportunity, have departmental permission, and have earned a minimum of 30 degree credits completed towards their associate degree. Corequisite: CWE 41",
+    "courses": [
+      "CWE 41"
+    ]
+  },
+  "CWE 43": {
+    "text": "Students must be accepted into an apprenticeship opportunity, have departmental permission, and have earned a minimum of 30 degree credits completed towards their associate degree. Corequisites: CWE 41 and CWE 42",
+    "courses": [
+      "CWE 41",
+      "CWE 42"
+    ]
+  },
+  "DAN 124": {
+    "text": "FOR DANCE MAJORS ONLY OR PERMISSION OF INSTRUCTOR",
+    "courses": []
+  },
+  "DAN 125": {
+    "text": "DAN 124 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 124"
+    ]
+  },
+  "DAN 126": {
+    "text": "DAN125 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 125"
+    ]
+  },
+  "DAN 127": {
+    "text": "DAN126 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 126"
+    ]
+  },
+  "DAN 134": {
+    "text": "FOR DANCE MAJORS ONLY OR PERMISSION OF INSTRUCTOR",
+    "courses": []
+  },
+  "DAN 135": {
+    "text": "DAN134 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "DAN 134"
+    ]
+  },
+  "DAN 136": {
+    "text": "DAN135 OR PERMISSION OF INSTRUCTOR",
+    "courses": [
+      "DAN 135"
+    ]
+  },
+  "DAN 137": {
+    "text": "DAN136 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 136"
+    ]
+  },
+  "DAN 140": {
+    "text": "DAN102 OR PE613 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "DAN 102",
+      "PE 613"
+    ]
+  },
+  "DAN 160": {
+    "text": "The student must be enrolled in Advanced Beginning or Intermediate Modern Dance and/or Ballet (DAN-125, DAN-126, DAN-127, DAN-220, DAN-221, DAN-222, DAN-135, DAN-136, DAN-137, DAN-230, DAN-231, DAN-232) or permission of the department",
+    "courses": [
+      "DAN 125",
+      "DAN 126",
+      "DAN 127",
+      "DAN 135",
+      "DAN 136",
+      "DAN 137",
+      "DAN 220",
+      "DAN 221",
+      "DAN 222",
+      "DAN 230",
+      "DAN 231",
+      "DAN 232"
+    ]
+  },
+  "DAN 161": {
+    "text": "The student must be enrolled in Advanced Beginning or Intermediate Modern Dance and/or Ballet (DAN-125, DAN-126, DAN-127, DAN-220, DAN-221, DAN-222, DAN-135, DAN-136, DAN-137, DAN-230, DAN-231, DAN-232) or permission of the department",
+    "courses": [
+      "DAN 125",
+      "DAN 126",
+      "DAN 127",
+      "DAN 135",
+      "DAN 136",
+      "DAN 137",
+      "DAN 220",
+      "DAN 221",
+      "DAN 222",
+      "DAN 230",
+      "DAN 231",
+      "DAN 232"
+    ]
+  },
+  "DAN 220": {
+    "text": "DAN123 (PE607) OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "DAN 123",
+      "PE 607"
+    ]
+  },
+  "DAN 221": {
+    "text": "DAN220 (PE725) OR DEPARTMENTAL PERMISSION",
+    "courses": [
+      "DAN 220",
+      "PE 725"
+    ]
+  },
+  "DAN 222": {
+    "text": "DAN 221 (PE726) OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 221",
+      "PE 726"
+    ]
+  },
+  "DAN 223": {
+    "text": "DAN 222 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "DAN 222"
+    ]
+  },
+  "DAN 230": {
+    "text": "DAN 131 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "DAN 131"
+    ]
+  },
+  "DAN 231": {
+    "text": "DAN230 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 230"
+    ]
+  },
+  "DAN 232": {
+    "text": "DAN 231 (PE728) OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 231",
+      "PE 728"
+    ]
+  },
+  "DAN 233": {
+    "text": "DAN 232 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "DAN 232"
+    ]
+  },
+  "DAN 249": {
+    "text": "DAN125 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 125"
+    ]
+  },
+  "DAN 251": {
+    "text": "DAN249 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 249"
+    ]
+  },
+  "DAN 252": {
+    "text": "DAN249 OR PERMISSION OF THE INSTRUCTOR",
+    "courses": [
+      "DAN 249"
+    ]
+  },
+  "DAN 260": {
+    "text": "BY AUDITION OR PERMISSION OF THE DEPARTMENT",
+    "courses": []
+  },
+  "DAN 261": {
+    "text": "BY AUDITION OR PERMISSION OF THE DEPARTMENT",
+    "courses": []
+  },
+  "DAN 262": {
+    "text": "By audition and/or permission of instructor",
+    "courses": []
+  },
+  "DAT 33": {
+    "text": "<p>Update Pre-requities</p>",
+    "courses": []
+  },
+  "DAT 49": {
+    "text": "<p>Change in Prereqs</p>",
+    "courses": []
+  },
+  "DD 108": {
+    "text": "DD 100 Foundation Drawing",
+    "courses": [
+      "DD 100"
+    ]
+  },
+  "DM 103": {
+    "text": "ENG 110",
+    "courses": [
+      "ENG 110"
+    ]
+  },
+  "DM 210": {
+    "text": "DM 106",
+    "courses": [
+      "DM 106"
+    ]
+  },
+  "ECO 1200": {
+    "text": "<p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p><u>Explanation</u>: The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5kChangeinPrereq-ECO1200-Macroeconomics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5kChangeinPrereq-ECO1200-Macroeconomics.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024"
+    ]
+  },
+  "ECO 1300": {
+    "text": "<p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p></p><p><u>Explanation</u>: The ACCUPLACER CUNY Assessment Test and M100 - Pre-Algebra, a stand alone mathematics developmental course, are no longer offered. It is therefore prudent to remove them as pre-requisites for this course.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5lChangeinPrereq-ECO1300-Microeconomics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5lChangeinPrereq-ECO1300-Microeconomics.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024"
+    ]
+  },
+  "ECON 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ECON 102": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ECON 150": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ECON 160": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "ECON 201": {
+    "text": "MATH 120 or equivalent",
+    "courses": [
+      "MATH 120"
+    ]
+  },
+  "ECON 235": {
+    "text": "ECON101 (SS211) OR ECON102 (SS212)",
+    "courses": [
+      "ECON 101",
+      "ECON 102",
+      "SS 211",
+      "SS 212"
+    ]
+  },
+  "EDS 202": {
+    "text": "<p>update prereq</p>",
+    "courses": []
+  },
+  "EDU 117": {
+    "text": "EDU 101",
+    "courses": [
+      "EDU 101"
+    ]
+  },
+  "EDU 150": {
+    "text": "9 Credits in EDU Co-requisite: ENG 100 or higher; or ESL 86 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "EDU 16": {
+    "text": "<p>Improved shortening/change in prereqs</p>",
+    "courses": []
+  },
+  "EDU 19": {
+    "text": "EDU 10 or EDU 70",
+    "courses": [
+      "EDU 10",
+      "EDU 70"
+    ]
+  },
+  "EDU 201": {
+    "text": "PSY 100",
+    "courses": [
+      "PSY 100"
+    ]
+  },
+  "EDU 202": {
+    "text": "EDU 201 or EDS 201",
+    "courses": [
+      "EDS 201",
+      "EDU 201"
+    ]
+  },
+  "EDU 205": {
+    "text": "Grade of \"C\" or better in EDU 202",
+    "courses": [
+      "EDU 202"
+    ]
+  },
+  "EDU 206": {
+    "text": "EDU 201",
+    "courses": [
+      "EDU 201"
+    ]
+  },
+  "EDU 207": {
+    "text": "EDU 201 and EDU 206 Corequisite: EDU 208",
+    "courses": [
+      "EDU 201",
+      "EDU 206",
+      "EDU 208"
+    ]
+  },
+  "EDU 208": {
+    "text": "EDU 201 and EDU 206 Corequisite: EDU 207",
+    "courses": [
+      "EDU 201",
+      "EDU 206",
+      "EDU 207"
+    ]
+  },
+  "EDU 227": {
+    "text": "Pre-requisite or Co-requisite: EDU 226",
+    "courses": [
+      "EDU 226"
+    ]
+  },
+  "EDU 30": {
+    "text": "<p><strong>Updating course pre and corequisites to align with current department advising practices. &nbsp;As EDU 10 is the gateway course for early childhood and childhood education, so is EDU 70 the gateway course for Liberal Arts – Secondary Education option.</strong></p>",
+    "courses": [
+      "EDU 10",
+      "EDU 70"
+    ]
+  },
+  "EDU 70": {
+    "text": "<p><strong>Rationale: Updating course pre and corequisites to align with current department advising practices as this course is recommended to be taken in the first semester.&nbsp; EDU 70, like EDU 10, should be a first semester course introducing students to the fundamental theories and practices for secondary education.</strong></p>",
+    "courses": [
+      "EDU 10"
+    ]
+  },
+  "EDU 71": {
+    "text": "<p><strong>Updating course pre and corequisites to align with current department advising practices as this course is recommended to be taken in the second semester. Just as EDU 12 can be taken with EDU 10, or can be taken prior to EDU 10, or as a stand alone elective, EDU 71 should be available to students who need to take both courses at the same time, in the cases of transfer, change of curriculum, or for paraprofessional certification.</strong></p>",
+    "courses": [
+      "EDU 10",
+      "EDU 12"
+    ]
+  },
+  "EDUC 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "EDUC 115": {
+    "text": "EDUC 101 (ED110)",
+    "courses": [
+      "ED 110",
+      "EDUC 101"
+    ]
+  },
+  "EDUC 222": {
+    "text": "<table><tbody><tr><td><p>The College proposes removing the pre-requisite that students must be LAS-SSE majors in order to enroll in the course. We hope that opening Education courses to students in other programs allows more students who might be interested in teaching to take a Gateway course in education while attending community college. </p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "EDUC 230": {
+    "text": "EDUC 101 (ED110)",
+    "courses": [
+      "ED 110",
+      "EDUC 101"
+    ]
+  },
+  "EDUC 240": {
+    "text": "EDUC 101 (ED110)",
+    "courses": [
+      "ED 110",
+      "EDUC 101"
+    ]
+  },
+  "EE 101": {
+    "text": "MA128 OR MA440 OR MA441",
+    "courses": [
+      "MA 128",
+      "MA 440",
+      "MA 441"
+    ]
+  },
+  "EE 103": {
+    "text": "COREQ: MA441",
+    "courses": [
+      "MA 441"
+    ]
+  },
+  "EE 204": {
+    "text": "MA441",
+    "courses": [
+      "MA 441"
+    ]
+  },
+  "EKG 78": {
+    "text": "BIO 24 and enrollment in the Medical Office Assistant Curriculum or Health Sciences Curriculum",
+    "courses": [
+      "BIO 24"
+    ]
+  },
+  "ELA 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELA 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELA 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELA 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELA 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELC 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELC 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELC 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELC 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELC 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELC 202": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELC 203": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELE 150": {
+    "text": "<p>Updating the prereqs for this course</p>",
+    "courses": []
+  },
+  "ELF 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELF 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELF 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELF 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELI 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELI 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELI 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELI 200": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELJ 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELJ 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELJ 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELJ 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELJ 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELK 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELK 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELK 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELK 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELK 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELM 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELM 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELM 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELN 122": {
+    "text": "<p>Adding the prerequisite for the class. Prerequisite: Math Proficiency</p><p>Pre/Co-Requisite: ENG102</p>",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ELP 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELP 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELP 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELP 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELR 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELR 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELR 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 104": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 106": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 200": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 204": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELS 209": {
+    "text": "<p>Removing prereq based on special action from 10/23/2023. </p>",
+    "courses": []
+  },
+  "ELS 210": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELT 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELU 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELV 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELV 103": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELV 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELV 201": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELY 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELY 105": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ELZ 102": {
+    "text": "<p>Removing the prerequisites for the Modern Languages and Literatures (ML) Program.</p>",
+    "courses": []
+  },
+  "ENG 110": {
+    "text": "<p>Currently, Language and Cognition students must wait until after grades are posted to register in gateway English courses. This change to English 110 pre-requisites would allow students to pre-register for gateway English classes while enrolled in preceding ESL co-requisite courses ESL 30/31 and ESL 86/88. </p>",
+    "courses": [
+      "ESL 30",
+      "ESL 86"
+    ]
+  },
+  "ENG 135": {
+    "text": "Prerequisites ENG 100, 110, or 111",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "ENG 165": {
+    "text": "<p>Change Prerequisites</p>",
+    "courses": []
+  },
+  "ENG 200W": {
+    "text": "ENG 111",
+    "courses": [
+      "ENG 111"
+    ]
+  },
+  "ENG 210": {
+    "text": "<p>Update to add description of prerequisites.</p>",
+    "courses": []
+  },
+  "ENG 211": {
+    "text": "<p>Update to add description of prerequisites.</p>",
+    "courses": []
+  },
+  "ENG 212": {
+    "text": "<p>Update to add description of prerequisite(s).</p>",
+    "courses": []
+  },
+  "ENG 213": {
+    "text": "<p>Update to add description of prerequisites.</p>",
+    "courses": []
+  },
+  "ENG 219": {
+    "text": "<p>Update to add prereq and description of prerequisite(s).</p>",
+    "courses": []
+  },
+  "ENG 225H": {
+    "text": "ENG 111",
+    "courses": [
+      "ENG 111"
+    ]
+  },
+  "ENG 252": {
+    "text": "Passing ENG 110 or equivalent or permission of the department",
+    "courses": [
+      "ENG 110"
+    ]
+  },
+  "ENG 252W": {
+    "text": "Passing ENG 110 or equivalent or permission of the department",
+    "courses": [
+      "ENG 110"
+    ]
+  },
+  "ENG 295": {
+    "text": "<p>The revision of ENG295 is necessary as the course is no longer the capstone for the English Major: the term capstone was removed from the description; other &nbsp;changes include removal of ENG102 and completion of 40 credits as a prerequisite and the course no longer being writing intensive.</p>",
+    "courses": [
+      "ENG 102"
+    ]
+  },
+  "ENG 314": {
+    "text": "ENG 121 or ENG 201 or departmental approval",
+    "courses": [
+      "ENG 121",
+      "ENG 201"
+    ]
+  },
+  "ENG 330": {
+    "text": "ENG 121 or ENG 201",
+    "courses": [
+      "ENG 121",
+      "ENG 201"
+    ]
+  },
+  "ENG 6000": {
+    "text": "<p><u>5/27/2025 -</u></p><p><strong>From:</strong>&nbsp;Jaime Berco &lt;Jaime.Berco@kbcc.cuny.edu&gt;<br><strong>Sent:</strong>&nbsp;Tuesday, May 27, 2025 11:55 AM<br><strong>To:</strong>&nbsp;KCC Academic Scheduling &lt;Academic_Scheduling@kbcc.cuny.edu&gt;; Seanna Carter &lt;Seanna.Carter@kbcc.cuny.edu&gt;; Avery Mullen &lt;Avery.Mullen@kbcc.cuny.edu&gt;; Shavone Sease &lt;Shavone.Sease@kbcc.cuny.edu&gt;<br><strong>Cc:</strong>&nbsp;Mary Dawson &lt;mdawson@kbcc.cuny.edu&gt;; Gordon Alley-Young &lt;Gordon.Young@kbcc.cuny.edu&gt;; Cynthia Olvina &lt;Cynthia.Olvina@kbcc.cuny.edu&gt;; KCC Faculty Workload &lt;Faculty.Workload@kbcc.cuny.edu&gt;<br><strong>Subject:</strong>&nbsp;ENG6000 - Updating Workload Hours</p><p>Please have the default number of workload hours updated for ENG6000 to the following:</p><p>ENG6000 (Creative Writing: Screenwriting)</p><p>0 Hours -&gt; 3 Hours</p><hr><hr><p><u>Explanation</u>: The removal ENG 5900 – Introduction to Creative Writing, as a prerequisite is inline with the other Creative Writing Courses (ENG 5600, ENG 5700, ENG 5800, and ENG 5900), which only require students to complete ENG 1200. Students do not need to complete ENG 5900 in order to be successful in this course.</p><p>SPRING 2023 CURRICULUM COMMITTEE FOR NOV/DEC AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3eChangeinPrerequisite-ENG6000-CreativeWriting_Screenwriting.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3eChangeinPrerequisite-ENG6000-CreativeWriting_Screenwriting.pdf</a></p>",
+    "courses": [
+      "ENG 1200",
+      "ENG 5600",
+      "ENG 5700",
+      "ENG 5800",
+      "ENG 5900"
+    ]
+  },
+  "ENGL 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "ENGL 102": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "ENGL 201": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 205": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 206": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 211": {
+    "text": "ENGL 103",
+    "courses": [
+      "ENGL 103"
+    ]
+  },
+  "ENGL 212": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 214": {
+    "text": "ENGL 103",
+    "courses": [
+      "ENGL 103"
+    ]
+  },
+  "ENGL 215": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 216": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 217": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 220": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 221": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 223": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 224": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 225": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 231": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 233": {
+    "text": "ENGL-102",
+    "courses": [
+      "ENGL 102"
+    ]
+  },
+  "ENGL 241": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 242": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 251": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 252": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 261": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 262": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 263": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 265": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 591": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 592": {
+    "text": "ENGL102 (EN102)",
+    "courses": [
+      "EN 102",
+      "ENGL 102"
+    ]
+  },
+  "ENGL 90": {
+    "text": "Milestone ACCUENGL90 for Mid Adv - ENGL 90",
+    "courses": []
+  },
+  "ENGL 99": {
+    "text": "A SCORE BELOW 65 ON THE ENGLISH PROFICIENCY INDEX (EGNLX) OR STUDENTS DEEMED NOT YET PROFICIENT IN ENGLISH BY CUNY INCLUDING ENGLISH AS A SECOND LANGUAGE (ESL) STUDENTS WHO DO NOT HAVE AN EGNLX SCORE. COREQ: ENGL101",
+    "courses": [
+      "BELOW 65",
+      "ENGL 101"
+    ]
+  },
+  "ESL 10": {
+    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "courses": []
+  },
+  "ESL 101": {
+    "text": "ESL Student Group and CUNY ESL Accuplacer Composite Score of 0-97COREQUISITE: ESL 101 AND ENG 1050",
+    "courses": [
+      "ENG 1050"
+    ]
+  },
+  "ESL 11": {
+    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "courses": []
+  },
+  "ESL 12": {
+    "text": "<p>Removes grammatical error. Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "courses": []
+  },
+  "ESL 20": {
+    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "courses": []
+  },
+  "ESL 21": {
+    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p><p></p>",
+    "courses": []
+  },
+  "ESL 22": {
+    "text": "<p>Removes grammatical error. Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "courses": []
+  },
+  "ESL 30": {
+    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "courses": []
+  },
+  "ESL 31": {
+    "text": "<p>Renames and renumbers to reflect its position in the ESL sequence, updates co- and pre-requisites, and revises description to match other ESL courses.</p>",
+    "courses": []
+  },
+  "ET 110": {
+    "text": "COREQ: MA114 OR 440 OR 441 OR 119 NOTE: ET110 MUST BE COMPLETED WITH A GRADE OF C OR BETTER BEFORE A STUDENT WILL BE PERMITTED TO REGISTER FOR ADVANCED COURSES IN ELECTRICAL ENGINEERING TECHNOLOGY",
+    "courses": [
+      "MA 114",
+      "OR 119",
+      "OR 440",
+      "OR 441"
+    ]
+  },
+  "ET 140": {
+    "text": "ET110 & COREQ: MA128",
+    "courses": [
+      "ET 110",
+      "MA 128"
+    ]
+  },
+  "ET 210": {
+    "text": "ET-110 with a grade of C or better",
+    "courses": [
+      "ET 110"
+    ]
+  },
+  "ET 220": {
+    "text": "ET210",
+    "courses": [
+      "ET 210"
+    ]
+  },
+  "ET 230": {
+    "text": "ET210",
+    "courses": [
+      "ET 210"
+    ]
+  },
+  "ET 232": {
+    "text": "ET704 OR DEPARTMENT PERMISSION",
+    "courses": [
+      "ET 704"
+    ]
+  },
+  "ET 320": {
+    "text": "COREQ: ET560",
+    "courses": [
+      "ET 560"
+    ]
+  },
+  "ET 350": {
+    "text": "COREQ: ET560",
+    "courses": [
+      "ET 560"
+    ]
+  },
+  "ET 375": {
+    "text": "ET-110 AND EITHER ET-510 OR ET-540, OR PERMISSION OF THE ET DEPARTMENT",
+    "courses": [
+      "ET 110",
+      "ET 510",
+      "ET 540"
+    ]
+  },
+  "ET 410": {
+    "text": "ET560",
+    "courses": [
+      "ET 560"
+    ]
+  },
+  "ET 420": {
+    "text": "ET560",
+    "courses": [
+      "ET 560"
+    ]
+  },
+  "ET 481": {
+    "text": "ET501 OR ET504 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "ET 501",
+      "ET 504"
+    ]
+  },
+  "ET 506": {
+    "text": "COREQ: ET704 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "ET 704"
+    ]
+  },
+  "ET 509": {
+    "text": "Either ET501 or TECH100",
+    "courses": [
+      "ET 501",
+      "TECH 100"
+    ]
+  },
+  "ET 542": {
+    "text": "ET540",
+    "courses": [
+      "ET 540"
+    ]
+  },
+  "ET 560": {
+    "text": "ET509 AND ET210 AND EITHER ET510 OR ET540",
+    "courses": [
+      "ET 210",
+      "ET 509",
+      "ET 510",
+      "ET 540"
+    ]
+  },
+  "ET 575": {
+    "text": "<p>Pre-requisite and co-requisites updated to improve student outcomes for students in the 7 applicable programs. &nbsp;For the current “Prereq: ET502 or ET574 or coreq: MA440 or Department Permission” we found that some students were taking both ET-574 and ET-575 at the same time due to math placement in MA-440.&nbsp; This was unintended and proved to be quite challenging for the students.&nbsp; It was clear that students who took ET-574 before ET-575 were more successful.&nbsp; Thus, we are proposing to change the prerequisite to be “A grade of C or better in one of the following: ET574 or ET712 or ET502 or MA441”.</p>",
+    "courses": [
+      "ET 502",
+      "ET 574",
+      "ET 712",
+      "MA 440",
+      "MA 441"
+    ]
+  },
+  "ET 580": {
+    "text": "ET575 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "ET 575"
+    ]
+  },
+  "ET 581": {
+    "text": "ET574 OR ET575 BOTH WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "ET 574",
+      "ET 575"
+    ]
+  },
+  "ET 585": {
+    "text": "ET574 OR ET575",
+    "courses": [
+      "ET 574",
+      "ET 575"
+    ]
+  },
+  "ET 705": {
+    "text": "ET704",
+    "courses": [
+      "ET 704"
+    ]
+  },
+  "ET 712": {
+    "text": "MUST COMPLETE ET710",
+    "courses": [
+      "ET 710"
+    ]
+  },
+  "ET 713": {
+    "text": "MUST COMPLETE ET710",
+    "courses": [
+      "ET 710"
+    ]
+  },
+  "ET 716": {
+    "text": "ET712 AND ET710",
+    "courses": [
+      "ET 710",
+      "ET 712"
+    ]
+  },
+  "ET 718": {
+    "text": "MUST COMPLETE ET710",
+    "courses": [
+      "ET 710"
+    ]
+  },
+  "ET 720": {
+    "text": "MUST COMPLETE ET710",
+    "courses": [
+      "ET 710"
+    ]
+  },
+  "ET 721": {
+    "text": "MUST COMPLETE ET712 & ET713",
+    "courses": [
+      "ET 712",
+      "ET 713"
+    ]
+  },
+  "ET 725": {
+    "text": "COREQ: ET704",
+    "courses": [
+      "ET 704"
+    ]
+  },
+  "ET 726": {
+    "text": "ET725",
+    "courses": [
+      "ET 725"
+    ]
+  },
+  "ET 756": {
+    "text": "COREQ: ET574 OR ET575",
+    "courses": [
+      "ET 574",
+      "ET 575"
+    ]
+  },
+  "ET 757": {
+    "text": "COREQ: ET713 OR ET718 OR ET756 OR DEPARTMENT PERMISSION",
+    "courses": [
+      "ET 713",
+      "ET 718",
+      "ET 756"
+    ]
+  },
+  "ET 758": {
+    "text": "COREQ: ET757 OR DEPARTMENT PERMISSION",
+    "courses": [
+      "ET 757"
+    ]
+  },
+  "ET 760": {
+    "text": "<p>This course was offered for the first time in Spring 2024 and after teaching the material we find the proposed course requirements make more impact on the student success in this course. Students who took the course and had the proposed prerequisite classes had better success in the class than those who did not.&nbsp; The pre- and co-requisite updates are based on the skills needed to be proficient in the topics covered in the course. </p>",
+    "courses": []
+  },
+  "ET 842": {
+    "text": "COREQ: ET841",
+    "courses": [
+      "ET 841"
+    ]
+  },
+  "ETH 211": {
+    "text": "[(ENG 100.5 or ENG 101 or equivalent) and (SPE 100 or SPE 102 or COM 100) and (one course from the Common Core from either any World Cultures and Global Issues course or US Experiences in its Diversity course)] or departmental approval",
+    "courses": [
+      "COM 100",
+      "ENG 100",
+      "ENG 101",
+      "SPE 100",
+      "SPE 102"
+    ]
+  },
+  "FMP 141": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "FMP 241": {
+    "text": "FMP141",
+    "courses": [
+      "FMP 141"
+    ]
+  },
+  "FMP 242": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "FMP 243": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "FMP 244": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "FMP 341": {
+    "text": "FMP 241 DIGIAL MEDIA FIELD PRODUCTION",
+    "courses": [
+      "FMP 241"
+    ]
+  },
+  "FMP 342": {
+    "text": "FMP 241 DIGIAL MEDIA FIELD PRODUCTION",
+    "courses": [
+      "FMP 241"
+    ]
+  },
+  "GD 102W": {
+    "text": "GD 101, AND Pre/Co-Requisite: ESL 30 or ENG 100 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 30",
+      "GD 101"
+    ]
+  },
+  "GE 125": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "HA 100": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": []
+  },
+  "HA 101": {
+    "text": "COREQ: BI301 ALL PREREQUISITES MUST BE COMPLETED WITH A GRADE OF C OR BETTER. MASSAGE THERAPY STUDENTS ONLY",
+    "courses": [
+      "BI 301"
+    ]
+  },
+  "HA 102": {
+    "text": "COREQ: BI301 ALL PREREQUISITES MUST BE COMPLETED WITH A GRADE OF C OR BETTER. MASSAGE THERAPY STUDENTS ONLY",
+    "courses": [
+      "BI 301"
+    ]
+  },
+  "HA 103": {
+    "text": "HA100, HA101 AND BI301. ALL PREREQUISITES MUST BE COMPLETED WITH A GRADE OF C OR BETTER. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "BI 301",
+      "HA 100",
+      "HA 101"
+    ]
+  },
+  "HA 104": {
+    "text": "HA102 COREQ: BI331. ALL PREREQUISITES MUST BE COMPLETED WITH A GRADE OF C OR BETTER. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "BI 331",
+      "HA 102"
+    ]
+  },
+  "HA 201": {
+    "text": "HA103 (COMPLETED WITH A GRADE OF C OR BETTER). OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "HA 103"
+    ]
+  },
+  "HA 202": {
+    "text": "HA104 (COMPLETED WITH A GRADE OF C OR BETTER) COREQ: HA203. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "HA 104",
+      "HA 203"
+    ]
+  },
+  "HA 203": {
+    "text": "BI331, COREQ: HA220 AND HA202. ALL PREREQUISITES MUS BE COMPLETED WITH A GRADE OF C OR BETTER. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "BI 331",
+      "HA 202",
+      "HA 220"
+    ]
+  },
+  "HA 204": {
+    "text": "HA203; COREQ: HA221. ALL PREREQUISITES MUST BE COMPLETED WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "HA 203",
+      "HA 221"
+    ]
+  },
+  "HA 205": {
+    "text": "COREQ: HA204. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "HA 204"
+    ]
+  },
+  "HA 206": {
+    "text": "CPR AND FIRST AID CERTIFICATIONS, BI302, BI331, HA101, HA104; OR PERMISSION OF INSTRUCTOR. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "BI 302",
+      "BI 331",
+      "HA 101",
+      "HA 104"
+    ]
+  },
+  "HA 207": {
+    "text": "CPR AND FIRST AID CERTIFICATIONS, BI302, BI331, HA101, HA104; OR PERMISSION OF INSTRUCTOR. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "BI 302",
+      "BI 331",
+      "HA 101",
+      "HA 104"
+    ]
+  },
+  "HA 208": {
+    "text": "CPR AND FIRST AID CERTIFICATIONS, BI302, BI331, HA101, HA104; OR PERMISSION OF INSTRUCTOR. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "BI 302",
+      "BI 331",
+      "HA 101",
+      "HA 104"
+    ]
+  },
+  "HA 209": {
+    "text": "BI 302, BI331, HA103, HA104 OR PERMISSION OF INSTRUCTOR. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "BI 302",
+      "BI 331",
+      "HA 103",
+      "HA 104"
+    ]
+  },
+  "HA 220": {
+    "text": "BI302 ANDHA104, COREQ: BI325. ALL PREREQUISITES MUST BE COMPLETED WITH A GRADE OF C OR BETTER. OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "ANDHA 104",
+      "BI 302",
+      "BI 325"
+    ]
+  },
+  "HA 221": {
+    "text": "HA220 (COMPLETED WITH A GRADE OF C OR BETTER). OPEN TO MASSAGE THERAPY MAJORS ONLY",
+    "courses": [
+      "HA 220"
+    ]
+  },
+  "HCM 11": {
+    "text": "<p><strong>This change is proposed to ensure that students possess adequate writing skills to succeed in this course. The current lack of prerequisites allows students with ESL need to take the course, putting them at a significant disadvantage. </strong>Change in Department</p>",
+    "courses": []
+  },
+  "HE 203": {
+    "text": "HE-103 and IS-151 or HE-114 (C or higher); departmental permission",
+    "courses": [
+      "HE 103",
+      "HE 114",
+      "IS 151"
+    ]
+  },
+  "HES 101": {
+    "text": "HTR100 Pre/Corequisite: SSY101, SCN195, ENG102",
+    "courses": [
+      "ENG 102",
+      "HTR 100",
+      "SCN 195",
+      "SSY 101"
+    ]
+  },
+  "HES 102": {
+    "text": "HES101, SSY101 Pre/Corequisites: SCN195, ENG102",
+    "courses": [
+      "ENG 102",
+      "HES 101",
+      "SCN 195",
+      "SSY 101"
+    ]
+  },
+  "HES 201": {
+    "text": "HES102 Pre/Corequisite: SSY241 Corequisite: HES202",
+    "courses": [
+      "HES 102",
+      "HES 202",
+      "SSY 241"
+    ]
+  },
+  "HES 202": {
+    "text": "HES102 Pre/Corequisite: SSY241 Corequisite: HES201",
+    "courses": [
+      "HES 102",
+      "HES 201",
+      "SSY 241"
+    ]
+  },
+  "HIS 11": {
+    "text": "<p>HIS 11 was created to serve students enrolled in remedial English and Reading classes (ENG 02 and RDL 02). When CUNY phased out stand-alone remedial classes in favor of co-requisite developmental classes, HIS 11’s corequisite English class was changed to the replacement for ENG 02, which was ENG 110. Faculty from English and Reading created a corequisite class for students who needed additional reading support, ENG 100, and that has been a successful course. The pass rate of ENG 100 students who have been allowed to enroll in HIS 11 is commensurate with that of students co-enrolled in ENG 110. Therefore, we are extending the corequisite options to include ENG 100.</p>",
+    "courses": [
+      "ENG 02",
+      "ENG 100",
+      "ENG 110",
+      "RDL 02"
+    ]
+  },
+  "HIST 110": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 111": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 112": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 127": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 128": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 133": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 135": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 136": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 140": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 141": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 152": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 178": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 179": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 204": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 205": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 206": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 212": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 218": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 222": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 226": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 236": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 240": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 244": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 250": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 262": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 276": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 290": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 291": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 292": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HIST 295": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "HITE 120": {
+    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "courses": []
+  },
+  "HITE 160": {
+    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "courses": []
+  },
+  "HITE 200": {
+    "text": "BIOL 211 - General Biology I",
+    "courses": [
+      "BIOL 211"
+    ]
+  },
+  "HITE 210": {
+    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "courses": []
+  },
+  "HITE 215": {
+    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "courses": []
+  },
+  "HITE 230": {
+    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "courses": []
+  },
+  "HITE 254": {
+    "text": "<p>Revising effective date to allow Enrollment Requirement Group field for correction of prerequisites.</p>",
+    "courses": []
+  },
+  "HLT 100": {
+    "text": "Pre/ Co Requisites: ENG 100 or higher",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "HLT 106": {
+    "text": "ENG 110",
+    "courses": [
+      "ENG 110"
+    ]
+  },
+  "HLT 120W": {
+    "text": "Pre/Co-Requisite: English Sections: ENG 100 or ENG 110 or ESL 86/ESL 88 or ESL 91 Spanish Sections: SPA 121",
+    "courses": [
+      "ENG 100",
+      "ENG 110",
+      "ESL 86",
+      "ESL 88",
+      "ESL 91",
+      "SPA 121"
+    ]
+  },
+  "HLT 211": {
+    "text": "HLT 106",
+    "courses": [
+      "HLT 106"
+    ]
+  },
+  "HPF 101": {
+    "text": "Basic skills prerequisites: English and Math Proficient",
+    "courses": []
+  },
+  "HSC 91": {
+    "text": "<p><strong>Rationale: Either PSY 11 or SOC 11 is allowed as a prerequisite for SOC 35, so students are not required to take both. ENG 110 is already a corequisite to HSC 12, which is a prerequisite to HSC 91; therefore, it is redundant to include here. HSC 11 corequisite is not necessary for success in HSC 91.</strong></p>",
+    "courses": [
+      "ENG 110",
+      "HSC 11",
+      "HSC 12",
+      "PSY 11",
+      "SOC 11",
+      "SOC 35"
+    ]
+  },
+  "HSS 101": {
+    "text": "<p>Updating the pre/co req requirements. Pre-requisites: English Proficiency, Math Proficiency and Pre-Requisites / Co-Requisites: HSF90 or equivalent. Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "courses": [
+      "HSF 90"
+    ]
+  },
+  "HSS 216": {
+    "text": "<p>Removal of SCN 195 as a pre/co-requisite enables students from other programs to enroll in this course. Title and course description updated to more clearly reflect the content. Classroom hours reduced to match course credit. </p>",
+    "courses": [
+      "SCN 195"
+    ]
+  },
+  "HSS 290": {
+    "text": "<p>The course title is changed as the program is no longer called Health and Human Services. SSP101 is removed as a prerequisite as it does not transfer to other programs.</p>",
+    "courses": [
+      "SSP 101"
+    ]
+  },
+  "HSS 295": {
+    "text": "<p>This course revisions reflect current practice and terminology in the field of Human Services. Additionally, the use of OER course materials enables students to engage with the most recent best practices in the field. SSP101 prerequisite has been removed as it is not part of the program core.</p>",
+    "courses": [
+      "SSP 101"
+    ]
+  },
+  "HSVC 223": {
+    "text": "<p>1/29/25 - Requirement group # was not removed which is the change that was requested submitted to remove the pre-requisite.</p><table><tbody><tr><td><p>The College proposes removing the pre-requisite of HSVC 103 in order open the course to students in programs of study outside of Human Services.</p></td></tr></tbody></table>",
+    "courses": [
+      "HSVC 103"
+    ]
+  },
+  "HTR 101": {
+    "text": "HTR100, SSY101 Pre/Corequisites: SCN195, ENG102",
+    "courses": [
+      "ENG 102",
+      "HTR 100",
+      "SCN 195",
+      "SSY 101"
+    ]
+  },
+  "HUA 121": {
+    "text": "<p>This revision of the course updates the catalog description, objectives, grading standards and course outline to reflect current practice in teaching this course. Prerequisites and corequisites are removed to facilitate enrollment.</p>",
+    "courses": []
+  },
+  "HUA 131": {
+    "text": "<p>Updated to match pre/co req in proposal. English Proficiency, Math Proficiency</p>",
+    "courses": []
+  },
+  "HUA 145": {
+    "text": "<p>Removing the HUA230 Intermediate Photography prerequisite and replacing it with either HUA130, HUA131 or HUV 240 will make the course available to students in other majors. The revision also adds the competencies and abilities for assessment.</p>",
+    "courses": [
+      "HUA 130",
+      "HUA 131",
+      "HUA 230",
+      "HUV 240"
+    ]
+  },
+  "HUA 231": {
+    "text": "<p>The course is being revised to include the assessment of Integrative Learning and Digital Communication. Prerequisites are changed to make the course available to a wider group of students.</p>",
+    "courses": []
+  },
+  "HUA 234": {
+    "text": "<p>Update to add prereq and description of prerequisite(s).</p>",
+    "courses": []
+  },
+  "HUA 238": {
+    "text": "<p>Update to add prereq and description of prerequisite(s).</p>",
+    "courses": []
+  },
+  "HUA 245": {
+    "text": "<p>Updated to add prerequisite and description of prerequisite(s).</p>",
+    "courses": []
+  },
+  "HUA 280": {
+    "text": "<p>Updated to add prerequisite and description of prerequisite(s).</p>",
+    "courses": []
+  },
+  "HUA 291": {
+    "text": "<p>Updated to add prerequisite and description of prerequisite(s).</p>",
+    "courses": []
+  },
+  "HUC 116": {
+    "text": "<p>Updating prereq to ENG/A101 from HUC101 and HUC106.</p>",
+    "courses": [
+      "HUC 101",
+      "HUC 106"
+    ]
+  },
+  "HUC 192": {
+    "text": "<p>Approved by Central. Update prereq to ENG/A101 from HUC101 and HUC106.</p>",
+    "courses": [
+      "HUC 101",
+      "HUC 106"
+    ]
+  },
+  "HUI 107": {
+    "text": "<p>Update the prereqs for the class. </p>",
+    "courses": []
+  },
+  "HUI 109": {
+    "text": "<p>Update to pre-requisites. </p>",
+    "courses": []
+  },
+  "HUI 113": {
+    "text": "<p>The prerequisites are being removed from this course to allow students greater flexibility in enrolling in it throughout the degree. The previous prerequisites were not necessary for the study of industrial design history. The course number is being changed from HUI213 to HUI113 in recognition of this course being taken by students in the first year of the degree.</p>",
+    "courses": [
+      "HUI 213"
+    ]
+  },
+  "HUI 114": {
+    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "courses": []
+  },
+  "HUI 129": {
+    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "courses": []
+  },
+  "HUI 190": {
+    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "courses": []
+  },
+  "HUI 209": {
+    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "courses": []
+  },
+  "HUI 214": {
+    "text": "<p> The course number is being changed from HUI118 to HUI214 in recognition of this course running in the second year of the degree. The current corequisite of HUI109 is causing enrollment problems for students and is therefore removed. This course was originally based on an engineering course with extra hours, but that is not necessary for the industrial design version.</p>",
+    "courses": [
+      "HUI 109",
+      "HUI 118"
+    ]
+  },
+  "HUI 216": {
+    "text": "HUI 214",
+    "courses": [
+      "HUI 214"
+    ]
+  },
+  "HUI 219": {
+    "text": "HUI 209",
+    "courses": [
+      "HUI 209"
+    ]
+  },
+  "HUI 295": {
+    "text": "<p>Update to correct/add pre-requisites.</p>",
+    "courses": []
+  },
+  "HUM 100": {
+    "text": "Pre- or Corequisite: ENG 100 or ESL 91 or higher if taken in English; or Pre- or Corequisite SPA 121 or Spanish placement if taken in Spanish",
+    "courses": [
+      "ENG 100",
+      "ESL 91",
+      "SPA 121"
+    ]
+  },
+  "HUN 212": {
+    "text": "ENG101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "HUZ 130": {
+    "text": "Pre/Corequisite: ENG101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "HUZ 131": {
+    "text": "HUZ130 or HUV112",
+    "courses": [
+      "HUV 112",
+      "HUZ 130"
+    ]
+  },
+  "HUZ 145": {
+    "text": "HUZ130 Pre/Corequisite: HUZ131",
+    "courses": [
+      "HUZ 130",
+      "HUZ 131"
+    ]
+  },
+  "HUZ 155": {
+    "text": "HUZ130",
+    "courses": [
+      "HUZ 130"
+    ]
+  },
+  "HUZ 202": {
+    "text": "ENA101/ENG101",
+    "courses": [
+      "ENA 101",
+      "ENG 101"
+    ]
+  },
+  "HUZ 230": {
+    "text": "HUZ 130",
+    "courses": [
+      "HUZ 130"
+    ]
+  },
+  "HUZ 231": {
+    "text": "HUZ131",
+    "courses": [
+      "HUZ 131"
+    ]
+  },
+  "HUZ 234": {
+    "text": "HUZ130",
+    "courses": [
+      "HUZ 130"
+    ]
+  },
+  "HUZ 238": {
+    "text": "HUZ130",
+    "courses": [
+      "HUZ 130"
+    ]
+  },
+  "HUZ 245": {
+    "text": "HUZ145 Prerequisite: HUZ131",
+    "courses": [
+      "HUZ 131",
+      "HUZ 145"
+    ]
+  },
+  "HUZ 275": {
+    "text": "HUZ231 Pre/Corequisite: HUZ245",
+    "courses": [
+      "HUZ 231",
+      "HUZ 245"
+    ]
+  },
+  "HUZ 280": {
+    "text": "HUZ231 Pre/Corequisite: HUZ245 Pre/Corequisite: HUZ275",
+    "courses": [
+      "HUZ 231",
+      "HUZ 245",
+      "HUZ 275"
+    ]
+  },
+  "HUZ 291": {
+    "text": "<p>This course is being submitted as a new course, with the new 3-letter Photography subject area indicator HUZ in the course number, so that photography courses at LaGuardia are discoverable when searching for courses via CUNYfirst. The prerequisites have been updated to ensure the students have a basic digital and studio photography knowledge before taking this option.</p>",
+    "courses": []
+  },
+  "INFT 216": {
+    "text": "<table><tbody><tr><td><p>The College proposes updated the course pre-requisites to better align with the content of the course.</p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "INFT 221": {
+    "text": "<table><tbody><tr><td><p>The College proposes updating the pre-requisites for INFT 221 to reflect the skills required for current course content.</p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "INFT 226": {
+    "text": "Pre-Requisite INFT 216",
+    "courses": [
+      "INFT 216"
+    ]
+  },
+  "INFT 233": {
+    "text": "<table><tbody><tr><td><p>The College proposes updating the pre-requisites for INFT 233 to better align with course sequencing across all of our IT programming.</p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "INTE 219": {
+    "text": "ENGL-102",
+    "courses": [
+      "ENGL 102"
+    ]
+  },
+  "JRL 3100": {
+    "text": "<p><u>7/9/2024</u> Correction: remove Civic Engagement</p><p><u>Explanation</u>: Upon reevaluation of the pre-/co-requisite of ENG 1200 - Composition I by the Communications and Performing Arts Department determined that students already directly learn journalistic writing nuances along with foundational writing principles in JRL 3100 - Basic Journalism, fostering a seamless learning experience. Additionally, removing the pre-/co-requisite facilitates a smoother academic journey for students. Students would be able to delve directly into JRL 3100 without the potential delay or scheduling conflict of first completing ENG 1200. Furthermore, not all students may have had the chance to complete ENG 1200 or an equivalent before entering the Journalism program. By removing this barrier, we are ensuring that all students, regardless of their prior coursework, have an equal opportunity to pursue JRL 3100</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5xChangePrer-_Coreq-JRL3100-BasicJournalism.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5xChangePrer-_Coreq-JRL3100-BasicJournalism.pdf</a></p>",
+    "courses": [
+      "ENG 1200",
+      "FALL 2023",
+      "FEB 2024"
+    ]
+  },
+  "LA 112": {
+    "text": "LA111 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LA 111"
+    ]
+  },
+  "LA 213": {
+    "text": "LA112 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LA 112"
+    ]
+  },
+  "LAW 19": {
+    "text": "<p><strong>The Paralegal and Legal Studies AAS degree was modified in spring 2019 (effective fall 2019).&nbsp; As part of the program modifications, DAT 10 (Computer Fundamentals and Applications) was removed from the required courses, and DAT 33 (Microcomputer Applications) was added.&nbsp; At that time, the Department’s proposals inadvertently omitted a change in the prerequisite for LAW 19, which was left as only DAT 10 only.&nbsp; The requested change allows students who were enrolled in the AAS degree prior to the spring 2019 modification, are enrolled in the Paralegal Certificate program (which still requires DAT 10) or have completed DAT 10 instead of DAT 33 for any other reason to enroll in LAW 19, a required course in both the AAS degree and the Certificate programs.</strong></p>",
+    "courses": [
+      "DAT 10",
+      "DAT 33"
+    ]
+  },
+  "LAW 47": {
+    "text": "<p>The proposed change in LAW 47 corequisite is made to remove the requirement of LAW 17 (Introduction to Paralegal Studies) as the American Bar Association has recently required an increased focus on ethics in this introductory Paralegal course.&nbsp; As this prerequisite has been waived several times in recent years, students have shown to be successful in completing LAW 47 without simultaneously enrolling in LAW 17.&nbsp; In addition, this change aligns the corequisite for LAW 47 with most other Paralegal and Legal Studies courses.</p>",
+    "courses": [
+      "LAW 17"
+    ]
+  },
+  "LAW 64": {
+    "text": "<p>The proposed change in LAW 64 prerequisite is made to align the pre/corequisites for LAW 64 with most other Paralegal and Legal Studies courses.&nbsp; The current prerequisite of POL 11 (American National Government) is not necessary for student success in LAW 64.&nbsp;</p>",
+    "courses": [
+      "POL 11"
+    ]
+  },
+  "LAW 91": {
+    "text": "<p>The proposed change in LAW 91 prerequisite is made to remove the requirement of both LAW 17 (Introduction to Paralegal Studies) and LAW 47 (Civil Procedure) along with other outdated items.&nbsp;&nbsp; Students will be prepared for LAW 91 after completing either LAW 17 or LAW 47.&nbsp; The additional credit and grade average requirements are no longer necessary.</p>",
+    "courses": [
+      "LAW 17",
+      "LAW 47"
+    ]
+  },
+  "LAW 95": {
+    "text": "<p>The proposed change in LAW 95 prerequisites is made to remove the requirement of LAW 17 (Introduction to Paralegal Studies).&nbsp;&nbsp; Students will be prepared for LAW 95 after completing LAW 47.&nbsp; Since LAW 17 is a co-requisite for LAW 47, we feel that this as an unnecessary redundancy.&nbsp; The change in English prerequisite aligns the verbiage to what is used throughout the college.</p>",
+    "courses": [
+      "LAW 17",
+      "LAW 47"
+    ]
+  },
+  "LAW 96": {
+    "text": "<p>The proposed change in LAW 96 prerequisites is made to remove redundant prerequisites, already required for LAW 95, and to include an option for permission from the Department.&nbsp;</p>",
+    "courses": [
+      "LAW 95"
+    ]
+  },
+  "LC 112": {
+    "text": "LC111 with a grade of “C” or higher, or placement by the Department of Foreign Languages and Literatures",
+    "courses": [
+      "LC 111"
+    ]
+  },
+  "LC 213": {
+    "text": "LC112 with a grade of “C” or higher, or placement by the Department of Foreign Languages and Literatures",
+    "courses": [
+      "LC 112"
+    ]
+  },
+  "LC 321": {
+    "text": "FOREIGN LANGUAGE PLACEMENT",
+    "courses": []
+  },
+  "LC 401": {
+    "text": "ENGL-101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "LF 112": {
+    "text": "LF111 with a grade of “C” or higher, or placement by the Department of Foreign Languages and Literatures",
+    "courses": [
+      "LF 111"
+    ]
+  },
+  "LF 213": {
+    "text": "LF112 with a grade of “C” or higher, or placement by the Department of Foreign Languages and Literatures",
+    "courses": [
+      "LF 112"
+    ]
+  },
+  "LF 214": {
+    "text": "LF213 with a grade of “C” or higher, or placement by the Department of Foreign Languages and Literatures",
+    "courses": [
+      "LF 213"
+    ]
+  },
+  "LF 401": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "LG 112": {
+    "text": "LG111 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LG 111"
+    ]
+  },
+  "LG 401": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "LH 112": {
+    "text": "LH111 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LH 111"
+    ]
+  },
+  "LH 215": {
+    "text": "LH112 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LH 112"
+    ]
+  },
+  "LI 112": {
+    "text": "LI111 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LI 111"
+    ]
+  },
+  "LI 213": {
+    "text": "LI112 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LI 112"
+    ]
+  },
+  "LI 401": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "LIB 105": {
+    "text": "<p>Adding prereqs</p>",
+    "courses": []
+  },
+  "LIN 100": {
+    "text": "ESL 86/88 or higher or ENG 100/110 or higher Co-requisite: ESL 86/88 or higher or ENG 100/110 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "LIN 100.6": {
+    "text": "<p>ESL co-requisite courses are proficiency designating courses, and instead of tying the co-req to a specific course, we are proposing that it be referred to as “for ESL reading and writing proficiency” and to remove reference to a specific course in the description. This is in line with changes to remediation and ESL set by CUNY Central.</p><p></p>",
+    "courses": []
+  },
+  "LIN 102": {
+    "text": "ESL 86/88 or higher or ENG 100/110 or higher Co-requisite: ESL 86/88 or higher or ENG 100/110 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "LIN 102W": {
+    "text": "Pre/Co-Requisite: ESL 86/88 or higher or ENG 100/110 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "LIN 103": {
+    "text": "ESL 86/88 or higher or ENG 100/110 or higher Co-requisite: ESL 86/88 or higher or ENG 100/110 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "LIN 103W": {
+    "text": "Pre/Co-Requisite: ESL 86/88 or higher or ENG 100/110 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "LIN 105": {
+    "text": "<p>Changing the pre-co requisites to ESL 86/88/91 or ENG 100/110 or higher makes LIN 105 consistent with the other Language and Cognition Linguistics courses.</p>",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "LIN 105W": {
+    "text": "Pre/Co-Requisite: ESL 86/88 or higher or ENG 100/110 or higher",
+    "courses": [
+      "ENG 100",
+      "ESL 86"
+    ]
+  },
+  "LIN 220": {
+    "text": "<p>This revision updates the prerequisite renumbering for this course. </p>",
+    "courses": []
+  },
+  "LPN 101": {
+    "text": "<p>This revision corrects the course title to what was submitted in the program proposal and removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course. </p>",
+    "courses": [
+      "LPN 102"
+    ]
+  },
+  "LPN 103": {
+    "text": "<p>This revision removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "courses": [
+      "LPN 102"
+    ]
+  },
+  "LPN 104": {
+    "text": "<p>This revision removes LPN 102 as a co-requisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "courses": [
+      "LPN 102"
+    ]
+  },
+  "LPN 201": {
+    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "courses": [
+      "LPN 102"
+    ]
+  },
+  "LPN 202": {
+    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "courses": [
+      "LPN 102"
+    ]
+  },
+  "LPN 203": {
+    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "courses": [
+      "LPN 102"
+    ]
+  },
+  "LPN 204": {
+    "text": "<p>This revision removes LPN 102 as a prerequisite. LPN 102 is more appropriate as a 2nd level course.</p>",
+    "courses": [
+      "LPN 102"
+    ]
+  },
+  "LPN 300": {
+    "text": "ENG 101, MAT 104, BIO 111, PSY 100 and HED 110 Corequisite: LPN 301 and LPN 302",
+    "courses": [
+      "BIO 111",
+      "ENG 101",
+      "HED 110",
+      "LPN 301",
+      "LPN 302",
+      "MAT 104",
+      "PSY 100"
+    ]
+  },
+  "LPN 301": {
+    "text": "LPN 101, LPN 103, LPN 104, LPN 201, LPN 202, LPN 203 and LPN 204 Corequisite: LPN 300",
+    "courses": [
+      "LPN 101",
+      "LPN 103",
+      "LPN 104",
+      "LPN 201",
+      "LPN 202",
+      "LPN 203",
+      "LPN 204",
+      "LPN 300"
+    ]
+  },
+  "LPN 302": {
+    "text": "LPN 101, LPN 103, LPN 104, LPN 201, LPN 202, LPN 203 and LPN 204 Corequisite: LPN 300",
+    "courses": [
+      "LPN 101",
+      "LPN 103",
+      "LPN 104",
+      "LPN 201",
+      "LPN 202",
+      "LPN 203",
+      "LPN 204",
+      "LPN 300"
+    ]
+  },
+  "LS 112": {
+    "text": "LS111 OR LS161 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LS 111",
+      "LS 161"
+    ]
+  },
+  "LS 213": {
+    "text": "LS112 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LS 112"
+    ]
+  },
+  "LS 214": {
+    "text": "LS213 WITH A GRADE OF “C” OR HIGHER, OR PLACEMENT BY THE DEPARTMENT OF FOREIGN LANGUAGES AND LITERATURES",
+    "courses": [
+      "LS 213"
+    ]
+  },
+  "LS 221": {
+    "text": "LS214 WITH A GRADE OF C OR BETTER OR PLACEMENT TO BE DETERMINED BY NATIVE/HERITAGE SPEAKERS PLACEMENT TEST AND THE DEPARTMENT",
+    "courses": [
+      "LS 214"
+    ]
+  },
+  "LS 222": {
+    "text": "LS221 WITH A GRADE OF C OR BETTER OR PLACEMENT THROUGH THE NATIVE/HERTAGE SPEAKERS PLACEMENT TEST",
+    "courses": [
+      "LS 221"
+    ]
+  },
+  "LS 223": {
+    "text": "LS222 WITH A GRADE OF C OR BETTER OR PLACEMENT THROUGH NATIVE/HERTAGE SPEAKERS",
+    "courses": [
+      "LS 222"
+    ]
+  },
+  "LS 312": {
+    "text": "LS-214 AND/OR LS-223 WITH A GRADE OF C OR BETTER, OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "LS 214",
+      "LS 223"
+    ]
+  },
+  "LS 315": {
+    "text": "LS-214 AND/OR LS-223 WITH A GRADE OF C OR BETTER, OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "LS 214",
+      "LS 223"
+    ]
+  },
+  "LS 401": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "LS 402": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "LS 410": {
+    "text": "ENGL-101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "LS 411": {
+    "text": "ENGL-101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "MA 114": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN MATHEMATICS (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MA 114ALP": {
+    "text": "PROF-MATHX 40-59, OR ACC MATH-5, 47-56, COREQ: MA114",
+    "courses": [
+      "MA 114",
+      "MATHX 40"
+    ]
+  },
+  "MA 119": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN MATHEMATICS (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MA 121": {
+    "text": "COREQ: MA119",
+    "courses": [
+      "MA 119"
+    ]
+  },
+  "MA 128": {
+    "text": "MA-114 with a grade of C or better, or MA-119 and MA-121 with a grade of C or better in both courses, or advanced math placement (see Proficiency in Math and English)",
+    "courses": [
+      "MA 114",
+      "MA 119",
+      "MA 121"
+    ]
+  },
+  "MA 136": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN MATHEMATICS (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MA 136ALP": {
+    "text": "COREQ: MA136",
+    "courses": [
+      "MA 136"
+    ]
+  },
+  "MA 301": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN MATHEMATICS (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MA 301ALP": {
+    "text": "PRE: MA-10 OR MA-13 OR MA 10ALP OR MA10CS OR MA10WS OR PASSING SCORE ON THE MATHEMATICS PLACEMENT TEST OR EXEMPTION FROM REMEDIAL MATHEMATICS OR CUNY MATH PROFICIENCY INDEX (MPI) 40-59 COREQ: MA301",
+    "courses": [
+      "MA 10",
+      "MA 13",
+      "MA 301"
+    ]
+  },
+  "MA 303": {
+    "text": "MA-119 with a grade of C or better, permission of the Department, or advanced math placement (see Proficiency in Math and English)",
+    "courses": [
+      "MA 119"
+    ]
+  },
+  "MA 315": {
+    "text": "MA301 OR MA303 OR PERMISSION OF DEPARTMENT",
+    "courses": [
+      "MA 301",
+      "MA 303"
+    ]
+  },
+  "MA 321": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN MATHEMATICS (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MA 321ALP": {
+    "text": "PROF-MATHX 40-59, OR ACC MATH-5, 40-56, OR SG ALPQ, COREQ: MA321",
+    "courses": [
+      "MA 321",
+      "MATHX 40"
+    ]
+  },
+  "MA 335": {
+    "text": "ACC-MATH5 TEST SCORE 47-56, OR PROF-INDEX-MATHX, 40-59",
+    "courses": [
+      "SCORE 47"
+    ]
+  },
+  "MA 336": {
+    "text": "MA-119 with a C or better or MA-114 with a C or better, or advanced math placement (see Proficiency in Math and English)",
+    "courses": [
+      "MA 114",
+      "MA 119"
+    ]
+  },
+  "MA 441": {
+    "text": "MA-440 (with a grade of C or better) or advanced math placement (see Proficiency in Math and English)",
+    "courses": [
+      "MA 440"
+    ]
+  },
+  "MA 442": {
+    "text": "MA441 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "MA 441"
+    ]
+  },
+  "MA 443": {
+    "text": "MA442 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "MA 442"
+    ]
+  },
+  "MA 451": {
+    "text": "MA442 WITH A GRADE OF C OR BETTER, COREQ: MA443",
+    "courses": [
+      "MA 442",
+      "MA 443"
+    ]
+  },
+  "MA 461": {
+    "text": "MA441 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "MA 441"
+    ]
+  },
+  "MA 471": {
+    "text": "MA440",
+    "courses": [
+      "MA 440"
+    ]
+  },
+  "MA 481": {
+    "text": "COREQ: MA442",
+    "courses": [
+      "MA 442"
+    ]
+  },
+  "MA 801": {
+    "text": "MA443 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "MA 443"
+    ]
+  },
+  "MA 901": {
+    "text": "OPEN ONLY TO MATRICULATED STUDENTS WHO HAVE AT LEAST 15 CREDITS(MA440 OR 240 & 250), WITH A MINIMUM GPA OF 3.0, MINIMUM MATH AVERAGE OF 3.0 AND APPROVAL OF MATHEMATICS DEPARTMENT AND COURSE COORDINATOR",
+    "courses": [
+      "LEAST 15",
+      "MA 440",
+      "OR 240"
+    ]
+  },
+  "MA 905": {
+    "text": "MA 440 OR PERMISSION OF THE DEPARTMENT. STUDENTS NEED PERMISSION FROM THE INSTRUCTOR IN ORDER TO REGISTER FOR A SECTION OF THIS COURSE. IN ADDITION, THEY NEED A LETTER OF RECOMMENDATION FROM A MATH & CS INSTRUCTOR WHO HAS HAD THE STUDENT IN A COLLEGE LEVEL CLASS",
+    "courses": [
+      "MA 440"
+    ]
+  },
+  "MA 906": {
+    "text": "MA 905 OR PERMISSION OF THE DEPARTMENT. STUDENTS NEED PERMISSION FROM THE INSTRUCTOR IN ORDER TO REGISTER FOR A SECTION OF THIS COURSE",
+    "courses": [
+      "MA 905"
+    ]
+  },
+  "MA 951": {
+    "text": "OPEN ONLY TO STUDENTS WHO: HAVE 15 COMPLETED CREDITS INCLUDING MA440 OR 240 AND 250, OR MA125 OR 128 OR 336 WITH A MIN GPA OF 2.7 AND MATH GPA OF 2.7 AND RECOMMENDED BY DEPT CHAIRPERSON",
+    "courses": [
+      "AND 250",
+      "HAVE 15",
+      "MA 125",
+      "MA 440",
+      "OR 128",
+      "OR 240",
+      "OR 336"
+    ]
+  },
+  "MA 952": {
+    "text": "OPEN ONLY TO STUDENTS WHO: HAVE 15 COMPLETED CREDITS INCLUDING MA440 OR 240 AND 250, OR MA125 OR 128 OR 336 WITH A MIN GPA OF 2.7 AND MATH GPA OF 2.7 AND RECOMMENDED BY DEPT CHAIRPERSON",
+    "courses": [
+      "AND 250",
+      "HAVE 15",
+      "MA 125",
+      "MA 440",
+      "OR 128",
+      "OR 240",
+      "OR 336"
+    ]
+  },
+  "MAT 120SI": {
+    "text": "<p>MA 10 is a sufficient pre-requisite for MAT120SI</p>",
+    "courses": [
+      "MA 10"
+    ]
+  },
+  "MAT 150SI": {
+    "text": "<p>MA 10 is a sufficient pre-requisite for MAT150 SI.</p>",
+    "courses": [
+      "MA 10",
+      "MAT 150"
+    ]
+  },
+  "MAT 157": {
+    "text": "<p>As of Fall 2022, The City University of New York will be eliminated “Stand Alone Remedial” courses. Presently STEM students are required to be exempt from MAT 56 in order to enroll in our PreCalculus course or to enroll in other courses in Business, Computer Science or Science Departments. The Math Department is proposing to provide an alternative credited course MAT 157 for those students. For STEM students who are not CUNY proficient in Elementary Algebra (MAT 51) and receive a CUNY proficiency index (CPI) less than 60, they must be able to enroll in a corequisite course. </p>",
+    "courses": [
+      "MAT 51",
+      "MAT 56"
+    ]
+  },
+  "MAT 157.5": {
+    "text": "<p>As of Fall 2022, The City University of New York will be eliminated “Stand Alone Remedial” courses. Presently STEM students are required to be exempt from MAT 56 in order to enroll in our PreCalculus course or to enroll in other courses in Business, Computer Science or Science Departments. The Math Department is proposing to provide an alternative credited course MAT 157 for those students. For STEM students who are not CUNY proficient in Elementary Algebra (MAT 51) and receive a CUNY proficiency index (CPI) less than 60, they must be able to enroll in a corequisite course. To comply with the mandate, the Math Department has proposed MAT 157.5.</p>",
+    "courses": [
+      "MAT 157",
+      "MAT 51",
+      "MAT 56"
+    ]
+  },
+  "MAT 201": {
+    "text": "MAT200 or Waiver",
+    "courses": [
+      "MAT 200"
+    ]
+  },
+  "MAT 2010": {
+    "text": "<p><u>5/9/2024</u> - ADDED PATHWAYS RCMQ (REDO)</p><p></p><p><u>Explanation</u>: The change in course title clarifies content for prospective enrollees in the course. The change in course description reflects the addition of MAT 20B0, which serves as a CUNY corequisite model course for Statistics. Students are informed they will not receive credit for MAT 20B0 if they completed MAT 2010. </p><p>COLLEGE COUNCIL SPRING 2023 FOR NOV/DEC 2023 AUR:</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3fChangeinTitleandDescription-MAT2010-IntegratedStatistics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/3fChangeinTitleandDescription-MAT2010-IntegratedStatistics.pdf</a></p>",
+    "courses": [
+      "DEC 2023"
+    ]
+  },
+  "MAT 202": {
+    "text": "MAT201 or Waiver",
+    "courses": [
+      "MAT 201"
+    ]
+  },
+  "MAT 206": {
+    "text": "MAT 157.5 or MAT 157",
+    "courses": [
+      "MAT 157"
+    ]
+  },
+  "MAT 20B0": {
+    "text": "<p><u>Explanation</u>: The new course MAT 20B0 - Statistics with Algebra was created to align with the CUNY transition, effective Fall 2022, to remove courses that follow Elementary Algebra, but precede the first-level Pathways MQR course.&nbsp; This new pedagogical approach to Elementary Statistics with more supported interaction for preparing students who are CUNY Math certified yet do not have the prerequisite for MAT 2000, and who want a first course in statistics.</p><p>MAT 20B0 - Statistics with Algebra , uses a lab-based model and more supported interaction for the development and fine-tuning of algebraic skills needed for mastery of statistical concepts. </p><p>This course has been submitted as a STEM Variant under MQR as the following degree programs require Statistics - A.A.S. Physical Therapist Assistant and A.A.S. Polysomnographic Technology. </p><p>COLLEGE COUNCIL SPRING 2023 FOR NOV/DEC 2023 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/2aNewCourse-MAT20B0-StatisticswithAlgebra.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/spring2023/2aNewCourse-MAT20B0-StatisticswithAlgebra.pdf</a></p>",
+    "courses": [
+      "DEC 2023",
+      "MAT 2000"
+    ]
+  },
+  "MAT 214": {
+    "text": "MAT 157.5 or MAT 157",
+    "courses": [
+      "MAT 157"
+    ]
+  },
+  "MEA 371": {
+    "text": "Departmental Approval",
+    "courses": []
+  },
+  "MED 11": {
+    "text": "BIO 22",
+    "courses": [
+      "BIO 22"
+    ]
+  },
+  "MED 12": {
+    "text": "Prerequisites BIO 22 Co-Requisites SEC 35",
+    "courses": [
+      "BIO 22",
+      "SEC 35"
+    ]
+  },
+  "MED 13": {
+    "text": "Prerequisites BIO 22 Co-Requisites LAW 45",
+    "courses": [
+      "BIO 22",
+      "LAW 45"
+    ]
+  },
+  "MKT 36": {
+    "text": "MKT 11",
+    "courses": [
+      "MKT 11"
+    ]
+  },
+  "MMP 202": {
+    "text": "MMP 100",
+    "courses": [
+      "MMP 100"
+    ]
+  },
+  "MMP 271": {
+    "text": "MMP 100",
+    "courses": [
+      "MMP 100"
+    ]
+  },
+  "MP 101": {
+    "text": "COREQ: MUS111 OR ONE OF THE FOLLOWING WITH SATISFACTORY SCORE ON MUSIC PLACEMENT TEST: MUS-112, MUS-122, MUS-225",
+    "courses": [
+      "MUS 111",
+      "MUS 112",
+      "MUS 122",
+      "MUS 225"
+    ]
+  },
+  "MP 102": {
+    "text": "MP-101 AND MUS-111, BOTH COMPLETED WITH A GRADE OF C OR BETTER, COREQ: MUS-112 AND MUS-132",
+    "courses": [
+      "MP 101",
+      "MUS 111",
+      "MUS 112",
+      "MUS 132"
+    ]
+  },
+  "MP 103": {
+    "text": "MP101 (ME270) WITH C OR BETTER",
+    "courses": [
+      "ME 270",
+      "MP 101"
+    ]
+  },
+  "MP 204": {
+    "text": "MP102 (ME251) WITH C OR BETTER",
+    "courses": [
+      "ME 251",
+      "MP 102"
+    ]
+  },
+  "MP 205": {
+    "text": "MP103 (ME270) WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "ME 270",
+      "MP 103"
+    ]
+  },
+  "MP 206": {
+    "text": "MP102 (ME251) OR EQUIVALENT COURSE",
+    "courses": [
+      "ME 251",
+      "MP 102"
+    ]
+  },
+  "MP 207": {
+    "text": "MP205 (ME281)",
+    "courses": [
+      "ME 281",
+      "MP 205"
+    ]
+  },
+  "MP 208": {
+    "text": "MP103 (ME270) AND MP204 (ME276) BOTH WITH A GRADE C OR BETTER",
+    "courses": [
+      "ME 270",
+      "ME 276",
+      "MP 103",
+      "MP 204"
+    ]
+  },
+  "MP 209": {
+    "text": "MP205 OR(ME281) WITH A GRADE B OR BETTER",
+    "courses": [
+      "ME 281",
+      "MP 205"
+    ]
+  },
+  "MP 900": {
+    "text": "MP205 OR (ME281) WITH A GRADE OF B OR BETTER AND COREQ: PERMISSION OF THE MUSIC PRODUCTION PROGRAM DIRECTOR",
+    "courses": [
+      "ME 281",
+      "MP 205"
+    ]
+  },
+  "MT 122": {
+    "text": "PREREQ OR COREQ: MT111",
+    "courses": [
+      "MT 111"
+    ]
+  },
+  "MT 124": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MT 125": {
+    "text": "COREQ: MT124",
+    "courses": [
+      "MT 124"
+    ]
+  },
+  "MT 140": {
+    "text": "COREQ: PH201",
+    "courses": [
+      "PH 201"
+    ]
+  },
+  "MT 161": {
+    "text": "MT122, OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "MT 122"
+    ]
+  },
+  "MT 293": {
+    "text": "PREREQ OR COREQ: MT111",
+    "courses": [
+      "MT 111"
+    ]
+  },
+  "MT 341": {
+    "text": "COREQ: PH201",
+    "courses": [
+      "PH 201"
+    ]
+  },
+  "MT 345": {
+    "text": "MT341",
+    "courses": [
+      "MT 341"
+    ]
+  },
+  "MT 346": {
+    "text": "COREQ: MT345",
+    "courses": [
+      "MT 345"
+    ]
+  },
+  "MT 369": {
+    "text": "MT161 OR MT488",
+    "courses": [
+      "MT 161",
+      "MT 488"
+    ]
+  },
+  "MT 491": {
+    "text": "MT161",
+    "courses": [
+      "MT 161"
+    ]
+  },
+  "MT 492": {
+    "text": "EITHER MT293 OR MT369",
+    "courses": [
+      "MT 293",
+      "MT 369"
+    ]
+  },
+  "MT 523": {
+    "text": "MA128 or MA 441 and PH201 BOTH WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "MA 128",
+      "MA 441",
+      "PH 201"
+    ]
+  },
+  "MTH 21": {
+    "text": "<p>The Department of Mathematics and Computer Science is proposing changes in course title and description of MTH 21 Survey of Mathematics I. The part II of the course, MTH 22 Survey of Mathematics II, has not been offered for many years. MTH 21 exposes students to the utility and relevance of mathematics in the context of every-day experience; hence we propose the new title, A Mathematical World. The new course description matches its corequisite course MTH 21.5. It also aligns better to the topics covered.</p>",
+    "courses": [
+      "MTH 22"
+    ]
+  },
+  "MTH 21.5": {
+    "text": "<p>This course is the corequisite version of MTH 21, A Mathematical World. One hybrid section was run experimentally in Spring 2022.&nbsp; The pass rate was 44.4% as compared with 37.5% for MTH 23.5 in hybrid modality. MTH 21.5 is now proposed for permanency, per CUNY’s decision to replace all stand-alone remedial courses with corequisite courses. This course has been approved for Required Core B Mathematical and Quantitative Reasoning by the CCCRC.</p><p>&nbsp;</p>",
+    "courses": [
+      "MTH 21",
+      "MTH 23"
+    ]
+  },
+  "MUS 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MUS 103": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MUS 104": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MUS 105": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MUS 106": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MUS 107": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "MUS 112": {
+    "text": "MUS111(MU208), WITH A GRADE OF C OR BETTER OR A SATISFACTORY SCORE ON THE MUSIC PLACEMENT TEST",
+    "courses": [
+      "MU 208",
+      "MUS 111"
+    ]
+  },
+  "MUS 117": {
+    "text": "MUS 105",
+    "courses": [
+      "MUS 105"
+    ]
+  },
+  "MUS 118": {
+    "text": "MUS 105",
+    "courses": [
+      "MUS 105"
+    ]
+  },
+  "MUS 119": {
+    "text": "MUS 105",
+    "courses": [
+      "MUS 105"
+    ]
+  },
+  "MUS 121": {
+    "text": "<p>The addition of a corequisite of MUS-111 Musicianship I will be added for students who do not demonstrate sufficient musical aptitude through the Basic Musicianship Aptitude Test (BMAT) and the Music Theory Placement Exam (MTPE). This addition is part of the program revisions necessary for NASM accreditation.</p>",
+    "courses": [
+      "MUS 111"
+    ]
+  },
+  "MUS 122": {
+    "text": "MUS121 OR MUS112 WITH A GRADE OF C OR BETTER., COREQ: MUS124",
+    "courses": [
+      "MUS 112",
+      "MUS 121",
+      "MUS 124"
+    ]
+  },
+  "MUS 124": {
+    "text": "MUS-121 OR MUS-112 WITH A GRADE OF C OR BETTER. COREQ: MUS122",
+    "courses": [
+      "MUS 112",
+      "MUS 121",
+      "MUS 122"
+    ]
+  },
+  "MUS 132": {
+    "text": "MUS-131, OR MUS-111, OR MUS-121 WITH A GRADE OF C OR BETTER, OR SATISFACTORY SCORE ON THE MUSIC PLACEMENT TEST",
+    "courses": [
+      "MUS 111",
+      "MUS 121",
+      "MUS 131"
+    ]
+  },
+  "MUS 134": {
+    "text": "MUS133(MU321)",
+    "courses": [
+      "MU 321",
+      "MUS 133"
+    ]
+  },
+  "MUS 141": {
+    "text": "<table><tbody><tr><td><p>Updating Corequisite courses</p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "MUS 142": {
+    "text": "<table><tbody><tr><td><p>Updating Corequisite courses</p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "MUS 143": {
+    "text": "<table><tbody><tr><td><p>Updating Corequisite courses</p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "MUS 144": {
+    "text": "Co-req: Individual Study in Music Performance, MUS-269, 279, 281, 285, 287, or 293 depending on instrument of instruction (or voice)",
+    "courses": [
+      "MUS 269"
+    ]
+  },
+  "MUS 164": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 168": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 169": {
+    "text": "MUS168 WITH A GRADE OF C OR BETTER. COR: MUS187",
+    "courses": [
+      "MUS 168",
+      "MUS 187"
+    ]
+  },
+  "MUS 178": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 179": {
+    "text": "MUS178 WITH A GRADE OF C OR BETTER. COR: MUS187",
+    "courses": [
+      "MUS 178",
+      "MUS 187"
+    ]
+  },
+  "MUS 180": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 181": {
+    "text": "MUS180 WITH A GRADE OF C OR BETTER. COR: MUS187",
+    "courses": [
+      "MUS 180",
+      "MUS 187"
+    ]
+  },
+  "MUS 182": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 183": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 184": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 185": {
+    "text": "MUS184 WITH A GRADE OF C OR BETTER. COR: MUS187",
+    "courses": [
+      "MUS 184",
+      "MUS 187"
+    ]
+  },
+  "MUS 221": {
+    "text": "MUS122 WITH A GRADE OF C OR BETTER. COREQ: MUS223",
+    "courses": [
+      "MUS 122",
+      "MUS 223"
+    ]
+  },
+  "MUS 222": {
+    "text": "MUS221 (MU243), WITH A GRADE OF C OR BETTER. COREQ: MUS224",
+    "courses": [
+      "MU 243",
+      "MUS 221",
+      "MUS 224"
+    ]
+  },
+  "MUS 223": {
+    "text": "MUS124 (MU212) WITH A GRADE OF C OR BETTER. COREQ: MUS221 (MU243) or MUS225 (MU231)",
+    "courses": [
+      "MU 212",
+      "MU 231",
+      "MU 243",
+      "MUS 124",
+      "MUS 221",
+      "MUS 225"
+    ]
+  },
+  "MUS 224": {
+    "text": "MUS223 WITH A GRADE OF C OR BETTER. COREQ: MUS222 OR MUS-226 (MU232)",
+    "courses": [
+      "MU 232",
+      "MUS 222",
+      "MUS 223",
+      "MUS 226"
+    ]
+  },
+  "MUS 225": {
+    "text": "MUS-112 OR MUS-121 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "MUS 112",
+      "MUS 121"
+    ]
+  },
+  "MUS 231": {
+    "text": "MUS132(MU312) WITH A GRADE OF C OR BETTER. OR SATISFACTORY SCORE ON THE MUSIC PLACEMENT TEST",
+    "courses": [
+      "MU 312",
+      "MUS 132"
+    ]
+  },
+  "MUS 232": {
+    "text": "MUS231(MU313) WITH A GRADE OF C OR BETTER. OR SATISFACTORY SCORE ON THE MUSIC PLACEMENT TEST",
+    "courses": [
+      "MU 313",
+      "MUS 231"
+    ]
+  },
+  "MUS 258": {
+    "text": "COREQ: MUS186",
+    "courses": [
+      "MUS 186"
+    ]
+  },
+  "MUS 268": {
+    "text": "MUS169 WITH A GRADE OF C OR BETTER. COR: MUS286",
+    "courses": [
+      "MUS 169",
+      "MUS 286"
+    ]
+  },
+  "MUS 269": {
+    "text": "MUS268 WITH A GRADE OF C OR BETTER. COR: MUS287",
+    "courses": [
+      "MUS 268",
+      "MUS 287"
+    ]
+  },
+  "MUS 278": {
+    "text": "MUS179 WITH A GRADE OF C OR BETTER. COR: MUS286",
+    "courses": [
+      "MUS 179",
+      "MUS 286"
+    ]
+  },
+  "MUS 279": {
+    "text": "MUS278 WITH A GRADE OF C OR BETTER. COR: MUS287",
+    "courses": [
+      "MUS 278",
+      "MUS 287"
+    ]
+  },
+  "MUS 280": {
+    "text": "MUS181 WITH A GRADE OF C OR BETTER. COR: MUS286",
+    "courses": [
+      "MUS 181",
+      "MUS 286"
+    ]
+  },
+  "MUS 281": {
+    "text": "MUS280 WITH A GRADE OF C OR BETTER. COR: MUS287",
+    "courses": [
+      "MUS 280",
+      "MUS 287"
+    ]
+  },
+  "MUS 284": {
+    "text": "MUS185 WITH A GRADE OF C OR BETTER. COR: MUS286",
+    "courses": [
+      "MUS 185",
+      "MUS 286"
+    ]
+  },
+  "MUS 285": {
+    "text": "MUS284 WITH A GRADE OF C OR BETTER. COR: MUS287",
+    "courses": [
+      "MUS 284",
+      "MUS 287"
+    ]
+  },
+  "MUS 311": {
+    "text": "Submission of Internship Application to Department; Completion of all remedial requirements; GPA 2.0 or higher; and departmental permission",
+    "courses": []
+  },
+  "MUS 405": {
+    "text": "MUS132 AND MP102, BOTH WITH A MINIMUM GRADE OF C",
+    "courses": [
+      "MP 102",
+      "MUS 132"
+    ]
+  },
+  "MUS 407": {
+    "text": "MUS132 AND MP102, BOTH WITH A MINIMUM GRADE OF C",
+    "courses": [
+      "MP 102",
+      "MUS 132"
+    ]
+  },
+  "MUS 408": {
+    "text": "MUS132 AND MP102, BOTH WITH A MINIMUM GRADE OF C",
+    "courses": [
+      "MP 102",
+      "MUS 132"
+    ]
+  },
+  "MUS 801": {
+    "text": "Student must pass an audition arranged through the Music and Art Department",
+    "courses": []
+  },
+  "MUS 802": {
+    "text": "MUS 801 or Departmental Permission",
+    "courses": [
+      "MUS 801"
+    ]
+  },
+  "MUS 803": {
+    "text": "MUS 802 or Departmental Permission",
+    "courses": [
+      "MUS 802"
+    ]
+  },
+  "MUS 804": {
+    "text": "MUS 803 or Departmental Permission",
+    "courses": [
+      "MUS 803"
+    ]
+  },
+  "NMT 81": {
+    "text": "Completion of Pre-NMT Sequence and permission of the NMT Program Director",
+    "courses": []
+  },
+  "NU 101": {
+    "text": "(a) completion of Pre-Clinical Sequence with a minimum gpa of 3.0 and a grade of C or better in BI-301; (b) completion of speech remediation if required; and (c) completion of Pre-Admission RN PAX exam;COREQ: BI302, PSYC220 & BCLS Certfication",
+    "courses": [
+      "BI 301",
+      "BI 302",
+      "PSYC 220"
+    ]
+  },
+  "NU 102": {
+    "text": "NU101 (OR NU110 AND NU111) AND BI302, (ALL COMPLETED WITH A GRADE OF C OR BETTER), AND PSYC220 (SS520) AND COREQ: BI311, AND *BCLS CERTIFICATION",
+    "courses": [
+      "BI 302",
+      "BI 311",
+      "NU 101",
+      "NU 110",
+      "NU 111",
+      "PSYC 220",
+      "SS 520"
+    ]
+  },
+  "NU 111": {
+    "text": "NU-110 AND THE FOLLOWING PRECLINICAL AND COMMON CORE REQUIREMENT COURSES: ENGL-101 AND ENGL-102, MA-119 OR MA-336, BI-301 AND BI-302, BI-311, PSYC-101, AND PSYC-220. ACCEPTANCE INTO THE NURSING PROGRAM MEETING STANDARDS AND CRITERIA AS REQUIRED BY THE ADMISSIONS COMMITTEE, CPR (AHA CERTIFICATION), MEDICAL /PHYSICAL EXAMINATION/TITERS AND CURRENT IMMUNIZATIONS, HIPAA TRAINING AND INFECTION CONTROL TRAINING",
+    "courses": [
+      "BI 301",
+      "BI 302",
+      "BI 311",
+      "ENGL 101",
+      "ENGL 102",
+      "MA 119",
+      "MA 336",
+      "NU 110",
+      "PSYC 101",
+      "PSYC 220"
+    ]
+  },
+  "NU 201": {
+    "text": "NU102 AND BI311 (BOTH COMPLETED WITH C OR BETTER) AND COREQ: *BCLS CERTIFICATION",
+    "courses": [
+      "BI 311",
+      "NU 102"
+    ]
+  },
+  "NU 202": {
+    "text": "NU201(COMPLETED WITH A GRADE OF C OR BETTER) AND COREQ: NU204,*BCLS CERTIFICATION",
+    "courses": [
+      "NU 201",
+      "NU 204"
+    ]
+  },
+  "NU 204": {
+    "text": "NU-201 (C or better) Co-Requisite: None",
+    "courses": [
+      "NU 201"
+    ]
+  },
+  "NUR 1000": {
+    "text": "Acceptance into LRN Program (including LPN Licensure) and ENG 1200, PSY 1100, BIO 1100, and SCI 2500 Pre-/Co-requisite: BIO 1200 Open Only To: LRN Code (student group)",
+    "courses": [
+      "BIO 1100",
+      "BIO 1200",
+      "ENG 1200",
+      "PSY 1100",
+      "SCI 2500"
+    ]
+  },
+  "NUR 211": {
+    "text": "<p>prereq update</p>",
+    "courses": []
+  },
+  "NUR 313": {
+    "text": "<p>prereq update</p>",
+    "courses": []
+  },
+  "NUR 411": {
+    "text": "<p>update prereq</p>",
+    "courses": []
+  },
+  "NUR 415": {
+    "text": "<p>update prereq</p>",
+    "courses": []
+  },
+  "OT 101": {
+    "text": "Pre-requisite ESL 25",
+    "courses": [
+      "ESL 25"
+    ]
+  },
+  "OT 209": {
+    "text": "OT 105 Co-requisite: HLT 124",
+    "courses": [
+      "HLT 124",
+      "OT 105"
+    ]
+  },
+  "PH 111": {
+    "text": "COREQ: PH-112",
+    "courses": [
+      "PH 112"
+    ]
+  },
+  "PH 112": {
+    "text": "COREQ: PH111",
+    "courses": [
+      "PH 111"
+    ]
+  },
+  "PH 201": {
+    "text": "MA114 or MA119 and MA121 or the equivalent, or advanced math placement (see Proficiency in Math and English)",
+    "courses": [
+      "MA 114",
+      "MA 119",
+      "MA 121"
+    ]
+  },
+  "PH 202": {
+    "text": "PH201 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "PH 201"
+    ]
+  },
+  "PH 301": {
+    "text": "MA114 or MA119 and MA121 or the equivalent, or advanced math placement (see Proficiency in Math and English)",
+    "courses": [
+      "MA 114",
+      "MA 119",
+      "MA 121"
+    ]
+  },
+  "PH 302": {
+    "text": "PH301 WITH A GRADE OF C OR BETTER",
+    "courses": [
+      "PH 301"
+    ]
+  },
+  "PH 303": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN MATHEMATICS (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "PH 311": {
+    "text": "MA441",
+    "courses": [
+      "MA 441"
+    ]
+  },
+  "PH 312": {
+    "text": "PH311",
+    "courses": [
+      "PH 311"
+    ]
+  },
+  "PH 416": {
+    "text": "MA443 & PH412 OR PH-421",
+    "courses": [
+      "MA 443",
+      "PH 412",
+      "PH 421"
+    ]
+  },
+  "PH 421": {
+    "text": "MA440 & COREQ: MA441",
+    "courses": [
+      "MA 440",
+      "MA 441"
+    ]
+  },
+  "PH 422": {
+    "text": "MA441 AND PH421 WITH A GRADE OF C OR BETTER, CORQ: MA442",
+    "courses": [
+      "MA 441",
+      "MA 442",
+      "PH 421"
+    ]
+  },
+  "PH 431": {
+    "text": "PH201 OR PH411 AND MA441, COREQ: PH231 AND MA442",
+    "courses": [
+      "MA 441",
+      "MA 442",
+      "PH 201",
+      "PH 231",
+      "PH 411"
+    ]
+  },
+  "PH 440": {
+    "text": "MUST TAKE (PH412 AND PH413) OR PH 422 ANDCOREQ: MA443 (Analytic Geometry and Calculus III)",
+    "courses": [
+      "MA 443",
+      "PH 412",
+      "PH 413",
+      "PH 422"
+    ]
+  },
+  "PH 900": {
+    "text": "PH201 OR PH301 OR PH411 OR PH421, CORQ: PH202 OR PH302 OR PH412 OR PH413 OR PH422 OR DEPARTMENT CONSENT",
+    "courses": [
+      "PH 201",
+      "PH 202",
+      "PH 301",
+      "PH 302",
+      "PH 411",
+      "PH 412",
+      "PH 413",
+      "PH 421",
+      "PH 422"
+    ]
+  },
+  "PH 931": {
+    "text": "12 CREDITS IN LASER AND FIBER-OPTICS TECHNOLOGY COURSES",
+    "courses": []
+  },
+  "PHI 100": {
+    "text": "<p>HUM 100 not needed as pre-requisite. </p>",
+    "courses": [
+      "HUM 100"
+    ]
+  },
+  "PHI 215": {
+    "text": "Any 100-level PHI course or departmental permission",
+    "courses": []
+  },
+  "PHI 220": {
+    "text": "Any 100-level PHI course or departmental permission",
+    "courses": []
+  },
+  "PHIL 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PHIL 120": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PHIL 130": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PHIL 140": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PHY 299": {
+    "text": "CHE 220 and PHY 220 Co-requisite: MAT 310",
+    "courses": [
+      "CHE 220",
+      "MAT 310",
+      "PHY 220"
+    ]
+  },
+  "PLB 79": {
+    "text": "Prerequisites BIO 24 and enrollment in the Medical Office Assistant Curriculum or Health Sciences Curriculum",
+    "courses": [
+      "BIO 24"
+    ]
+  },
+  "PLSC 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PLSC 170": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PNR 101": {
+    "text": "<p>Add prerequisite</p>",
+    "courses": []
+  },
+  "POL 202": {
+    "text": "ENG 100 or higher",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "POL 202W": {
+    "text": "ENG 100 or higher",
+    "courses": [
+      "ENG 100"
+    ]
+  },
+  "POL 261": {
+    "text": "Any Social Science 100-level course",
+    "courses": []
+  },
+  "POL 42": {
+    "text": "<p>Add Prerequisites</p>",
+    "courses": []
+  },
+  "POL 50": {
+    "text": "Co-Requisites ENG 110, if required",
+    "courses": [
+      "ENG 110"
+    ]
+  },
+  "POL 9300": {
+    "text": "<p><u>Explanation</u>: Removal of references to deleted curricular requirements. The Global and Environmental Concentration under the A.A. Liberal Arts has been deleted and there is no reason to limit the course to only Liberal Arts majors. In turn, an update to the course description and prerequisite were required. </p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5mChangeinDescriptionandPrereq-POL9300-GlobalPolitics.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5mChangeinDescriptionandPrereq-POL9300-GlobalPolitics.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024"
+    ]
+  },
+  "PSG 103": {
+    "text": "<p><u>Explanation</u>: MAT 20B0 (passed at Spring 2023 Curriculum Committee &amp; June 2023 College Council) is a new Statistics corequisite model course being added as an option under Mathematics and Quantitative Reasoning (MQR) for the A.A.S. Polysomnographic Technology. In turn, the prerequisite for PSG 103 is being updated to reflect this option.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5iChangeinPrereq-PSG103-ClinicalPracticuminSleepMedicineI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5iChangeinPrereq-PSG103-ClinicalPracticuminSleepMedicineI.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024"
+    ]
+  },
+  "PSY 220": {
+    "text": "<p>clerical fix on prereq</p>",
+    "courses": []
+  },
+  "PSY 295": {
+    "text": "PSY 100",
+    "courses": [
+      "PSY 100"
+    ]
+  },
+  "PSYC 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PSYC 125": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "PSYC 201": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 215": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 220": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 230": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 240": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 245": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 250": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 255": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 260": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 270": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 280": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PSYC 290": {
+    "text": "PSYC101 (FORMERLY SS510)",
+    "courses": [
+      "PSYC 101",
+      "SS 510"
+    ]
+  },
+  "PTA 900": {
+    "text": "<p>Removed Coreq PTA 800 from description .</p>",
+    "courses": [
+      "PTA 800"
+    ]
+  },
+  "RAD 101": {
+    "text": "None Co-Req: CH-151",
+    "courses": [
+      "CH 151"
+    ]
+  },
+  "RAD 102": {
+    "text": "RAD-101 Co-req: PH-301",
+    "courses": [
+      "PH 301",
+      "RAD 101"
+    ]
+  },
+  "RAD 12": {
+    "text": "<p>The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program.</p>",
+    "courses": [
+      "CLE 11",
+      "MTH 13",
+      "MTH 28",
+      "RAD 16"
+    ]
+  },
+  "RAD 16": {
+    "text": "<p>The elimination of stand-alone remediation in Fall 2022 necessitated changes to the math requirements of the Radiologic Technology program: MTH 13 was no longer required for the degree and was replaced by MTH 28/28.5. When this programmatic change was approved in Fall 2022, we overlooked the need to change the prerequisites of CLE 11, RAD 12, and RAD 16 on the course level. This proposed change corrects the issue on the course level and reflects the current approved math standards for the program.</p>",
+    "courses": [
+      "CLE 11",
+      "MTH 13",
+      "MTH 28",
+      "RAD 12"
+    ]
+  },
+  "SCB 203": {
+    "text": "English proficiency, Mathematics proficiency",
+    "courses": []
+  },
+  "SCB 204": {
+    "text": "Pre-requisite of SCB203 is required",
+    "courses": [
+      "SCB 203"
+    ]
+  },
+  "SCB 207": {
+    "text": "<p>This course is part of the program core for the Associate of Science Degree in Biotechnology track of the Biology Program. We propose changing the prerequisites to SCB201 or SCB101 and MAT 115/117 to increase course enrollment and enable students from other majors to take SCB 207. This will not affect students in the Biotechnology track, as they are required to take SCB 201 as part of their major. </p><p>We propose adding an introduction to Python and R to the curriculum, as these are essential skills for students in data analysis and bioinformatics. </p>",
+    "courses": [
+      "MAT 115",
+      "SCB 101",
+      "SCB 201"
+    ]
+  },
+  "SCB 208": {
+    "text": "<p>Course was approved for Pathways Scientific World category by the CCRC. Updated Prereqs for this course for Fall 2025.</p>",
+    "courses": []
+  },
+  "SCB 257": {
+    "text": "SCB202, SCC202, ENG102",
+    "courses": [
+      "ENG 102",
+      "SCB 202",
+      "SCC 202"
+    ]
+  },
+  "SCD 266": {
+    "text": "Pre/Corequisite: SCD253 Culinary Management",
+    "courses": [
+      "SCD 253"
+    ]
+  },
+  "SCG 230": {
+    "text": "SGN115 OR SCN240",
+    "courses": [
+      "SCN 240",
+      "SGN 115"
+    ]
+  },
+  "SCG 231": {
+    "text": "SCG230",
+    "courses": [
+      "SCG 230"
+    ]
+  },
+  "SCH 205": {
+    "text": "<p>Updated to add prerequisite and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "courses": []
+  },
+  "SCH 215": {
+    "text": "<p>Prerequisites have been changed to reflect changes in the program curriculum and opening the course to students in other programs. </p>",
+    "courses": []
+  },
+  "SCH 225": {
+    "text": "<p>Updated to add prerequisite(s) and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "courses": []
+  },
+  "SCH 235": {
+    "text": "<p>Updated to add prerequisite(s) and description of prerequisite(s). Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "courses": []
+  },
+  "SCH 285": {
+    "text": "<p>Updating course content and objectives to align with CUNY Community Health Major Gateway objectives and change from program curriculum as the previous capstone course. Prerequisities have been adjusted to reflect the course's new place within the program curriculum. Updates now align the course with the Council on Education for Public Health (CEPH) 4-year degree program accreditation standards. Updating the Academic Department from Health Science to Community Health and Wellness.</p>",
+    "courses": []
+  },
+  "SCI 215": {
+    "text": "<table><tbody><tr><td><p>This proposal is in support of three changes that have occurred since this course was created: </p><p>1) This course was approved for CUNY Pathways Flexible Core,</p><p>2) GCC student math requirement has changed and not all students are required to take MATH 103, and</p><p>3) The Science A.S. Degree map has changed and MATH 103 is no longer required.</p><p> </p><p>In response, we would like to remove the MATH and ENGL pre-requisites so that they do not continue to provide a barrier to student enrollment. We have also revised the course description to reflect updates to the course.</p></td></tr></tbody></table>",
+    "courses": [
+      "MATH 103"
+    ]
+  },
+  "SCL 100": {
+    "text": "ENA/ENG101, SCB204 Co-Requisites: SCL103",
+    "courses": [
+      "ENG 101",
+      "SCB 204",
+      "SCL 103"
+    ]
+  },
+  "SCO 294": {
+    "text": "SCO114, SCO204, SCO214, SCO284",
+    "courses": [
+      "SCO 114",
+      "SCO 204",
+      "SCO 214",
+      "SCO 284"
+    ]
+  },
+  "SCO 295": {
+    "text": "SCO175, SCO205, SCO215, SCO285 Additional Pre/Pre-Co/Corequisites: Permission of the Occupational Therapy Assistant Program Director",
+    "courses": [
+      "SCO 175",
+      "SCO 205",
+      "SCO 215",
+      "SCO 285"
+    ]
+  },
+  "SCT 101": {
+    "text": "HSF090, SCN195, SCB204, ENG102, SSY240, HUP102 or HUC106, MAT119/120 or MAT115/117 Corequisite: SCT102 Corequisite: SCO230",
+    "courses": [
+      "ENG 102",
+      "HSF 090",
+      "HUC 106",
+      "HUP 102",
+      "MAT 115",
+      "MAT 119",
+      "SCB 204",
+      "SCN 195",
+      "SCO 230",
+      "SCT 102",
+      "SSY 240"
+    ]
+  },
+  "SCT 102": {
+    "text": "ENG 102, SCB 204, SSY 240, HSF090, HUC 106 or HUP 102, MAT 120 or MAT 115 Corequisite: SCT101 Corequisite: SCO230 Additional Pre/Pre-Co/Corequisites: PTA 000 Candidacy",
+    "courses": [
+      "ENG 102",
+      "HSF 090",
+      "HUC 106",
+      "HUP 102",
+      "MAT 115",
+      "MAT 120",
+      "PTA 000",
+      "SCB 204",
+      "SCO 230",
+      "SCT 101",
+      "SSY 240"
+    ]
+  },
+  "SCT 211": {
+    "text": "SCT101, SCT102, SCO230 Corequisites: SCT203, SCT220",
+    "courses": [
+      "SCO 230",
+      "SCT 101",
+      "SCT 102",
+      "SCT 203",
+      "SCT 220"
+    ]
+  },
+  "SCT 212": {
+    "text": "SCT203, SCT211, SCO220 Corequisite: SCT221",
+    "courses": [
+      "SCO 220",
+      "SCT 203",
+      "SCT 211",
+      "SCT 221"
+    ]
+  },
+  "SCT 220": {
+    "text": "SCT101 & SCT102 Corequisites: SCT203 & SCT211",
+    "courses": [
+      "SCT 101",
+      "SCT 102",
+      "SCT 203",
+      "SCT 211"
+    ]
+  },
+  "SCT 221": {
+    "text": "SCT 203, SCT 211, SCT 220 Corequisites: SCT 212",
+    "courses": [
+      "SCT 203",
+      "SCT 211",
+      "SCT 212",
+      "SCT 220"
+    ]
+  },
+  "SCV 101": {
+    "text": "<p>This revised course will be offered to clinical phase, Veterinary Technology students only.!&nbsp; The credits, instructional objectives and grading standards are being revised to reflect that the course will no longer teach students about Vet Tech program admission nor offer an introduction to anatomy. Medical dosing will be introduced in this course to augment the new Vet Tech math requirement and prerequisite MAT115/MAT117.</p>",
+    "courses": [
+      "MAT 115",
+      "MAT 117"
+    ]
+  },
+  "SCV 151": {
+    "text": "<p>SCV151 is a required course for the Veterinary Technology major. It is open to the college</p><p>community at all levels so that pre-clinical Veterinary Technology students have the option</p><p>to take the course prior to entering the clinical phase.The revision of the prerequisite(s) for</p><p>Shelter Medicine and Management (SCV151) is being proposed because its former prerequisite,</p><p>Introduction to Veterinary Technology (SCV101), is now a second semester, clinical phase Veterinary Technology course .</p>",
+    "courses": [
+      "SCV 101"
+    ]
+  },
+  "SCV 202": {
+    "text": "<p>This course is being proposed to accommodate an increase in the number of students admitted to the Veterinary Technology Program’s clinical phase. This lecture course will be a corequisite to either SCV203 (on-campus) or SCV204 (off-campus)</p>",
+    "courses": [
+      "SCV 203",
+      "SCV 204"
+    ]
+  },
+  "SCV 203": {
+    "text": "<p>This course is being proposed to provide the on-campus veterinary nursing lab for the Veterinary Nursing Option I track of veterinary nursing training. This on-campus course will be a corequisite to SCV202. The SCV202/SCV203 course pair replaces Veterinary Nursing I (SCV210).</p>",
+    "courses": [
+      "SCV 202",
+      "SCV 210"
+    ]
+  },
+  "SCV 204": {
+    "text": "<p>This new course is being proposed to accommodate an increase in the number of students admitted to the Veterinary Technology Program’s clinical phase. This course will be a corequisite to SCV202. The SCV202/SCV204 course pair replaces Veterinary Nursing I (SCV210).</p>",
+    "courses": [
+      "SCV 202",
+      "SCV 210"
+    ]
+  },
+  "SEC 35": {
+    "text": "<p>SEC 35 is being modified as part of the Medical Office Assistant (MOA) AAS degree revision.&nbsp; The current prerequisites, KEY 11 and WPR 11, are no longer part of the MOA AAS degree.&nbsp; The new prerequisite of BIO 22 will prepare students for the content of SEC 35. Minor grammatical changes have been made to the course description.</p>",
+    "courses": [
+      "BIO 22",
+      "KEY 11",
+      "WPR 11"
+    ]
+  },
+  "SGN 115": {
+    "text": "Mathematics proficiency Pre-Requisite/Co-Requisite: ENA/ENG101",
+    "courses": [
+      "ENG 101"
+    ]
+  },
+  "SOCI 203": {
+    "text": "<table><tbody><tr><td><p>The College proposes revising the course description and removing the pre-requisite of HSVC 103 in order to open the course to students in programs of study outside of Human Services.</p></td></tr></tbody></table>",
+    "courses": [
+      "HSVC 103"
+    ]
+  },
+  "SOCI 214": {
+    "text": "<table><tbody><tr><td><p>The College proposes removing the pre-requisites for the course in order to broaden access and enable more students to enroll in the course.</p></td></tr></tbody></table>",
+    "courses": []
+  },
+  "SOCY 101": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "SOCY 125": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "SOCY 185": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE OR ENROLL IN ENGL-101 AND ENGL-99 AT THE SAME TIME AS THIS COURSE",
+    "courses": [
+      "ENGL 101",
+      "ENGL 99"
+    ]
+  },
+  "SOCY 220": {
+    "text": "SOCY101 (FORMERLY SS310)",
+    "courses": [
+      "SOCY 101",
+      "SS 310"
+    ]
+  },
+  "SOCY 230": {
+    "text": "SOCY101 (FORMERLY SS310)",
+    "courses": [
+      "SOCY 101",
+      "SS 310"
+    ]
+  },
+  "SOCY 240": {
+    "text": "SOCY101 (FORMERLY SS310)",
+    "courses": [
+      "SOCY 101",
+      "SS 310"
+    ]
+  },
+  "SOCY 250": {
+    "text": "SOCY101 (FORMERLY SS310)",
+    "courses": [
+      "SOCY 101",
+      "SS 310"
+    ]
+  },
+  "SOCY 275": {
+    "text": "SOCY101 (FORMERLY SS310)",
+    "courses": [
+      "SOCY 101",
+      "SS 310"
+    ]
+  },
+  "SOCY 290": {
+    "text": "SOCY-101",
+    "courses": [
+      "SOCY 101"
+    ]
+  },
+  "SP 212": {
+    "text": "ENGL101",
+    "courses": [
+      "ENGL 101"
+    ]
+  },
+  "SP 7": {
+    "text": "Speech Placement Test or referral by the Speech or Nursing Department",
+    "courses": []
+  },
+  "SP 900": {
+    "text": "Open to matriculated students with at least 24 credits completed in Liberal Arts & Sciences, GPA of 2.00 and are recommended by the Speech Dept. Students will earn a grade of PASS or FAIL. A field experience of 90 hrs minimum is required",
+    "courses": []
+  },
+  "SP 901": {
+    "text": "Open to matriculated students with at least 24 credits completed in Liberal Arts & Sciences, GPA of 2.00 and are recommended by the Speech Dept. Students will earn a grade of PASS or FAIL. A field experience of 90 hrs minimum is required",
+    "courses": []
+  },
+  "SPA 101": {
+    "text": "Placement Co-Requisite: SPA 111",
+    "courses": [
+      "SPA 111"
+    ]
+  },
+  "SPA 111": {
+    "text": "Placement / Co-requisite: SPA 101",
+    "courses": [
+      "SPA 101"
+    ]
+  },
+  "SPE 100": {
+    "text": "<p>update prereq RG</p>",
+    "courses": []
+  },
+  "SPE 102": {
+    "text": "<p>Update prereq RG</p>",
+    "courses": []
+  },
+  "SPN 109": {
+    "text": "<p>This semester, the World Languages and Cultures Department is running two sections of an introductory medical Spanish course that has not been offered in quite some time. The revamped course, SPN 108-Spanish for Health Professions, has generated significant interest, and both sections have strong enrollment (16 students in one section, 10 students in the other). The course has also garnered interest from students who are either heritage or native speakers of Spanish—a total of 26 students who enrolled in SPN 108 were identified as having a degree of knowledge and fluency that exceeds what is covered in an introductory language course. Unfortunately, this cohort of students could not be allowed to take the class because of their more advanced fluency. Many of these students asked to remain enrolled in the course so that they could learn medical terminology in Spanish. However, in keeping with best practices in language pedagogy, courses with a wide spectrum of linguistic ability and knowledge pose challenges to true beginners, who often feel that they are making insufficient progress when they compare their output to that of more advanced students, as well as to heritage/native speakers, who benefit from a different approach to grammatical instruction that assumes prior knowledge.</p><p>To accommodate heritage and native speakers interested in taking a medical Spanish course and to ensure instructional environments conducive to learners at all levels, the department proposes modifying another course currently on the books, SPN 19-Elementary Spanish for Nurses and Hospital Personnel II. The modified course, SPN 109-Spanish for Health Professions II, will be designed for students with intermediate to advanced fluency and will cover medical terminology, cultural topics relevant to Spanish-speaking communities in medical settings (e.g., attitudes toward healthcare professionals and more holistic/traditional forms of medicine; regional differences in diet; the role of families in caring for aging and sick relatives), and grammatical concepts typically presented in upper-level Spanish classes. This course will not only provide students with the kind of technical vocabulary in which they have expressed interest but will also help students refine their reading and writing skills in Spanish (two linguistic competencies that are often weaker than speaking and listening ability in heritage and some native speakers), thereby giving students a greater set of skills to employ in their chosen medical field.</p><p>The proposed reduction in the number of credits is intended to make this course Pathways compliant and to make it easier for students in the allied health fields who may be interested in taking a medical Spanish class to accommodate the course in their respective programs of study. The revised course title will create consistency between this course and SPN 108-Spanish for Health Professions. The revised course number also aims to create continuity between this course and SPN 108, aligning with the department’s regular Spanish offerings, all of which have three-digit designations. The revised prerequisite helps distinguish this upper intermediate-low advanced course from the beginner-level SPN 108. Finally, the proposed changes to the course description specify the level of the course and provide greater clarity regarding the class’s lexical, grammatical, and cultural content.</p><p>&nbsp;</p>",
+    "courses": [
+      "SPN 108",
+      "SPN 19"
+    ]
+  },
+  "SPN 112": {
+    "text": "<p>Including SPN 108-Spanish for Health Professions among the prerequisites for SPN 112 will make it clear to students (and advisors) that SPN 111 and SPN 108 are equivalent and that both courses prepare students for successful completion of SPN 112. The proposed change in course description is intended to highlight the equivalency between SPN 108 and SPN 111, provide more information regarding the course’s grammatical, lexical, and cultural content, and make clear that the course is not intended for heritage or native speakers.</p>",
+    "courses": [
+      "SPN 108",
+      "SPN 111"
+    ]
+  },
+  "SPN 120": {
+    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses.</p>",
+    "courses": [
+      "SPN 113",
+      "SPN 117"
+    ]
+  },
+  "SPN 121": {
+    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "courses": [
+      "SPN 113",
+      "SPN 117",
+      "SPN 120"
+    ]
+  },
+  "SPN 122": {
+    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p><p>&nbsp;</p>",
+    "courses": [
+      "SPN 113",
+      "SPN 117",
+      "SPN 120"
+    ]
+  },
+  "SPN 124": {
+    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "courses": [
+      "SPN 113",
+      "SPN 117",
+      "SPN 120"
+    ]
+  },
+  "SPN 125": {
+    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "courses": [
+      "SPN 113",
+      "SPN 117",
+      "SPN 120"
+    ]
+  },
+  "SPN 126": {
+    "text": "<p>The Department of World Languages and Cultures plans to offer its business Spanish course for the first time in several years. The course increases the diversity of the department’s course offerings, as current upper-level Spanish classes are mostly dedicated to history, cultural, and/or literary production. The course, which will be of interest both to students in the AA-Spanish Option and to students in other AA-Liberal Arts and Sciences degree programs, aligns with a larger nationwide trend of developing classes dedicated to Spanish for the professions. The proposed change in course title reflects the international reach of Spanish in the business world and aligns with comparable courses at several CUNY schools, including Hunter (SPAN 37143-Spanish for Global Work), LaGuardia (ELS 220-Spanish for Global Business), and City College (SPAN 32600-Spanish in the Business World). We propose changing the course number to create greater consistency with the department’s regular offerings in Spanish, all of which have three-digit course numbers. Similarly, the revised pre-requisite also aligns with the department’s regular Pathways offerings at the intermediate and advanced levels, all of which have SPN 113 and/or the Spanish placement test as a pre-requisite. Finally, the proposed revision to the course description seeks to add clarity regarding the level of the class (i.e., this is an upper-intermediate to low-advanced course and specifying that the class is only intended for advanced-level students may dissuade students who place into intermediate-level courses from enrolling.)</p><p>&nbsp;</p>",
+    "courses": [
+      "ELS 220",
+      "SPN 113"
+    ]
+  },
+  "SPN 130": {
+    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description highlights that the course is conducted in Spanish and seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "courses": [
+      "SPN 113",
+      "SPN 117",
+      "SPN 120"
+    ]
+  },
+  "SPN 131": {
+    "text": "<p>The Department of World Languages and Cultures proposes revising prerequisites for all upper-level (SPN 120+) Spanish classes to help ensure that students who take these courses have the grammatical knowledge as well as the critical reading and writing skills in Spanish needed to be successful at the advanced level. Students who take SPN 113-Intermediate Spanish Language and Culture, an Intermediate-I class, and then enroll in an upper-level course will be at a disadvantage both in terms of the grammar they have learned and the amount of time they have spent developing the fundamentals of reading literary texts and writing academic essays in Spanish. SPN 117-Advanced Spanish Composition, an Intermediate-II course focused on high-intermediate to low-advanced writing and grammar, will help ensure student success in the department’s upper-level classes, almost all of which are taught as Writing Intensive and include literary texts and academic articles. Further, setting SPN 117, an Intermediate-II course, as a prerequisite for upper-level classes is consistent with course sequencing at other CUNY schools, including Hostos, BMCC, and Lehman, all of which have equivalents of our SPN-117 as requirements for advanced courses. Finally, the proposed revision to the course description highlights that the course is conducted in Spanish and seeks to add greater clarity regarding the general topics covered in the class and the skills students will further develop in the target language.</p>",
+    "courses": [
+      "SPN 113",
+      "SPN 117",
+      "SPN 120"
+    ]
+  },
+  "SPN 150": {
+    "text": "SPN 106 or SPN 121 or departmental approval",
+    "courses": [
+      "SPN 106",
+      "SPN 121"
+    ]
+  },
+  "SPN 490": {
+    "text": "SPN 211/SPN 300, any course at the 400-level, or departmental approval",
+    "courses": [
+      "SPN 211",
+      "SPN 300"
+    ]
+  },
+  "SPN 490H": {
+    "text": "SPN 211/SPN 300, any course at the 400-level, or departmental approval",
+    "courses": [
+      "SPN 211",
+      "SPN 300"
+    ]
+  },
+  "SSJ 204": {
+    "text": "English proficiency, Mathematics proficiency, SSJ101",
+    "courses": [
+      "SSJ 101"
+    ]
+  },
+  "SSY 201": {
+    "text": "SYF101, MAT119 or MAT120 Pre/Corequisite: SSY101",
+    "courses": [
+      "MAT 119",
+      "MAT 120",
+      "SSY 101",
+      "SYF 101"
+    ]
+  },
+  "ST 100": {
+    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>The program is adding a new course, ST 990 – Integrated Healthcare Sciences and Medical Terminology (3 credits, 3 hours lecture). This will serve as a Gateway course for program admission and addresses the ARC/STSA CCST-7e requirements. In addition, the course incorporates some content for sterile processing in line with ARC/STSA CCST- 7e requirements, allowing students who have the sterile processing credential to receive Credit for Prior Learning (CPL) for the course. </p><p>ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements. </p><p>In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5aChangeinPrereqandCorequ-ST100-SurgicalTechnologyI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5aChangeinPrereqandCorequ-ST100-SurgicalTechnologyI.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024",
+      "ST 200",
+      "ST 990"
+    ]
+  },
+  "ST 200": {
+    "text": "BIO 1100, ENG 1200, and ST 990 Corequisite: ST 100 and ST 2P00",
+    "courses": [
+      "BIO 1100",
+      "ENG 1200",
+      "ST 100",
+      "ST 990"
+    ]
+  },
+  "ST 2P00": {
+    "text": "ENG 1200, BIO 1100, and ST 990 Corequisite: ST100 and ST 200",
+    "courses": [
+      "BIO 1100",
+      "ENG 1200",
+      "ST 100",
+      "ST 200",
+      "ST 990"
+    ]
+  },
+  "ST 300": {
+    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. This included revisions to ST 300 – Surgical Technology III and the determination that the course could be reconfigured to a 3 credit 3 hour lecture. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>Revisions to course description reflects that the corequisite course of ST 3P00 – Practicum I is a clinical component as opposed to a practice laboratory</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5cChangeinCrd_Hrs_Description_Prereq_Coreq-ST300-SurgicalTechnologyIII.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5cChangeinCrd_Hrs_Description_Prereq_Coreq-ST300-SurgicalTechnologyIII.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024",
+      "ST 200",
+      "ST 400"
+    ]
+  },
+  "ST 3P00": {
+    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>ST 200 – Surgical Technology II originally incorporated both lecture and lab within the one course. It was recommended during our site visit to separate out the laboratory component of the course. In turn, ST 2P00 – Surgical Technology II Laboratory Component was created to address this recommendation, with ST 200 – Surgical Technology II being reconfigured to a 3-credit lecture course that aligns with the ARC/STSA CCST – 7e requirements. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5dChangeinPrereq_Coreq-ST3P00-PracticumI.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5dChangeinPrereq_Coreq-ST3P00-PracticumI.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024",
+      "ST 200",
+      "ST 300",
+      "ST 400"
+    ]
+  },
+  "ST 400": {
+    "text": "<p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5eChangeinPrereq_Coreq-ST400-SurgicalProcedures.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5eChangeinPrereq_Coreq-ST400-SurgicalProcedures.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024",
+      "ST 300"
+    ]
+  },
+  "ST 4P00": {
+    "text": "<p>11/20/2024 - Per A Kalin <a href=\"https://cuny907.sharepoint.com/sites/CUNYChancellorUniversityReportsandAcademicUniversityReportCA/Shared%20Documents/General/2008/2%20-%20JUNE%202008%20Chancellor%27s%20Report%20-%20Part%20A_%20Academic%20Matters.pdf\" target=\"_blank\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">JUNE 2008 Chancellor's Report - Part A_ Academic Matters.pdf</a> ST 4P00 Changed from 3crs - 2crs.</p><p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e requirements. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>Modification to course content for ST 300 to be compliant with the ARC/STSA CCST – 7e requirements and changes to the program course sequencing, with ST 400, ST 4P00, ST 300, and ST 3P00 now taken in the same semester, will allow for better alignment with student clinical and lecture expectations. In turn, an update to the prerequisites and corequisites for the course was required to reflect these changes.</p><p>CURRUCULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5fChangeinPrereq_Coreq-ST4P00-PracticumII.pdf\" class=\"open_in_new_tab\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5fChangeinPrereq_Coreq-ST4P00-PracticumII.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024",
+      "JUNE 2008",
+      "ST 300",
+      "ST 400"
+    ]
+  },
+  "ST 6P00": {
+    "text": "<p>5/6/2024 - removed Civic Engagement per Kalin email 4/28/2023 (redo)</p><p><u>Explanation</u>: The ARC/STSA is a private, non-profit accreditation services agency that provides national recognition for more than 400 higher education programs in surgical technology and surgical assisting in collaboration with the Commission on Accreditation of Allied Health Education Programs (CAAHEP). The ARC/STSA has established August 1, 2024, as the date for full implementation of the Core Curriculum for Surgical Technology (CCST), 7th edition. Surgical Technology programs must be utilizing the (CCST), 7th edition, in its entirety after this date. </p><p>The Core Curriculum Revision Panel began the process of completing a peer-reviewed revision of the Core Curriculum for Surgical Technology (CCST), 7th edition, in February 2019. The Panel consisted of representatives of the Association of Surgical Technologists (AST), the Accreditation Council on Surgical Technology and Surgical Assisting (ARC/STSA), and the National Board of Surgical Technology and Surgical Assisting (NBSTSA). The Panel focused on multiple transformations that have occurred in the profession since the publication of the 6th edition while preserving the principles of the entry-level knowledge that the graduate needs to provide safe, quality surgical patient care. </p><p>Based on ARC/STSA CCST-7e requirements a number of revisions to Kingsborough’s Surgical Technology curriculum was completed in order to ensure full compliance with the ARC/STSA CCST – 7e. </p><p>In addition, the program had its reaccreditation visit in June 2023 by the ARC/STSA. They made a number of recommendations for the program. </p><p>Material covered in ST 4500 – Surgical Pharmacology has been distributed to ST 300. In addition, the changes to course sequencing, with ST 400, ST 4P00 and ST 300 and ST 3P00 be taken in the same semester, allowed for better alignment with student clinical and lecture expectations, in turn making ST 4500 redundant within the curriculum. In turn, an update to the pre-/co-requisite for the course was required to reflect these changes.</p><p>CURRICULUM COMMITTEE FALL 2023 FOR JAN/FEB 2024 AUR</p><p><a href=\"https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5hChangeinPre-_Co-req-ST6P00-PracticumIV.pdf\" rel=\"noopener noreferrer nofollow\">https://www.kbcc.cuny.edu/college_council/currcomm/documents/fall2023/5hChangeinPre-_Co-req-ST6P00-PracticumIV.pdf</a></p>",
+    "courses": [
+      "FALL 2023",
+      "FEB 2024",
+      "ST 300",
+      "ST 400",
+      "ST 4500"
+    ]
+  },
+  "ST 990": {
+    "text": "Corequisite: BIO 1100 and ENG 1200 Open Only To: Students applying to the Surgical Technology program",
+    "courses": [
+      "BIO 1100",
+      "ENG 1200"
+    ]
+  },
+  "TH 111": {
+    "text": "STUDENTS MUST COMPLETE ANY DEVELOPMENTAL REQUIREMENTS IN ENGLISH (SEE PROFICIENCY IN MATH AND ENGLISH) PRIOR TO TAKING THIS COURSE",
+    "courses": []
+  },
+  "TH 120": {
+    "text": "FOR NON-THEATRE MAJORS",
+    "courses": []
+  },
+  "TH 121": {
+    "text": "FOR THEATRE MAJORS. STUDENTS WHO HAVE PASSED TH-120 SHOULD NOT ENROLL IN THIS COURSE, BUT TAKE TH-221",
+    "courses": [
+      "TH 120",
+      "TH 221"
+    ]
+  },
+  "TH 122": {
+    "text": "BY AUDITION OR PERMISSION OF THE DEPARTMENT",
+    "courses": []
+  },
+  "TH 221": {
+    "text": "TH120 (SP531) OR TH121",
+    "courses": [
+      "SP 531",
+      "TH 120",
+      "TH 121"
+    ]
+  },
+  "TH 222": {
+    "text": "BY AUDITION OR PERMISSION OF THE DEPARTMENT",
+    "courses": []
+  },
+  "TH 231": {
+    "text": "TH131",
+    "courses": [
+      "TH 131"
+    ]
+  },
+  "TH 232": {
+    "text": "TH131 & TH132 OR PERMISSION OF THE DEPARTMENT",
+    "courses": [
+      "TH 131",
+      "TH 132"
+    ]
+  },
+  "TH 235": {
+    "text": "TH131",
+    "courses": [
+      "TH 131"
+    ]
+  },
+  "TRS 202": {
+    "text": "<p>This prerequisite change aims to raise proficiency level in Spanish of entering students. </p>",
+    "courses": []
+  },
+  "TRS 233": {
+    "text": "<p>This prerequisite change aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate.</p>",
+    "courses": []
+  },
+  "TRS 234": {
+    "text": "<p>This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate.</p>",
+    "courses": []
+  },
+  "TRS 235": {
+    "text": "<p>This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate.</p>",
+    "courses": []
+  },
+  "TRS 237": {
+    "text": "<p>This change to prerequisites aims to require students to take an introductory course on morphology and syntax of the language into which students plan to translate and to remove TRS 202 as a mandatory course and allow room for an extra TRS 23x course.</p>",
+    "courses": [
+      "TRS 202"
+    ]
+  },
+  "TRS 345": {
+    "text": "<p>This course number change is to more accurately represent the course level and prerequisite change aims to expand students' course options at the TRS 23x level. </p>",
+    "courses": []
+  },
+  "UBST 101": {
+    "text": "UBST101 is an internship program does not meet on specific days/times. Students must have at least 24 earned credits and a GPA of 2.5 or higher. Students must contact DTricarico@Qcc.cuny.edu to arrange individual meeting times",
+    "courses": []
+  },
+  "UBST 202": {
+    "text": "UBST101 (SS901); internship program does not meet on specific days/times. Students must have at least 24 earned credits and a GPA of 2.5 or higher. Students must contact DTricarico@Qcc.cuny.edu to arrange individual meeting times",
+    "courses": [
+      "SS 901",
+      "UBST 101"
+    ]
+  },
+  "WPR 21": {
+    "text": "<p>WPR 21 is being modified as part of the Medical Office Assistant (MOA) AAS degree revision.&nbsp; The current co-requisite, KEY 11, is no longer part of the MOA AAS degree and thus eliminated.&nbsp; The course credits are being reduced from three down to two.&nbsp; The current course hours (3 recitation) does not adequately reflect how the course is taught. &nbsp;The course relies heavily on computer applications (MS Word) and thus two of the hours are lab hours.&nbsp; The change correctly computes the total credits for a 1-hour recitation, 2-hour lab course.</p>",
+    "courses": [
+      "KEY 11"
+    ]
+  }
+}

--- a/scripts/lib/check-prereq-regression.ts
+++ b/scripts/lib/check-prereq-regression.ts
@@ -1,0 +1,112 @@
+/**
+ * check-prereq-regression.ts
+ *
+ * Guards prereq-scraper freshness runs against silent regressions. Run
+ * AFTER the scraper has written `data/<state>/prereqs.json` but BEFORE
+ * committing it back to the repo.
+ *
+ * Compares the newly-written JSON against the version committed at
+ * git HEAD. Exits non-zero if the new file:
+ *   1. Is missing or malformed
+ *   2. Has zero entries (HEAD had some → total breakage)
+ *   3. Has <80% of HEAD's entry count (>20% drop → likely schema change
+ *      upstream; human should look)
+ *
+ * A strictly non-decreasing key set is NOT required. Schools occasionally
+ * retire courses, and a handful of deletions is normal.
+ *
+ * Usage:
+ *   npx tsx scripts/lib/check-prereq-regression.ts ny
+ *   npx tsx scripts/lib/check-prereq-regression.ts ny --threshold=0.7
+ */
+
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+type Prereqs = Record<string, PrereqEntry>;
+
+function loadFromDisk(p: string): Prereqs | null {
+  if (!fs.existsSync(p)) return null;
+  try {
+    const raw = fs.readFileSync(p, "utf8");
+    const j = JSON.parse(raw);
+    if (j && typeof j === "object" && !Array.isArray(j)) return j as Prereqs;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function loadFromGitHead(relPath: string): Prereqs | null {
+  try {
+    const raw = execSync(`git show HEAD:${relPath}`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const j = JSON.parse(raw);
+    if (j && typeof j === "object" && !Array.isArray(j)) return j as Prereqs;
+    return null;
+  } catch {
+    // File not tracked in HEAD yet (first run) → no baseline to compare.
+    return null;
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const state = args.find((a) => !a.startsWith("--"));
+  const thresholdArg = args.find((a) => a.startsWith("--threshold="));
+  const threshold = thresholdArg
+    ? parseFloat(thresholdArg.split("=")[1])
+    : 0.8;
+
+  if (!state) {
+    console.error("usage: check-prereq-regression <state> [--threshold=0.8]");
+    process.exit(2);
+  }
+
+  const relPath = `data/${state}/prereqs.json`;
+  const absPath = path.join(process.cwd(), relPath);
+
+  const next = loadFromDisk(absPath);
+  if (!next) {
+    console.error(`✗ ${relPath} missing or malformed`);
+    process.exit(1);
+  }
+  const nextCount = Object.keys(next).length;
+  if (nextCount === 0) {
+    console.error(`✗ ${relPath} has zero entries`);
+    process.exit(1);
+  }
+
+  const prev = loadFromGitHead(relPath);
+  if (!prev) {
+    console.log(
+      `✓ ${relPath}: ${nextCount} entries (no HEAD baseline — first run, skipping regression check)`,
+    );
+    return;
+  }
+  const prevCount = Object.keys(prev).length;
+
+  const ratio = nextCount / prevCount;
+  const pct = (ratio * 100).toFixed(1);
+  if (ratio < threshold) {
+    console.error(
+      `✗ ${relPath}: ${nextCount} entries vs HEAD ${prevCount} (${pct}% — below ${(threshold * 100).toFixed(0)}% threshold)`,
+    );
+    process.exit(1);
+  }
+
+  const delta = nextCount - prevCount;
+  const sign = delta >= 0 ? "+" : "";
+  console.log(
+    `✓ ${relPath}: ${nextCount} entries vs HEAD ${prevCount} (${sign}${delta}, ${pct}%)`,
+  );
+}
+
+main();

--- a/scripts/ny/scrape-catalog-prereqs.ts
+++ b/scripts/ny/scrape-catalog-prereqs.ts
@@ -1,0 +1,472 @@
+/**
+ * scrape-catalog-prereqs.ts (NY / CUNY)
+ *
+ * Scrapes course prerequisite text for the 7 CUNY community colleges, which
+ * all publish their catalogs through Coursedog at {slug}.catalog.cuny.edu.
+ *
+ * Coursedog architecture
+ * ----------------------
+ * The catalog front-end is a Nuxt SSR app that fetches course data
+ * client-side from app.coursedog.com. Every catalog page call requires
+ * session cookies set by the tenant subdomain, so a bare curl returns 401.
+ * We use Playwright to establish the session, then drive the JSON API via
+ * `page.evaluate(fetch(...))` so requests inherit the page's cookies.
+ *
+ * Prereq field discovery
+ * ----------------------
+ * CUNY's course documents do NOT put prereq data in the obvious `requisites`
+ * field (that's program requirement data — which programs/degrees require
+ * the course). Real prereq text lives in `customFields.<obfuscated-key>`
+ * as a string starting with "PREREQ/COREQ:" or similar. The obfuscated key
+ * differs per school (e.g. QCC uses "Mmgow"). We locate it per-course by
+ * scanning every customFields string value for the PREREQ marker.
+ *
+ * Output
+ * ------
+ * data/ny/prereqs.json keyed by "${PREFIX} ${NUMBER}" (e.g. "ENGL 101"),
+ * value `{ text, courses }`. Matches the shape produced by VT/CT/RI/PA.
+ *
+ * Usage:
+ *   npx tsx scripts/ny/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/ny/scrape-catalog-prereqs.ts --school qcc
+ *   npx tsx scripts/ny/scrape-catalog-prereqs.ts --limit=50
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { chromium, type Browser, type Page, type Request } from "playwright";
+
+// CUNY community college Coursedog subdomains. Slug matches the subdomain.
+// Some schools may 500 intermittently — we log and continue past failures.
+const SCHOOLS: { slug: string; label: string }[] = [
+  { slug: "bmcc", label: "Borough of Manhattan CC" },
+  { slug: "bcc", label: "Bronx CC" },
+  { slug: "guttman", label: "Guttman CC" },
+  { slug: "hostos", label: "Hostos CC" },
+  { slug: "kbcc", label: "Kingsborough CC" },
+  { slug: "laguardia", label: "LaGuardia CC" },
+  { slug: "qcc", label: "Queensborough CC" },
+];
+
+const PAGE_SIZE = 200;
+const CONCURRENCY = 4;
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+interface CourseDoc {
+  _id: string;
+  code?: string;
+  subjectCode?: string;
+  courseNumber?: string;
+  name?: string;
+  description?: string;
+  customFields?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Session capture
+// ---------------------------------------------------------------------------
+
+async function captureCatalogSession(
+  page: Page,
+  slug: string,
+): Promise<{ tenantId: string; catalogId: string } | null> {
+  let tenantId: string | null = null;
+  let catalogId: string | null = null;
+
+  const handler = (req: Request) => {
+    const u = req.url();
+    const m = u.match(
+      /app\.coursedog\.com\/api\/v1\/cm\/([^/]+)\/courses\/search/,
+    );
+    if (m && !tenantId) {
+      tenantId = m[1];
+      const cm = u.match(/catalogId=([^&]+)/);
+      if (cm) catalogId = decodeURIComponent(cm[1]);
+    }
+  };
+  page.on("request", handler);
+
+  const listUrl = `https://${slug}.catalog.cuny.edu/courses`;
+  try {
+    await page.goto(listUrl, {
+      waitUntil: "domcontentloaded",
+      timeout: 45000,
+    });
+  } catch (e) {
+    console.warn(`  [${slug}] goto error: ${(e as Error).message}`);
+  }
+
+  // Wait up to 20s for the first Coursedog API request to fire.
+  for (let i = 0; i < 40 && !tenantId; i++) {
+    await page.waitForTimeout(500);
+  }
+  page.off("request", handler);
+
+  if (!tenantId || !catalogId) return null;
+  return { tenantId, catalogId };
+}
+
+// ---------------------------------------------------------------------------
+// API helpers (run in-page so cookies are attached)
+// ---------------------------------------------------------------------------
+
+const SEARCH_BODY = {
+  condition: "AND",
+  filters: [
+    {
+      filters: [
+        {
+          id: "status-course",
+          condition: "field",
+          name: "status",
+          inputType: "select",
+          group: "course",
+          type: "is",
+          value: "Active",
+          customField: false,
+        },
+        {
+          id: "catalogPrint-course",
+          condition: "field",
+          name: "catalogPrint",
+          inputType: "boolean",
+          group: "course",
+          type: "is",
+          value: true,
+          customField: false,
+        },
+      ],
+      id: "I5KglKp3",
+      condition: "and",
+    },
+  ],
+};
+
+async function fetchCourseList(
+  page: Page,
+  tenantId: string,
+  catalogId: string,
+  skip: number,
+  limit: number,
+): Promise<CourseDoc[]> {
+  const url =
+    `https://app.coursedog.com/api/v1/cm/${tenantId}/courses/search/%24filters` +
+    `?catalogId=${encodeURIComponent(catalogId)}` +
+    `&skip=${skip}&limit=${limit}` +
+    `&orderBy=code` +
+    `&columns=code,name,longName,subjectCode,courseNumber,_id,description,requisites,customFields` +
+    `&formatDependents=false`;
+
+  const result = await page.evaluate(
+    async ({ url, body }) => {
+      try {
+        const r = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-requested-with": "catalog",
+            Accept: "application/json",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!r.ok) return { ok: false, status: r.status, data: null };
+        return { ok: true, status: r.status, data: await r.json() };
+      } catch (e) {
+        return { ok: false, status: 0, data: null, error: String(e) };
+      }
+    },
+    { url, body: SEARCH_BODY },
+  );
+
+  if (!result.ok) {
+    throw new Error(`list fetch failed status=${result.status}`);
+  }
+  const d = result.data;
+  if (Array.isArray(d)) return d as CourseDoc[];
+  if (d && Array.isArray(d.data)) return d.data as CourseDoc[];
+  if (d && Array.isArray(d.courses)) return d.courses as CourseDoc[];
+  return [];
+}
+
+async function fetchCourseDetail(
+  page: Page,
+  tenantId: string,
+  id: string,
+): Promise<CourseDoc | null> {
+  const url = `https://app.coursedog.com/api/v1/cm/${tenantId}/courses/${encodeURIComponent(id)}`;
+  const result = await page.evaluate(async (url) => {
+    try {
+      const r = await fetch(url, {
+        headers: {
+          "x-requested-with": "catalog",
+          Accept: "application/json",
+        },
+      });
+      if (!r.ok) return { ok: false, status: r.status, data: null };
+      return { ok: true, status: r.status, data: await r.json() };
+    } catch (e) {
+      return { ok: false, status: 0, data: null, error: String(e) };
+    }
+  }, url);
+  if (!result.ok) return null;
+  const d = result.data;
+  return (d?.course ?? d) as CourseDoc | null;
+}
+
+// ---------------------------------------------------------------------------
+// Prereq extraction
+// ---------------------------------------------------------------------------
+
+// CUNY prereq text typically begins with "PREREQ", "Prerequisite", or
+// "PREREQ/COREQ". We accept any customField string value that matches.
+const PREREQ_MARKER_RE = /\b(pre[- ]?req|prerequisite|co[- ]?req|corequisite)/i;
+
+// Strip the leading "PREREQ/COREQ:" style label so `text` reads naturally.
+const PREREQ_PREFIX_RE =
+  /^(pre[- ]?req(?:uisite)?s?\s*(?:\/\s*co[- ]?req(?:uisite)?s?)?\s*:\s*)/i;
+
+function extractPrereqString(course: CourseDoc): string | null {
+  const cf = course.customFields;
+  if (!cf || typeof cf !== "object") return null;
+  // Prefer explicitly-named keys first, fall back to marker scan.
+  const explicit = ["prerequisite", "prerequisites", "catalogPrerequisite"];
+  for (const k of explicit) {
+    const v = (cf as Record<string, unknown>)[k];
+    if (typeof v === "string" && v.trim()) return v;
+  }
+  for (const v of Object.values(cf)) {
+    if (typeof v === "string" && PREREQ_MARKER_RE.test(v)) return v;
+  }
+  return null;
+}
+
+/**
+ * Clean raw prereq text: trim label prefix, collapse whitespace, strip
+ * trailing punctuation. Keep the actual content intact — the UI renders
+ * this verbatim.
+ */
+function normalizePrereqText(raw: string): string {
+  let t = raw.replace(/\s+/g, " ").trim();
+  t = t.replace(PREREQ_PREFIX_RE, "").trim();
+  t = t.replace(/[.;,]+\s*$/, "").trim();
+  return t;
+}
+
+// Boilerplate that means "no real prereq". CUNY reuses a handful of these.
+const BOILERPLATE_RE =
+  /^(none|n\/a|not applicable|no prerequisites?( required)?)\.?$/i;
+
+/**
+ * Extract course codes referenced in the prereq text. CUNY uses three forms:
+ *   1. "ENGL-101" (hyphenated — PeopleSoft-style)
+ *   2. "ENGL 101" (spaced)
+ *   3. "ENGL101"  (jammed)
+ * All normalize to the canonical "PREFIX NUMBER" used elsewhere in this
+ * repo's prereq data.
+ */
+function extractCourseCodes(
+  text: string,
+  selfKey: string,
+): string[] {
+  const out = new Set<string>();
+  const re = /\b([A-Z]{2,5})[-\s]?(\d{2,4}[A-Z]?)\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const code = `${m[1]} ${m[2]}`;
+    if (code === selfKey) continue;
+    out.add(code);
+  }
+  return Array.from(out).sort();
+}
+
+function courseKey(c: CourseDoc): string | null {
+  if (c.subjectCode && c.courseNumber) {
+    return `${String(c.subjectCode).toUpperCase().trim()} ${String(c.courseNumber).toUpperCase().trim()}`;
+  }
+  if (c.code) {
+    const m = String(c.code).match(/^([A-Z]{2,5})[-\s]?(\d{2,4}[A-Z]?)/i);
+    if (m) return `${m[1].toUpperCase()} ${m[2].toUpperCase()}`;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Per-school scrape
+// ---------------------------------------------------------------------------
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`    pmap[${idx}] error: ${(e as Error).message}`);
+        results[idx] = undefined as unknown as R;
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+async function scrapeSchool(
+  browser: Browser,
+  school: { slug: string; label: string },
+  limit: number,
+): Promise<Record<string, PrereqEntry>> {
+  const ctx = await browser.newContext({
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0 Safari/537.36",
+  });
+  const page = await ctx.newPage();
+
+  console.log(`\n=== ${school.slug} (${school.label}) ===`);
+
+  const session = await captureCatalogSession(page, school.slug);
+  if (!session) {
+    console.warn(`  [${school.slug}] could not capture session — skipping`);
+    await ctx.close();
+    return {};
+  }
+  const { tenantId, catalogId } = session;
+  console.log(`  tenant=${tenantId} catalog=${catalogId}`);
+
+  // Paginate list.
+  const all: CourseDoc[] = [];
+  let skip = 0;
+  while (true) {
+    let batch: CourseDoc[];
+    try {
+      batch = await fetchCourseList(page, tenantId, catalogId, skip, PAGE_SIZE);
+    } catch (e) {
+      console.error(`  [${school.slug}] list error at skip=${skip}: ${(e as Error).message}`);
+      break;
+    }
+    if (batch.length === 0) break;
+    all.push(...batch);
+    console.log(`  listed ${all.length} courses (skip=${skip})`);
+    if (batch.length < PAGE_SIZE) break;
+    skip += PAGE_SIZE;
+    if (limit > 0 && all.length >= limit) break;
+  }
+
+  let pool = all;
+  if (limit > 0) pool = pool.slice(0, limit);
+
+  // Check if list already includes customFields (columns param should have
+  // returned them). If not, per-course detail fetches fill the gap.
+  const sample = pool.find((c) => c.customFields && Object.keys(c.customFields).length > 0);
+  const needDetail = !sample;
+  if (needDetail) {
+    console.log(`  list omitted customFields; fetching details for ${pool.length} courses`);
+    const filled = await pmap(pool, CONCURRENCY, async (c) => {
+      const d = await fetchCourseDetail(page, tenantId, c._id);
+      return d ?? c;
+    });
+    pool = filled.filter((c): c is CourseDoc => !!c);
+  } else {
+    console.log(`  list included customFields — no detail fetches needed`);
+  }
+
+  const prereqs: Record<string, PrereqEntry> = {};
+  let hits = 0;
+  for (const c of pool) {
+    const key = courseKey(c);
+    if (!key) continue;
+    const raw = extractPrereqString(c);
+    if (!raw) continue;
+    const text = normalizePrereqText(raw);
+    if (!text || BOILERPLATE_RE.test(text)) continue;
+    const courses = extractCourseCodes(text, key);
+    prereqs[key] = { text, courses };
+    hits++;
+  }
+  console.log(`  ${hits} courses with prereqs (of ${pool.length} scanned)`);
+
+  await ctx.close();
+  return prereqs;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const schoolArg = args.find((a) => a.startsWith("--school="))?.split("=")[1]
+    ?? (args.indexOf("--school") >= 0 ? args[args.indexOf("--school") + 1] : null);
+  const limit = parseInt(
+    args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0",
+    10,
+  );
+
+  const targets = schoolArg
+    ? SCHOOLS.filter((s) => s.slug === schoolArg)
+    : SCHOOLS;
+  if (targets.length === 0) {
+    console.error(`unknown school: ${schoolArg}`);
+    console.error(`available: ${SCHOOLS.map((s) => s.slug).join(", ")}`);
+    process.exit(1);
+  }
+
+  console.log("CUNY Coursedog prereq scraper");
+  console.log(`  targets: ${targets.map((t) => t.slug).join(", ")}`);
+  if (limit > 0) console.log(`  limit=${limit} per school`);
+
+  const browser = await chromium.launch({ headless: true });
+  const merged: Record<string, PrereqEntry> = {};
+  const counts: { slug: string; count: number }[] = [];
+
+  for (const school of targets) {
+    try {
+      const res = await scrapeSchool(browser, school, limit);
+      counts.push({ slug: school.slug, count: Object.keys(res).length });
+      // Merge: last writer wins. If two schools describe the same course key
+      // with different text, keep the one with more referenced courses (more
+      // informative). This is rare — CUNY codes like "ENGL 101" exist on
+      // multiple campuses but the prereq boilerplate tends to match.
+      for (const [k, v] of Object.entries(res)) {
+        const existing = merged[k];
+        if (!existing || v.courses.length > existing.courses.length) {
+          merged[k] = v;
+        }
+      }
+    } catch (e) {
+      console.error(`  [${school.slug}] fatal: ${(e as Error).message}`);
+      counts.push({ slug: school.slug, count: 0 });
+    }
+  }
+
+  await browser.close();
+
+  // Sort keys for deterministic output.
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const k of Object.keys(merged).sort()) sorted[k] = merged[k];
+
+  const outDir = path.join(process.cwd(), "data", "ny");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, "prereqs.json");
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2));
+
+  console.log("\n=== Summary ===");
+  for (const c of counts) console.log(`  ${c.slug}: ${c.count}`);
+  console.log(`  merged unique keys: ${Object.keys(sorted).length}`);
+  console.log(`\n✓ Wrote ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds **NY** to the states with `data/<state>/prereqs.json`. Scrapes all 7 CUNY community colleges through their shared Coursedog platform via Playwright; 900 merged unique prereq entries.
- Adds a **weekly freshness cron** ([.github/workflows/scrape-prereqs.yml](../blob/feature/ny-prereqs-and-freshness-cron/.github/workflows/scrape-prereqs.yml)) that re-runs all 11 states' prereq pipelines (6 dedicated catalog scrapers + 5 aggregate-from-courses states) and commits updated files back on success.
- Adds [check-prereq-regression.ts](../blob/feature/ny-prereqs-and-freshness-cron/scripts/lib/check-prereq-regression.ts) as a guard — any scrape that produces 0 entries, malformed JSON, or <80% of the git-HEAD baseline fails the job, blocks the commit, and triggers GitHub's default workflow-failure email.

## Why this matters
Prereq JSON has been one-shot scrapes. As more states come online, silent upstream schema drift becomes the likely failure mode — the scraper runs clean, writes a near-empty file, product breaks, nobody notices. The regression guard catches that case; the cron makes freshness automatic instead of event-driven.

## Design notes
- Per-state matrix jobs (not a single batched job) — one flaky upstream can't block the others, and each failing state surfaces independently.
- NY-only step installs Playwright Chromium; other states are HTTP-pure and skip it.
- Auto-commits carry `[skip ci]` so they don't cascade into the courses/transfers workflows.
- `concurrency: scrape-prereqs-<state>` prevents manual dispatches from colliding with scheduled runs.
- Scoped `file_pattern` per job — a scraper touching anything outside `data/<state>/prereqs.json` won't accidentally get committed.

## NY prereq discovery (documented in commit message for future archaeology)
Coursedog's obvious `requisites` field is actually program-requirement data. Real prereq text lives in `customFields.<obfuscated-key>` as strings beginning with `PREREQ/COREQ:`. The obfuscated key differs per school (QCC uses `Mmgow`). Scraper scans customFields string values for the marker rather than hard-coding keys.

## Test plan
- [x] `scripts/lib/check-prereq-regression.ts` tested locally: healthy case (VT 101→101 passes), synthetic 50% drop (fails with exit 1), first-run case (no HEAD baseline, passes).
- [x] Full NY scrape executed locally end-to-end: 900 unique entries across 7 CUNY schools.
- [ ] Trigger workflow via `workflow_dispatch` with `state: vt` to smoke-test one state end-to-end before relying on the Sunday cron.
- [ ] After merge, verify `/api/ny/prereqs/courses` on prod returns >800 entries and `/api/ny/prereqs/chain?course=ACC%20122` renders a chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)