### PR TITLE
Fold NH + MA lessons into the add-new-state skill

### DIFF
--- a/.claude/skills/add-new-state/SKILL.md
+++ b/.claude/skills/add-new-state/SKILL.md
@@ -32,28 +32,79 @@ Pattern reference: commit `9fb92bc` (CT/RI/VT/ME bootstrap — four states in on
 
 1. **Inspect the registration system** on one of the colleges' public course-search pages. Identify the platform:
    - Banner SSB 9 (modern REST) — TN, DC, GA template
-   - Banner 8 (flat table) — RI template
-   - Colleague Self-Service — VT, NC, SC template
+   - Banner 8 classic (hierarchical `ddtitle` HTML) — MD, DE, SC, NH, MA (gcc/middlesex) template
+   - Banner 8 flat-table — RI template (outlier; don't default to this)
+   - Colleague Self-Service — VT, NC, SC, MA (bhcc/berkshire/stcc) template
    - PeopleSoft Campus Solutions — NY (CUNY), VA (VCCS enrichment)
-   - Jenzabar / custom — case-by-case
+   - Coursedog (API-backed catalog) — MA (gcc) template for prereqs
+   - Jenzabar / Modern Campus / Acalog / Oracle APEX / custom — case-by-case
 2. **Clone the nearest same-platform scraper** from an existing state as your starting point. SC was adapted from NC; TN was adapted from GA. This is the normal pattern — don't write from scratch.
 3. Place at `scripts/{ST}/scrape-<platform>.ts`. Output to `data/{ST}/courses/{college-slug}/{term}.json`.
 4. Terms follow the state's convention (VCCS: `2026FA`; TBR: `202680`; CUNY: `2026FA`). Encode in the scraper, don't try to normalize until import.
 
+### Expect some colleges to be un-scrapable
+
+In any given state, **a meaningful fraction of colleges won't have publicly scrapable course search** — they're behind SSO (SAML/OIDC) or serve only stale/archived terms in their public view. MA's 15 colleges broke down 6 scrapable / 9 not; of those 9, five required Microsoft SAML auth or had decommissioned their public Banner/Jenzabar endpoint in favor of Ellucian Experience cloud.
+
+Signals the platform is auth-gated:
+- Probe redirects to `login.microsoftonline.com`, a SAML `/Shibboleth.sso/`, or the school's SSO portal.
+- The public course-search URL returns HTTP 200 but with an empty/stale term dropdown (e.g. no terms after 2023).
+- The page loads a portlet (Jenzabar `.jnz`, PeopleSoft `.GBL`) that has zero form fields until you authenticate.
+
+**What to do when a college is gated:** document it in the commit, move on, and don't try to work around auth. Don't log in with a student account; don't use cached credentials. Note these colleges as Phase 2 gaps — Phase 3 (state-level transfer portal, if one exists) frequently covers them anyway. MA Phase 2 shipped with 6 of 15 colleges' course data; Phase 3 via MassTransfer filled the gap with transfer data for all 15.
+
 ## Phase 3 — Transfer equivalencies
 
-1. Find the transfer-data source: state-level portal (ARTSYS/MD, NJTransfer.org, CollegeTransfer.net), TES Public View, or per-receiving-university scrapers (VA's model).
-2. Multi-university states get `scripts/{ST}/scrape-transfer-all.ts` orchestrator + per-university scripts (see VA: `scrape-transfer-vcu.ts`, `scrape-transfer-odu.ts`, etc.).
-3. Output to `data/{ST}/transfer-equiv.json`.
-4. **Flip `transferSupported: false → true`** in `lib/states/{ST}/config.ts` only after transfer data lands.
+**Start here by asking "does the state run an official articulation system?"** A state-run portal — where every CC ↔ university mapping is already curated in one place — is by a wide margin the highest-leverage move in the whole 5-phase workflow. One scrape can yield transfer data for *every* college in the state, including the ones whose scheduling systems are gated and thus have zero Phase 2 data. MA's MassTransfer scrape delivered 45,764 mappings across all 15 colleges × 14 receivers in ~70 seconds; five of those 15 colleges had zero course data from Phase 2 but got full transfer coverage here.
+
+Known state-run sources:
+- **MA** — [MassTransfer](https://www.mass.edu/masstransfer/equivalencies/) (pattern: `scripts/ma/scrape-masstransfer.ts`)
+- **MD** — ARTSYS
+- **NJ** — NJTransfer.org
+- **TN** — TNTransfers
+- If the state has a **University System of X** (USNH, USG, etc.), check for a central portal before falling back to per-university scrapes.
+
+### Fallback sources when no state portal exists
+1. **CollegeTransfer.Net** — public OData v2 API. Each CC registers individually with a `SourceInstitutionId`. Pattern: `scripts/me/scrape-transfer.ts` (ME's 7 MCCS colleges), `scripts/nh/scrape-transfer.ts`. Note: free tier rate-limits after ~4–5 source institutions per run; scraper should merge-preserve prior runs.
+2. **TES Public View** — some receiving universities publish their own TES-backed equivalency search.
+3. **Per-receiving-university scrapers** — last resort. VA's model. Multi-university states get `scripts/{ST}/scrape-transfer-all.ts` orchestrator + per-university scripts (see VA: `scrape-transfer-vcu.ts`, `scrape-transfer-odu.ts`, etc.).
+
+Output to `data/{ST}/transfer-equiv.json`.
+
+**Flip `transferSupported: false → true`** in `lib/states/{ST}/config.ts` only after transfer data lands. Document any known gaps in the config comment (e.g. NH's in-state USNH transfers are absent because USNH doesn't publish to CollegeTransfer.Net).
 
 ## Phase 4 — Prereqs
 
 Prereq data is often a separate scrape path (catalog-driven or Banner `getSectionPrerequisites` endpoint). Output to `data/{ST}/prereqs.json`. Pattern reference: `d9e9a9a` (RI CCRI CourseLeaf), `5c45bce` (VT CCV catalog).
 
+### Skip what Phase 2 already got
+Colleague Self-Service scrapes get prereq info inline via the `SectionDetails` API, and Banner SSB 9 via `getSectionPrerequisites`. If your Phase 2 scraper already populated `prerequisite_text` on sections, Phase 4 only needs to cover colleges Phase 2 missed. MA Phase 4 only ran against GCC + Middlesex (the two Banner 8 colleges); the other four had prereqs from Phase 2.
+
+### Multi-college states: handle course-code collisions
+When a state has multiple CCs whose course codes overlap — e.g. MA has "ART 123" at both GCC and Middlesex with different prereqs — merging into a single `prereqs.json` collapses them and silently loses data. Pattern reference: `scripts/ma/scrape-catalog-prereqs-gcc.ts` + `scripts/ma/scrape-catalog-prereqs-middlesex.ts` demonstrate the shared-file merge:
+
+- Each scraper writes to the same `data/{ST}/prereqs.json` and tags every entry with `source: "<college-slug>"`.
+- On merge, if a key already exists from a different source, the new one is stashed under a `"<source>:KEY"` prefix (e.g. `"middlesex:ART 123"`) instead of overwriting the bare key.
+- Re-running one scraper replaces only that source's entries, leaving the other college's data intact.
+
+Single-CC states and states where colleges use suffixed codes (NH's CCSNH: `ACCT113G` at GBCC, `ACCT113M` at MCC) don't need this — no collisions possible.
+
 ## Phase 5 — Supabase import
 
 Run `scripts/import-courses.ts` and `scripts/import-transfers.ts` for the new state. These auto-derive the state list from the registry — no edits needed. Verify row counts before and after.
+
+### After import: confirm the next prod build completes
+Supabase imports add a lot of rows at once. The static-generation step for `/colleges` runs `buildTransferLookupForCourses` per college per state; this query scales with total transfer rows across all states and has a strict `service_role` statement timeout.
+
+MA's Phase 5 import (45k+ transfer mappings) triggered exactly this failure — the next Vercel build failed with `canceling statement due to statement timeout` on `/colleges/page`. We bandaided by bumping `service_role statement_timeout` to 180s in Supabase; [issue #44](https://github.com/rohan-c0de/coursemap/issues/44) tracks the proper query optimization.
+
+**After running the imports, watch the next Vercel deploy.** If it fails on `/colleges/page` with a timeout, run this once in Supabase SQL Editor:
+
+```sql
+ALTER ROLE service_role SET statement_timeout = '180s';
+```
+
+Then retry the deploy. If the symptom recurs at a larger ceiling, read issue #44 before raising the timeout further — the real fix is a query refactor, not more slack.
 
 ## Checklist before each PR
 
@@ -70,7 +121,7 @@ Observed pattern: one-line summary → blank → bullet points of what's in the 
 
 ## Keeping this skill fresh
 
-This skill is a **static markdown file** — it does NOT auto-update as new states are added. The state names and commit hashes below are snapshots from when this skill was written (April 2026, covering through CT/RI/VT/ME/NJ/PA). Treat them as examples, not the ground truth.
+This skill is a **static markdown file** — it does NOT auto-update as new states are added. The state names and commit hashes below are snapshots from when this skill was last updated (April 2026, covering through CT/RI/VT/ME/NJ/PA/NH/MA). Treat them as examples, not the ground truth.
 
 ### Before using a cited state as a template
 Don't blindly clone from a named state (NC, SC, TN, etc.). The cited state was the best same-platform exemplar *at the time this skill was written*. A newer state may now be a better template. Before cloning, verify:


### PR DESCRIPTION
## Summary
Four targeted updates to \`.claude/skills/add-new-state/SKILL.md\` based on what I learned adding NH and MA this session. Docs-only — no code changes, no user-facing impact.

## The four edits

### Phase 2 — new "auth-gated outcome" section
MA's 15 colleges broke down 6 scrapable / 9 not. Five of the nine were behind Microsoft SAML. The skill previously said "identify the platform" but didn't say what to do when the answer is "no public access." New content:
- Signals that a platform is auth-gated (SAML redirect, stale term dropdown, empty portlet)
- Rule: document the gap, move on, don't fight auth

Also expanded the platform template list with MD/DE/SC/NH/MA exemplars and flagged Banner 8 flat-table (RI) as an outlier so future cloners default to the MD/DE/SC hierarchical variant.

### Phase 3 — reframed state-run portals as the primary lever
Current text lists ARTSYS/NJTransfer/CollegeTransfer.Net as "sources." Updated version leads with: **check for a state-run articulation system first; it can compensate for Phase 2 gaps.** MassTransfer covered all 15 MA colleges including 5 with zero Phase 2 data — that's a ~10× leverage play vs. slogging through per-college work. Added a known-source list (MassTransfer, ARTSYS, NJTransfer, TNTransfers, + USNH-style system lookups).

### Phase 4 — skip what Phase 2 got; collision handling for multi-CC states
Two additions:
1. Colleague + Banner SSB 9 scrapes include prereqs inline. Phase 4 only needs to cover colleges Phase 2 missed. MA Phase 4 only ran on GCC + Middlesex (the two Banner 8 colleges).
2. When a state has multiple CCs with overlapping course codes (MA's "ART 123" exists at both GCC and Middlesex with different prereqs), use the source-tag merge pattern from \`scripts/ma/scrape-catalog-prereqs-{gcc,middlesex}.ts\`. Single-CC states and states with suffixed codes (NH's ACCT113G vs ACCT113M) don't need it.

### Phase 5 — post-import build check
Large Supabase imports can blow past \`service_role\` statement_timeout during the next Vercel build (MA = 45k rows broke it). Documented the bandaid SQL and pointed at [issue #44](https://github.com/rohan-c0de/coursemap/issues/44) for the real fix.

## What I considered and explicitly rejected
Per the user's prompt ("recommend only if it makes sense"):

- Additional CLAUDE.md changes — file already grew significantly this session; more would dilute.
- Acalog AWS WAF retry guidance — too niche, one-off during Middlesex scrape.
- Explicit Playwright-probe-script convention — judgment call, doesn't need codifying.
- Duplicating the three-verification-checks guidance in this skill — already in CLAUDE.md, duplication causes drift.

## Diff stats
59 insertions, 8 deletions, 1 file. Went from 96 → 146 lines (+52%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)