### PR TITLE
Declare scraper coverage in StateConfig + coverage CI (part 1 of #59)

### DIFF
--- a/.github/workflows/scraper-coverage.yml
+++ b/.github/workflows/scraper-coverage.yml
@@ -1,0 +1,23 @@
+name: Scraper coverage
+
+on:
+  pull_request:
+    paths:
+      - "lib/states/**"
+      - "scripts/**"
+      - "scripts/check-scraper-coverage.ts"
+      - ".github/workflows/scraper-coverage.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run check:scrapers

--- a/lib/states/ct/config.ts
+++ b/lib/states/ct/config.ts
@@ -47,6 +47,11 @@ const ctConfig: StateConfig = {
       "Connecticut community college schedule",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/ct/scrape-banner.ts"], runner: "http" }],
+    transfers: [{ scripts: ["scripts/ct/scrape-transfer-all.ts"], runner: "http" }],
+    prereqs: [{ scripts: ["scripts/ct/scrape-catalog-prereqs.ts"], runner: "http" }],
+  },
 };
 
 export default ctConfig;

--- a/lib/states/dc/config.ts
+++ b/lib/states/dc/config.ts
@@ -57,6 +57,11 @@ const dcConfig: StateConfig = {
       "UDC schedule builder",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/dc/scrape-banner.ts"], runner: "http" }],
+    transfers: [{ scripts: ["scripts/dc/scrape-transfer.ts"], runner: "http" }],
+    prereqs: { source: "aggregate-from-courses" },
+  },
 };
 
 export default dcConfig;

--- a/lib/states/de/config.ts
+++ b/lib/states/de/config.ts
@@ -53,6 +53,19 @@ const deConfig: StateConfig = {
       "Del Tech schedule builder",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/de/scrape-banner-ssb.ts"], runner: "http" }],
+    transfers: [
+      {
+        scripts: [
+          "scripts/de/scrape-transfer-udel.ts",
+          "scripts/de/scrape-transfer-collegetransfer.ts",
+        ],
+        runner: "http",
+      },
+    ],
+    prereqs: [{ scripts: ["scripts/de/scrape-catalog-prereqs.ts"], runner: "http" }],
+  },
 };
 
 export default deConfig;

--- a/lib/states/ga/config.ts
+++ b/lib/states/ga/config.ts
@@ -80,6 +80,21 @@ const gaConfig: StateConfig = {
       "Georgia community college courses",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/ga/scrape-banner-ssb.ts"], runner: "http" }],
+    transfers: [
+      {
+        scripts: [
+          "scripts/ga/scrape-transfer-gatech.ts",
+          "scripts/ga/scrape-transfer-uga.ts",
+          "scripts/ga/scrape-transfer-gsu.ts",
+          "scripts/ga/scrape-transfer-usg.ts",
+        ],
+        runner: "http",
+      },
+    ],
+    prereqs: { source: "aggregate-from-courses" },
+  },
 };
 
 export default gaConfig;

--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -1,5 +1,11 @@
 import type { StateConfig } from "../registry";
 
+// manual-only: MA has rich scraper coverage (scrape-banner-ssb, scrape-banner8,
+// scrape-colleague, scrape-masstransfer, two per-college prereq scrapers) but nothing
+// is wired to cron yet. Intentional — 6 of 15 colleges are scrapable and we want to
+// confirm the long tail is stable before cron'ing. MassTransfer is weekly-ish-stable
+// and could be scheduled first.
+
 const maConfig: StateConfig = {
   slug: "ma",
   name: "Massachusetts",

--- a/lib/states/md/config.ts
+++ b/lib/states/md/config.ts
@@ -133,6 +133,23 @@ const mdConfig: StateConfig = {
       "MD schedule builder",
     ],
   },
+  scrapers: {
+    courses: [
+      {
+        scripts: [
+          "scripts/md/scrape-banner-ssb.ts",
+          "scripts/md/scrape-banner8.ts",
+          "scripts/md/scrape-custom.ts",
+        ],
+        runner: "http",
+      },
+      {
+        scripts: ["scripts/md/scrape-colleague.ts", "scripts/md/scrape-jenzabar.ts"],
+        runner: "playwright",
+      },
+    ],
+    transfers: [{ scripts: ["scripts/md/scrape-transfer-artsys.ts"], runner: "http" }],
+  },
 };
 
 export default mdConfig;

