### PR TITLE
Resurrect CLAUDE.md updates orphaned by PR #41 merge race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,37 @@ Branch naming convention used so far: `claude/<state>-phase<N><letter>-<topic>` 
 
 Merging is the user's job — they click "Squash and merge" on GitHub. Don't run `gh pr merge` on their behalf unless they explicitly ask.
 
+## Verifying your work — three checks, in order
+
+Typecheck passing and a scraper completing without errors are necessary but not sufficient. Data can be wrong, APIs can return the right shape with broken content, and a PR that looks fine in isolation can break the UI for real users. Do these three, every time:
+
+### 1. Pre-PR feature check ("does the feature I just shipped actually work?")
+Before opening a PR that ships new data or a new endpoint, load the matching feature in local dev and exercise it end-to-end. Don't just hit the API — click through the UI the way the feature will be used:
+
+- New course data for a state → load `/{state}` and search for a course; confirm sections render with the expected fields.
+- New transfer data → load `/{state}/transfer`, pick a sending CC and a course, confirm the equivalency shows up.
+- New prereq data → load the semester planner, type a course that you know has a prereq, confirm the prereq chain resolves.
+- A bug fix → reproduce the bug path and confirm it's fixed.
+
+Cost: usually under 5 minutes. Catches: "the JSON parsed but the field names don't match what the UI reads."
+
+### 2. Post-merge prod check ("did Vercel actually ship it?")
+After merging a PR, wait ~2-3 minutes for Vercel to redeploy, then load prod and verify one concrete thing changed:
+
+- `curl communitycollegepath.com/api/{state}/…` returns the new data.
+- The visible symptom that motivated the PR (empty page, missing state card, 404) is gone.
+
+Cost: one minute. Catches: missing registry entries, static-import gaps (see the NH/MA `/colleges` bug), Vercel build failures, environment variable drift. Silence here looks identical to success — so always pick a specific thing to verify, not just "it looks fine."
+
+### 3. Student-perspective walkthrough at major milestones
+After a whole state lands, or after a user-facing feature ships, use the site the way a first-gen student with no prior college experience would. Example scope:
+
+> "I live in 02108, want a weekend accounting class, need to know if it transfers to UMass Boston."
+
+Walk through the full flow. If any step confuses you, it'll confuse a real student. This is where empty states, missing copy, broken filter combos, and data shape mismatches across features reveal themselves.
+
+Cost: 5-10 minutes. Catches: the things the other two checks miss — interaction bugs, UX cliffs, cross-feature inconsistencies.
+
 ## Environment quirks
 
 **This is NOT the Next.js you know.** Next 16 has breaking changes vs. training-data-era Next.js. Before writing routing, caching, or server-component code, read the relevant page in `node_modules/next/dist/docs/`. Heed deprecation notices.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ A national community college course navigator. Helps students find classes, plan
 
 The project is **national, expanding state-by-state**. East Coast is nearly complete. Never treat this as a Virginia-only tool — VA was the original scope but the architecture is multi-state.
 
-Currently covered states (as of this writing): ct, dc, de, ga, md, me, nc, nj, ny, pa, ri, sc, tn, va, vt. Run `getAllStates()` for the authoritative list.
+Currently covered states (as of this writing): ct, dc, de, ga, ma, md, me, nc, nh, nj, ny, pa, ri, sc, tn, va, vt. Run `getAllStates()` for the authoritative list.
 
 ## Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,12 @@ Branch naming convention used so far: `claude/<state>-phase<N><letter>-<topic>` 
 
 Merging is the user's job — they click "Squash and merge" on GitHub. Don't run `gh pr merge` on their behalf unless they explicitly ask.
 
+**Don't push to a PR branch after you've told the user to merge.** GitHub squashes whatever is on the branch at merge-time; a commit pushed seconds after they click Merge becomes an orphaned dead commit on the remote branch and never reaches `main`. This has happened twice (PR #37 and PR #41). If you realize you need one more small edit after saying "go merge", either:
+1. Wait for the merge to land, then open a tiny follow-up PR, or
+2. Grab the user's attention before they click Merge ("one more commit coming, hold on").
+
+Never push a commit and _hope_ the user hasn't merged yet. That's what caused the lost commits.
+
 ## Verifying your work — three checks, in order
 
 Typecheck passing and a scraper completing without errors are necessary but not sufficient. Data can be wrong, APIs can return the right shape with broken content, and a PR that looks fine in isolation can break the UI for real users. Do these three, every time:


### PR DESCRIPTION
## What happened
I pushed two commits to the \`claude/ma-phase4-prereqs\` branch **after** you merged [#41](https://github.com/rohan-c0de/cc-coursemap/pull/41):
- \`07c2518\` — update CLAUDE.md state list to include nh + ma
- \`621b507\` — add "Verifying your work" section to CLAUDE.md

GitHub's squash merge captured only the first commit of that branch (the prereq data itself). The two CLAUDE.md commits became orphaned on the remote branch and never reached \`main\`. Same pattern as the earlier [#37](https://github.com/rohan-c0de/cc-coursemap/pull/37) merge race.

## What this PR does
1. Cherry-picks the two orphaned commits onto a fresh branch off \`main\`.
2. Adds a guardrail to CLAUDE.md's Git section documenting the mistake so it stops happening: **don't push after you've said "go merge"** — either wait for the merge and open a follow-up, or flag the user before they click.

Three commits, all doc-only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)