### PR TITLE
Change-detection preflight on Supabase imports (closes #51)

### DIFF
--- a/.claude/skills/add-new-state/SKILL.md
+++ b/.claude/skills/add-new-state/SKILL.md
@@ -53,6 +53,10 @@ Signals the platform is auth-gated:
 
 **What to do when a college is gated:** document it in the commit, move on, and don't try to work around auth. Don't log in with a student account; don't use cached credentials. Note these colleges as Phase 2 gaps — Phase 3 (state-level transfer portal, if one exists) frequently covers them anyway. MA Phase 2 shipped with 6 of 15 colleges' course data; Phase 3 via MassTransfer filled the gap with transfer data for all 15.
 
+### Re-scrapes: change detection guards the import
+
+On any re-scrape (not a first-time state add), the import does a row-count preflight against what's currently in Supabase. If your new scrape produces **<50% of the existing rows** for a (college, term), the import aborts that combination — the scraper is almost certainly broken (expired auth cookie, source site returning partial results, parser regression). Investigate and fix the scraper rather than reaching for `--force`. A 50–90% shrinkage logs a warning and proceeds; growth always proceeds.
+
 ## Phase 3 — Transfer equivalencies
 
 **Start here by asking "does the state run an official articulation system?"** A state-run portal — where every CC ↔ university mapping is already curated in one place — is by a wide margin the highest-leverage move in the whole 5-phase workflow. One scrape can yield transfer data for *every* college in the state, including the ones whose scheduling systems are gated and thus have zero Phase 2 data. MA's MassTransfer scrape delivered 45,764 mappings across all 15 colleges × 14 receivers in ~70 seconds; five of those 15 colleges had zero course data from Phase 2 but got full transfer coverage here.

--- a/scripts/import-courses.ts
+++ b/scripts/import-courses.ts
@@ -18,6 +18,7 @@ async function main() {
   const args = process.argv.slice(2);
   const stateIdx = args.indexOf("--state");
   const isAll = args.includes("--all");
+  const force = args.includes("--force");
 
   let states: string[];
   if (isAll) {
@@ -42,7 +43,7 @@ async function main() {
 
   let grandTotal = 0;
   for (const state of states) {
-    const count = await importCoursesToSupabase(state);
+    const count = await importCoursesToSupabase(state, { force });
     grandTotal += count || 0;
   }
 

--- a/scripts/import-transfers.ts
+++ b/scripts/import-transfers.ts
@@ -17,6 +17,7 @@ async function main() {
   const args = process.argv.slice(2);
   const stateIdx = args.indexOf("--state");
   const isAll = args.includes("--all");
+  const force = args.includes("--force");
 
   let states: string[];
   if (isAll) {
@@ -41,7 +42,7 @@ async function main() {
 
   let grandTotal = 0;
   for (const state of states) {
-    const count = await importTransfersToSupabase(state);
+    const count = await importTransfersToSupabase(state, { force });
     grandTotal += count || 0;
   }
 

--- a/scripts/lib/supabase-import.ts
+++ b/scripts/lib/supabase-import.ts
@@ -25,6 +25,77 @@ import {
 
 const BATCH_SIZE = 500;
 
+// Change-detection thresholds (issue #51). A scraper that produces a
+// dramatically smaller dataset than what's already in Supabase is almost
+// always broken (expired auth cookie, source site offline, parser regression).
+// Keyed off incoming/existing ratio:
+//   < ABORT_RATIO   → refuse to import; require --force
+//   < WARN_RATIO    → proceed with a loud warning
+//   >= WARN_RATIO   → proceed silently (normal churn or growth)
+const ABORT_RATIO = 0.5;
+const WARN_RATIO = 0.9;
+
+/**
+ * Compare incoming row count against what's currently in Supabase for
+ * the given filter. Returns `{ ok, existing, message }` — if `ok` is
+ * false, caller should skip the import (or respect `--force`).
+ */
+export async function changeDetection(
+  sb: SupabaseClient,
+  table: "courses" | "transfers",
+  filter: Record<string, string>,
+  incoming: number,
+  label: string,
+  force: boolean
+): Promise<{ ok: boolean; existing: number; message: string }> {
+  let q = sb.from(table).select("*", { count: "exact", head: true });
+  for (const [k, v] of Object.entries(filter)) {
+    q = q.eq(k, v);
+  }
+  const { count, error } = await q;
+  if (error) {
+    return {
+      ok: true,
+      existing: 0,
+      message: `  (change-detection skipped for ${label}: ${error.message})`,
+    };
+  }
+  const existing = count ?? 0;
+
+  // First-time import (nothing to compare against) always proceeds.
+  if (existing === 0) {
+    return { ok: true, existing: 0, message: "" };
+  }
+
+  const ratio = incoming / existing;
+  const pct = (ratio * 100).toFixed(1);
+  const delta = incoming - existing;
+  const diff = `incoming ${incoming} vs. existing ${existing} (${delta >= 0 ? "+" : ""}${delta}, ${pct}%)`;
+
+  if (ratio < ABORT_RATIO) {
+    if (force) {
+      return {
+        ok: true,
+        existing,
+        message: `  FORCE ${label}: ${diff} — would have aborted (<${(ABORT_RATIO * 100).toFixed(0)}%), proceeding due to --force.`,
+      };
+    }
+    return {
+      ok: false,
+      existing,
+      message: `  ABORT ${label}: ${diff} — below ${(ABORT_RATIO * 100).toFixed(0)}% threshold. Scraper likely broken. Re-run --force to override.`,
+    };
+  }
+  if (ratio < WARN_RATIO) {
+    return {
+      ok: true,
+      existing,
+      message: `  WARN  ${label}: ${diff} — under ${(WARN_RATIO * 100).toFixed(0)}% of prior, proceeding.`,
+    };
+  }
+  return { ok: true, existing, message: "" };
+}
+
 function getSupabase(): SupabaseClient {
   loadEnv();
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -69,7 +140,11 @@ interface CourseRow {
  * Reads from data/{state}/courses/{slug}/{term}.json and upserts into the
  * `courses` table (delete-then-insert per college+term).
  */
-export async function importCoursesToSupabase(state: string): Promise<number> {
+export async function importCoursesToSupabase(
+  state: string,
+  opts: { force?: boolean } = {}
+): Promise<number> {
+  const force = !!opts.force;
   let sb: SupabaseClient;
   try {
     sb = getSupabase();
@@ -107,6 +182,19 @@ export async function importCoursesToSupabase(state: string): Promise<number> {
       const sections = JSON.parse(raw) as Array<Record<string, unknown>>;
 
       if (sections.length === 0) continue;
+
+      // Change-detection preflight: if incoming is far below existing,
+      // the scraper is probably broken. Abort unless --force. See issue #51.
+      const cd = await changeDetection(
+        sb,
+        "courses",
+        { state, college_code: slug, term },
+        sections.length,
+        `${slug}/${term}`,
+        force
+      );
+      if (cd.message) console.log(cd.message);
+      if (!cd.ok) continue;
 
       // Schema-validate every section before touching Supabase. If >5% fail,
       // abort this (college, term) entirely — the scraper is broken and
@@ -269,8 +357,10 @@ interface TransferRow {
  * Reads from data/{state}/transfer-equiv.json.
  */
 export async function importTransfersToSupabase(
-  state: string
+  state: string,
+  opts: { force?: boolean } = {}
 ): Promise<number> {
+  const force = !!opts.force;
   let sb: SupabaseClient;
   try {
     sb = getSupabase();
@@ -300,6 +390,18 @@ export async function importTransfersToSupabase(
     console.log(`  No transfer mappings for ${state}.`);
     return 0;
   }
+
+  // Change-detection preflight (issue #51).
+  const cd = await changeDetection(
+    sb,
+    "transfers",
+    { state },
+    data.length,
+    `${state} transfers`,
+    force
+  );
+  if (cd.message) console.log(cd.message);
+  if (!cd.ok) return 0;
 
   // Schema-validate. Same 5% abort threshold as course import (issue #49).
   const validation = validateRows(


### PR DESCRIPTION
## Summary
- New \`changeDetection()\` preflight in \`scripts/lib/supabase-import.ts\` that compares incoming row count against the existing Supabase count for the same filter.
- Thresholds: **<50% → abort** (cloud data unchanged, requires \`--force\` to override), **<90% → warn + proceed**, **>=90% → clean**. First-time imports (existing = 0) always proceed.
- Runs before the delete-then-insert in both \`importCoursesToSupabase\` (per state/college/term) and \`importTransfersToSupabase\` (per state).
- \`--force\` flag threaded through \`scripts/import-courses.ts\` and \`scripts/import-transfers.ts\` for intentional purges.
- \`add-new-state\` skill Phase 2 documents the re-scrape behavior.

## Scenarios this catches
- Banner endpoint format change → 10 rows instead of 500 → abort.
- College takes catalog offline → \`[]\` → abort.
- Scraper auth cookie expires mid-run → partial results → abort.
- Few sections drop between runs → warn, proceed.
- New sections open → proceed silently.

## Test plan
- [x] Stubbed-Supabase smoke test covers all branches: abort, force-override, warn, clean, growth, and first-time (existing = 0).
- [x] \`npx tsc --noEmit\` clean.
- [x] Error message format: \`ABORT brcc/2026SP: incoming 10 vs. existing 500 (-490, 2.0%) — below 50% threshold. Scraper likely broken. Re-run --force to override.\`
- [ ] CI green.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)