--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -53,6 +53,10 @@ const meConfig: StateConfig = {
       "Maine community college schedule",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/me/scrape-mccs.ts"], runner: "playwright" }],
+    transfers: [{ scripts: ["scripts/me/scrape-transfer.ts"], runner: "http" }],
+  },
 };
 
 export default meConfig;

--- a/lib/states/nc/config.ts
+++ b/lib/states/nc/config.ts
@@ -107,6 +107,40 @@ const ncConfig: StateConfig = {
       "NC schedule builder",
     ],
   },
+  scrapers: {
+    courses: [
+      {
+        scripts: [
+          "scripts/nc/scrape-albemarle.ts",
+          "scripts/nc/scrape-cape-fear.ts",
+          "scripts/nc/scrape-cleveland.ts",
+          "scripts/nc/scrape-martin.ts",
+          "scripts/nc/scrape-mayland.ts",
+          "scripts/nc/scrape-pamlico.ts",
+          "scripts/nc/scrape-sandhills.ts",
+          "scripts/nc/scrape-southeastern.ts",
+          "scripts/nc/scrape-tri-county.ts",
+        ],
+        runner: "http",
+      },
+      { scripts: ["scripts/nc/scrape-colleague.ts"], runner: "playwright" },
+    ],
+    transfers: [
+      {
+        scripts: [
+          "scripts/nc/scrape-transfer-cns.ts",
+          "scripts/nc/scrape-transfer-catawba.ts",
+          "scripts/nc/scrape-transfer-elon.ts",
+          "scripts/nc/scrape-transfer-hpu.ts",
+          "scripts/nc/scrape-transfer-ncstate.ts",
+          "scripts/nc/scrape-transfer-uncg.ts",
+          "scripts/nc/scrape-transfer-wingate.ts",
+        ],
+        runner: "http",
+      },
+    ],
+    prereqs: { source: "aggregate-from-courses" },
+  },
 };
 
 export default ncConfig;

--- a/lib/states/nh/config.ts
+++ b/lib/states/nh/config.ts
@@ -1,5 +1,9 @@
 import type { StateConfig } from "../registry";
 
+// manual-only: NH scrapers exist (scrape-banner8 / scrape-catalog-prereqs / scrape-transfer)
+// but none are yet wired to a scheduled workflow. Intentional — state landed recently and
+// we want a few manual-run cycles before cron'ing it. See issue #33 for USNH transfer gap.
+
 const nhConfig: StateConfig = {
   slug: "nh",
   name: "New Hampshire",

--- a/lib/states/nj/config.ts
+++ b/lib/states/nj/config.ts
@@ -1,5 +1,9 @@
 import type { StateConfig } from "../registry";
 
+// manual-only: NJ has a transfer scraper (scripts/nj/scrape-transfer.ts from NJTransfer.org)
+// but no public-accessible course-scheduling system — Colleague Self-Service is auth-gated
+// at most NJ colleges. No prereq coverage yet. Revisit once a course scraper is viable.
+
 // NJ community colleges predominantly use Ellucian Colleague Self-Service
 // for course scheduling. The public Self-Service JSON REST API endpoints
 // vary by college but follow a common URL pattern:

--- a/lib/states/ny/config.ts
+++ b/lib/states/ny/config.ts
@@ -83,6 +83,11 @@ const nyConfig: StateConfig = {
       "City University of New York",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/ny/scrape-cuny.ts"], runner: "http" }],
+    transfers: [{ scripts: ["scripts/ny/scrape-transfer-trex.ts"], runner: "http" }],
+    prereqs: [{ scripts: ["scripts/ny/scrape-catalog-prereqs.ts"], runner: "playwright" }],
+  },
 };
 
 export default nyConfig;

--- a/lib/states/pa/config.ts
+++ b/lib/states/pa/config.ts
@@ -51,6 +51,12 @@ const paConfig: StateConfig = {
       "PA TRAC transfer equivalencies",
     ],
   },
