### PR TITLE
Auto-import data changes to Supabase on merge (closes #74)

### DIFF
--- a/.github/workflows/import-on-merge.yml
+++ b/.github/workflows/import-on-merge.yml
@@ -1,0 +1,84 @@
+name: Import data to Supabase on merge
+
+# Closes the loop in the #59 redesign. After scheduled-scrape.yml opens
+# a PR with fresh JSON and a human merges it, this workflow detects the
+# merged data change and pushes it to Supabase so the live site sees it.
+#
+# Why this is safe even though it auto-writes to prod:
+#   - Schema validation (#49) runs per row before any upsert.
+#   - Change-detection (#51) aborts a (state, college, term) if the new
+#     data is <50% of existing rows in Supabase. Bad scrapes can't
+#     silently replace good data.
+#   - The trigger is a *human-merged* PR — someone has already eyeballed
+#     the diff and approved it.
+#
+# Manual workflow_dispatch is exposed for one-time backfills (e.g. data
+# that landed before this workflow existed, like PRs #64 and #65).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "data/**"
+  workflow_dispatch:
+    inputs:
+      state:
+        description: "State slug to import, or 'all'"
+        default: "all"
+      datatype:
+        description: "Which import(s) to run"
+        type: choice
+        options: [both, courses, transfers]
+        default: both
+
+permissions:
+  contents: read
+
+# Serialize so two near-simultaneous merges don't fight over Supabase.
+concurrency:
+  group: import-on-merge
+  cancel-in-progress: false
+
+env:
+  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+
+      - name: Resolve inputs
+        id: args
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            state="${{ inputs.state }}"
+            dt="${{ inputs.datatype }}"
+          else
+            state="all"
+            dt="both"
+          fi
+          if [ "$state" = "all" ]; then
+            flag="--all"
+          else
+            flag="--state $state"
+          fi
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          echo "datatype=$dt"  >> "$GITHUB_OUTPUT"
+          echo "flag=$flag"    >> "$GITHUB_OUTPUT"
+          echo "Importing state=$state, datatype=$dt"
+
+      - name: Import courses
+        if: steps.args.outputs.datatype != 'transfers'
+        run: npx tsx scripts/import-courses.ts ${{ steps.args.outputs.flag }}
+
+      - name: Import transfers
+        if: steps.args.outputs.datatype != 'courses'
+        run: npx tsx scripts/import-transfers.ts ${{ steps.args.outputs.flag }}


### PR DESCRIPTION
## Summary

Closes the loop in the #59 redesign. Adds `.github/workflows/import-on-merge.yml`:

- **Trigger 1: `push: branches: [main], paths: ['data/**']`** — every time a PR with data changes lands, this fires automatically and runs the right import script.
- **Trigger 2: `workflow_dispatch`** — manual one-shot for backfills (e.g. data already merged in #64/#65 before this workflow existed).

## What runs

For each event, the workflow runs `scripts/import-courses.ts` and/or `scripts/import-transfers.ts` with `--all` (or `--state X` if dispatched manually).

## Why it's safe to auto-write to prod

The import scripts already have two layers of protection from earlier PRs:

| Safety | Source | What it does |
|---|---|---|
| Schema validation | [#49 / PR #56](https://github.com/rohan-c0de/cc-coursemap/pull/56) | >5% bad rows in a (college, term) → abort that combination |
| Change detection | [#51 / PR #57](https://github.com/rohan-c0de/cc-coursemap/pull/57) | <50% of existing row count → abort with cloud unchanged |

Combined with the human-review gate on the PR itself (someone already approved the diff before merging), the surface for "bad data lands in Supabase" is small.

## After landing — backfill

Dispatch the workflow manually with `state=all, datatype=both` to import the data already merged via #64 (courses) and #65 (prereqs/courses-aggregated):

```
gh workflow run "Import data to Supabase on merge" -f state=all -f datatype=both
```

That replaces the manual `npx tsx scripts/import-courses.ts --all` instruction I gave you earlier.

## After this lands, the redesign loop is fully automatic

1. Cron fires → `scheduled-scrape.yml` opens a PR with the diff
2. You skim and squash-merge
3. **`import-on-merge.yml` fires on push to main → Supabase updated → site fresh**

No terminal commands required.

## Test plan
- [x] Workflow YAML syntax-valid (no `act`/lint here, but mirrors patterns from existing workflows)
- [ ] After merge: dispatch with `state=va, datatype=courses` for a small smoke test
- [ ] Confirm Supabase has fresh rows via spot-check
- [ ] Then dispatch with `state=all, datatype=both` for full backfill

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)