### PR TITLE
Add NH prereq data via CCSNH Clean Catalog scraper — Phase 4

### DIFF
--- a/data/nh/prereqs.json
+++ b/data/nh/prereqs.json
@@ -1,0 +1,4211 @@
+{
+  "ACCT 102C": {
+    "text": "ACCT101C: Accounting and Financial Reporting I",
+    "courses": [
+      "ACCT 101C"
+    ],
+    "source": "nhti"
+  },
+  "ACCT 102R": {
+    "text": "ACCT101R",
+    "courses": [
+      "ACCT 101R"
+    ],
+    "source": "rvcc"
+  },
+  "ACCT 105R": {
+    "text": "BCPT101R",
+    "courses": [
+      "BCPT 101R"
+    ],
+    "source": "rvcc"
+  },
+  "ACCT 110C": {
+    "text": "ACCT102C: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 102C"
+    ],
+    "source": "nhti"
+  },
+  "ACCT 114W": {
+    "text": "ACCT111W: Accounting I",
+    "courses": [
+      "ACCT 111W"
+    ],
+    "source": "wmcc"
+  },
+  "ACCT 123G": {
+    "text": "ACCT113G: Accounting and Financial Reporting I",
+    "courses": [
+      "ACCT 113G"
+    ],
+    "source": "gbcc"
+  },
+  "ACCT 200R": {
+    "text": "ACCT203R",
+    "courses": [
+      "ACCT 203R"
+    ],
+    "source": "rvcc"
+  },
+  "ACCT 203R": {
+    "text": "ACCT102R",
+    "courses": [
+      "ACCT 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ACCT 204R": {
+    "text": "ACCT102R MATH106R",
+    "courses": [
+      "ACCT 102R",
+      "MATH 106R"
+    ],
+    "source": "rvcc"
+  },
+  "ACCT 205C": {
+    "text": "ACCT102C: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 102C"
+    ],
+    "source": "nhti"
+  },
+  "ACCT 206C": {
+    "text": "ACCT205C: Intermediate Accounting I",
+    "courses": [
+      "ACCT 205C"
+    ],
+    "source": "nhti"
+  },
+  "ACCT 213G": {
+    "text": "ACCT123G: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 123G"
+    ],
+    "source": "gbcc"
+  },
+  "ACCT 214W": {
+    "text": "ACCT111W: Accounting I",
+    "courses": [
+      "ACCT 111W"
+    ],
+    "source": "wmcc"
+  },
+  "ACCT 215G": {
+    "text": "ACCT213G: Cost Accounting I",
+    "courses": [
+      "ACCT 213G"
+    ],
+    "source": "gbcc"
+  },
+  "ACCT 215R": {
+    "text": "ACCT102R",
+    "courses": [
+      "ACCT 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ACCT 216G": {
+    "text": "ACCT123G: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 123G"
+    ],
+    "source": "gbcc"
+  },
+  "ACCT 216R": {
+    "text": "ACCT101R BCPT101R",
+    "courses": [
+      "ACCT 101R",
+      "BCPT 101R"
+    ],
+    "source": "rvcc"
+  },
+  "ACCT 222W": {
+    "text": "ACCT114W: Financial Accounting",
+    "courses": [
+      "ACCT 114W"
+    ],
+    "source": "wmcc"
+  },
+  "ACCT 223G": {
+    "text": "ACCT123G: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 123G"
+    ],
+    "source": "gbcc"
+  },
+  "ACCT 230C": {
+    "text": "ACCT102C: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 102C"
+    ],
+    "source": "nhti"
+  },
+  "ACCT 231L": {
+    "text": "ACCT132L: Accounting II",
+    "courses": [
+      "ACCT 132L"
+    ],
+    "source": "lrcc"
+  },
+  "ACCT 233G": {
+    "text": "ACCT223G: Intermediate Accounting I",
+    "courses": [
+      "ACCT 223G"
+    ],
+    "source": "gbcc"
+  },
+  "ACCT 235L": {
+    "text": "ACCT132L: Accounting II",
+    "courses": [
+      "ACCT 132L"
+    ],
+    "source": "lrcc"
+  },
+  "ACCT 243G": {
+    "text": "ACCT123G: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 123G"
+    ],
+    "source": "gbcc"
+  },
+  "ACCT 250C": {
+    "text": "ACCT102C: Accounting and Financial Reporting II",
+    "courses": [
+      "ACCT 102C"
+    ],
+    "source": "nhti"
+  },
+  "ACCT 250W": {
+    "text": "ACCT222W: Intermediate Accounting I",
+    "courses": [
+      "ACCT 222W"
+    ],
+    "source": "wmcc"
+  },
+  "ACCT 251L": {
+    "text": "ACCT132L: Accounting II",
+    "courses": [
+      "ACCT 132L"
+    ],
+    "source": "lrcc"
+  },
+  "ACCT 273L": {
+    "text": "ACCT131L: Accounting I",
+    "courses": [
+      "ACCT 131L"
+    ],
+    "source": "lrcc"
+  },
+  "ADCL 205C": {
+    "text": "ADCL120C: Survey of Addictive Behaviors and Treatment",
+    "courses": [
+      "ADCL 120C"
+    ],
+    "source": "nhti"
+  },
+  "ADCL 235C": {
+    "text": "ADCL120C: Survey of Addictive Behaviors and Treatment",
+    "courses": [
+      "ADCL 120C"
+    ],
+    "source": "nhti"
+  },
+  "ADCL 296C": {
+    "text": "ADCL120C: Survey of Addictive Behaviors and Treatment",
+    "courses": [
+      "ADCL 120C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 103C": {
+    "text": "BIOL195C: Anatomy and Physiology I",
+    "courses": [
+      "BIOL 195C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 111C": {
+    "text": "ADED110C: Dental Assisting Science I",
+    "courses": [
+      "ADED 110C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 112C": {
+    "text": "ADED100C: Dental Hygiene I",
+    "courses": [
+      "ADED 100C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 114C": {
+    "text": "ADED100C: Dental Hygiene I",
+    "courses": [
+      "ADED 100C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 126C": {
+    "text": "ADED100C: Dental Hygiene I",
+    "courses": [
+      "ADED 100C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 134C": {
+    "text": "ADED101C: Intro to Dental Hygiene Science",
+    "courses": [
+      "ADED 101C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 136C": {
+    "text": "BIOL195C: Anatomy and Physiology I",
+    "courses": [
+      "BIOL 195C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 140C": {
+    "text": "ADED134C: Oral Anatomy I",
+    "courses": [
+      "ADED 134C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 162C": {
+    "text": "ADED100C: Dental Hygiene I",
+    "courses": [
+      "ADED 100C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 182C": {
+    "text": "ADED110C: Dental Assisting Science I",
+    "courses": [
+      "ADED 110C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 191C": {
+    "text": "ADED110C: Dental Assisting Science I",
+    "courses": [
+      "ADED 110C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 196C": {
+    "text": "ADED105C: Dental Radiology for Dental Assisting",
+    "courses": [
+      "ADED 105C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 201C": {
+    "text": "ADED103C: Dental Hygiene II",
+    "courses": [
+      "ADED 103C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 212C": {
+    "text": "ADED103C: Dental Hygiene II",
+    "courses": [
+      "ADED 103C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 221C": {
+    "text": "ADED240C: Advanced Periodontology",
+    "courses": [
+      "ADED 240C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 225C": {
+    "text": "ADED103C: Dental Hygiene II",
+    "courses": [
+      "ADED 103C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 239C": {
+    "text": "ADED110C: Dental Assisting Science I",
+    "courses": [
+      "ADED 110C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 240C": {
+    "text": "ADED112C: Introduction to Periodontology",
+    "courses": [
+      "ADED 112C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 242C": {
+    "text": "ADED103C: Dental Hygiene II",
+    "courses": [
+      "ADED 103C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 243C": {
+    "text": "ADED212C: Clinical Dental Hygiene III",
+    "courses": [
+      "ADED 212C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 247C": {
+    "text": "BIOL202C: Microbiology",
+    "courses": [
+      "BIOL 202C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 248C": {
+    "text": "BIOL196C: Anatomy and Physiology II",
+    "courses": [
+      "BIOL 196C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 275C": {
+    "text": "ADED105C: Dental Radiology for Dental Assisting",
+    "courses": [
+      "ADED 105C"
+    ],
+    "source": "nhti"
+  },
+  "ADED 298C": {
+    "text": "ADED196C: Dental Assisting Clinical Experience II",
+    "courses": [
+      "ADED 196C"
+    ],
+    "source": "nhti"
+  },
+  "ADNR 197R": {
+    "text": "BIOL201R BIOL202R PSYC101R PSYC114R ENGL102R",
+    "courses": [
+      "BIOL 201R",
+      "BIOL 202R",
+      "ENGL 102R",
+      "PSYC 101R",
+      "PSYC 114R"
+    ],
+    "source": "rvcc"
+  },
+  "ADNR 220R": {
+    "text": "ADNR117R",
+    "courses": [
+      "ADNR 117R"
+    ],
+    "source": "rvcc"
+  },
+  "ADNR 230R": {
+    "text": "ADNR220R",
+    "courses": [
+      "ADNR 220R"
+    ],
+    "source": "rvcc"
+  },
+  "ADNR 235R": {
+    "text": "ADNR220R",
+    "courses": [
+      "ADNR 220R"
+    ],
+    "source": "rvcc"
+  },
+  "AGGP 101C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "AGGP 131C": {
+    "text": "AGGP101C: Introduction to Game Design and Creation with Programming",
+    "courses": [
+      "AGGP 101C"
+    ],
+    "source": "nhti"
+  },
+  "AGGP 140C": {
+    "text": "AGGP103C: Introduction to Content Development",
+    "courses": [
+      "AGGP 103C"
+    ],
+    "source": "nhti"
+  },
+  "AGGP 225C": {
+    "text": "AGGP131C: Introduction to 2-D and 3-D Game Development",
+    "courses": [
+      "AGGP 131C"
+    ],
+    "source": "nhti"
+  },
+  "AGGP 231C": {
+    "text": "AGGP131C: Introduction to 2-D and 3-D Game Development",
+    "courses": [
+      "AGGP 131C"
+    ],
+    "source": "nhti"
+  },
+  "AGGP 247C": {
+    "text": "AGGP101C: Introduction to Game Design and Creation with Programming",
+    "courses": [
+      "AGGP 101C"
+    ],
+    "source": "nhti"
+  },
+  "AGGP 292C": {
+    "text": "AGGP291C: Project Definition and Portfolio Specifications",
+    "courses": [
+      "AGGP 291C"
+    ],
+    "source": "nhti"
+  },
+  "AGGP 294C": {
+    "text": "AGGP291C: Project Definition and Portfolio Specifications",
+    "courses": [
+      "AGGP 291C"
+    ],
+    "source": "nhti"
+  },
+  "AGRI 115C": {
+    "text": "AGRI112C: Practical Applications for Sustainable Agriculture I",
+    "courses": [
+      "AGRI 112C"
+    ],
+    "source": "nhti"
+  },
+  "AHLT 123R": {
+    "text": "BIOL201R",
+    "courses": [
+      "BIOL 201R"
+    ],
+    "source": "rvcc"
+  },
+  "AHLT 135R": {
+    "text": "AHLT104R",
+    "courses": [
+      "AHLT 104R"
+    ],
+    "source": "rvcc"
+  },
+  "AHLT 210R": {
+    "text": "PTAC190R OCTA215R",
+    "courses": [
+      "OCTA 215R",
+      "PTAC 190R"
+    ],
+    "source": "rvcc"
+  },
+  "ARET 102C": {
+    "text": "ARET101C: AutoCAD 2-D",
+    "courses": [
+      "ARET 101C"
+    ],
+    "source": "nhti"
+  },
+  "ARET 104C": {
+    "text": "ARET103C: Architectural Graphics and Sketching",
+    "courses": [
+      "ARET 103C"
+    ],
+    "source": "nhti"
+  },
+  "ARET 150C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "ARET 195C": {
+    "text": "ARET192C: Revit Architecture",
+    "courses": [
+      "ARET 192C"
+    ],
+    "source": "nhti"
+  },
+  "ARET 202C": {
+    "text": "ARET103C: Architectural Graphics and Sketching",
+    "courses": [
+      "ARET 103C"
+    ],
+    "source": "nhti"
+  },
+  "ARET 250C": {
+    "text": "PHYS135C: Physics II (Algebra-based)",
+    "courses": [
+      "PHYS 135C"
+    ],
+    "source": "nhti"
+  },
+  "ARET 270C": {
+    "text": "ARET202C: Architectural Design Studio II",
+    "courses": [
+      "ARET 202C"
+    ],
+    "source": "nhti"
+  },
+  "ARET 297C": {
+    "text": "ARET202C: Architectural Design Studio II",
+    "courses": [
+      "ARET 202C"
+    ],
+    "source": "nhti"
+  },
+  "ARTS 203G": {
+    "text": "ARTS103G: Fundamentals of Acting I",
+    "courses": [
+      "ARTS 103G"
+    ],
+    "source": "gbcc"
+  },
+  "ARTS 223G": {
+    "text": "ARTS123G: Drawing I",
+    "courses": [
+      "ARTS 123G"
+    ],
+    "source": "gbcc"
+  },
+  "ARTS 270L": {
+    "text": "ARTS240L: Painting I",
+    "courses": [
+      "ARTS 240L"
+    ],
+    "source": "lrcc"
+  },
+  "ASL 105C": {
+    "text": "ASL104C: American Sign Language for Beginners",
+    "courses": [
+      "ASL 104C"
+    ],
+    "source": "nhti"
+  },
+  "ASL 120G": {
+    "text": "ASL110G: American Sign Language I",
+    "courses": [
+      "ASL 110G"
+    ],
+    "source": "gbcc"
+  },
+  "AUTO 113W": {
+    "text": "AUTO101W: Introduction to Automotive Service",
+    "courses": [
+      "AUTO 101W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 114W": {
+    "text": "AUTO112W: Automotive Electricity I",
+    "courses": [
+      "AUTO 112W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 2023M": {
+    "text": "AUTO1022M: Electronic Controls",
+    "courses": [
+      "AUTO 1022M"
+    ],
+    "source": "mccnh"
+  },
+  "AUTO 211W": {
+    "text": "AUTO114W: Automotive Electricity II",
+    "courses": [
+      "AUTO 114W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 212W": {
+    "text": "AUTO101W: Introduction to Automotive Service",
+    "courses": [
+      "AUTO 101W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 215W": {
+    "text": "AUTO101W: Introduction to Automotive Service",
+    "courses": [
+      "AUTO 101W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 217W": {
+    "text": "AUTO211W: Automotive Electronics",
+    "courses": [
+      "AUTO 211W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 218W": {
+    "text": "AUTO101W: Introduction to Automotive Service",
+    "courses": [
+      "AUTO 101W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 219W": {
+    "text": "AUTO101W: Introduction to Automotive Service",
+    "courses": [
+      "AUTO 101W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 220W": {
+    "text": "AUTO101W: Introduction to Automotive Service",
+    "courses": [
+      "AUTO 101W"
+    ],
+    "source": "wmcc"
+  },
+  "AUTO 267L": {
+    "text": "AUTO135L: Toyota/Lexus Electrical II",
+    "courses": [
+      "AUTO 135L"
+    ],
+    "source": "lrcc"
+  },
+  "BIOL 112C": {
+    "text": "BIOL111C: General Biology I",
+    "courses": [
+      "BIOL 111C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 115C": {
+    "text": "BIOL100C: Introduction to Biology with Lab",
+    "courses": [
+      "BIOL 100C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 115W": {
+    "text": "BIOL114W: Human Anatomy and Physiology I",
+    "courses": [
+      "BIOL 114W"
+    ],
+    "source": "wmcc"
+  },
+  "BIOL 117C": {
+    "text": "BIOL100C: Introduction to Biology with Lab",
+    "courses": [
+      "BIOL 100C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 121W": {
+    "text": "BIOL101W: Veterinary Anatomy and Physiology I",
+    "courses": [
+      "BIOL 101W"
+    ],
+    "source": "wmcc"
+  },
+  "BIOL 122C": {
+    "text": "BIOL120C: Human Biology",
+    "courses": [
+      "BIOL 120C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 196C": {
+    "text": "BIOL195C: Anatomy and Physiology I",
+    "courses": [
+      "BIOL 195C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 202C": {
+    "text": "BIOL112C: General Biology II",
+    "courses": [
+      "BIOL 112C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 210M": {
+    "text": "BIOL108M: College Biology I",
+    "courses": [
+      "BIOL 108M"
+    ],
+    "source": "mccnh"
+  },
+  "BIOL 211C": {
+    "text": "BIOL112C: General Biology II",
+    "courses": [
+      "BIOL 112C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 211W": {
+    "text": "BIOL114W: Human Anatomy and Physiology I",
+    "courses": [
+      "BIOL 114W"
+    ],
+    "source": "wmcc"
+  },
+  "BIOL 212C": {
+    "text": "BIOL112C: General Biology II",
+    "courses": [
+      "BIOL 112C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 215C": {
+    "text": "BIOL111C: General Biology I",
+    "courses": [
+      "BIOL 111C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 220R": {
+    "text": "BIOL101R BIOL102R BIOL162R BIOL201R BIOL202R BIOL205R BIOL210R",
+    "courses": [
+      "BIOL 101R",
+      "BIOL 102R",
+      "BIOL 162R",
+      "BIOL 201R",
+      "BIOL 202R",
+      "BIOL 205R",
+      "BIOL 210R"
+    ],
+    "source": "rvcc"
+  },
+  "BIOL 222C": {
+    "text": "BIOL196C: Anatomy and Physiology II",
+    "courses": [
+      "BIOL 196C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 229C": {
+    "text": "BIOL195C: Anatomy and Physiology I",
+    "courses": [
+      "BIOL 195C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 239C": {
+    "text": "BIOL129C: Introduction to Sports Nutrition",
+    "courses": [
+      "BIOL 129C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 259C": {
+    "text": "BIOL195C: Anatomy and Physiology I",
+    "courses": [
+      "BIOL 195C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 260C": {
+    "text": "BIOL112C: General Biology II",
+    "courses": [
+      "BIOL 112C"
+    ],
+    "source": "nhti"
+  },
+  "BIOL 279C": {
+    "text": "BIOL159C: Personal Nutrition",
+    "courses": [
+      "BIOL 159C"
+    ],
+    "source": "nhti"
+  },
+  "BIPE 110C": {
+    "text": "BIPE101C: Introduction to International Code Council Codes",
+    "courses": [
+      "BIPE 101C"
+    ],
+    "source": "nhti"
+  },
+  "BTEC 223G": {
+    "text": "BTEC210G: Biotechnology Research",
+    "courses": [
+      "BTEC 210G"
+    ],
+    "source": "gbcc"
+  },
+  "BTEC 224G": {
+    "text": "BTEC210G: Biotechnology Research",
+    "courses": [
+      "BTEC 210G"
+    ],
+    "source": "gbcc"
+  },
+  "BUS 110R": {
+    "text": "BUS101R",
+    "courses": [
+      "BUS 101R"
+    ],
+    "source": "rvcc"
+  },
+  "BUS 174C": {
+    "text": "BUS170C: Principles of Marketing",
+    "courses": [
+      "BUS 170C"
+    ],
+    "source": "nhti"
+  },
+  "BUS 204R": {
+    "text": "BUS101R BUS110R",
+    "courses": [
+      "BUS 101R",
+      "BUS 110R"
+    ],
+    "source": "rvcc"
+  },
+  "BUS 205R": {
+    "text": "BUS101R ENGL102R",
+    "courses": [
+      "BUS 101R",
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "BUS 216R": {
+    "text": "BUS101R ENGL102R",
+    "courses": [
+      "BUS 101R",
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "BUS 216W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "BUS 239L": {
+    "text": "BUS238L: Business Law I",
+    "courses": [
+      "BUS 238L"
+    ],
+    "source": "lrcc"
+  },
+  "BUS 240C": {
+    "text": "ACCT101C: Accounting and Financial Reporting I",
+    "courses": [
+      "ACCT 101C"
+    ],
+    "source": "nhti"
+  },
+  "BUS 240R": {
+    "text": "BUS101R ENGL102R",
+    "courses": [
+      "BUS 101R",
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "BUS 242R": {
+    "text": "BUS101R ENGL102R",
+    "courses": [
+      "BUS 101R",
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "BUS 245C": {
+    "text": "BUS101C: Introduction to Business",
+    "courses": [
+      "BUS 101C"
+    ],
+    "source": "nhti"
+  },
+  "BUS 255C": {
+    "text": "ACCT101C: Accounting and Financial Reporting I",
+    "courses": [
+      "ACCT 101C"
+    ],
+    "source": "nhti"
+  },
+  "BUS 260R": {
+    "text": "BUS101R",
+    "courses": [
+      "BUS 101R"
+    ],
+    "source": "rvcc"
+  },
+  "BUS 273C": {
+    "text": "BUS101C: Introduction to Business",
+    "courses": [
+      "BUS 101C"
+    ],
+    "source": "nhti"
+  },
+  "CHEM 104C": {
+    "text": "CHEM103C: General Chemistry I",
+    "courses": [
+      "CHEM 103C"
+    ],
+    "source": "nhti"
+  },
+  "CHEM 105C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "CHEM 141R": {
+    "text": "CHEM140R",
+    "courses": [
+      "CHEM 140R"
+    ],
+    "source": "rvcc"
+  },
+  "CHEM 205C": {
+    "text": "CHEM104C: General Chemistry II",
+    "courses": [
+      "CHEM 104C"
+    ],
+    "source": "nhti"
+  },
+  "CIS 118G": {
+    "text": "CIS112G: Introduction to Object Oriented Programming",
+    "courses": [
+      "CIS 112G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 126M": {
+    "text": "CIS107M: Introduction to Program Development",
+    "courses": [
+      "CIS 107M"
+    ],
+    "source": "mccnh"
+  },
+  "CIS 146G": {
+    "text": "CIS112G: Introduction to Object Oriented Programming",
+    "courses": [
+      "CIS 112G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 148G": {
+    "text": "CIS112G: Introduction to Object Oriented Programming",
+    "courses": [
+      "CIS 112G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 158G": {
+    "text": "CIS112G: Introduction to Object Oriented Programming",
+    "courses": [
+      "CIS 112G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 218G": {
+    "text": "CIS118G: Introduction to .NET",
+    "courses": [
+      "CIS 118G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 223G": {
+    "text": "CIS113G: Database Design and Management",
+    "courses": [
+      "CIS 113G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 224G": {
+    "text": "CIS112G: Introduction to Object Oriented Programming",
+    "courses": [
+      "CIS 112G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 246G": {
+    "text": "CIS146G: Linux I",
+    "courses": [
+      "CIS 146G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 248G": {
+    "text": "CIS148G: Introduction to Java Programming",
+    "courses": [
+      "CIS 148G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 249G": {
+    "text": "CIS113G: Database Design and Management",
+    "courses": [
+      "CIS 113G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 253G": {
+    "text": "CIS223G: Advanced SQL",
+    "courses": [
+      "CIS 223G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 258G": {
+    "text": "CIS158G: Introduction to C++",
+    "courses": [
+      "CIS 158G"
+    ],
+    "source": "gbcc"
+  },
+  "CIS 268L": {
+    "text": "CIS261L: Installing and Configuring Windows Servers",
+    "courses": [
+      "CIS 261L"
+    ],
+    "source": "lrcc"
+  },
+  "CISXR 210M": {
+    "text": "CISXR100M: Introduction to XR",
+    "courses": [
+      "CISXR 100M"
+    ],
+    "source": "mccnh"
+  },
+  "CLAW 208W": {
+    "text": "CRMJ101W: Introduction to Criminal Justice",
+    "courses": [
+      "CRMJ 101W"
+    ],
+    "source": "wmcc"
+  },
+  "COMM 201C": {
+    "text": "COMM120C: Communication",
+    "courses": [
+      "COMM 120C"
+    ],
+    "source": "nhti"
+  },
+  "COMM 202C": {
+    "text": "COMM120C: Communication",
+    "courses": [
+      "COMM 120C"
+    ],
+    "source": "nhti"
+  },
+  "COMM 203C": {
+    "text": "COMM120C: Communication",
+    "courses": [
+      "COMM 120C"
+    ],
+    "source": "nhti"
+  },
+  "COMM 220C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "COMM 294MC": {
+    "text": "ENGL101MC: English Composition: Mindful",
+    "courses": [
+      "ENGL 101MC"
+    ],
+    "source": "nhti"
+  },
+  "CPET 125C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "CPET 215C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "CPET 222C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "CPET 240C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "CPET 252C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "CPET 260C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "CPET 301C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "CPET 303C": {
+    "text": "CPET301C: Computer Project Definition",
+    "courses": [
+      "CPET 301C"
+    ],
+    "source": "nhti"
+  },
+  "CRMJ 282G": {
+    "text": "MATH145G: Quantitative Reasoning",
+    "courses": [
+      "MATH 145G"
+    ],
+    "source": "gbcc"
+  },
+  "CRMJ 283G": {
+    "text": "CRMJ282G: Criminal Justice Research Methods",
+    "courses": [
+      "CRMJ 282G"
+    ],
+    "source": "gbcc"
+  },
+  "CSAI 260M": {
+    "text": "CSAI100M: Introduction to Artificial Intelligence",
+    "courses": [
+      "CSAI 100M"
+    ],
+    "source": "mccnh"
+  },
+  "CSCI 110R": {
+    "text": "CSCI101R",
+    "courses": [
+      "CSCI 101R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 121R": {
+    "text": "CSCI110R",
+    "courses": [
+      "CSCI 110R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 125R": {
+    "text": "BCPT101R",
+    "courses": [
+      "BCPT 101R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 150R": {
+    "text": "CSCI125R",
+    "courses": [
+      "CSCI 125R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 185R": {
+    "text": "CSCI175R",
+    "courses": [
+      "CSCI 175R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 204R": {
+    "text": "CSCI110R",
+    "courses": [
+      "CSCI 110R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 212R": {
+    "text": "CSCI121R",
+    "courses": [
+      "CSCI 121R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 217R": {
+    "text": "CSCI103R CSCI175R",
+    "courses": [
+      "CSCI 103R",
+      "CSCI 175R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 220R": {
+    "text": "CSCI204R",
+    "courses": [
+      "CSCI 204R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 223R": {
+    "text": "CSCI175R",
+    "courses": [
+      "CSCI 175R"
+    ],
+    "source": "rvcc"
+  },
+  "CSCI 236R": {
+    "text": "CSCI121R",
+    "courses": [
+      "CSCI 121R"
+    ],
+    "source": "rvcc"
+  },
+  "CSXR 120M": {
+    "text": "CISXR100M: Introduction to XR",
+    "courses": [
+      "CISXR 100M"
+    ],
+    "source": "mccnh"
+  },
+  "CULA 200W": {
+    "text": "CULA115W: Food Theory and Meat Fabrication",
+    "courses": [
+      "CULA 115W"
+    ],
+    "source": "wmcc"
+  },
+  "CULA 210W": {
+    "text": "CULA121W: Baking Theory",
+    "courses": [
+      "CULA 121W"
+    ],
+    "source": "wmcc"
+  },
+  "CULA 220L": {
+    "text": "CULA148L: Cake Decorating",
+    "courses": [
+      "CULA 148L"
+    ],
+    "source": "lrcc"
+  },
+  "CULA 225L": {
+    "text": "CULA146L: Bakery Production",
+    "courses": [
+      "CULA 146L"
+    ],
+    "source": "lrcc"
+  },
+  "CULA 232L": {
+    "text": "CULA151L: Culinary Fundamentals",
+    "courses": [
+      "CULA 151L"
+    ],
+    "source": "lrcc"
+  },
+  "CVET 201C": {
+    "text": "ARET104C: Architectural Design Studio I",
+    "courses": [
+      "ARET 104C"
+    ],
+    "source": "nhti"
+  },
+  "CVET 202C": {
+    "text": "ARET150C: Statics and Strength of Materials",
+    "courses": [
+      "ARET 150C"
+    ],
+    "source": "nhti"
+  },
+  "CVET 220C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "CVET 235C": {
+    "text": "CVET240C: Timber and Steel Design",
+    "courses": [
+      "CVET 240C"
+    ],
+    "source": "nhti"
+  },
+  "CVET 240C": {
+    "text": "ARET120C: Materials and Methods of Construction",
+    "courses": [
+      "ARET 120C"
+    ],
+    "source": "nhti"
+  },
+  "CVET 245C": {
+    "text": "CVET220C: Surveying",
+    "courses": [
+      "CVET 220C"
+    ],
+    "source": "nhti"
+  },
+  "CVET 297C": {
+    "text": "CVET220C: Surveying",
+    "courses": [
+      "CVET 220C"
+    ],
+    "source": "nhti"
+  },
+  "CYBS 120R": {
+    "text": "CSCI110R",
+    "courses": [
+      "CSCI 110R"
+    ],
+    "source": "rvcc"
+  },
+  "CYBS 130R": {
+    "text": "CYBS120R",
+    "courses": [
+      "CYBS 120R"
+    ],
+    "source": "rvcc"
+  },
+  "CYBS 140R": {
+    "text": "CYBS130R",
+    "courses": [
+      "CYBS 130R"
+    ],
+    "source": "rvcc"
+  },
+  "CYBS 200R": {
+    "text": "CYBS110R",
+    "courses": [
+      "CYBS 110R"
+    ],
+    "source": "rvcc"
+  },
+  "CYBS 250R": {
+    "text": "CYBS140R",
+    "courses": [
+      "CYBS 140R"
+    ],
+    "source": "rvcc"
+  },
+  "DGMS 221C": {
+    "text": "DGMS201C: Principles of Sonography",
+    "courses": [
+      "DGMS 201C"
+    ],
+    "source": "nhti"
+  },
+  "DGMS 233C": {
+    "text": "DGMS297C: DMS Clinic III",
+    "courses": [
+      "DGMS 297C"
+    ],
+    "source": "nhti"
+  },
+  "DGMS 241C": {
+    "text": "DGMS201C: Principles of Sonography",
+    "courses": [
+      "DGMS 201C"
+    ],
+    "source": "nhti"
+  },
+  "DGMS 266C": {
+    "text": "DGMS201C: Principles of Sonography",
+    "courses": [
+      "DGMS 201C"
+    ],
+    "source": "nhti"
+  },
+  "DGMS 277C": {
+    "text": "DGMS201C: Principles of Sonography",
+    "courses": [
+      "DGMS 201C"
+    ],
+    "source": "nhti"
+  },
+  "DGMS 296C": {
+    "text": "DGMS201C: Principles of Sonography",
+    "courses": [
+      "DGMS 201C"
+    ],
+    "source": "nhti"
+  },
+  "DGMS 297C": {
+    "text": "DGMS221C: Sonographic Physics",
+    "courses": [
+      "DGMS 221C"
+    ],
+    "source": "nhti"
+  },
+  "DGMS 298C": {
+    "text": "DGMS241C: Principles of Vascular Ultrasound",
+    "courses": [
+      "DGMS 241C"
+    ],
+    "source": "nhti"
+  },
+  "DGMT 120G": {
+    "text": "DGMT115G: Introduction to Graphic Design",
+    "courses": [
+      "DGMT 115G"
+    ],
+    "source": "gbcc"
+  },
+  "DGMT 125G": {
+    "text": "DGMT115G: Introduction to Graphic Design",
+    "courses": [
+      "DGMT 115G"
+    ],
+    "source": "gbcc"
+  },
+  "DGMT 142G": {
+    "text": "DGMT115G: Introduction to Graphic Design",
+    "courses": [
+      "DGMT 115G"
+    ],
+    "source": "gbcc"
+  },
+  "DGMT 175G": {
+    "text": "DGMT115G: Introduction to Graphic Design",
+    "courses": [
+      "DGMT 115G"
+    ],
+    "source": "gbcc"
+  },
+  "DGMT 205G": {
+    "text": "DGMT135G: Introduction to Photoshop",
+    "courses": [
+      "DGMT 135G"
+    ],
+    "source": "gbcc"
+  },
+  "DGMT 264G": {
+    "text": "DGMT125G: Introduction to Animation",
+    "courses": [
+      "DGMT 125G"
+    ],
+    "source": "gbcc"
+  },
+  "DGMT 265G": {
+    "text": "DGMT125G: Introduction to Animation",
+    "courses": [
+      "DGMT 125G"
+    ],
+    "source": "gbcc"
+  },
+  "DSL 119W": {
+    "text": "DSL111W: Introduction to Diesel Heavy Equipment Technology",
+    "courses": [
+      "DSL 111W"
+    ],
+    "source": "wmcc"
+  },
+  "DSL 216W": {
+    "text": "PHYS215W: Fluid Power",
+    "courses": [
+      "PHYS 215W"
+    ],
+    "source": "wmcc"
+  },
+  "DSL 222W": {
+    "text": "DSL216W: Mobile Hydraulics I",
+    "courses": [
+      "DSL 216W"
+    ],
+    "source": "wmcc"
+  },
+  "ECE 104R": {
+    "text": "ECE101R ECE102R",
+    "courses": [
+      "ECE 101R",
+      "ECE 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ECE 105R": {
+    "text": "ECE102R",
+    "courses": [
+      "ECE 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ECE 106M": {
+    "text": "ECE100M: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 119W": {
+    "text": "ECE118W: Infant, Toddler, and Preschool Curriculum",
+    "courses": [
+      "ECE 118W"
+    ],
+    "source": "wmcc"
+  },
+  "ECE 167C": {
+    "text": "ECE101C: Growth and Development of the Young Child",
+    "courses": [
+      "ECE 101C"
+    ],
+    "source": "nhti"
+  },
+  "ECE 195C": {
+    "text": "HSV111C: Introduction to Human Service",
+    "courses": [
+      "HSV 111C"
+    ],
+    "source": "nhti"
+  },
+  "ECE 200R": {
+    "text": "ECE102R",
+    "courses": [
+      "ECE 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ECE 201M": {
+    "text": "ECE100M: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 202M": {
+    "text": "ECE111M: Infant/Toddler Practicum: Nurturing Environments",
+    "courses": [
+      "ECE 111M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 204M": {
+    "text": "ECE100M: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 204R": {
+    "text": "ECE101R ECE102R",
+    "courses": [
+      "ECE 101R",
+      "ECE 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ECE 206G": {
+    "text": "ECE100G: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100G"
+    ],
+    "source": "gbcc"
+  },
+  "ECE 209R": {
+    "text": "ECE102R PSYC114R",
+    "courses": [
+      "ECE 102R",
+      "PSYC 114R"
+    ],
+    "source": "rvcc"
+  },
+  "ECE 210L": {
+    "text": "ECE121L: Growth and Development of the Young Child",
+    "courses": [
+      "ECE 121L"
+    ],
+    "source": "lrcc"
+  },
+  "ECE 210M": {
+    "text": "ECE100M: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 212G": {
+    "text": "ECE100G: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100G"
+    ],
+    "source": "gbcc"
+  },
+  "ECE 212M": {
+    "text": "ECE202M: Student Teaching Practicum",
+    "courses": [
+      "ECE 202M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 214M": {
+    "text": "ECE100M: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 215C": {
+    "text": "ECE101C: Growth and Development of the Young Child",
+    "courses": [
+      "ECE 101C"
+    ],
+    "source": "nhti"
+  },
+  "ECE 218W": {
+    "text": "ECE118W: Infant, Toddler, and Preschool Curriculum",
+    "courses": [
+      "ECE 118W"
+    ],
+    "source": "wmcc"
+  },
+  "ECE 225C": {
+    "text": "ECE101C: Growth and Development of the Young Child",
+    "courses": [
+      "ECE 101C"
+    ],
+    "source": "nhti"
+  },
+  "ECE 242C": {
+    "text": "ECE101C: Growth and Development of the Young Child",
+    "courses": [
+      "ECE 101C"
+    ],
+    "source": "nhti"
+  },
+  "ECE 250M": {
+    "text": "ECE100M: Early Childhood Growth and Development",
+    "courses": [
+      "ECE 100M"
+    ],
+    "source": "mccnh"
+  },
+  "ECE 270C": {
+    "text": "ECE101C: Growth and Development of the Young Child",
+    "courses": [
+      "ECE 101C"
+    ],
+    "source": "nhti"
+  },
+  "ECE 290C": {
+    "text": "ECE275C: Practicum 1 - Observation, Interpretation, Assessment, and Portfolio Documentation",
+    "courses": [
+      "ECE 275C"
+    ],
+    "source": "nhti"
+  },
+  "ECE 298C": {
+    "text": "HSV111C: Introduction to Human Service",
+    "courses": [
+      "HSV 111C"
+    ],
+    "source": "nhti"
+  },
+  "ECON 235G": {
+    "text": "ECON234G: Macroeconomics",
+    "courses": [
+      "ECON 234G"
+    ],
+    "source": "gbcc"
+  },
+  "EDU 201C": {
+    "text": "EDU104C: Foundations of Education",
+    "courses": [
+      "EDU 104C"
+    ],
+    "source": "nhti"
+  },
+  "EDU 201W": {
+    "text": "EDU101W: Introduction to Exceptionalities",
+    "courses": [
+      "EDU 101W"
+    ],
+    "source": "wmcc"
+  },
+  "EDU 204C": {
+    "text": "EDU104C: Foundations of Education",
+    "courses": [
+      "EDU 104C"
+    ],
+    "source": "nhti"
+  },
+  "EDU 207W": {
+    "text": "EDU101W: Introduction to Exceptionalities",
+    "courses": [
+      "EDU 101W"
+    ],
+    "source": "wmcc"
+  },
+  "EDU 208C": {
+    "text": "EDU104C: Foundations of Education",
+    "courses": [
+      "EDU 104C"
+    ],
+    "source": "nhti"
+  },
+  "EDU 209C": {
+    "text": "EDU101C: Introduction to Exceptionalities",
+    "courses": [
+      "EDU 101C"
+    ],
+    "source": "nhti"
+  },
+  "EDU 211C": {
+    "text": "EDU104C: Foundations of Education",
+    "courses": [
+      "EDU 104C"
+    ],
+    "source": "nhti"
+  },
+  "EDU 214W": {
+    "text": "EDU101W: Introduction to Exceptionalities",
+    "courses": [
+      "EDU 101W"
+    ],
+    "source": "wmcc"
+  },
+  "EDUP 201G": {
+    "text": "EDUP104G: Foundations of Education",
+    "courses": [
+      "EDUP 104G"
+    ],
+    "source": "gbcc"
+  },
+  "ELET 101C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 102C": {
+    "text": "ELET101C: Circuit Analysis I",
+    "courses": [
+      "ELET 101C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 110C": {
+    "text": "ELET101C: Circuit Analysis I",
+    "courses": [
+      "ELET 101C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 115C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 144C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 210C": {
+    "text": "ELET110C: Electronics I",
+    "courses": [
+      "ELET 110C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 215C": {
+    "text": "CPET107C: Introduction to Programming with C++",
+    "courses": [
+      "CPET 107C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 251C": {
+    "text": "ELET115C: Digital Fundamentals",
+    "courses": [
+      "ELET 115C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 305C": {
+    "text": "ELET102C: Circuit Analysis II",
+    "courses": [
+      "ELET 102C"
+    ],
+    "source": "nhti"
+  },
+  "ELET 306C": {
+    "text": "ELET144C: Embedded Microsystems",
+    "courses": [
+      "ELET 144C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 113R": {
+    "text": "ENGL102R",
+    "courses": [
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ENGL 201C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 201R": {
+    "text": "ENGL102R",
+    "courses": [
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ENGL 211W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "ENGL 214W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "ENGL 220M": {
+    "text": "ENGL101M: College Composition",
+    "courses": [
+      "ENGL 101M"
+    ],
+    "source": "mccnh"
+  },
+  "ENGL 221AC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221BC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221CC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221DC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221EC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221FC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221GC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221HC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 221IC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 235W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "ENGL 240C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 243R": {
+    "text": "ENGL102R",
+    "courses": [
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ENGL 248": {
+    "text": "ENGL102R",
+    "courses": [
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ENGL 248C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 248M": {
+    "text": "ENGL101M: College Composition",
+    "courses": [
+      "ENGL 101M"
+    ],
+    "source": "mccnh"
+  },
+  "ENGL 249C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 251C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 258C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 259C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 272C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 285C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 286C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 287C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 288C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 288R": {
+    "text": "ENGL102R",
+    "courses": [
+      "ENGL 102R"
+    ],
+    "source": "rvcc"
+  },
+  "ENGL 295AC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 295BC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 295CC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGL 295DC": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ENGR 202G": {
+    "text": "ENGR201G: Introduction to Chemical Engineering I",
+    "courses": [
+      "ENGR 201G"
+    ],
+    "source": "gbcc"
+  },
+  "ENVS 202W": {
+    "text": "BIOL111W: Biology",
+    "courses": [
+      "BIOL 111W"
+    ],
+    "source": "wmcc"
+  },
+  "ENVS 204W": {
+    "text": "BIOL111W: Biology",
+    "courses": [
+      "BIOL 111W"
+    ],
+    "source": "wmcc"
+  },
+  "ENVS 205W": {
+    "text": "BIOL111W: Biology",
+    "courses": [
+      "BIOL 111W"
+    ],
+    "source": "wmcc"
+  },
+  "ENVS 210W": {
+    "text": "CHEM113W: Environmental Sampling and Analysis",
+    "courses": [
+      "CHEM 113W"
+    ],
+    "source": "wmcc"
+  },
+  "ENVS 250C": {
+    "text": "BIOL111C: General Biology I",
+    "courses": [
+      "BIOL 111C"
+    ],
+    "source": "nhti"
+  },
+  "ESOL 201C": {
+    "text": "ESOL101C: Basic Writing",
+    "courses": [
+      "ESOL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ESOL 205C": {
+    "text": "ESOL101C: Basic Writing",
+    "courses": [
+      "ESOL 101C"
+    ],
+    "source": "nhti"
+  },
+  "ETEC 121M": {
+    "text": "ETEC111M: Electrical Fundamentals I - Line Worker",
+    "courses": [
+      "ETEC 111M"
+    ],
+    "source": "mccnh"
+  },
+  "ETEC 130L": {
+    "text": "ETEC124L: AC/DC Theory",
+    "courses": [
+      "ETEC 124L"
+    ],
+    "source": "lrcc"
+  },
+  "ETEC 135M": {
+    "text": "ETEC110M: Electrical Fundamentals I",
+    "courses": [
+      "ETEC 110M"
+    ],
+    "source": "mccnh"
+  },
+  "ETEC 146M": {
+    "text": "ETEC145M: Commercial Driver Training Theory",
+    "courses": [
+      "ETEC 145M"
+    ],
+    "source": "mccnh"
+  },
+  "ETEC 147M": {
+    "text": "ETEC145M: Commercial Driver Training Theory",
+    "courses": [
+      "ETEC 145M"
+    ],
+    "source": "mccnh"
+  },
+  "ETEC 215L": {
+    "text": "ETEC124L: AC/DC Theory",
+    "courses": [
+      "ETEC 124L"
+    ],
+    "source": "lrcc"
+  },
+  "ETEC 224L": {
+    "text": "ETEC123L: Wiring Theory and Techniques (Commercial)",
+    "courses": [
+      "ETEC 123L"
+    ],
+    "source": "lrcc"
+  },
+  "ETEC 225M": {
+    "text": "ETEC150M: Power, Transformers and Rotating Machinery",
+    "courses": [
+      "ETEC 150M"
+    ],
+    "source": "mccnh"
+  },
+  "ETEC 230M": {
+    "text": "ETEC110M: Electrical Fundamentals I",
+    "courses": [
+      "ETEC 110M"
+    ],
+    "source": "mccnh"
+  },
+  "ETEC 240L": {
+    "text": "ETEC124L: AC/DC Theory",
+    "courses": [
+      "ETEC 124L"
+    ],
+    "source": "lrcc"
+  },
+  "ETEC 270M": {
+    "text": "ETEC210M: Electrical and Electronic Motor Controls",
+    "courses": [
+      "ETEC 210M"
+    ],
+    "source": "mccnh"
+  },
+  "FIRE 200L": {
+    "text": "FIRE136L: Fire-ground Procedures",
+    "courses": [
+      "FIRE 136L"
+    ],
+    "source": "lrcc"
+  },
+  "FIRE 210L": {
+    "text": "FIRE131L: Fire Protection Systems",
+    "courses": [
+      "FIRE 131L"
+    ],
+    "source": "lrcc"
+  },
+  "FIRE 224L": {
+    "text": "FIRE127L: Fire Behavior and Combustion",
+    "courses": [
+      "FIRE 127L"
+    ],
+    "source": "lrcc"
+  },
+  "FIRE 230L": {
+    "text": "FIRE160L: Fire Prevention",
+    "courses": [
+      "FIRE 160L"
+    ],
+    "source": "lrcc"
+  },
+  "FIRE 234L": {
+    "text": "FIRE224L: Strategy and Tactics",
+    "courses": [
+      "FIRE 224L"
+    ],
+    "source": "lrcc"
+  },
+  "FIRE 236L": {
+    "text": "FIRE127L: Fire Behavior and Combustion",
+    "courses": [
+      "FIRE 127L"
+    ],
+    "source": "lrcc"
+  },
+  "FIRE 237L": {
+    "text": "FIRE236L: Fire Investigation I",
+    "courses": [
+      "FIRE 236L"
+    ],
+    "source": "lrcc"
+  },
+  "FIRE 281L": {
+    "text": "FIRE124L: Principles of Emergency Services",
+    "courses": [
+      "FIRE 124L"
+    ],
+    "source": "lrcc"
+  },
+  "FREN 121L": {
+    "text": "FREN120L: Elementary French I",
+    "courses": [
+      "FREN 120L"
+    ],
+    "source": "lrcc"
+  },
+  "FREN 122C": {
+    "text": "FREN121C: French I",
+    "courses": [
+      "FREN 121C"
+    ],
+    "source": "nhti"
+  },
+  "GDES 204M": {
+    "text": "GDES110M: Page Layout and Design",
+    "courses": [
+      "GDES 110M"
+    ],
+    "source": "mccnh"
+  },
+  "GERN 195C": {
+    "text": "HSV111C: Introduction to Human Service",
+    "courses": [
+      "HSV 111C"
+    ],
+    "source": "nhti"
+  },
+  "GERN 298C": {
+    "text": "GERN195C: Gerontology Practicum I",
+    "courses": [
+      "GERN 195C"
+    ],
+    "source": "nhti"
+  },
+  "GIS 211W": {
+    "text": "GIS110W: Introduction to Geographic Information Systems",
+    "courses": [
+      "GIS 110W"
+    ],
+    "source": "wmcc"
+  },
+  "GRA 228L": {
+    "text": "GRA120L: Design Software Essentials",
+    "courses": [
+      "GRA 120L"
+    ],
+    "source": "lrcc"
+  },
+  "HSV 125R": {
+    "text": "HSV110R",
+    "courses": [
+      "HSV 110R"
+    ],
+    "source": "rvcc"
+  },
+  "HSV 126R": {
+    "text": "HSV110R",
+    "courses": [
+      "HSV 110R"
+    ],
+    "source": "rvcc"
+  },
+  "HSV 195C": {
+    "text": "HSV111C: Introduction to Human Service",
+    "courses": [
+      "HSV 111C"
+    ],
+    "source": "nhti"
+  },
+  "HSV 214L": {
+    "text": "HSV112L: Overview of Developmental Disabilities",
+    "courses": [
+      "HSV 112L"
+    ],
+    "source": "lrcc"
+  },
+  "HSV 215L": {
+    "text": "HSV112L: Overview of Developmental Disabilities",
+    "courses": [
+      "HSV 112L"
+    ],
+    "source": "lrcc"
+  },
+  "HSV 216W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "HSV 221W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "HSV 223W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "HSV 242C": {
+    "text": "HSV111C: Introduction to Human Service",
+    "courses": [
+      "HSV 111C"
+    ],
+    "source": "nhti"
+  },
+  "HSV 271R": {
+    "text": "HSV110R HSV123R HSV125R HSV126R HSV270R",
+    "courses": [
+      "HSV 110R",
+      "HSV 123R",
+      "HSV 125R",
+      "HSV 126R",
+      "HSV 270R"
+    ],
+    "source": "rvcc"
+  },
+  "HSV 298C": {
+    "text": "HSV195C: Human Service Practicum I",
+    "courses": [
+      "HSV 195C"
+    ],
+    "source": "nhti"
+  },
+  "HUMA 211M": {
+    "text": "ENGL101M: College Composition",
+    "courses": [
+      "ENGL 101M"
+    ],
+    "source": "mccnh"
+  },
+  "HUMA 215M": {
+    "text": "ENGL101M: College Composition",
+    "courses": [
+      "ENGL 101M"
+    ],
+    "source": "mccnh"
+  },
+  "HUMA 240W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "HVAC 230M": {
+    "text": "HVAC134M: Fundamentals of Gas Heating and Piping Installation Theory",
+    "courses": [
+      "HVAC 134M"
+    ],
+    "source": "mccnh"
+  },
+  "HVAC 259M": {
+    "text": "HVAC256M: HVAC Equipment- Operation, Maintenance, & Optimization",
+    "courses": [
+      "HVAC 256M"
+    ],
+    "source": "mccnh"
+  },
+  "IARB 236L": {
+    "text": "CIS140L: Introduction to Programming",
+    "courses": [
+      "CIS 140L"
+    ],
+    "source": "lrcc"
+  },
+  "IARB 276L": {
+    "text": "CIS215L: Intermediate Programming",
+    "courses": [
+      "CIS 215L"
+    ],
+    "source": "lrcc"
+  },
+  "INDS 250C": {
+    "text": "INDS150C: Industrial Design Studio 1",
+    "courses": [
+      "INDS 150C"
+    ],
+    "source": "nhti"
+  },
+  "IST 170C": {
+    "text": "IST103C: Programming with Raspberry Pi",
+    "courses": [
+      "IST 103C"
+    ],
+    "source": "nhti"
+  },
+  "IST 212G": {
+    "text": "IST112G: Applied Logic",
+    "courses": [
+      "IST 112G"
+    ],
+    "source": "gbcc"
+  },
+  "IST 215C": {
+    "text": "IST140C: Database Design and Management",
+    "courses": [
+      "IST 140C"
+    ],
+    "source": "nhti"
+  },
+  "IST 216C": {
+    "text": "IST140C: Database Design and Management",
+    "courses": [
+      "IST 140C"
+    ],
+    "source": "nhti"
+  },
+  "IST 226W": {
+    "text": "IST113W: IT Essentials",
+    "courses": [
+      "IST 113W"
+    ],
+    "source": "wmcc"
+  },
+  "IST 235W": {
+    "text": "IST125W: Introduction to Programming",
+    "courses": [
+      "IST 125W"
+    ],
+    "source": "wmcc"
+  },
+  "IST 240C": {
+    "text": "IST140C: Database Design and Management",
+    "courses": [
+      "IST 140C"
+    ],
+    "source": "nhti"
+  },
+  "IST 260C": {
+    "text": "IST154C: Introduction to Networks",
+    "courses": [
+      "IST 154C"
+    ],
+    "source": "nhti"
+  },
+  "IST 265G": {
+    "text": "IST122G: Introduction to Networks",
+    "courses": [
+      "IST 122G"
+    ],
+    "source": "gbcc"
+  },
+  "IST 270C": {
+    "text": "IST170C: Introduction to Linux",
+    "courses": [
+      "IST 170C"
+    ],
+    "source": "nhti"
+  },
+  "LAND 218C": {
+    "text": "LAND101C: Identification and Uses of Trees",
+    "courses": [
+      "LAND 101C"
+    ],
+    "source": "nhti"
+  },
+  "LAND 220C": {
+    "text": "LAND112C: Landscape Drawing and Presentation Techniques",
+    "courses": [
+      "LAND 112C"
+    ],
+    "source": "nhti"
+  },
+  "LAND 225C": {
+    "text": "LAND112C: Landscape Drawing and Presentation Techniques",
+    "courses": [
+      "LAND 112C"
+    ],
+    "source": "nhti"
+  },
+  "LAND 290C": {
+    "text": "LAND220C: Planting Design",
+    "courses": [
+      "LAND 220C"
+    ],
+    "source": "nhti"
+  },
+  "LANG 106R": {
+    "text": "LANG105R",
+    "courses": [
+      "LANG 105R"
+    ],
+    "source": "rvcc"
+  },
+  "LANG 121R": {
+    "text": "LANG120R",
+    "courses": [
+      "LANG 120R"
+    ],
+    "source": "rvcc"
+  },
+  "LBSC 299M": {
+    "text": "ENGL101M: College Composition",
+    "courses": [
+      "ENGL 101M"
+    ],
+    "source": "mccnh"
+  },
+  "LXMO 159C": {
+    "text": "LXMO103C: Radiographic Positioning I",
+    "courses": [
+      "LXMO 103C"
+    ],
+    "source": "nhti"
+  },
+  "LXMO 201C": {
+    "text": "LXMO103C: Radiographic Positioning I",
+    "courses": [
+      "LXMO 103C"
+    ],
+    "source": "nhti"
+  },
+  "LXMO 220C": {
+    "text": "LXMO103C: Radiographic Positioning I",
+    "courses": [
+      "LXMO 103C"
+    ],
+    "source": "nhti"
+  },
+  "MANF 132L": {
+    "text": "MANF131L: Blueprint Reading",
+    "courses": [
+      "MANF 131L"
+    ],
+    "source": "lrcc"
+  },
+  "MANF 211L": {
+    "text": "MANF151L: CNC Machines I",
+    "courses": [
+      "MANF 151L"
+    ],
+    "source": "lrcc"
+  },
+  "MANF 212L": {
+    "text": "MANF142L: Machine Processes",
+    "courses": [
+      "MANF 142L"
+    ],
+    "source": "lrcc"
+  },
+  "MAR 272L": {
+    "text": "MAR270L: Advanced Marine Systems I",
+    "courses": [
+      "MAR 270L"
+    ],
+    "source": "lrcc"
+  },
+  "MASS 103R": {
+    "text": "MASS102R",
+    "courses": [
+      "MASS 102R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 104R": {
+    "text": "MASS103R",
+    "courses": [
+      "MASS 103R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 111R": {
+    "text": "MASS101R",
+    "courses": [
+      "MASS 101R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 112R": {
+    "text": "MASS101R",
+    "courses": [
+      "MASS 101R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 117R": {
+    "text": "MASS101R",
+    "courses": [
+      "MASS 101R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 118R": {
+    "text": "MASS117R",
+    "courses": [
+      "MASS 117R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 121R": {
+    "text": "MASS101R MASS102R",
+    "courses": [
+      "MASS 101R",
+      "MASS 102R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 126R": {
+    "text": "MASS105R",
+    "courses": [
+      "MASS 105R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 130R": {
+    "text": "MASS103R MASS121R",
+    "courses": [
+      "MASS 103R",
+      "MASS 121R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 192R": {
+    "text": "MASS121R",
+    "courses": [
+      "MASS 121R"
+    ],
+    "source": "rvcc"
+  },
+  "MASS 195R": {
+    "text": "MASS192R",
+    "courses": [
+      "MASS 192R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 106C": {
+    "text": "MATH092C: Introduction to Algebra",
+    "courses": [
+      "MATH 092C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 107R": {
+    "text": "MATH106R",
+    "courses": [
+      "MATH 106R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 120C": {
+    "text": "MATH092C: Introduction to Algebra",
+    "courses": [
+      "MATH 092C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 120XC": {
+    "text": "MATH092C: Introduction to Algebra",
+    "courses": [
+      "MATH 092C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 122C": {
+    "text": "MATH092C: Introduction to Algebra",
+    "courses": [
+      "MATH 092C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 124C": {
+    "text": "MATH122C: Intermediate Algebra",
+    "courses": [
+      "MATH 122C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 124XC": {
+    "text": "MATH122C: Intermediate Algebra",
+    "courses": [
+      "MATH 122C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 125C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 130C": {
+    "text": "MATH120C: Quantitative Reasoning",
+    "courses": [
+      "MATH 120C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 140C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 205C": {
+    "text": "MATH140C: Precalculus",
+    "courses": [
+      "MATH 140C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 206C": {
+    "text": "MATH205C: Calculus I",
+    "courses": [
+      "MATH 205C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 208C": {
+    "text": "MATH206C: Calculus II",
+    "courses": [
+      "MATH 206C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 210C": {
+    "text": "MATH206C: Calculus II",
+    "courses": [
+      "MATH 206C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 211R": {
+    "text": "MATH210R",
+    "courses": [
+      "MATH 210R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 212R": {
+    "text": "MATH211R",
+    "courses": [
+      "MATH 211R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 215C": {
+    "text": "MATH205C: Calculus I",
+    "courses": [
+      "MATH 205C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 215R": {
+    "text": "MATH211R",
+    "courses": [
+      "MATH 211R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 215W": {
+    "text": "MATH180W: Pre-Calculus",
+    "courses": [
+      "MATH 180W"
+    ],
+    "source": "wmcc"
+  },
+  "MATH 216R": {
+    "text": "MATH210R",
+    "courses": [
+      "MATH 210R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 217R": {
+    "text": "MATH210R MATH211R",
+    "courses": [
+      "MATH 210R",
+      "MATH 211R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 220C": {
+    "text": "MATH205C: Calculus I",
+    "courses": [
+      "MATH 205C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 221R": {
+    "text": "MATH211R",
+    "courses": [
+      "MATH 211R"
+    ],
+    "source": "rvcc"
+  },
+  "MATH 222W": {
+    "text": "MATH220W: Math in Our World I",
+    "courses": [
+      "MATH 220W"
+    ],
+    "source": "wmcc"
+  },
+  "MATH 271C": {
+    "text": "MATH205C: Calculus I",
+    "courses": [
+      "MATH 205C"
+    ],
+    "source": "nhti"
+  },
+  "MATH 290C": {
+    "text": "MATH205C: Calculus I",
+    "courses": [
+      "MATH 205C"
+    ],
+    "source": "nhti"
+  },
+  "MCET 106C": {
+    "text": "MCET105C: Engineering Design",
+    "courses": [
+      "MCET 105C"
+    ],
+    "source": "nhti"
+  },
+  "MCET 110C": {
+    "text": "MCET105C: Engineering Design",
+    "courses": [
+      "MCET 105C"
+    ],
+    "source": "nhti"
+  },
+  "MCET 150C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "MCET 205C": {
+    "text": "CHEM105C: Chemistry",
+    "courses": [
+      "CHEM 105C"
+    ],
+    "source": "nhti"
+  },
+  "MCET 229C": {
+    "text": "MATH205C: Calculus I",
+    "courses": [
+      "MATH 205C"
+    ],
+    "source": "nhti"
+  },
+  "MCET 250C": {
+    "text": "ENGL120C: Communication",
+    "courses": [
+      "ENGL 120C"
+    ],
+    "source": "nhti"
+  },
+  "MCET 260C": {
+    "text": "MATH205C: Calculus I",
+    "courses": [
+      "MATH 205C"
+    ],
+    "source": "nhti"
+  },
+  "MCOD 118C": {
+    "text": "HLTH101C: Medical Terminology",
+    "courses": [
+      "HLTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "MCOD 119C": {
+    "text": "MCOD118C: Introduction to Hospital Diagnosis Coding",
+    "courses": [
+      "MCOD 118C"
+    ],
+    "source": "nhti"
+  },
+  "MCOD 218C": {
+    "text": "MCOD119C: Introduction to Hospital Procedure Coding",
+    "courses": [
+      "MCOD 119C"
+    ],
+    "source": "nhti"
+  },
+  "MCOD 219C": {
+    "text": "MCOD218C: Advanced Hospital Coding",
+    "courses": [
+      "MCOD 218C"
+    ],
+    "source": "nhti"
+  },
+  "MFET 202C": {
+    "text": "PHYS135C: Physics II (Algebra-based)",
+    "courses": [
+      "PHYS 135C"
+    ],
+    "source": "nhti"
+  },
+  "MFET 220C": {
+    "text": "MFET111C: Manufacturing and Materials Processing",
+    "courses": [
+      "MFET 111C"
+    ],
+    "source": "nhti"
+  },
+  "MFET 231C": {
+    "text": "MFET111C: Manufacturing and Materials Processing",
+    "courses": [
+      "MFET 111C"
+    ],
+    "source": "nhti"
+  },
+  "MFET 241C": {
+    "text": "MFET220C: Manufacturing Processes and Machine Tools",
+    "courses": [
+      "MFET 220C"
+    ],
+    "source": "nhti"
+  },
+  "MFET 252C": {
+    "text": "MATH106C: Statistics I: An Introduction to Statistical Reasoning",
+    "courses": [
+      "MATH 106C"
+    ],
+    "source": "nhti"
+  },
+  "MHTH 195C": {
+    "text": "HSV111C: Introduction to Human Service",
+    "courses": [
+      "HSV 111C"
+    ],
+    "source": "nhti"
+  },
+  "MHTH 298C": {
+    "text": "MHTH195C: Mental Health Practicum I",
+    "courses": [
+      "MHTH 195C"
+    ],
+    "source": "nhti"
+  },
+  "MKTG 224G": {
+    "text": "MKTG101G: Principles of Marketing",
+    "courses": [
+      "MKTG 101G"
+    ],
+    "source": "gbcc"
+  },
+  "MLTC 111R": {
+    "text": "MLTC126R",
+    "courses": [
+      "MLTC 126R"
+    ],
+    "source": "rvcc"
+  },
+  "MLTC 112R": {
+    "text": "MLTC126R",
+    "courses": [
+      "MLTC 126R"
+    ],
+    "source": "rvcc"
+  },
+  "MLTC 113R": {
+    "text": "MLTC126R CHEM140R",
+    "courses": [
+      "CHEM 140R",
+      "MLTC 126R"
+    ],
+    "source": "rvcc"
+  },
+  "MLTC 201R": {
+    "text": "MLTC126R MLTC112R",
+    "courses": [
+      "MLTC 112R",
+      "MLTC 126R"
+    ],
+    "source": "rvcc"
+  },
+  "MLTC 202R": {
+    "text": "MLTC126R MLTC112R",
+    "courses": [
+      "MLTC 112R",
+      "MLTC 126R"
+    ],
+    "source": "rvcc"
+  },
+  "MLTC 204R": {
+    "text": "MLTC126R BIOL205R",
+    "courses": [
+      "BIOL 205R",
+      "MLTC 126R"
+    ],
+    "source": "rvcc"
+  },
+  "MTTN 201R": {
+    "text": "MTTN101R",
+    "courses": [
+      "MTTN 101R"
+    ],
+    "source": "rvcc"
+  },
+  "MTTN 204R": {
+    "text": "MTTN106R",
+    "courses": [
+      "MTTN 106R"
+    ],
+    "source": "rvcc"
+  },
+  "NURS 112W": {
+    "text": "BIOL114W: Human Anatomy and Physiology I",
+    "courses": [
+      "BIOL 114W"
+    ],
+    "source": "wmcc"
+  },
+  "NURS 116C": {
+    "text": "NURS115C: Nursing I",
+    "courses": [
+      "NURS 115C"
+    ],
+    "source": "nhti"
+  },
+  "NURS 117C": {
+    "text": "NURS115C: Nursing I",
+    "courses": [
+      "NURS 115C"
+    ],
+    "source": "nhti"
+  },
+  "NURS 120R": {
+    "text": "NURS110R",
+    "courses": [
+      "NURS 110R"
+    ],
+    "source": "rvcc"
+  },
+  "NURS 175C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "NURS 178C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "NURS 210W": {
+    "text": "NURS112W: Nursing II",
+    "courses": [
+      "NURS 112W"
+    ],
+    "source": "wmcc"
+  },
+  "NURS 214W": {
+    "text": "NURS210W: Nursing III",
+    "courses": [
+      "NURS 210W"
+    ],
+    "source": "wmcc"
+  },
+  "NURS 215C": {
+    "text": "NURS116C: Nursing IIA",
+    "courses": [
+      "NURS 116C"
+    ],
+    "source": "nhti"
+  },
+  "NURS 230R": {
+    "text": "NURS120R",
+    "courses": [
+      "NURS 120R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 110R": {
+    "text": "AHLT104R",
+    "courses": [
+      "AHLT 104R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 120R": {
+    "text": "OCTA110R",
+    "courses": [
+      "OCTA 110R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 192R": {
+    "text": "OCTA190R",
+    "courses": [
+      "OCTA 190R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 212R": {
+    "text": "PSYC114R OCTA190R",
+    "courses": [
+      "OCTA 190R",
+      "PSYC 114R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 213R": {
+    "text": "OCTA110R PSYC101R",
+    "courses": [
+      "OCTA 110R",
+      "PSYC 101R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 214R": {
+    "text": "OCTA110R AHLT135R BIOL201R",
+    "courses": [
+      "AHLT 135R",
+      "BIOL 201R",
+      "OCTA 110R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 215R": {
+    "text": "OCTA190R OCTA214R",
+    "courses": [
+      "OCTA 190R",
+      "OCTA 214R"
+    ],
+    "source": "rvcc"
+  },
+  "OCTA 221R": {
+    "text": "OCTA190R",
+    "courses": [
+      "OCTA 190R"
+    ],
+    "source": "rvcc"
+  },
+  "ORTH 102C": {
+    "text": "ORTH101C: Orthopaedic Anatomy and Physiology I",
+    "courses": [
+      "ORTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "ORTH 104C": {
+    "text": "ORTH101C: Orthopaedic Anatomy and Physiology I",
+    "courses": [
+      "ORTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "ORTH 113C": {
+    "text": "ORTH101C: Orthopaedic Anatomy and Physiology I",
+    "courses": [
+      "ORTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "ORTH 150C": {
+    "text": "ORTH101C: Orthopaedic Anatomy and Physiology I",
+    "courses": [
+      "ORTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "ORTH 208C": {
+    "text": "ORTH113C: Orthopaedic Patient Care",
+    "courses": [
+      "ORTH 113C"
+    ],
+    "source": "nhti"
+  },
+  "ORTH 219C": {
+    "text": "ORTH104C: Physical Assessment of the Orthopaedic Patient",
+    "courses": [
+      "ORTH 104C"
+    ],
+    "source": "nhti"
+  },
+  "OTM 228W": {
+    "text": "BIOL120W: Human Biology",
+    "courses": [
+      "BIOL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "PEM 290C": {
+    "text": "PEM194C: Hospital Clinical",
+    "courses": [
+      "PEM 194C"
+    ],
+    "source": "nhti"
+  },
+  "PEM 296C": {
+    "text": "PEM194C: Hospital Clinical",
+    "courses": [
+      "PEM 194C"
+    ],
+    "source": "nhti"
+  },
+  "PEM 297C": {
+    "text": "PEM296C: Field Clinical I",
+    "courses": [
+      "PEM 296C"
+    ],
+    "source": "nhti"
+  },
+  "PEM 298C": {
+    "text": "PEM297C: Field Clinical II",
+    "courses": [
+      "PEM 297C"
+    ],
+    "source": "nhti"
+  },
+  "PHBC 190R": {
+    "text": "PHBC110R",
+    "courses": [
+      "PHBC 110R"
+    ],
+    "source": "rvcc"
+  },
+  "PHYS 130R": {
+    "text": "MATH110R",
+    "courses": [
+      "MATH 110R"
+    ],
+    "source": "rvcc"
+  },
+  "PHYS 131R": {
+    "text": "PHYS130R",
+    "courses": [
+      "PHYS 130R"
+    ],
+    "source": "rvcc"
+  },
+  "PHYS 135C": {
+    "text": "PHYS133C: Physics I (Algebra-based)",
+    "courses": [
+      "PHYS 133C"
+    ],
+    "source": "nhti"
+  },
+  "PHYS 232C": {
+    "text": "PHYS231C: Physics I (Calculus-Based)",
+    "courses": [
+      "PHYS 231C"
+    ],
+    "source": "nhti"
+  },
+  "PHYS 233C": {
+    "text": "PHYS232C: Physics II (Calculus-Based)",
+    "courses": [
+      "PHYS 232C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 103C": {
+    "text": "PLGL101C: Foundations of Paralegal Studies",
+    "courses": [
+      "PLGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 104C": {
+    "text": "PLGL101C: Foundations of Paralegal Studies",
+    "courses": [
+      "PLGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 107C": {
+    "text": "PLGL106C: Introduction to Legal Studies",
+    "courses": [
+      "PLGL 106C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 110C": {
+    "text": "PLGL107C: Contracts and Torts",
+    "courses": [
+      "PLGL 107C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 221C": {
+    "text": "PLGL107C: Contracts and Torts",
+    "courses": [
+      "PLGL 107C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 225C": {
+    "text": "PLGL110C: Litigation and Trial Preparation",
+    "courses": [
+      "PLGL 110C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 231C": {
+    "text": "PLGL107C: Contracts and Torts",
+    "courses": [
+      "PLGL 107C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 242C": {
+    "text": "PLGL107C: Contracts and Torts",
+    "courses": [
+      "PLGL 107C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 251C": {
+    "text": "PLGL103C: Causes of Action in Contract and Tort",
+    "courses": [
+      "PLGL 103C"
+    ],
+    "source": "nhti"
+  },
+  "PLGL 262C": {
+    "text": "PLGL110C: Litigation and Trial Preparation",
+    "courses": [
+      "PLGL 110C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 200L": {
+    "text": "PSYC125L: Introduction to Psychology",
+    "courses": [
+      "PSYC 125L"
+    ],
+    "source": "lrcc"
+  },
+  "PSYC 200R": {
+    "text": "PSYC101R",
+    "courses": [
+      "PSYC 101R"
+    ],
+    "source": "rvcc"
+  },
+  "PSYC 205C": {
+    "text": "PSYC105C: Introduction to Psychology",
+    "courses": [
+      "PSYC 105C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 205G": {
+    "text": "PSYC110G: Introduction to Psychology",
+    "courses": [
+      "PSYC 110G"
+    ],
+    "source": "gbcc"
+  },
+  "PSYC 205W": {
+    "text": "ENGL120W: College Composition",
+    "courses": [
+      "ENGL 120W"
+    ],
+    "source": "wmcc"
+  },
+  "PSYC 210C": {
+    "text": "PSYC105C: Introduction to Psychology",
+    "courses": [
+      "PSYC 105C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 210G": {
+    "text": "PSYC110G: Introduction to Psychology",
+    "courses": [
+      "PSYC 110G"
+    ],
+    "source": "gbcc"
+  },
+  "PSYC 210R": {
+    "text": "PSYC101R",
+    "courses": [
+      "PSYC 101R"
+    ],
+    "source": "rvcc"
+  },
+  "PSYC 211R": {
+    "text": "PSYC101R",
+    "courses": [
+      "PSYC 101R"
+    ],
+    "source": "rvcc"
+  },
+  "PSYC 214R": {
+    "text": "PSYC101R",
+    "courses": [
+      "PSYC 101R"
+    ],
+    "source": "rvcc"
+  },
+  "PSYC 215G": {
+    "text": "PSYC110G: Introduction to Psychology",
+    "courses": [
+      "PSYC 110G"
+    ],
+    "source": "gbcc"
+  },
+  "PSYC 220C": {
+    "text": "PSYC105C: Introduction to Psychology",
+    "courses": [
+      "PSYC 105C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 222G": {
+    "text": "PSYC110G: Introduction to Psychology",
+    "courses": [
+      "PSYC 110G"
+    ],
+    "source": "gbcc"
+  },
+  "PSYC 225C": {
+    "text": "PSYC105C: Introduction to Psychology",
+    "courses": [
+      "PSYC 105C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 226AC": {
+    "text": "PSYC105C: Introduction to Psychology",
+    "courses": [
+      "PSYC 105C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 230G": {
+    "text": "PSYC110G: Introduction to Psychology",
+    "courses": [
+      "PSYC 110G"
+    ],
+    "source": "gbcc"
+  },
+  "PSYC 230L": {
+    "text": "PSYC125L: Introduction to Psychology",
+    "courses": [
+      "PSYC 125L"
+    ],
+    "source": "lrcc"
+  },
+  "PSYC 235G": {
+    "text": "PSYC110G: Introduction to Psychology",
+    "courses": [
+      "PSYC 110G"
+    ],
+    "source": "gbcc"
+  },
+  "PSYC 280C": {
+    "text": "MHTH187C: The Helping Relationship: Interpersonal Communication Skills for Today's Professional",
+    "courses": [
+      "MHTH 187C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 283C": {
+    "text": "MHTH187C: The Helping Relationship: Interpersonal Communication Skills for Today's Professional",
+    "courses": [
+      "MHTH 187C"
+    ],
+    "source": "nhti"
+  },
+  "PSYC 290L": {
+    "text": "PSYC125L: Introduction to Psychology",
+    "courses": [
+      "PSYC 125L"
+    ],
+    "source": "lrcc"
+  },
+  "PTAC 115R": {
+    "text": "AHLT123R PTAC122R",
+    "courses": [
+      "AHLT 123R",
+      "PTAC 122R"
+    ],
+    "source": "rvcc"
+  },
+  "PTAC 122R": {
+    "text": "PTAC112R",
+    "courses": [
+      "PTAC 112R"
+    ],
+    "source": "rvcc"
+  },
+  "PTAC 211R": {
+    "text": "PTAC122R",
+    "courses": [
+      "PTAC 122R"
+    ],
+    "source": "rvcc"
+  },
+  "PTAC 221R": {
+    "text": "PTAC115R",
+    "courses": [
+      "PTAC 115R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 110R": {
+    "text": "RADT101R RADT115R",
+    "courses": [
+      "RADT 101R",
+      "RADT 115R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 115R": {
+    "text": "BIOL201R RADT110R RADT132R",
+    "courses": [
+      "BIOL 201R",
+      "RADT 110R",
+      "RADT 132R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 116C": {
+    "text": "RADT103C: Radiographic Positioning I",
+    "courses": [
+      "RADT 103C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 120R": {
+    "text": "MATH110R RADT101R RADT132R",
+    "courses": [
+      "MATH 110R",
+      "RADT 101R",
+      "RADT 132R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 121R": {
+    "text": "RADT101R RADT110R RADT115R RADT132R",
+    "courses": [
+      "RADT 101R",
+      "RADT 110R",
+      "RADT 115R",
+      "RADT 132R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 122R": {
+    "text": "RADT121R RADT215R",
+    "courses": [
+      "RADT 121R",
+      "RADT 215R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 123C": {
+    "text": "RADT180C: Radiographic Physics",
+    "courses": [
+      "RADT 180C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 132R": {
+    "text": "MATH110R RADT101R",
+    "courses": [
+      "MATH 110R",
+      "RADT 101R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 151MC": {
+    "text": "RADT109C: Introduction to Healthcare in Radiologic Technology",
+    "courses": [
+      "RADT 109C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 159C": {
+    "text": "RADT151MC: Patient Care",
+    "courses": [
+      "RADT 151MC"
+    ],
+    "source": "nhti"
+  },
+  "RADT 164C": {
+    "text": "RADT116C: Radiographic Imaging Technology I",
+    "courses": [
+      "RADT 116C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 165C": {
+    "text": "RADT164C: Radiographic Positioning III and Clinical Procedures II",
+    "courses": [
+      "RADT 164C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 203C": {
+    "text": "RADT103C: Radiographic Positioning I",
+    "courses": [
+      "RADT 103C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 214R": {
+    "text": "BIOL202R RADT115R RADT215R RADT218R",
+    "courses": [
+      "BIOL 202R",
+      "RADT 115R",
+      "RADT 215R",
+      "RADT 218R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 215R": {
+    "text": "RADT110R RADT115R",
+    "courses": [
+      "RADT 110R",
+      "RADT 115R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 218R": {
+    "text": "RADT115R RADT215R",
+    "courses": [
+      "RADT 115R",
+      "RADT 215R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 220C": {
+    "text": "RADT116C: Radiographic Imaging Technology I",
+    "courses": [
+      "RADT 116C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 223R": {
+    "text": "RADT115R RADT121R RADT122R RADT215R RADT218R",
+    "courses": [
+      "RADT 115R",
+      "RADT 121R",
+      "RADT 122R",
+      "RADT 215R",
+      "RADT 218R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 224R": {
+    "text": "RADT223R",
+    "courses": [
+      "RADT 223R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 228R": {
+    "text": "RADT101R RADT120R RADT132R",
+    "courses": [
+      "RADT 101R",
+      "RADT 120R",
+      "RADT 132R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 229R": {
+    "text": "BIOL202R",
+    "courses": [
+      "BIOL 202R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 235R": {
+    "text": "RADT110R RADT120R RADT132R",
+    "courses": [
+      "RADT 110R",
+      "RADT 120R",
+      "RADT 132R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 246R": {
+    "text": "RADT224R",
+    "courses": [
+      "RADT 224R"
+    ],
+    "source": "rvcc"
+  },
+  "RADT 294C": {
+    "text": "RADT203C: Advanced Radiographic Procedures",
+    "courses": [
+      "RADT 203C"
+    ],
+    "source": "nhti"
+  },
+  "RADT 295C": {
+    "text": "RADT294C: Radiographic Clinical Procedures IV",
+    "courses": [
+      "RADT 294C"
+    ],
+    "source": "nhti"
+  },
+  "RAET 205C": {
+    "text": "MATH124C: College Algebra",
+    "courses": [
+      "MATH 124C"
+    ],
+    "source": "nhti"
+  },
+  "RAET 210C": {
+    "text": "MATH140C: Precalculus",
+    "courses": [
+      "MATH 140C"
+    ],
+    "source": "nhti"
+  },
+  "RAET 220C": {
+    "text": "RAET205C: PLC Programming",
+    "courses": [
+      "RAET 205C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 150C": {
+    "text": "RDTH101C: Introduction to Radiation Therapy",
+    "courses": [
+      "RDTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 190C": {
+    "text": "RDTH101C: Introduction to Radiation Therapy",
+    "courses": [
+      "RDTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 195C": {
+    "text": "RDTH190C: Clinical Practice I",
+    "courses": [
+      "RDTH 190C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 200C": {
+    "text": "RDTH101C: Introduction to Radiation Therapy",
+    "courses": [
+      "RDTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 205C": {
+    "text": "RDTH101C: Introduction to Radiation Therapy",
+    "courses": [
+      "RDTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 210C": {
+    "text": "RDTH101C: Introduction to Radiation Therapy",
+    "courses": [
+      "RDTH 101C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 215C": {
+    "text": "BIOL195C: Anatomy and Physiology I",
+    "courses": [
+      "BIOL 195C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 220C": {
+    "text": "RADT180C: Radiographic Physics",
+    "courses": [
+      "RADT 180C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 280C": {
+    "text": "RDTH220C: Radiation Therapy Physics",
+    "courses": [
+      "RDTH 220C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 290C": {
+    "text": "RDTH190C: Clinical Practice I",
+    "courses": [
+      "RDTH 190C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 293C": {
+    "text": "RDTH290C: Clinical Practice III",
+    "courses": [
+      "RDTH 290C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 295C": {
+    "text": "RDTH293C: Clinical Practice IV",
+    "courses": [
+      "RDTH 293C"
+    ],
+    "source": "nhti"
+  },
+  "RDTH 296C": {
+    "text": "RDTH295C: Clinical Practice V",
+    "courses": [
+      "RDTH 295C"
+    ],
+    "source": "nhti"
+  },
+  "RSPT 151R": {
+    "text": "BIOL201R",
+    "courses": [
+      "BIOL 201R"
+    ],
+    "source": "rvcc"
+  },
+  "RSPT 152R": {
+    "text": "RSPT151R BIOL202R",
+    "courses": [
+      "BIOL 202R",
+      "RSPT 151R"
+    ],
+    "source": "rvcc"
+  },
+  "RSPT 191R": {
+    "text": "RSPT151R",
+    "courses": [
+      "RSPT 151R"
+    ],
+    "source": "rvcc"
+  },
+  "RSPT 253R": {
+    "text": "RSPT152R",
+    "courses": [
+      "RSPT 152R"
+    ],
+    "source": "rvcc"
+  },
+  "RSPT 254R": {
+    "text": "RSPT253R",
+    "courses": [
+      "RSPT 253R"
+    ],
+    "source": "rvcc"
+  },
+  "RSPT 281R": {
+    "text": "RSPT191R RSPT152R",
+    "courses": [
+      "RSPT 152R",
+      "RSPT 191R"
+    ],
+    "source": "rvcc"
+  },
+  "RSPT 282R": {
+    "text": "RSPT281R RSPT253R",
+    "courses": [
+      "RSPT 253R",
+      "RSPT 281R"
+    ],
+    "source": "rvcc"
+  },
+  "SCWK 220L": {
+    "text": "SCWK110L: Introduction to Social Work",
+    "courses": [
+      "SCWK 110L"
+    ],
+    "source": "lrcc"
+  },
+  "SCWK 240L": {
+    "text": "SCWK210L: Social Work Practicum I",
+    "courses": [
+      "SCWK 210L"
+    ],
+    "source": "lrcc"
+  },
+  "SOCI 250M": {
+    "text": "SOCI110M: Introduction to Sociology",
+    "courses": [
+      "SOCI 110M"
+    ],
+    "source": "mccnh"
+  },
+  "SOCI 298C": {
+    "text": "PSYC105C: Introduction to Psychology",
+    "courses": [
+      "PSYC 105C"
+    ],
+    "source": "nhti"
+  },
+  "SPAN 112C": {
+    "text": "SPAN111C: Elementary Spanish I",
+    "courses": [
+      "SPAN 111C"
+    ],
+    "source": "nhti"
+  },
+  "SPTS 170C": {
+    "text": "SPTS101C: Introduction to Sports Management",
+    "courses": [
+      "SPTS 101C"
+    ],
+    "source": "nhti"
+  },
+  "SPTS 180C": {
+    "text": "SPTS101C: Introduction to Sports Management",
+    "courses": [
+      "SPTS 101C"
+    ],
+    "source": "nhti"
+  },
+  "TCHE 206M": {
+    "text": "TCHE104M: Foundations of Education",
+    "courses": [
+      "TCHE 104M"
+    ],
+    "source": "mccnh"
+  },
+  "TCHE 220M": {
+    "text": "TCHE104M: Foundations of Education",
+    "courses": [
+      "TCHE 104M"
+    ],
+    "source": "mccnh"
+  },
+  "TCHE 225M": {
+    "text": "TCHE101M: Introduction to Exceptionalities",
+    "courses": [
+      "TCHE 101M"
+    ],
+    "source": "mccnh"
+  },
+  "TECP 61C": {
+    "text": "EDU104C: Foundations of Education",
+    "courses": [
+      "EDU 104C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 63C": {
+    "text": "EDU104C: Foundations of Education",
+    "courses": [
+      "EDU 104C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 66C": {
+    "text": "TECP51C: Foundations of Education",
+    "courses": [
+      "TECP 51C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 67C": {
+    "text": "TECP51C: Foundations of Education",
+    "courses": [
+      "TECP 51C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 68C": {
+    "text": "TECP51C: Foundations of Education",
+    "courses": [
+      "TECP 51C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 71C": {
+    "text": "EDU101C: Introduction to Exceptionalities",
+    "courses": [
+      "EDU 101C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 86C": {
+    "text": "ENGL101C: English Composition",
+    "courses": [
+      "ENGL 101C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 94": {
+    "text": "TECP93C: Internship Clinical Practice I: Methods/Clinical Practice for Middle/Secondary School Science Teachers",
+    "courses": [
+      "TECP 93C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 96": {
+    "text": "TECP93C: Internship Clinical Practice I: Methods/Clinical Practice for Middle/Secondary School Science Teachers",
+    "courses": [
+      "TECP 93C"
+    ],
+    "source": "nhti"
+  },
+  "TECP 99C": {
+    "text": "TECP93C: Internship Clinical Practice I: Methods/Clinical Practice for Middle/Secondary School Science Teachers",
+    "courses": [
+      "TECP 93C"
+    ],
+    "source": "nhti"
+  },
+  "VETA 114W": {
+    "text": "VETA110W: Introduction to Veterinary Technology",
+    "courses": [
+      "VETA 110W"
+    ],
+    "source": "wmcc"
+  },
+  "VETA 115W": {
+    "text": "VETA110W: Introduction to Veterinary Technology",
+    "courses": [
+      "VETA 110W"
+    ],
+    "source": "wmcc"
+  },
+  "VETN 212G": {
+    "text": "VETN130G: Veterinary Clinical Affiliation I",
+    "courses": [
+      "VETN 130G"
+    ],
+    "source": "gbcc"
+  },
+  "VETN 215G": {
+    "text": "VETN130G: Veterinary Clinical Affiliation I",
+    "courses": [
+      "VETN 130G"
+    ],
+    "source": "gbcc"
+  },
+  "VETN 224G": {
+    "text": "VETN130G: Veterinary Clinical Affiliation I",
+    "courses": [
+      "VETN 130G"
+    ],
+    "source": "gbcc"
+  },
+  "VRTS 121C": {
+    "text": "VRTS101C: Introduction to Drawing",
+    "courses": [
+      "VRTS 101C"
+    ],
+    "source": "nhti"
+  },
+  "VRTS 133C": {
+    "text": "VRTS101C: Introduction to Drawing",
+    "courses": [
+      "VRTS 101C"
+    ],
+    "source": "nhti"
+  },
+  "VRTS 201C": {
+    "text": "VRTS101C: Introduction to Drawing",
+    "courses": [
+      "VRTS 101C"
+    ],
+    "source": "nhti"
+  },
+  "VRTS 210C": {
+    "text": "VRTS101C: Introduction to Drawing",
+    "courses": [
+      "VRTS 101C"
+    ],
+    "source": "nhti"
+  },
+  "VRTS 230C": {
+    "text": "VRTS130C: Introduction to Photography",
+    "courses": [
+      "VRTS 130C"
+    ],
+    "source": "nhti"
+  },
+  "VRTS 235C": {
+    "text": "VRTS135C: Introduction to Ceramics",
+    "courses": [
+      "VRTS 135C"
+    ],
+    "source": "nhti"
+  },
+  "WELD 150G": {
+    "text": "WELD100G: Basic Welding Technologies",
+    "courses": [
+      "WELD 100G"
+    ],
+    "source": "gbcc"
+  },
+  "WELD 206W": {
+    "text": "WELD106W: Blueprint Reading I",
+    "courses": [
+      "WELD 106W"
+    ],
+    "source": "wmcc"
+  },
+  "WELD 216W": {
+    "text": "WELD106W: Blueprint Reading I",
+    "courses": [
+      "WELD 106W"
+    ],
+    "source": "wmcc"
+  },
+  "WELD 221W": {
+    "text": "WELD106W: Blueprint Reading I",
+    "courses": [
+      "WELD 106W"
+    ],
+    "source": "wmcc"
+  },
+  "WELD 226W": {
+    "text": "WELD106W: Blueprint Reading I",
+    "courses": [
+      "WELD 106W"
+    ],
+    "source": "wmcc"
+  },
+  "WELD 228W": {
+    "text": "WELD106W: Blueprint Reading I",
+    "courses": [
+      "WELD 106W"
+    ],
+    "source": "wmcc"
+  }
+}

--- a/scripts/nh/scrape-catalog-prereqs.ts
+++ b/scripts/nh/scrape-catalog-prereqs.ts
@@ -1,0 +1,281 @@
+/**
+ * scrape-catalog-prereqs.ts
+ *
+ * Scrapes prerequisite data from the CCSNH colleges' Clean Catalog sites.
+ * 6 of 7 CCSNH colleges use Clean Catalog with a per-course URL scheme:
+ *
+ *   gbcc      catalog.greatbay.edu/classes
+ *   lrcc      catalog.lrcc.edu/classes
+ *   mccnh     catalog.mccnh.edu/courses      (note: /courses, not /classes)
+ *   nhti      catalog.nhti.edu/classes
+ *   rvcc      catalog.rivervalley.edu/classes
+ *   wmcc      catalog.wmcc.edu/classes
+ *
+ * Nashua CC (nashuacc) uses a PDF catalog — not covered here; tracked as
+ * future work in the follow-up issue.
+ *
+ * Clean Catalog structure (verified across all 6):
+ *   - Listing pages at /{classes|courses}?page=N, paginated until empty
+ *   - Each course lives at /{category-slug}/{coursecode} (code lowercased)
+ *   - Course page has <h1>PREFIXNUMBER: Title</h1>
+ *   - Prereqs in <div class="field field--name-field-prerequisite-courses">
+ *     containing <a href="...">CODE: Title</a> entries
+ *
+ * Output: data/nh/prereqs.json — single flat object keyed by "PREFIX NUMBER"
+ * with { text, courses, source } per entry. `source` is the CCSNH college
+ * slug so downstream consumers can tell which college's catalog authored
+ * the prereq (since the same course code can differ slightly across the
+ * system's colleges).
+ *
+ * Usage:
+ *   npx tsx scripts/nh/scrape-catalog-prereqs.ts
+ *   npx tsx scripts/nh/scrape-catalog-prereqs.ts --college nhti
+ *   npx tsx scripts/nh/scrape-catalog-prereqs.ts --limit-pages 2       # smoke test
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 6;
+const DELAY_MS = 100;
+
+interface CollegeCatalog {
+  slug: string;
+  host: string;
+  listingPath: "classes" | "courses";
+}
+
+const COLLEGES: CollegeCatalog[] = [
+  { slug: "gbcc", host: "catalog.greatbay.edu", listingPath: "classes" },
+  { slug: "lrcc", host: "catalog.lrcc.edu", listingPath: "classes" },
+  { slug: "mccnh", host: "catalog.mccnh.edu", listingPath: "courses" },
+  { slug: "nhti", host: "catalog.nhti.edu", listingPath: "classes" },
+  { slug: "rvcc", host: "catalog.rivervalley.edu", listingPath: "classes" },
+  { slug: "wmcc", host: "catalog.wmcc.edu", listingPath: "classes" },
+];
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+  source: string;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(url: string, attempts = 3): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status === 404) return "";
+      lastErr = new Error(`HTTP ${res.status}`);
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`fetch ${url} failed: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) => String.fromCharCode(parseInt(code, 10)))
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Split a raw course code like "ACCT113G" into { prefix: "ACCT", number: "113G" }. */
+function splitCode(raw: string): { prefix: string; number: string } | null {
+  const m = raw.toUpperCase().match(/^([A-Z]{2,5})(\d{2,4}[A-Z]{0,3})$/);
+  if (!m) return null;
+  return { prefix: m[1], number: m[2] };
+}
+
+/** Extract all distinct course paths from one listing page. */
+function extractCoursePaths(html: string): string[] {
+  const re = /href="(\/[a-z0-9-]+\/[a-z]{2,6}\d{2,4}[a-z]{0,3})"/gi;
+  const paths = new Set<string>();
+  let m;
+  while ((m = re.exec(html)) !== null) paths.add(m[1]);
+  return [...paths];
+}
+
+/** Parse one course page and return { code, prereq text, prereq codes } or null. */
+function parseCoursePage(html: string): {
+  prefix: string;
+  number: string;
+  text: string;
+  courses: string[];
+} | null {
+  // Course code from <h1>PREFIXNUMBER: ...</h1>
+  const h1Match = html.match(/<h1[^>]*>\s*([A-Z]{2,5}\d{2,4}[A-Z]{0,3})\s*:/i);
+  if (!h1Match) return null;
+  const split = splitCode(h1Match[1]);
+  if (!split) return null;
+
+  // Find the prereq courses block.
+  const blockMatch = html.match(
+    /<div[^>]*field--name-field-prerequisite-courses[^>]*>([\s\S]*?)<\/div>\s*<\/div>/i
+  );
+  if (!blockMatch) return null;
+
+  const block = blockMatch[1];
+
+  // Course links inside the block. Anchor text is "PREFIXNUMBER: Title".
+  const courses = new Set<string>();
+  // Anchor text is typically "PREFIXNUMBER: Title" but some CCSNH catalogs
+  // (e.g. RVCC) emit just "PREFIXNUMBER" — colon is optional.
+  const linkRegex =
+    /<a\s+href="\/[a-z0-9-]+\/[a-z]{2,6}\d{2,4}[a-z]{0,3}"[^>]*>\s*([A-Z]{2,5}\d{2,4}[A-Z]{0,3})\b/gi;
+  let m;
+  while ((m = linkRegex.exec(block)) !== null) {
+    const s = splitCode(m[1]);
+    if (!s) continue;
+    const code = `${s.prefix} ${s.number}`;
+    if (code !== `${split.prefix} ${split.number}`) courses.add(code);
+  }
+
+  if (courses.size === 0) return null;
+
+  // Human-readable text: join prereq titles from the block.
+  const text = htmlToText(block).replace(/^Prerequisite Courses\s*/i, "").trim();
+
+  return {
+    prefix: split.prefix,
+    number: split.number,
+    text,
+    courses: [...courses].sort(),
+  };
+}
+
+async function scrapeCollege(
+  college: CollegeCatalog,
+  limitPages: number
+): Promise<Record<string, PrereqEntry>> {
+  const base = `https://${college.host}`;
+  console.log(`\n=== ${college.slug} (${college.host}) ===`);
+
+  // Phase 1: enumerate course paths via pagination.
+  const coursePaths = new Set<string>();
+  for (let page = 0; ; page++) {
+    if (limitPages > 0 && page >= limitPages) break;
+    const html = await retryFetch(`${base}/${college.listingPath}?page=${page}`);
+    const paths = extractCoursePaths(html);
+    if (paths.length === 0) break;
+    for (const p of paths) coursePaths.add(p);
+    await sleep(DELAY_MS);
+  }
+  console.log(`  Found ${coursePaths.size} distinct course URLs`);
+
+  // Phase 2: fetch each course page in parallel.
+  const entries: Record<string, PrereqEntry> = {};
+  const pathsList = [...coursePaths];
+  let withPrereqs = 0;
+  await pmap(pathsList, CONCURRENCY, async (p) => {
+    const html = await retryFetch(`${base}${p}`);
+    if (!html) return;
+    const parsed = parseCoursePage(html);
+    if (!parsed) return;
+    const key = `${parsed.prefix} ${parsed.number}`;
+    if (entries[key]) return; // first-seen wins within a college
+    entries[key] = {
+      text: parsed.text,
+      courses: parsed.courses,
+      source: college.slug,
+    };
+    withPrereqs++;
+  });
+  console.log(`  Parsed ${withPrereqs} courses with prereqs`);
+  return entries;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const onlyCollege = args.includes("--college") ? args[args.indexOf("--college") + 1] : null;
+  const limitPagesArg = args.includes("--limit-pages")
+    ? parseInt(args[args.indexOf("--limit-pages") + 1], 10)
+    : 0;
+
+  const targets = onlyCollege
+    ? COLLEGES.filter((c) => c.slug === onlyCollege)
+    : COLLEGES;
+  if (targets.length === 0) {
+    console.error(`Unknown college: ${onlyCollege}. Available: ${COLLEGES.map((c) => c.slug).join(", ")}`);
+    process.exit(1);
+  }
+
+  // Merge across colleges: when two colleges list the same course code with
+  // different prereqs, the first-seen wins. We record `source` on each entry.
+  const merged: Record<string, PrereqEntry> = {};
+  let totalPerCollege: Record<string, number> = {};
+
+  for (const college of targets) {
+    const entries = await scrapeCollege(college, limitPagesArg);
+    totalPerCollege[college.slug] = Object.keys(entries).length;
+    for (const [key, entry] of Object.entries(entries)) {
+      if (!merged[key]) merged[key] = entry;
+    }
+  }
+
+  // Sort keys for deterministic output.
+  const sorted: Record<string, PrereqEntry> = {};
+  for (const key of Object.keys(merged).sort()) sorted[key] = merged[key];
+
+  const outPath = path.join(process.cwd(), "data", "nh", "prereqs.json");
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(sorted, null, 2) + "\n");
+
+  console.log("\n=== Summary ===");
+  for (const [slug, n] of Object.entries(totalPerCollege)) {
+    console.log(`  ${slug.padEnd(8)} ${n} courses with prereqs`);
+  }
+  console.log(`  merged: ${Object.keys(sorted).length} unique course codes`);
+  console.log(`  written → ${outPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- CCSNH prereq scraper built against Clean Catalog (the Drupal-based catalog software each CCSNH college uses for \`catalog.<college>.edu\`).
- 592 unique course codes with prerequisites parsed across 6 of 7 CCSNH colleges.

## Per-college prereq counts
| college | host | path | prereqs |
|---|---|---|---:|
| Great Bay (gbcc) | catalog.greatbay.edu | /classes | 51 |
| Lakes Region (lrcc) | catalog.lrcc.edu | /classes | 39 |
| Manchester (mccnh) | catalog.mccnh.edu | /courses | 33 |
| NHTI (nhti) | catalog.nhti.edu | /classes | 290 |
| River Valley (rvcc) | catalog.rivervalley.edu | /classes | 123 |
| White Mountains (wmcc) | catalog.wmcc.edu | /classes | 56 |
| **total unique** | | | **592** |

## Cross-college quirks handled
- MCC uses \`/courses\` as the listing path; all others use \`/classes\`.
- RVCC's prereq anchor text is bare (\`BUS101R\`) while others emit \`BUS101R: Title\` — the link regex accepts both. (Caught during smoke testing — RVCC initially returned 0 prereqs before this fix.)
- Each college stamps its own letter suffix on course numbers (G=gbcc, R=rvcc, M=mccnh, C=nhti, etc.). Suffixes are preserved verbatim so codes round-trip exactly with the Phase 2 Banner data.

## Not covered — Nashua Community College (nashuacc)
NCC publishes its catalog as a PDF rather than Clean Catalog. Would need a separate PDF scrape path (or Playwright against whatever rendered page exists). Flagging for future work.

## Output
\`data/nh/prereqs.json\` — flat object keyed by \`"PREFIX NUMBER"\`, each value has \`{ text, courses, source }\` where \`source\` is the college slug that authored the prereq.

## Test plan
- [x] Smoke test on NHTI (2 pages) — 64 prereqs parsed cleanly.
- [x] Full run across 6 colleges, ~2 min wall clock.
- [x] RVCC variant verified: 123 prereqs after fixing the colon-optional link regex.
- [x] \`tsc --noEmit\` clean.
- [ ] Reviewer spot-checks a handful of prereqs against live catalog pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)