### PR TITLE
Fix empty NH + MA college listings; document the trap in add-new-state skill

### DIFF
--- a/.claude/skills/add-new-state/SKILL.md
+++ b/.claude/skills/add-new-state/SKILL.md
@@ -15,10 +15,18 @@ Since commit `be494a7`, adding a state is config-driven. You should only need to
 - `data/{ST}/transfer-equiv.json` — start empty (`[]`) — transfer data lands in Phase 3
 - `lib/states/{ST}/config.ts` — `StateConfig` including `defaultZip`, `defaultZipCity`, SIS platform URLs, senior-waiver statute, `transferSupported: false` initially
 - `lib/states/registry.ts` — one-line registration
+- **`lib/institutions.ts`** — two-line registration: one `import nhInstitutions from "@/data/nh/institutions.json"` and one line in the `REGISTRY` map.
+- **`lib/geo.ts`** — same two-line pattern for `zipcodes.json` in the `ZIP_REGISTRY` map.
+
+### Why `lib/institutions.ts` and `lib/geo.ts` are hardcoded
+
+These two files look like they violate the "never hardcode state lists" invariant, but they can't be dynamic. Both are imported from code that may run on the **edge runtime** (middleware, some API routes), which cannot use `fs.readFileSync` or dynamic filesystem paths. The imports have to be static so the bundler knows at build time which JSON to include.
+
+If you miss these two files, `/{state}/colleges` renders an empty grid (no colleges shown) and `/{state}` zip-code search silently returns nothing. There's no runtime error — it just looks like the state has no data. Ask how we know: NH shipped without these edits in April 2026 (PR #30) and the bug wasn't caught until a user opened `/nh/colleges` on prod.
 
 **If you find yourself editing `components/SearchForm.tsx`, `components/blog/ProductCallout.tsx`, `app/page.tsx`, or `lib/blog.ts` to add a state — stop.** Those are registry-driven (see `getAllStates()` / `getStateConfig()`). Editing them re-introduces the exact coupling `be494a7` removed.
 
-Pattern reference: commit `9fb92bc` (CT/RI/VT/ME bootstrap — four states in one commit, only these 5 file types touched).
+Pattern reference: commit `9fb92bc` (CT/RI/VT/ME bootstrap — four states in one commit, only these file types touched).
 
 ## Phase 2 — Course scraper
 
@@ -53,7 +61,8 @@ Run `scripts/import-courses.ts` and `scripts/import-transfers.ts` for the new st
 - [ ] `transferSupported` flag reflects reality (false until Phase 3 completes)
 - [ ] Senior-waiver law cited with statute reference in the config
 - [ ] Scraper filename matches SIS platform (`scrape-banner-ssb.ts`, `scrape-colleague.ts`, etc.)
-- [ ] No hardcoded state slugs introduced anywhere outside `data/{ST}/`, `scripts/{ST}/`, `lib/states/{ST}/`
+- [ ] No hardcoded state slugs introduced anywhere outside `data/{ST}/`, `scripts/{ST}/`, `lib/states/{ST}/`, `lib/institutions.ts`, `lib/geo.ts`
+- [ ] **Phase 1 smoke test:** before opening the PR, hit `/{state}/colleges` in the local dev server. It should show all colleges, not an empty grid. An empty grid almost always means `lib/institutions.ts` wasn't updated.
 
 ## Commit message convention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,20 @@ Source of truth: `.env.example` in repo root. Local dev uses `.env.local` (gitig
 
 This is the most frequent multi-step workflow. See the `add-new-state` skill (`.claude/skills/add-new-state/`). Short version: bootstrap (data + config + registry) → course scraper → transfer data → prereqs → Supabase import. Each phase is its own PR.
 
+## Git — narrate as you go
+
+The user is learning git in real time and wants to understand what's happening, not just approve blind steps. When running any git or `gh` command, narrate it in **one or two plain-English sentences** before or after the tool call:
+
+- What the command does ("create a new branch off main" / "push this branch to GitHub" / "open a pull request")
+- What state the repo is in after ("you now have 1 commit not yet on main" / "the branch is on GitHub but not merged yet")
+- What the next step looks like and who does it ("now you click Merge on GitHub" / "I'll wait for you to confirm the PR is merged before starting the next branch")
+
+Avoid jargon unless you define it inline. Say "squash and merge = collapse the branch's commits into one, then land it on main" the first time, not just "squash". If the user has already been told a concept this session, don't re-explain — just use it.
+
+Branch naming convention used so far: `claude/<state>-phase<N><letter>-<topic>` (e.g. `claude/ma-phase2b-colleague`). Stick to that so the user sees a consistent pattern.
+
+Merging is the user's job — they click "Squash and merge" on GitHub. Don't run `gh pr merge` on their behalf unless they explicitly ask.
+
 ## Environment quirks
 
 **This is NOT the Next.js you know.** Next 16 has breaking changes vs. training-data-era Next.js. Before writing routing, caching, or server-component code, read the relevant page in `node_modules/next/dist/docs/`. Heed deprecation notices.

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -20,6 +20,8 @@ import ctZipcodes from "@/data/ct/zipcodes.json";
 import meZipcodes from "@/data/me/zipcodes.json";
 import paZipcodes from "@/data/pa/zipcodes.json";
 import njZipcodes from "@/data/nj/zipcodes.json";
