### PR TITLE
Fix: course-search filters ignored on deep links

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -108,13 +108,25 @@ interface CourseSearchProps {
 export default function CourseSearchClient({ state, systemName, collegeCount, courseUrlMap, defaultZip }: CourseSearchProps) {
   const searchParams = useSearchParams();
   const initialQuery = searchParams.get("q")?.replace(/\+/g, " ") || "";
+  // Initialize filter state from URL so deep links like
+  // /{state}/courses?q=accounting&days=Sa&transfersTo=umass-boston actually
+  // apply the filters on first load. Previously only `q` was read and the
+  // rest defaulted to empty, which silently dropped every other filter.
+  const initialZip = searchParams.get("zip") || "";
+  const initialMode = searchParams.get("mode") || "";
+  const initialDays = (searchParams.get("days") || "")
+    .split(",")
+    .map((d) => d.trim())
+    .filter(Boolean);
+  const initialTimeOfDay = searchParams.get("timeOfDay") || "";
+  const initialTransferTo = searchParams.get("transfersTo") || "";
   const { user, openLoginModal } = useAuth();
 
   const [query, setQuery] = useState(initialQuery);
-  const [zip, setZip] = useState("");
-  const [mode, setMode] = useState("");
-  const [days, setDays] = useState<string[]>([]);
-  const [timeOfDay, setTimeOfDay] = useState("");
+  const [zip, setZip] = useState(initialZip);
+  const [mode, setMode] = useState(initialMode);
+  const [days, setDays] = useState<string[]>(initialDays);
+  const [timeOfDay, setTimeOfDay] = useState(initialTimeOfDay);
 
   // Bookmark state
   const [bookmarkedCourses, setBookmarkedCourses] = useState<Set<string>>(new Set());
@@ -175,7 +187,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     setBookmarkLoading((prev) => { const next = new Set(prev); next.delete(key); return next; });
   }, [user, openLoginModal, bookmarkedCourses, state]);
 
-  const [transferTo, setTransferTo] = useState("");
+  const [transferTo, setTransferTo] = useState(initialTransferTo);
   const [transferLookup, setTransferLookup] = useState<Record<string, { university: string; type: string }[]> | null>(null);
   const [universities, setUniversities] = useState<{ slug: string; name: string }[]>([]);
 


### PR DESCRIPTION
## The bug
A deep link like \`/{state}/courses?q=accounting&days=Sa&transfersTo=umass-boston\` loaded with only the query applied — every other filter was silently dropped. A student searching for Saturday accounting classes saw 73 unfiltered sections instead of 2 Saturday sections. Found during the post-merge student walkthrough for MA Phase 4 ([noted here](https://github.com/rohan-c0de/cc-coursemap/pull/41)).

## Why it happened
\`app/[state]/courses/CourseSearchClient.tsx\` read only \`searchParams.get("q")\` into initial state and defaulted the rest (\`zip\`, \`mode\`, \`days\`, \`timeOfDay\`, \`transfersTo\`) to empty. The auto-search effect on mount then fired with those empty defaults, so the URL's filter intent never reached the API.

Worth noting: the backend (\`lib/courses-search.ts\` + \`/api/[state]/courses/search\`) was already correct. Hitting \`/api/ma/courses/search?q=accounting&days=Sa\` directly returns 2 sections — the filter logic is per-section and strict. The bug was purely UI.

## Fix
Read all filter params from \`useSearchParams()\` on initial render and seed the useState hooks with them.

## Verification
- Local: \`/ma/courses?q=accounting&days=Sa\` now shows "2 sections of 2 courses" with only Saturday section times displayed. Zero weekday pollution.
- Typecheck clean.
- No backend changes; the search API already worked correctly.

## Also worth future follow-up (not in this PR)
The form's submit button doesn't update the URL when filters change in the UI. After this fix, deep links work on load — but you still can't share the link you just built by clicking filters. That's a separate UX gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)