### PR TITLE
Fix GA transfer runner classification + install pdfplumber for NC (closes #68, #69)

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -103,6 +103,14 @@ jobs:
         if: matrix.runner == 'playwright'
         run: npx playwright install chromium --with-deps
 
+      - name: Install pdfplumber (NC scrapers shell out to Python for PDF parsing)
+        # scripts/nc/scrape-pamlico.ts and scrape-cleveland.ts call
+        # `python3 -c '... pdfplumber ...'` to parse college-published PDF
+        # course catalogs. The Ubuntu runner has python3 pre-installed but
+        # not the pdfplumber package, so install on demand for nc entries.
+        if: matrix.state == 'nc'
+        run: pip install --quiet pdfplumber
+
       - name: Run scraper scripts
         env:
           # Scrapers have an inline Supabase-import fallback when env is set;

--- a/lib/states/ga/config.ts
+++ b/lib/states/ga/config.ts
@@ -88,10 +88,12 @@ const gaConfig: StateConfig = {
           "scripts/ga/scrape-transfer-gatech.ts",
           "scripts/ga/scrape-transfer-uga.ts",
           "scripts/ga/scrape-transfer-gsu.ts",
-          "scripts/ga/scrape-transfer-usg.ts",
         ],
         runner: "http",
       },
+      // scrape-transfer-usg.ts uses Playwright to drive the USG TES portal,
+      // unlike the other three transfer scripts which are pure HTTP.
+      { scripts: ["scripts/ga/scrape-transfer-usg.ts"], runner: "playwright" },
     ],
     prereqs: { source: "aggregate-from-courses" },
   },


### PR DESCRIPTION
## Summary

Two scraper-execution bugs surfaced by the first live runs of `scheduled-scrape.yml`:

### #68 — GA transfer runner mis-classification
`scripts/ga/scrape-transfer-usg.ts` uses Playwright to drive the USG TES portal, while `scrape-transfer-{gatech,uga,gsu}.ts` are pure HTTP. PR #60 lumped all four into a single `runner: "http"` ScrapeJob, so the runner didn't install Chromium and `usg.ts` crashed with:
```
browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/...
```

Fix: split GA transfers into two `ScrapeJob` entries — 3 http + 1 playwright. The matrix now produces `ga-transfers-0` (http, 3 scripts) and `ga-transfers-1` (playwright, 1 script).

### #69 — NC pdfplumber dep missing
`scripts/nc/scrape-pamlico.ts` and `scrape-cleveland.ts` shell out to `python3 -c '... pdfplumber ...'` to parse PDF course catalogs. The Ubuntu runner has python3 but not pdfplumber, so both crashed with `ModuleNotFoundError`.

Fix: add a conditional install step that runs only when `matrix.state == 'nc'`. ~3 sec install, no impact on other states. Not worth introducing a generic `needsPython` field on `ScrapeJob` for a single state.

## Test plan
- [x] `npm run check:scrapers` passes (17/17 states)
- [x] `scraper-matrix.ts --datatype transfers` shows GA correctly split: `ga-transfers-0 http 3` / `ga-transfers-1 playwright 1`
- [ ] After merge: dispatch `Scheduled scrape (unified)` with `datatype=transfers`, expect ga-transfers-1 and nc-transfers-0 to succeed (they were red on the previous runs)

Closes #68, closes #69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)