### PR TITLE
CI: registry-integrity check (closes #48)

### DIFF
--- a/.github/workflows/registry-integrity.yml
+++ b/.github/workflows/registry-integrity.yml
@@ -1,0 +1,25 @@
+name: Registry integrity
+
+on:
+  pull_request:
+    paths:
+      - "lib/states/**"
+      - "lib/institutions.ts"
+      - "lib/geo.ts"
+      - "data/**"
+      - "scripts/check-registry-integrity.ts"
+      - ".github/workflows/registry-integrity.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run check:registry

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "check:registry": "tsx scripts/check-registry-integrity.ts",
     "scrape": "tsx scripts/scrape-vccs.ts",
     "scrape:college": "tsx scripts/scrape-vccs.ts --college",
     "discover:ps": "tsx scripts/discover-ps-responses.ts",

--- a/scripts/check-registry-integrity.ts
+++ b/scripts/check-registry-integrity.ts
@@ -1,0 +1,124 @@
+/**
+ * Registry integrity check.
+ *
+ * For every slug in `getAllStates()`, verifies that every per-state
+ * touchpoint is wired up — data files present, config importable, and
+ * the slug appears in both `lib/institutions.ts` (REGISTRY) and
+ * `lib/geo.ts` (ZIP_REGISTRY). These two files use static imports for
+ * edge-runtime compatibility, so a missing entry silently produces an
+ * empty page in production rather than a build error. See issue #48.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { getAllStates } from "../lib/states/registry";
+import { loadInstitutions } from "../lib/institutions";
+
+const ROOT = resolve(__dirname, "..");
+const errors: string[] = [];
+
+function err(slug: string, msg: string) {
+  errors.push(`[${slug}] ${msg}`);
+}
+
+const institutionsSrc = readFileSync(resolve(ROOT, "lib/institutions.ts"), "utf8");
+const geoSrc = readFileSync(resolve(ROOT, "lib/geo.ts"), "utf8");
+
+for (const { slug } of getAllStates()) {
+  // 1. Data files exist and parse with the expected shape.
+  const instPath = resolve(ROOT, `data/${slug}/institutions.json`);
+  const zipPath = resolve(ROOT, `data/${slug}/zipcodes.json`);
+  const transferPath = resolve(ROOT, `data/${slug}/transfer-equiv.json`);
+
+  if (!existsSync(instPath)) {
+    err(slug, `data/${slug}/institutions.json missing`);
+  } else {
+    try {
+      const inst = JSON.parse(readFileSync(instPath, "utf8"));
+      if (!Array.isArray(inst) || inst.length === 0) {
+        err(slug, `data/${slug}/institutions.json must be a non-empty array`);
+      }
+    } catch (e) {
+      err(slug, `data/${slug}/institutions.json failed to parse: ${(e as Error).message}`);
+    }
+  }
+
+  if (!existsSync(zipPath)) {
+    err(slug, `data/${slug}/zipcodes.json missing`);
+  } else {
+    try {
+      const zips = JSON.parse(readFileSync(zipPath, "utf8"));
+      if (zips === null || typeof zips !== "object" || Array.isArray(zips)) {
+        err(slug, `data/${slug}/zipcodes.json must be an object (may be empty)`);
+      }
+    } catch (e) {
+      err(slug, `data/${slug}/zipcodes.json failed to parse: ${(e as Error).message}`);
+    }
+  }
+
+  if (!existsSync(transferPath)) {
+    err(slug, `data/${slug}/transfer-equiv.json missing`);
+  } else {
+    try {
+      const t = JSON.parse(readFileSync(transferPath, "utf8"));
+      if (!Array.isArray(t)) {
+        err(slug, `data/${slug}/transfer-equiv.json must be an array (may be empty)`);
+      }
+    } catch (e) {
+      err(slug, `data/${slug}/transfer-equiv.json failed to parse: ${(e as Error).message}`);
+    }
+  }
+
+  // 2. Per-state config file present.
+  if (!existsSync(resolve(ROOT, `lib/states/${slug}/config.ts`))) {
+    err(slug, `lib/states/${slug}/config.ts missing`);
+  }
+
+  // 3. `lib/institutions.ts` must import and register this slug.
+  //    Matches the key-colon pattern inside the REGISTRY literal, e.g. `  ma: maInstitutions`.
+  const instImport = institutionsSrc.includes(`@/data/${slug}/institutions.json`);
+  const instKey = new RegExp(`\\b${slug}:\\s*\\w+Institutions\\b`).test(institutionsSrc);
+  if (!instImport || !instKey) {
+    err(
+      slug,
+      `lib/institutions.ts missing import/registry entry for "${slug}". Add the static import and the REGISTRY key.`
+    );
+  }
+
+  // 4. `lib/geo.ts` must import and register this slug in ZIP_REGISTRY.
+  const zipImport = geoSrc.includes(`@/data/${slug}/zipcodes.json`);
+  const zipKey = new RegExp(`\\b${slug}:\\s*\\w+Zipcodes\\b`).test(geoSrc);
+  if (!zipImport || !zipKey) {
+    err(
+      slug,
+      `lib/geo.ts missing import/registry entry for "${slug}". Add the static import and the ZIP_REGISTRY key.`
+    );
+  }
+
+  // 5. Runtime check: loadInstitutions(slug) returns a non-empty array.
+  //    Guards against the REGISTRY map being present but wired to the wrong import.
+  try {
+    const loaded = loadInstitutions(slug);
+    if (!Array.isArray(loaded) || loaded.length === 0) {
+      err(slug, `loadInstitutions("${slug}") returned empty — registry entry not wired correctly`);
+    }
+  } catch (e) {
+    err(slug, `loadInstitutions("${slug}") threw: ${(e as Error).message}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Registry integrity check FAILED:\n");
+  for (const line of errors) console.error("  " + line);
+  console.error(
+    `\n${errors.length} issue(s) found across ${getAllStates().length} registered state(s).`
+  );
+  console.error(
+    "\nEvery state slug in lib/states/registry.ts must also be registered in lib/institutions.ts and lib/geo.ts."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Registry integrity OK — ${getAllStates().length} states fully registered.`
+);


### PR DESCRIPTION
## Summary
- New CI check that loads every slug from `getAllStates()` and asserts each is fully registered in `lib/institutions.ts` and `lib/geo.ts`, plus has the required data files (`institutions.json`, `zipcodes.json`, `transfer-equiv.json`) and config.
- Catches the exact class of bug that silently broke `/nh/colleges` and `/ma/colleges` in production — state in the registry but missing from the static-import maps, so the page rendered empty with no error.
- Runs on every PR touching `lib/states/**`, `lib/institutions.ts`, `lib/geo.ts`, or `data/**`.

## Test plan
- [x] `npm run check:registry` passes on the current 17-state main.
- [x] Negative test: removing the `ma:` entry from `lib/institutions.ts` causes the script to exit 1 with a clear error naming the slug and the file.
- [ ] CI run on this PR turns green.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)