+  scrapers: {
+    // PA has no scheduled course scraper today — PASSHE / state-system
+    // public course search is inconsistent across 14 colleges.
+    transfers: [{ scripts: ["scripts/pa/scrape-transfer.ts"], runner: "http" }],
+    prereqs: [{ scripts: ["scripts/pa/scrape-catalog-prereqs.ts"], runner: "http" }],
+  },
 };
 
 export default paConfig;

--- a/lib/states/registry.ts
+++ b/lib/states/registry.ts
@@ -15,6 +15,42 @@ export interface SeniorWaiverConfig {
   bannerDetail: string;
 }
 
+/**
+ * One scrape job unit: a group of scripts run on the same runner.
+ * A state can have multiple jobs per data type when scrapers target
+ * different platforms (e.g. VA courses splits across VCCS-HTTP and
+ * PeopleSoft-Playwright).
+ *
+ * `scripts` are repo-relative tsx paths, e.g. "scripts/va/scrape-vccs.ts".
+ * `runner` controls whether the scheduled workflow needs Playwright installed.
+ */
+export interface ScrapeJob {
+  scripts: string[];
+  runner: "http" | "playwright";
+}
+
+/**
+ * Declares which scheduled-scrape coverage a state has. Issue #59: this
+ * registry field — not YAML — is the source of truth for what gets
+ * re-scraped on cron. A unified workflow (PR 2) reads these entries to
+ * build its matrix. A CI check (PR 1, this PR) fails any change that
+ * registers a new state without populating this field or explicitly
+ * opting out.
+ */
+export interface ScraperCoverage {
+  /** Course-section scrapers, writing data/{state}/courses/**. */
+  courses?: ScrapeJob[];
+  /** Transfer-equivalency scrapers, writing data/{state}/transfer-equiv.json. */
+  transfers?: ScrapeJob[];
+  /**
+   * Prereq coverage. Either dedicated scrape jobs writing data/{state}/prereqs.json,
+   * or `aggregate-from-courses` for states where prereqs are flattened out of
+   * the course scrape (prerequisite_text field on each section) rather than
+   * scraped independently.
+   */
+  prereqs?: ScrapeJob[] | { source: "aggregate-from-courses" };
+}
+
 export interface StateConfig {
   /** Two-letter lowercase state slug, e.g. "va", "md", "nc" */
   slug: string;
@@ -50,6 +86,13 @@ export interface StateConfig {
     disclaimer: string;
     metaKeywords: string[];
   };
+  /**
+   * Scheduled-scrape coverage. Declarative source of truth for cron
+   * orchestration — see issue #59. Leaving this `undefined` requires a
+   * `// manual-only: <reason>` marker in the config file (enforced by
+   * scripts/check-scraper-coverage.ts).
+   */
+  scrapers?: ScraperCoverage;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/states/ri/config.ts
+++ b/lib/states/ri/config.ts
@@ -47,6 +47,11 @@ const riConfig: StateConfig = {
       "Rhode Island community college schedule",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/ri/scrape-banner8.ts"], runner: "http" }],
+    transfers: [{ scripts: ["scripts/ri/scrape-transfer.ts"], runner: "http" }],
+    prereqs: [{ scripts: ["scripts/ri/scrape-catalog-prereqs.ts"], runner: "http" }],
+  },
 };
 
 export default riConfig;

--- a/lib/states/sc/config.ts
+++ b/lib/states/sc/config.ts
@@ -93,6 +93,30 @@ const scConfig: StateConfig = {
       "SC schedule builder",
     ],
   },
+  scrapers: {
+    courses: [
+      {
+        scripts: [
+          "scripts/sc/scrape-banner.ts",
+          "scripts/sc/scrape-banner8.ts",
+          "scripts/sc/scrape-cygnet.ts",
+          "scripts/sc/scrape-midlands.ts",
+        ],
+        runner: "http",
+      },
+      { scripts: ["scripts/sc/scrape-colleague.ts"], runner: "playwright" },
+    ],
+    transfers: [
+      {
+        scripts: [
+          "scripts/sc/scrape-transfer-clemson.ts",
+          "scripts/sc/scrape-transfer-universities.ts",
+        ],
+        runner: "http",
+      },
+    ],
+    prereqs: { source: "aggregate-from-courses" },
+  },
 };
 
 export default scConfig;

