### PR TITLE
Add guidance taxonomy to CLAUDE.md; align walkthrough with usability-reviewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,26 @@ Source of truth: `.env.example` in repo root. Local dev uses `.env.local` (gitig
 
 This is the most frequent multi-step workflow. See the `add-new-state` skill (`.claude/skills/add-new-state/`). Short version: bootstrap (data + config + registry) → course scraper → transfer data → prereqs → Supabase import. Each phase is its own PR.
 
+## Where guidance lives
+
+Before adding a new rule, recommendation, or reminder anywhere in this repo, ask which of these it is. Each category has one correct home. Putting the wrong thing in the wrong place either bloats a file no one wants to read or buries a rule no one will follow.
+
+| Category | Question it answers | Home |
+|---|---|---|
+| Universal rule | "Every session, every task — what should I always do?" | `CLAUDE.md` (this file) |
+| Workflow rule | "When I'm doing X specifically, what's the right sequence?" | Skill at `.claude/skills/{name}/SKILL.md` |
+| Analysis framework | "When reviewing / evaluating, what lens do I apply?" | Agent at `.claude/agents/{name}.md` |
+| Location-specific convention | "Why is this file / line / pattern this way?" | Comment at the site of the convention |
+| Long-lived decision + rationale | "Why did we choose A over B?" | Code comment, or (if one exists) an ADR |
+| Future work | "This should be built later" | GitHub issue — **not** a rule at all |
+
+**Decision procedure** when tempted to add guidance:
+1. Is this a **rule** (always-on behavior) or a **project** (build-once code / infra)? If project → GitHub issue. Stop.
+2. If rule: **universal** (every session) or **situational** (specific workflow)? Universal → CLAUDE.md. Situational → skill.
+3. Can this be **machine-enforced** (CI check, lint rule, hook, schema validation)? If yes, prefer that. Keep the human-readable rule only as a backstop, not the primary.
+
+CLAUDE.md is always in context; every line here costs per-session tokens. Keep it tight. Use skills and code comments for the bulky stuff.
+
 ## Git — narrate as you go
 
 The user is learning git in real time and wants to understand what's happening, not just approve blind steps. When running any git or `gh` command, narrate it in **one or two plain-English sentences** before or after the tool call:
@@ -81,14 +101,14 @@ After merging a PR, wait ~2-3 minutes for Vercel to redeploy, then load prod and
 
 Cost: one minute. Catches: missing registry entries, static-import gaps (see the NH/MA `/colleges` bug), Vercel build failures, environment variable drift. Silence here looks identical to success — so always pick a specific thing to verify, not just "it looks fine."
 
-### 3. Student-perspective walkthrough at major milestones
-After a whole state lands, or after a user-facing feature ships, use the site the way a first-gen student with no prior college experience would. Example scope:
+### 3. Heuristic walkthrough at major milestones
+After a whole state lands, or after a user-facing feature ships, walk through a concrete task against the live site using the `usability-reviewer` agent's nine lenses (information hierarchy, flow completeness, feedback & state, consistency, error recovery, affordances, data accuracy & trust, mobile parity, performance). Don't adopt a persona. Example task scope:
 
-> "I live in 02108, want a weekend accounting class, need to know if it transfers to UMass Boston."
+> "From a cold start at /, use the site to find a weekend accounting class at a Boston-area college that transfers to UMass Boston."
 
-Walk through the full flow. If any step confuses you, it'll confuse a real student. This is where empty states, missing copy, broken filter combos, and data shape mismatches across features reveal themselves.
+Walk through step by step. If any step dead-ends, shows no feedback, or produces inconsistent output across pages, that's a finding — quote the exact element and classify severity (blocker / friction / polish) and reach (universal / conditional / demographic).
 
-Cost: 5-10 minutes. Catches: the things the other two checks miss — interaction bugs, UX cliffs, cross-feature inconsistencies.
+Cost: 5–10 minutes. Catches: the things the other two checks miss — interaction bugs, UX cliffs, cross-feature inconsistencies, state drift in the URL vs. UI.
 
 ## Environment quirks
 


### PR DESCRIPTION
## Why
Two things have drifted:

1. There's no decision rule for **where a new piece of guidance should live**. CLAUDE.md grew ~20 lines this session alone with real universal rules, but without a stated taxonomy, the next session could just as easily dump workflow-specific or future-work content here. CLAUDE.md is always loaded into context, so every line carries a per-session token cost — it needs to stay tight.
2. The existing "Student-perspective walkthrough" section (check #3 of the three verification checks) still tells sessions to "use the site the way a first-gen student with no prior college experience would." That framing directly contradicts the rewritten \`usability-reviewer\` agent in PR #46, which drops personas entirely and applies nine heuristic lenses instead.

## Changes
Both edits are in \`CLAUDE.md\`, no code changes.

### 1. New "Where guidance lives" section
Short table classifying every kind of guidance by its correct home:

| Category | Home |
|---|---|
| Universal rule (every session) | CLAUDE.md |
| Workflow rule (specific task) | Skill |
| Analysis framework | Agent |
| Location-specific convention | Code comment |
| Long-lived decision + rationale | Code comment or ADR |
| Future work | GitHub issue — not a rule |

Plus a three-step decision procedure: rule or project? universal or situational? can it be machine-enforced?

### 2. Reframed check #3
"Student-perspective walkthrough" → "Heuristic walkthrough". The check still exists (still 5–10 min, still catches UX cliffs), but now it references the \`usability-reviewer\` agent's nine lenses and requires findings to carry severity + reach classification. Example task scope updated to a persona-free framing.

## What I explicitly didn't do
Per the taxonomy: the seven roadmap items from my previous answer (registry-drift CI check, schema validation, scheduled scrapes, etc.) are **future work**, not rules. They get GitHub issues, not CLAUDE.md bullets. Separate pass.

## Stats
\`CLAUDE.md\`: 96 → 115 lines (+19, +20%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)