### PR TITLE
Schema validation on scraper output before Supabase import (closes #49)

### DIFF
--- a/.claude/skills/add-new-state/SKILL.md
+++ b/.claude/skills/add-new-state/SKILL.md
@@ -93,6 +93,8 @@ Single-CC states and states where colleges use suffixed codes (NH's CCSNH: `ACCT
 
 Run `scripts/import-courses.ts` and `scripts/import-transfers.ts` for the new state. These auto-derive the state list from the registry — no edits needed. Verify row counts before and after.
 
+Imports run every row through schema validation (`lib/schemas.ts`). If your scraper's output fails validation, **fix the scraper** — don't bypass the check. When >5% of rows in a (college, term) combination fail, the import aborts that combination with cloud data unchanged; when <5% fail, bad rows are logged and skipped. Run `npx tsx scripts/check-scraper-output.ts --state <slug>` as a dry-run before the real import.
+
 ### After import: confirm the next prod build completes
 Supabase imports add a lot of rows at once. The static-generation step for `/colleges` runs `buildTransferLookupForCourses` per college per state; this query scales with total transfer rows across all states and has a strict `service_role` statement timeout.
 

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,152 @@
+/**
+ * Zod schemas for scraper output.
+ *
+ * These are the shapes that scrapers produce and that import scripts
+ * consume. Validate before upsert to Supabase so a broken scraper can't
+ * silently poison student-facing data. See issue #49.
+ *
+ * Shapes match the interfaces in `scripts/lib/supabase-import.ts` plus
+ * `data/{state}/prereqs.json`.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// CourseSection — one entry in data/{state}/courses/{college}/{term}.json
+// ---------------------------------------------------------------------------
+
+export const CourseSectionSchema = z.object({
+  // `state`, `college_code`, and `term` in the JSON are advisory — the
+  // import script trusts the directory + filename instead. Accept them if
+  // present but do not require them.
+  state: z.string().optional(),
+  college_code: z.string().optional(),
+  term: z.string().optional(),
+
+  // Required identity + content fields. A row missing any of these is unusable.
+  course_prefix: z.string().min(1, "course_prefix required"),
+  course_number: z.string().min(1, "course_number required"),
+  course_title: z.string().min(1, "course_title required"),
+  credits: z.number().nonnegative("credits must be >= 0"),
+  crn: z.string().min(1, "crn required"),
+
+  // Schedule fields — may legitimately be empty strings or "TBA".
+  days: z.string(),
+  start_time: z.string(),
+  end_time: z.string(),
+  start_date: z.string().nullable().optional(),
+  location: z.string(),
+  campus: z.string(),
+
+  // Constrained vocabulary. Anything else means the scraper invented a mode.
+  // `zoom` = synchronous remote class (distinct from asynchronous `online`).
+  mode: z.enum(["in-person", "online", "hybrid", "zoom"]),
+
+  instructor: z.string().nullable().optional(),
+  seats_open: z.number().nullable().optional(),
+  seats_total: z.number().nullable().optional(),
+
+  prerequisite_text: z.string().nullable().optional(),
+  prerequisite_courses: z.array(z.string()),
+});
+
+export type CourseSection = z.infer<typeof CourseSectionSchema>;
+
+// ---------------------------------------------------------------------------
+// TransferMapping — one entry in data/{state}/transfer-equiv.json
+// ---------------------------------------------------------------------------
+
+export const TransferMappingSchema = z.object({
+  cc_prefix: z.string().min(1),
+  cc_number: z.string().min(1),
+  cc_course: z.string().min(1),
+  cc_title: z.string(),
+  cc_credits: z.string(),
+  university: z.string().min(1),
+  university_name: z.string().min(1),
+  univ_course: z.string(),
+  univ_title: z.string(),
+  univ_credits: z.string(),
+  notes: z.string(),
+  no_credit: z.boolean(),
+  is_elective: z.boolean(),
+});
+
+export type TransferMapping = z.infer<typeof TransferMappingSchema>;
+
+/**
+ * Header rows (e.g. `cc_prefix: "VCCS"`, `cc_number: "Course Number"`) are
+ * carried in some transfer files as a metadata row. Callers should filter
+ * these out before validation — see `isTransferHeaderRow`.
+ */
+export function isTransferHeaderRow(m: Record<string, unknown>): boolean {
+  return (
+    m.cc_number === "Course Number" ||
+    m.cc_prefix === "VCCS" ||
+    m.cc_prefix === "NCCCS" ||
+    m.cc_prefix === "SCTCS"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PrereqEntry — value side of data/{state}/prereqs.json (keyed by "ACC 212")
+// ---------------------------------------------------------------------------
+
+export const PrereqEntrySchema = z.object({
+  text: z.string(),
+  courses: z.array(z.string()),
+});
+
+export type PrereqEntry = z.infer<typeof PrereqEntrySchema>;
+
+export const PrereqMapSchema = z.record(z.string(), PrereqEntrySchema);
+
+// ---------------------------------------------------------------------------
+// Validation helper with row-level error reporting
+// ---------------------------------------------------------------------------
+
+export interface ValidationResult<T> {
+  valid: T[];
+  /** One entry per invalid row, with the original index and the failure summary. */
+  invalid: Array<{ index: number; identity: string; errors: string[] }>;
+}
+
+/**
+ * Validate an array of rows against a schema. Keeps invalid rows out of the
+ * `valid` list and records a compact error summary for each.
+ *
+ * `identify` derives a short human label (e.g. "brcc/2026SP CRN 70056") so
+ * log output points at the specific row, not just the file as a whole.
+ */
+export function validateRows<T>(
+  rows: unknown[],
+  schema: z.ZodType<T>,
+  identify: (row: unknown, index: number) => string
+): ValidationResult<T> {
+  const valid: T[] = [];
+  const invalid: ValidationResult<T>["invalid"] = [];
+
+  rows.forEach((row, index) => {
+    const result = schema.safeParse(row);
+    if (result.success) {
+      valid.push(result.data);
+    } else {
+      invalid.push({
+        index,
+        identity: identify(row, index),
+        errors: result.error.issues.map(
+          (i) => `${i.path.join(".") || "<root>"}: ${i.message}`
+        ),
+      });
+    }
+  });
+
+  return { valid, invalid };
+}
+
+/**
+ * Threshold above which an import should abort rather than proceed with
+ * partial data. At 5%, a single bad-field regression across one college
+ * still lets the import complete; a systemic scraper break does not.
+ */
+export const MAX_INVALID_RATIO = 0.05;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "auditmap-virginia",
+  "name": "cc-coursemap",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "auditmap-virginia",
+      "name": "cc-coursemap",
       "version": "0.1.0",
       "dependencies": {
         "@mdx-js/loader": "^3.1.1",
@@ -21,7 +21,8 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-leaflet": "^5.0.0",
-        "resend": "^6.10.0"
+        "resend": "^6.10.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -9565,7 +9566,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-leaflet": "^5.0.0",
-    "resend": "^6.10.0"
+    "resend": "^6.10.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/scripts/check-scraper-output.ts
+++ b/scripts/check-scraper-output.ts
@@ -1,0 +1,96 @@
+/**
+ * Dry-run validator for existing scraper output.
+ *
+ * Runs the same schemas the import scripts now enforce against every JSON
+ * file under `data/{state}/...`. Flags (state, college, term) combinations
+ * that would exceed the 5% failure threshold and abort on import.
+ *
+ * Usage:
+ *   npx tsx scripts/check-scraper-output.ts          # all states
+ *   npx tsx scripts/check-scraper-output.ts --state va
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { getAllStates } from "../lib/states/registry";
+import {
+  CourseSectionSchema,
+  TransferMappingSchema,
+  MAX_INVALID_RATIO,
+  validateRows,
+  isTransferHeaderRow,
+} from "../lib/schemas";
+
+const ROOT = resolve(__dirname, "..");
+const args = process.argv.slice(2);
+const stateIdx = args.indexOf("--state");
+const onlyState = stateIdx >= 0 ? args[stateIdx + 1] : null;
+
+const states = getAllStates()
+  .map((s) => s.slug)
+  .filter((s) => !onlyState || s === onlyState);
+
+let wouldAbort = 0;
+let totalBad = 0;
+
+for (const state of states) {
+  const coursesDir = resolve(ROOT, "data", state, "courses");
+  if (existsSync(coursesDir)) {
+    for (const college of readdirSync(coursesDir)) {
+      const dir = resolve(coursesDir, college);
+      if (!statSync(dir).isDirectory()) continue;
+      for (const file of readdirSync(dir).filter((f) => f.endsWith(".json"))) {
+        const term = file.replace(".json", "");
+        const rows = JSON.parse(readFileSync(resolve(dir, file), "utf8"));
+        if (!Array.isArray(rows) || rows.length === 0) continue;
+        const v = validateRows(rows, CourseSectionSchema, (r, i) => {
+          const x = r as Record<string, unknown>;
+          return `${college}/${term} CRN ${x.crn ?? i}`;
+        });
+        const ratio = v.invalid.length / rows.length;
+        if (v.invalid.length > 0) {
+          totalBad += v.invalid.length;
+          const flag = ratio > MAX_INVALID_RATIO ? "ABORT" : "warn ";
+          if (ratio > MAX_INVALID_RATIO) wouldAbort++;
+          console.log(
+            `${flag} ${state}/${college}/${term}: ${v.invalid.length}/${rows.length} bad (${(ratio * 100).toFixed(1)}%)`
+          );
+          for (const bad of v.invalid.slice(0, 3)) {
+            console.log(`       ${bad.identity}: ${bad.errors.join("; ")}`);
+          }
+        }
+      }
+    }
+  }
+
+  const transferPath = resolve(ROOT, "data", state, "transfer-equiv.json");
+  if (existsSync(transferPath)) {
+    const all = JSON.parse(readFileSync(transferPath, "utf8"));
+    if (Array.isArray(all) && all.length > 0) {
+      const data = all.filter((m: Record<string, unknown>) => !isTransferHeaderRow(m));
+      if (data.length > 0) {
+        const v = validateRows(data, TransferMappingSchema, (r, i) => {
+          const x = r as Record<string, unknown>;
+          return `${x.cc_course ?? i} -> ${x.university ?? "?"}`;
+        });
+        const ratio = v.invalid.length / data.length;
+        if (v.invalid.length > 0) {
+          totalBad += v.invalid.length;
+          const flag = ratio > MAX_INVALID_RATIO ? "ABORT" : "warn ";
+          if (ratio > MAX_INVALID_RATIO) wouldAbort++;
+          console.log(
+            `${flag} ${state}/transfer-equiv: ${v.invalid.length}/${data.length} bad (${(ratio * 100).toFixed(1)}%)`
+          );
+          for (const bad of v.invalid.slice(0, 3)) {
+            console.log(`       ${bad.identity}: ${bad.errors.join("; ")}`);
+          }
+        }
+      }
+    }
+  }
+}
+
+console.log(
+  `\n${totalBad} invalid row(s) total. ${wouldAbort} (state, college, term) combination(s) would abort on import.`
+);
+if (wouldAbort > 0) process.exit(1);

--- a/scripts/lib/supabase-import.ts
+++ b/scripts/lib/supabase-import.ts
@@ -15,6 +15,13 @@ import * as fs from "fs";
 import * as path from "path";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { loadEnv } from "./load-env";
+import {
+  CourseSectionSchema,
+  TransferMappingSchema,
+  MAX_INVALID_RATIO,
+  validateRows,
+  isTransferHeaderRow,
+} from "../../lib/schemas";
 
 const BATCH_SIZE = 500;
 
@@ -101,6 +108,46 @@ export async function importCoursesToSupabase(state: string): Promise<number> {
 
       if (sections.length === 0) continue;
 
+      // Schema-validate every section before touching Supabase. If >5% fail,
+      // abort this (college, term) entirely — the scraper is broken and
+      // half-importing would replace good cloud data with partial data.
+      // If <5% fail, log and skip the bad rows so one malformed section
+      // doesn't block an otherwise-good import. See issue #49.
+      const validation = validateRows(
+        sections,
+        CourseSectionSchema,
+        (row, i) => {
+          const r = row as Record<string, unknown>;
+          const label = r.crn ? `CRN ${r.crn}` : `row ${i}`;
+          const course = r.course_prefix && r.course_number
+            ? `${r.course_prefix} ${r.course_number}`
+            : "<unknown course>";
+          return `${slug}/${term} ${course} ${label}`;
+        }
+      );
+
+      const invalidRatio = validation.invalid.length / sections.length;
+      if (validation.invalid.length > 0) {
+        console.warn(
+          `  SCHEMA ${slug}/${term}: ${validation.invalid.length}/${sections.length} rows failed validation (${(invalidRatio * 100).toFixed(1)}%)`
+        );
+        for (const bad of validation.invalid.slice(0, 10)) {
+          console.warn(`    - ${bad.identity}: ${bad.errors.join("; ")}`);
+        }
+        if (validation.invalid.length > 10) {
+          console.warn(
+            `    - ...and ${validation.invalid.length - 10} more`
+          );
+        }
+      }
+
+      if (invalidRatio > MAX_INVALID_RATIO) {
+        console.error(
+          `  ABORT ${slug}/${term}: invalid-row ratio ${(invalidRatio * 100).toFixed(1)}% exceeds ${(MAX_INVALID_RATIO * 100).toFixed(0)}% threshold. Fix the scraper and re-run. Cloud data for this (college, term) is unchanged.`
+        );
+        continue;
+      }
+
       // Delete existing rows for this (state, college, term)
       const { error: delError } = await sb
         .from("courses")
@@ -122,9 +169,12 @@ export async function importCoursesToSupabase(state: string): Promise<number> {
       // term but inserts off the row term — leaving stale rows forever. Same
       // for college_code: if a scraper wrote the wrong slug, future imports
       // never clean it up. Always trust the directory structure.
+      const validatedSections = validation.valid;
+      if (validatedSections.length === 0) continue;
+
       let rowTermOverrides = 0;
       let rowSlugOverrides = 0;
-      const rows: CourseRow[] = sections.map((s) => {
+      const rows: CourseRow[] = validatedSections.map((s) => {
         if (s.term && s.term !== term) rowTermOverrides++;
         if (s.college_code && s.college_code !== slug) rowSlugOverrides++;
         return {
@@ -244,21 +294,52 @@ export async function importTransfersToSupabase(
   const mappings = JSON.parse(raw) as Array<Record<string, unknown>>;
 
   // Skip header row if present (cc_prefix === "VCCS" or similar header-like value)
-  const data = mappings.filter(
-    (m) =>
-      m.cc_number !== "Course Number" &&
-      m.cc_prefix !== "VCCS" &&
-      m.cc_prefix !== "NCCCS" &&
-      m.cc_prefix !== "SCTCS"
-  );
+  const data = mappings.filter((m) => !isTransferHeaderRow(m));
 
   if (data.length === 0) {
     console.log(`  No transfer mappings for ${state}.`);
     return 0;
   }
 
+  // Schema-validate. Same 5% abort threshold as course import (issue #49).
+  const validation = validateRows(
+    data,
+    TransferMappingSchema,
+    (row, i) => {
+      const r = row as Record<string, unknown>;
+      const cc = r.cc_course || `${r.cc_prefix ?? "?"} ${r.cc_number ?? "?"}`;
+      return `${state} ${cc} -> ${r.university ?? "?"} (row ${i})`;
+    }
+  );
+
+  const invalidRatio = validation.invalid.length / data.length;
+  if (validation.invalid.length > 0) {
+    console.warn(
+      `  SCHEMA ${state} transfers: ${validation.invalid.length}/${data.length} rows failed validation (${(invalidRatio * 100).toFixed(1)}%)`
+    );
+    for (const bad of validation.invalid.slice(0, 10)) {
+      console.warn(`    - ${bad.identity}: ${bad.errors.join("; ")}`);
+    }
+    if (validation.invalid.length > 10) {
+      console.warn(`    - ...and ${validation.invalid.length - 10} more`);
+    }
+  }
+
+  if (invalidRatio > MAX_INVALID_RATIO) {
+    console.error(
+      `  ABORT ${state} transfers: invalid-row ratio ${(invalidRatio * 100).toFixed(1)}% exceeds ${(MAX_INVALID_RATIO * 100).toFixed(0)}% threshold. Fix the scraper and re-run. Cloud transfer data for this state is unchanged.`
+    );
+    return 0;
+  }
+
+  const validated = validation.valid;
+  if (validated.length === 0) {
+    console.log(`  No valid transfer mappings for ${state} after validation.`);
+    return 0;
+  }
+
   console.log(
-    `\nImporting ${state.toUpperCase()} transfers into Supabase: ${data.length} mappings`
+    `\nImporting ${state.toUpperCase()} transfers into Supabase: ${validated.length} mappings`
   );
 
   // Delete existing rows for this state
@@ -273,21 +354,21 @@ export async function importTransfersToSupabase(
   }
 
   // Prepare rows
-  const rows: TransferRow[] = data.map((m) => ({
+  const rows: TransferRow[] = validated.map((m) => ({
     state,
-    cc_prefix: (m.cc_prefix as string) || "",
-    cc_number: (m.cc_number as string) || "",
-    cc_course: (m.cc_course as string) || "",
-    cc_title: (m.cc_title as string) || "",
-    cc_credits: (m.cc_credits as string) || "",
-    university: (m.university as string) || "",
-    university_name: (m.university_name as string) || "",
-    univ_course: (m.univ_course as string) || "",
-    univ_title: (m.univ_title as string) || "",
-    univ_credits: (m.univ_credits as string) || "",
-    notes: (m.notes as string) || "",
-    no_credit: (m.no_credit as boolean) || false,
-    is_elective: (m.is_elective as boolean) || false,
+    cc_prefix: m.cc_prefix,
+    cc_number: m.cc_number,
+    cc_course: m.cc_course,
+    cc_title: m.cc_title,
+    cc_credits: m.cc_credits,
+    university: m.university,
+    university_name: m.university_name,
+    univ_course: m.univ_course,
+    univ_title: m.univ_title,
+    univ_credits: m.univ_credits,
+    notes: m.notes,
+    no_credit: m.no_credit,
+    is_elective: m.is_elective,
   }));
 
   // Insert in batches — abort on first failure to limit data loss


### PR DESCRIPTION
## Summary
- `lib/schemas.ts` — Zod schemas for `CourseSection`, `TransferMapping`, `PrereqEntry`, plus a `validateRows` helper that returns per-row errors with identity strings (`brcc/2026SP ACC 211 CRN 70056`).
- `scripts/lib/supabase-import.ts` — both the course and transfer import paths validate every row before the delete-then-insert. >5% invalid → abort this (college, term) with cloud data unchanged; <5% → skip and log the specific bad rows.
- `scripts/check-scraper-output.ts` — dry-run validator across all state data.
- Skill update in `add-new-state` Phase 5: \"fix the scraper, don't bypass the check.\"

## Test plan
- [x] `npx tsx scripts/check-scraper-output.ts` — against all 17 states' current data, zero (state, college, term) combinations would abort. Real scraper edge cases (empty `course_title` in 2 NC rows; malformed MD transfer rows) fall within the <5% skip-and-log path.
- [x] Threshold smoke test: 95 good + 5 bad → proceed with 95 valid; 90 good + 10 bad → abort with clear error.
- [x] `npx tsc --noEmit` clean.
- [x] Error messages name the specific row (\"dyersburg-state/2026FA CRN 83053: mode: Invalid option...\"), not just the file.
- [ ] CI green on this PR.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)