--- a/lib/states/tn/config.ts
+++ b/lib/states/tn/config.ts
@@ -75,6 +75,11 @@ const tnConfig: StateConfig = {
       "Tennessee senior tuition waiver",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/tn/scrape-banner-ssb.ts"], runner: "http" }],
+    // transfers: TN has scripts under scripts/tn/transfer/ but none wired to cron yet.
+    // prereqs: scrape-catalog-prereqs.ts exists but is not scheduled.
+  },
 };
 
 export default tnConfig;

--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -48,6 +48,28 @@ const vaConfig: StateConfig = {
       "VCCS schedule builder",
     ],
   },
+  scrapers: {
+    courses: [
+      { scripts: ["scripts/va/scrape-vccs.ts"], runner: "http" },
+      { scripts: ["scripts/va/scrape-peoplesoft.ts", "scripts/va/enrich-peoplesoft.ts"], runner: "playwright" },
+    ],
+    transfers: [
+      {
+        scripts: [
+          "scripts/va/scrape-transfer-equiv.ts",
+          "scripts/va/scrape-transfer-gmu.ts",
+          "scripts/va/scrape-transfer-odu.ts",
+          "scripts/va/scrape-transfer-uva.ts",
+          "scripts/va/scrape-transfer-vcu.ts",
+          "scripts/va/scrape-transfer-vsu.ts",
+          "scripts/va/scrape-transfer-umw.ts",
+          "scripts/va/scrape-transfer-vwu.ts",
+        ],
+        runner: "http",
+      },
+    ],
+    prereqs: { source: "aggregate-from-courses" },
+  },
 };
 
 export default vaConfig;

--- a/lib/states/vt/config.ts
+++ b/lib/states/vt/config.ts
@@ -47,6 +47,11 @@ const vtConfig: StateConfig = {
       "Vermont community college schedule",
     ],
   },
+  scrapers: {
+    courses: [{ scripts: ["scripts/vt/scrape-colleague.ts"], runner: "playwright" }],
+    transfers: [{ scripts: ["scripts/vt/scrape-transfer.ts"], runner: "http" }],
+    prereqs: [{ scripts: ["scripts/vt/scrape-catalog-prereqs.ts"], runner: "http" }],
+  },
 };
 
 export default vtConfig;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "check:registry": "tsx scripts/check-registry-integrity.ts",
+    "check:scrapers": "tsx scripts/check-scraper-coverage.ts",
     "scrape": "tsx scripts/scrape-vccs.ts",
     "scrape:college": "tsx scripts/scrape-vccs.ts --college",
     "discover:ps": "tsx scripts/discover-ps-responses.ts",

