### PR TITLE
Weekly VA scrape workflow — PR-gated exemplar (closes #50)

### DIFF
--- a/.github/workflows/weekly-scrape-va.yml
+++ b/.github/workflows/weekly-scrape-va.yml
@@ -1,0 +1,116 @@
+name: Weekly scrape — VA (exemplar)
+
+# Exemplar for issue #50: re-scrape one state on a schedule and open a
+# PR with the updated data. Deliberately does NOT push to Supabase
+# (scripts run with --no-import) and does NOT auto-merge. A human reads
+# the diff before student-facing data changes.
+#
+# If the scraper produces a (college, term) file with <50% of the prior
+# row count, the workflow opens an issue instead of a PR — that pattern
+# matches the change-detection threshold in scripts/lib/supabase-import.ts
+# so the workflow and the import path agree on what "broken" means.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      term:
+        description: "Term(s) to scrape, comma-separated (default: auto-resolve)"
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Resolve current VCCS terms
+        id: terms
+        run: |
+          if [ -n "${{ inputs.term }}" ]; then
+            echo "value=${{ inputs.term }}" >> "$GITHUB_OUTPUT"
+          else
+            resolved=$(npx tsx scripts/lib/resolve-terms.ts --system vccs 2>/dev/null | jq -r '.terms | join(",")')
+            echo "value=${resolved}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Scrape VCCS (no Supabase import)
+        run: npx tsx scripts/va/scrape-vccs.ts --term "${{ steps.terms.outputs.value }}" --no-import
+
+      - name: Diff against main
+        id: diff
+        run: |
+          report=$(npx tsx scripts/va/weekly-scrape-diff.ts)
+          echo "$report"
+          # Collapse to single line for GITHUB_OUTPUT.
+          {
+            echo "report<<EOF"
+            echo "$report"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "broken=$(echo "$report" | jq -r '.broken')" >> "$GITHUB_OUTPUT"
+          echo "changed=$(echo "$report" | jq -r '.changed')" >> "$GITHUB_OUTPUT"
+
+      - name: Open issue on regression
+        if: steps.diff.outputs.broken == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIFF_REPORT: ${{ steps.diff.outputs.report }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          today=$(date -u +"%Y-%m-%d")
+          {
+            echo "The weekly VA scrape on ${today} produced one or more files with <50% of the prior row count — the scraper is likely broken (expired cookie, source-site change, parser regression)."
+            echo
+            echo '```json'
+            printf '%s\n' "$DIFF_REPORT"
+            echo '```'
+            echo
+            echo "**No PR was opened.** Inspect the scraper before re-running."
+            echo
+            echo "Workflow run: ${RUN_URL}"
+          } > issue-body.md
+          # Not using --label so the workflow doesn't hard-fail on a
+          # first-ever regression before anyone has created that label.
+          gh issue create \
+            --title "VA weekly scrape: suspected regression (${today})" \
+            --body-file issue-body.md
+
+      - name: Open PR with fresh data
+        if: steps.diff.outputs.broken == 'false' && steps.diff.outputs.changed != '0'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: weekly-scrape/va
+          commit-message: "Weekly VA scrape — ${{ steps.diff.outputs.changed }} file(s) updated"
+          title: "Weekly VA scrape — ${{ steps.diff.outputs.changed }} file(s) updated"
+          body: |
+            Automated output of the weekly VA scrape workflow (issue #50).
+
+            Diff summary:
+            ```json
+            ${{ steps.diff.outputs.report }}
+            ```
+
+            **Do not auto-merge.** Skim the changes — spot-check a couple of colleges in the preview URL before landing. Schema validation and change-detection both run again at import time when these files are picked up by `scripts/import-courses.ts`.
+          labels: scraper-output,automated
+          delete-branch: true
+
+      - name: No-op summary
+        if: steps.diff.outputs.broken == 'false' && steps.diff.outputs.changed == '0'
+        run: echo "No changes vs. main — nothing to PR."

--- a/scripts/va/weekly-scrape-diff.ts
+++ b/scripts/va/weekly-scrape-diff.ts
@@ -1,0 +1,109 @@
+/**
+ * weekly-scrape-diff.ts
+ *
+ * Compares the freshly-scraped `data/va/courses/**.json` files in the
+ * working tree against the versions committed on `HEAD`. Used by the
+ * weekly scheduled-scrape workflow (issue #50) to decide whether to open
+ * a PR with the new data, or instead open an issue because the scraper
+ * probably broke.
+ *
+ * Exits 0 always; writes a JSON report to stdout:
+ *   {
+ *     "broken": <boolean>,           // true if any (college,term) dropped >50%
+ *     "changed": <number>,           // total files with any diff
+ *     "regressions": [               // only populated when broken=true
+ *       { "file": "...", "before": 500, "after": 10, "ratio": "2.0%" }
+ *     ],
+ *     "summary": "human-readable one-liner"
+ *   }
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ABORT_RATIO = 0.5;
+const ROOT = resolve(__dirname, "..", "..");
+
+interface Regression {
+  file: string;
+  before: number;
+  after: number;
+  ratio: string;
+}
+
+function sh(cmd: string): string {
+  // 64 MB buffer — a single VA (college, term) JSON can exceed the
+  // Node default 1 MB limit once a few hundred sections land.
+  return execSync(cmd, { cwd: ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+}
+
+function countRows(json: string): number {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function beforeCount(file: string): number {
+  try {
+    // `git show HEAD:path` — if file didn't exist on HEAD, throws.
+    return countRows(sh(`git show HEAD:${file}`));
+  } catch {
+    return 0;
+  }
+}
+
+function afterCount(file: string): number {
+  const abs = resolve(ROOT, file);
+  if (!existsSync(abs)) return 0;
+  return countRows(readFileSync(abs, "utf8"));
+}
+
+const tracked = sh("git ls-files data/va/courses")
+  .trim()
+  .split("\n")
+  .filter((f) => f.endsWith(".json"));
+
+const untracked = sh("git ls-files --others --exclude-standard data/va/courses")
+  .trim()
+  .split("\n")
+  .filter((f) => f.endsWith(".json"));
+
+const files = Array.from(new Set([...tracked, ...untracked])).filter(Boolean);
+
+const regressions: Regression[] = [];
+let changed = 0;
+
+for (const file of files) {
+  const before = beforeCount(file);
+  const after = afterCount(file);
+  if (before === after) continue;
+  changed++;
+
+  // First-time-added file (before = 0) cannot regress.
+  if (before === 0) continue;
+
+  const ratio = after / before;
+  if (ratio < ABORT_RATIO) {
+    regressions.push({
+      file,
+      before,
+      after,
+      ratio: `${(ratio * 100).toFixed(1)}%`,
+    });
+  }
+}
+
+const broken = regressions.length > 0;
+const summary = broken
+  ? `ABORT: ${regressions.length} file(s) dropped below ${(ABORT_RATIO * 100).toFixed(0)}% of prior row count.`
+  : changed === 0
+    ? "No changes — scraper output identical to main."
+    : `${changed} file(s) changed; all within acceptable range.`;
+
+console.log(
+  JSON.stringify({ broken, changed, regressions, summary }, null, 2)
+);


### PR DESCRIPTION
## Summary
- First scheduled scraper, proving the review-gated pattern on one exemplar state (VA / VCCS).
- Runs every Monday 06:00 UTC (plus manual dispatch with an optional `term` input).
- `scripts/va/scrape-vccs.ts --no-import` writes into `data/va/courses/**` in the checkout.
- `scripts/va/weekly-scrape-diff.ts` compares each changed file's row count vs. `HEAD`.
  - Any (college, term) <50% of its prior row count → **open an issue**, no PR.
  - Diff looks sane → **open a PR** (branch `weekly-scrape/va`) via `peter-evans/create-pull-request@v7`.
  - Zero changes → no-op.
- Deliberately does NOT auto-merge and does NOT push to Supabase. Schema validation (#49) + change-detection (#51) run again when the PR lands and the import picks the files up.

## Matches acceptance criteria from #50
- [x] Scheduled + manual dispatch.
- [x] Successful run produces a PR (or no-op if no changes).
- [x] Broken-scraper case produces an issue, not a PR.

## Test plan
- [x] Diff script dry-run on a clean checkout: `{"broken":false,"changed":0,"summary":"No changes..."}`.
- [x] Negative test: truncate `data/va/courses/nova/2026SP.json` to 5 rows — diff reports `broken:true` with `before:4489 after:5 ratio:"0.1%"`.
- [x] Fixed a `maxBuffer` bug found during testing — large course JSON files exceed Node's default 1MB exec buffer.
- [ ] First live run on `main` — you'll see either a PR or a no-op summary step.

## Follow-up
- #52 fans this pattern out to the other states once this exemplar has run cleanly at least once.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)