+import nhZipcodes from "@/data/nh/zipcodes.json";
+import maZipcodes from "@/data/ma/zipcodes.json";
 
 type ZipEntry = { lat: number; lng: number; city: string };
 
@@ -39,6 +41,8 @@ const ZIP_REGISTRY: Record<string, Record<string, ZipEntry>> = {
   me: meZipcodes as Record<string, ZipEntry>,
   pa: paZipcodes as Record<string, ZipEntry>,
   nj: njZipcodes as Record<string, ZipEntry>,
+  nh: nhZipcodes as Record<string, ZipEntry>,
+  ma: maZipcodes as Record<string, ZipEntry>,
 };
 
 function loadZipData(state = "va"): Record<string, ZipEntry> {

--- a/lib/institutions.ts
+++ b/lib/institutions.ts
@@ -18,6 +18,8 @@ import ctInstitutions from "@/data/ct/institutions.json";
 import meInstitutions from "@/data/me/institutions.json";
 import paInstitutions from "@/data/pa/institutions.json";
 import njInstitutions from "@/data/nj/institutions.json";
+import nhInstitutions from "@/data/nh/institutions.json";
+import maInstitutions from "@/data/ma/institutions.json";
 
 // Double-cast via `unknown` because the JSON-inferred types narrow some fields
 // to `null` where `Institution` expects a concrete type (e.g. `minimum_age` is
@@ -40,6 +42,8 @@ const REGISTRY: Record<string, Institution[]> = {
   me: meInstitutions as unknown as Institution[],
   pa: paInstitutions as unknown as Institution[],
   nj: njInstitutions as unknown as Institution[],
+  nh: nhInstitutions as unknown as Institution[],
+  ma: maInstitutions as unknown as Institution[],
 };
 
 /**


### PR DESCRIPTION
## The bug
\`/{state}/colleges\` rendered an empty grid for NH and MA on production. The page header and description showed, but no college cards. (Reported in-session after loading [communitycollegepath.com/nh/colleges](https://communitycollegepath.com/nh/colleges) and seeing "All 7 CCSNH Colleges" with nothing under it.)

## Root cause
Two files maintain hardcoded \`import\` statements for every state's JSON data:

- \`lib/institutions.ts\` — \`REGISTRY\` map of state slug → institutions JSON
- \`lib/geo.ts\` — \`ZIP_REGISTRY\` map of state slug → zipcodes JSON

They're hardcoded because they run on the **edge runtime** (middleware, some API routes), which can't use \`fs.readFileSync\`. The bundler needs to see the imports statically at build time.

NH shipped in [#30](https://github.com/rohan-c0de/cc-coursemap/pull/30) and MA in [#35](https://github.com/rohan-c0de/cc-coursemap/pull/35) without entries in either registry. Result: \`loadInstitutions("nh")\` returned \`[]\` → empty grid. No runtime error — just silent data absence.

## The fix (this PR)
1. Add NH and MA to both registries (6 lines total across 2 files).
2. Update the \`add-new-state\` skill to include these two files in the Phase 1 checklist and explain *why* they can't be dynamic. Future state additions inherit the fix.
3. Add a Phase 1 smoke-test item: hit \`/{state}/colleges\` locally before opening the PR.
4. Resurrect a lost CLAUDE.md narration commit from a push/merge race on [#37](https://github.com/rohan-c0de/cc-coursemap/pull/37).

## Verification
- [x] Local dev: \`/nh/colleges\` shows all 7 CCSNH colleges.
- [x] Local dev: \`/ma/colleges\` shows all 15 MassCC colleges.
- [x] \`tsc --noEmit\` clean.
- [ ] Prod: after merge, Vercel rebuild picks up the static imports and the pages populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)