--- a/scripts/check-scraper-coverage.ts
+++ b/scripts/check-scraper-coverage.ts
@@ -1,0 +1,82 @@
+/**
+ * Scraper-coverage integrity check (issue #59).
+ *
+ * For every state in `getAllStates()`:
+ *   - If `scrapers` is populated, verify every declared script path exists.
+ *   - If `scrapers` is omitted entirely, require a `manual-only:` marker
+ *     in the config file explaining why (so the gap is intentional, not
+ *     accidental drift).
+ *
+ * Fails the PR if any slug is silently missing coverage. Same shape as
+ * scripts/check-registry-integrity.ts.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { getAllStates, type StateConfig } from "../lib/states/registry";
+
+const ROOT = resolve(__dirname, "..");
+const errors: string[] = [];
+
+function err(slug: string, msg: string) {
+  errors.push(`[${slug}] ${msg}`);
+}
+
+function jobsFromCoverage(cfg: StateConfig): string[] {
+  const scrapers = cfg.scrapers;
+  if (!scrapers) return [];
+  const paths: string[] = [];
+  for (const job of scrapers.courses ?? []) paths.push(...job.scripts);
+  for (const job of scrapers.transfers ?? []) paths.push(...job.scripts);
+  if (Array.isArray(scrapers.prereqs)) {
+    for (const job of scrapers.prereqs) paths.push(...job.scripts);
+  }
+  return paths;
+}
+
+for (const cfg of getAllStates()) {
+  const { slug } = cfg;
+  const configPath = resolve(ROOT, `lib/states/${slug}/config.ts`);
+  if (!existsSync(configPath)) {
+    err(slug, `lib/states/${slug}/config.ts missing (also caught by check-registry-integrity)`);
+    continue;
+  }
+
+  const hasScrapers = !!cfg.scrapers;
+  if (!hasScrapers) {
+    // Omitting `scrapers` is fine if the config is explicit about why.
+    const source = readFileSync(configPath, "utf8");
+    if (!/manual-only:/i.test(source)) {
+      err(
+        slug,
+        `config has no \`scrapers\` field and no \`manual-only: <reason>\` marker. Either declare scrapers or explain the gap — see issue #59.`
+      );
+    }
+    continue;
+  }
+
+  // Script paths must resolve. A typo here silently breaks the unified
+  // scheduled-scrape workflow (PR 2) at runtime, so catch it now.
+  for (const script of jobsFromCoverage(cfg)) {
+    const abs = resolve(ROOT, script);
+    if (!existsSync(abs)) {
+      err(slug, `declared scraper script "${script}" does not exist`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Scraper-coverage check FAILED:\n");
+  for (const line of errors) console.error("  " + line);
+  console.error(
+    `\n${errors.length} issue(s) across ${getAllStates().length} registered state(s).`
+  );
+  console.error(
+    "\nEvery state must either declare `scrapers` in its StateConfig or include a `manual-only:` comment explaining the gap. See issue #59."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Scraper-coverage OK — ${getAllStates().length} states accounted for.`
+);


### PR DESCRIPTION
## Summary
First of three PRs implementing [#59](https://github.com/rohan-c0de/cc-coursemap/issues/59). **No behavior change** — just declarative metadata and a CI gate. Same shape as the registry-integrity check from #48.

- New `ScrapeJob` / `ScraperCoverage` types and an optional `scrapers` field on `StateConfig`.
- Every state currently on cron has `scrapers` populated with its real script paths and runners.
- `nj`, `nh`, `ma` get explicit `// manual-only: <reason>` comment markers since their scrapers exist but aren't scheduled yet.
- `scripts/check-scraper-coverage.ts` fails the PR if a state is missing both `scrapers` and the `manual-only:` marker, or if any declared script path doesn't exist.
- Wired to CI on PRs touching `lib/states/**` or `scripts/**`.

## What each state declares now
| State | Courses | Transfers | Prereqs |
|---|---|---|---|
| va | http + playwright | http (8 scripts) | aggregate-from-courses |
| nc | http (9 per-college) + playwright | http (7 scripts) | aggregate |
| sc | http (4) + playwright | http (2) | aggregate |
| ga | http | http (4) | aggregate |
| dc | http | http | aggregate |
| tn | http | — | — |
| me | playwright | http | — |
| md | http (3) + playwright (2) | http | — |
| pa | — | http | http catalog |
| ct | http | http | http catalog |
| de | http | http (2) | http catalog |
| ny | http | http | **playwright** catalog |
| ri | http | http | http catalog |
| vt | playwright | http | http catalog |
| nj | `// manual-only` | | |
| nh | `// manual-only` | | |
| ma | `// manual-only` | | |

## Test plan
- [x] `npm run check:scrapers` → 17/17 states pass.
- [x] Negative: strip VA's `scrapers` → exit 1 with clear error.
- [x] Negative: typo a declared script path → exit 1 naming the bad path.
- [x] `npx tsc --noEmit` clean.
- [ ] CI run green on this PR.

## Follow-ups (don't block this PR)
- PR 2: new unified `scheduled-scrape.yml` reading this metadata to build its matrix, running in parallel with the existing 4 scrape-*.yml files.
- PR 3: retire the old 4 workflow files once the new one has run clean for 2–3 weeks.
- CLAUDE.md + `add-new-state` skill updates (batch into PR 2).

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)