### PR TITLE
Wire term resolution into scheduled-scrape.yml (fixes #73)

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -111,6 +111,16 @@ jobs:
         if: matrix.state == 'nc'
         run: pip install --quiet pdfplumber
 
+      - name: Resolve terms
+        id: terms
+        if: matrix.termSystem != ''
+        run: |
+          resolved=$(npx tsx scripts/lib/resolve-terms.ts --system "${{ matrix.termSystem }}")
+          # Extract comma-separated human-readable term names for --term flag
+          term_arg=$(echo "$resolved" | jq -r '.terms | join(",")')
+          echo "term_arg=$term_arg" >> "$GITHUB_OUTPUT"
+          echo "Resolved terms for ${{ matrix.termSystem }}: $term_arg" >&2
+
       - name: Run scraper scripts
         env:
           # Scrapers have an inline Supabase-import fallback when env is set;
@@ -119,10 +129,15 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ""
         run: |
           set -e
+          term_arg="${{ steps.terms.outputs.term_arg }}"
           echo "${{ matrix.scripts }}" | while IFS= read -r script; do
             [ -z "$script" ] && continue
             echo "::group::$script"
-            npx tsx "$script" --no-import
+            if [ -n "$term_arg" ]; then
+              npx tsx "$script" --no-import --term "$term_arg"
+            else
+              npx tsx "$script" --no-import
+            fi
             echo "::endgroup::"
           done
 

--- a/lib/states/md/config.ts
+++ b/lib/states/md/config.ts
@@ -146,6 +146,7 @@ const mdConfig: StateConfig = {
       {
         scripts: ["scripts/md/scrape-colleague.ts", "scripts/md/scrape-jenzabar.ts"],
         runner: "playwright",
+        termSystem: "colleague-md",
       },
     ],
     transfers: [{ scripts: ["scripts/md/scrape-transfer-artsys.ts"], runner: "http" }],

--- a/lib/states/nc/config.ts
+++ b/lib/states/nc/config.ts
@@ -123,7 +123,7 @@ const ncConfig: StateConfig = {
         ],
         runner: "http",
       },
-      { scripts: ["scripts/nc/scrape-colleague.ts"], runner: "playwright" },
+      { scripts: ["scripts/nc/scrape-colleague.ts"], runner: "playwright", termSystem: "colleague-nc" },
     ],
     transfers: [
       {

--- a/lib/states/registry.ts
+++ b/lib/states/registry.ts
@@ -27,6 +27,13 @@ export interface SeniorWaiverConfig {
 export interface ScrapeJob {
   scripts: string[];
   runner: "http" | "playwright";
+  /**
+   * Which term-resolution system to use (see scripts/lib/resolve-terms.ts).
+   * When set, the scheduled workflow resolves live terms and passes --term
+   * to each script. Omit for scrapers that auto-discover terms internally
+   * or don't have term semantics (transfers, prereqs).
+   */
+  termSystem?: string;
 }
 
 /**

--- a/lib/states/sc/config.ts
+++ b/lib/states/sc/config.ts
@@ -104,7 +104,7 @@ const scConfig: StateConfig = {
         ],
         runner: "http",
       },
-      { scripts: ["scripts/sc/scrape-colleague.ts"], runner: "playwright" },
+      { scripts: ["scripts/sc/scrape-colleague.ts"], runner: "playwright", termSystem: "colleague-sc" },
     ],
     transfers: [
       {

--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -50,8 +50,8 @@ const vaConfig: StateConfig = {
   },
   scrapers: {
     courses: [
-      { scripts: ["scripts/va/scrape-vccs.ts"], runner: "http" },
-      { scripts: ["scripts/va/scrape-peoplesoft.ts", "scripts/va/enrich-peoplesoft.ts"], runner: "playwright" },
+      { scripts: ["scripts/va/scrape-vccs.ts"], runner: "http", termSystem: "vccs" },
+      { scripts: ["scripts/va/scrape-peoplesoft.ts", "scripts/va/enrich-peoplesoft.ts"], runner: "playwright", termSystem: "vccs-ps" },
     ],
     transfers: [
       {

--- a/lib/states/vt/config.ts
+++ b/lib/states/vt/config.ts
@@ -48,7 +48,7 @@ const vtConfig: StateConfig = {
     ],
   },
   scrapers: {
-    courses: [{ scripts: ["scripts/vt/scrape-colleague.ts"], runner: "playwright" }],
+    courses: [{ scripts: ["scripts/vt/scrape-colleague.ts"], runner: "playwright", termSystem: "colleague-vt" }],
     transfers: [{ scripts: ["scripts/vt/scrape-transfer.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/vt/scrape-catalog-prereqs.ts"], runner: "http" }],
   },

--- a/scripts/lib/scraper-matrix.ts
+++ b/scripts/lib/scraper-matrix.ts
@@ -47,6 +47,8 @@ interface MatrixEntry {
   runner: "http" | "playwright";
   /** Newline-joined so the workflow can iterate via `while read`. */
   scripts: string;
+  /** Term-resolution system (see resolve-terms.ts). Empty string when not needed. */
+  termSystem: string;
 }
 
 const include: MatrixEntry[] = [];
@@ -61,6 +63,7 @@ for (const cfg of getAllStates()) {
       datatype,
       runner: job.runner,
       scripts: job.scripts.join("\n"),
+      termSystem: job.termSystem ?? "",
     });
   });
 }

--- a/scripts/va/enrich-peoplesoft.ts
+++ b/scripts/va/enrich-peoplesoft.ts
@@ -34,8 +34,26 @@ import * as path from "path";
 // ---------------------------------------------------------------------------
 
 const PS_BASE = "https://ps-sis.vccs.edu";
-const TERM_CODE = process.argv.find(a => a.startsWith("--term-code="))?.split("=")[1] || "2262";
-const JSON_TERM = process.argv.find(a => a.startsWith("--json-term="))?.split("=")[1] || "2026SP";
+
+// Term name → PS term code + file code (mirrors scrape-peoplesoft.ts)
+const PS_TERM_MAP: Record<string, { code: string; file: string }> = {
+  "Spring 2026": { code: "2262", file: "2026SP" },
+  "Summer 2026": { code: "2263", file: "2026SU" },
+  "Fall 2026":   { code: "2264", file: "2026FA" },
+  "Spring 2027": { code: "2272", file: "2027SP" },
+};
+
+// Accept --term "Summer 2026" (human-readable, matching scrape-peoplesoft.ts)
+// or legacy --term-code= / --json-term= flags
+const termNameArg = process.argv.find(a => a === "--term")
+  ? process.argv[process.argv.indexOf("--term") + 1]?.split(",")[0]?.trim()
+  : null;
+const legacyTermCode = process.argv.find(a => a.startsWith("--term-code="))?.split("=")[1];
+const legacyJsonTerm = process.argv.find(a => a.startsWith("--json-term="))?.split("=")[1];
+
+const resolved = termNameArg ? PS_TERM_MAP[termNameArg] : null;
+const TERM_CODE = resolved?.code ?? legacyTermCode ?? "2262";
+const JSON_TERM = resolved?.file ?? legacyJsonTerm ?? "2026SP";
 const NAV_TIMEOUT = 30_000;
 const SEARCH_WAIT = 20_000; // max wait for search results
 const INTER_SEARCH_DELAY = 2000; // ms between subject searches

--- a/scripts/va/scrape-peoplesoft.ts
+++ b/scripts/va/scrape-peoplesoft.ts
@@ -89,16 +89,22 @@ interface RawCard {
 // CLI args
 // ---------------------------------------------------------------------------
 
+interface ParsedTerm {
+  termName: string;
+  psTermCode: string;
+  fileTermCode: string;
+}
+
 function parseArgs() {
   const args = process.argv.slice(2);
   let slugs: string[] = Object.keys(PS_CODES);
-  let termName = "";
+  let termArg = "";
   let subject: string | null = null;
   let headed = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--term" && args[i + 1]) {
-      termName = args[i + 1];
+      termArg = args[i + 1];
       i++;
     } else if (args[i] === "--slug" && args[i + 1]) {
       slugs = [args[i + 1]];
@@ -111,17 +117,23 @@ function parseArgs() {
     }
   }
 
-  if (!termName) {
+  if (!termArg) {
     console.error("Error: --term is required. Example: --term \"Summer 2026\"");
     console.error("Available terms:", Object.keys(TERM_CODES).join(", "));
     process.exit(1);
   }
 
-  const psTermCode = TERM_CODES[termName];
-  const fileTermCode = TERM_FILE_CODES[termName];
-  if (!psTermCode || !fileTermCode) {
-    console.error(`Unknown term: "${termName}". Available:`, Object.keys(TERM_CODES).join(", "));
-    process.exit(1);
+  // Support comma-separated terms: --term "Summer 2026,Fall 2026"
+  const termNames = termArg.split(",").map((t) => t.trim()).filter(Boolean);
+  const terms: ParsedTerm[] = [];
+  for (const termName of termNames) {
+    const psTermCode = TERM_CODES[termName];
+    const fileTermCode = TERM_FILE_CODES[termName];
+    if (!psTermCode || !fileTermCode) {
+      console.error(`Unknown term: "${termName}". Available:`, Object.keys(TERM_CODES).join(", "));
+      process.exit(1);
+    }
+    terms.push({ termName, psTermCode, fileTermCode });
   }
 
   for (const s of slugs) {
@@ -131,7 +143,7 @@ function parseArgs() {
     }
   }
 
-  return { slugs, termName, psTermCode, fileTermCode, subject, headed };
+  return { slugs, terms, subject, headed };
 }
 
 // ---------------------------------------------------------------------------
@@ -568,32 +580,36 @@ async function scrapeCollege(
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const { slugs, termName, psTermCode, fileTermCode, subject, headed } = parseArgs();
-
-  console.log(`\n${"=".repeat(60)}`);
-  console.log(`PeopleSoft Scraper — ${termName}`);
-  console.log(`Term code: ${psTermCode} → ${fileTermCode}`);
-  console.log(`Colleges: ${slugs.length}`);
-  if (subject) console.log(`Subject filter: ${subject}`);
-  console.log(`${"=".repeat(60)}\n`);
+  const { slugs, terms, subject, headed } = parseArgs();
 
   const browser = await chromium.launch({ headless: !headed });
   const startTime = Date.now();
-  let totalSections = 0;
+  let grandTotal = 0;
 
   try {
-    for (const slug of slugs) {
-      const sections = await scrapeCollege(browser, slug, psTermCode, fileTermCode, subject);
+    for (const { termName, psTermCode, fileTermCode } of terms) {
+      console.log(`\n${"=".repeat(60)}`);
+      console.log(`PeopleSoft Scraper — ${termName}`);
+      console.log(`Term code: ${psTermCode} → ${fileTermCode}`);
+      console.log(`Colleges: ${slugs.length}`);
+      if (subject) console.log(`Subject filter: ${subject}`);
+      console.log(`${"=".repeat(60)}\n`);
 
-      if (sections.length > 0) {
-        // Save to file
-        const dir = path.join(DATA_DIR, slug);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-        const filePath = path.join(dir, `${fileTermCode}.json`);
-        fs.writeFileSync(filePath, JSON.stringify(sections, null, 2) + "\n");
-        console.log(`  💾 Saved ${sections.length} sections → ${filePath}`);
-        totalSections += sections.length;
+      let totalSections = 0;
+      for (const slug of slugs) {
+        const sections = await scrapeCollege(browser, slug, psTermCode, fileTermCode, subject);
+
+        if (sections.length > 0) {
+          const dir = path.join(DATA_DIR, slug);
+          if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+          const filePath = path.join(dir, `${fileTermCode}.json`);
+          fs.writeFileSync(filePath, JSON.stringify(sections, null, 2) + "\n");
+          console.log(`  💾 Saved ${sections.length} sections → ${filePath}`);
+          totalSections += sections.length;
+        }
       }
+      console.log(`  ${termName}: ${totalSections} sections`);
+      grandTotal += totalSections;
     }
   } finally {
     await browser.close();
@@ -601,7 +617,7 @@ async function main() {
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
   console.log(`\n${"=".repeat(60)}`);
-  console.log(`Done! ${totalSections} total sections across ${slugs.length} college(s) in ${elapsed}s`);
+  console.log(`Done! ${grandTotal} total sections across ${slugs.length} college(s), ${terms.length} term(s) in ${elapsed}s`);
   console.log(`${"=".repeat(60)}\n`);
 }
 


### PR DESCRIPTION
## Summary

- Adds `termSystem` field to `ScrapeJob` interface so course scrapers declare which term-resolution system they use
- `scheduled-scrape.yml` now resolves live academic terms before running scripts, passing `--term "Summer 2026,Fall 2026"` automatically
- Fixes `va-courses-1` (PeopleSoft) which hard-fails without `--term`, and prevents stale defaults on VCCS/Colleague scrapers

## What changed

| File | Change |
|---|---|
| `lib/states/registry.ts` | Add optional `termSystem?: string` to `ScrapeJob` |
| `lib/states/{va,nc,sc,md,vt}/config.ts` | Set `termSystem` on 6 course scrape jobs |
| `scripts/lib/scraper-matrix.ts` | Pass `termSystem` through to workflow matrix |
| `.github/workflows/scheduled-scrape.yml` | Add "Resolve terms" step + pass `--term` to scripts |
| `scripts/va/scrape-peoplesoft.ts` | Support comma-separated terms, loop over each |
| `scripts/va/enrich-peoplesoft.ts` | Accept `--term` (human-readable) alongside legacy flags |

## Which jobs get term resolution

| Job | termSystem | Resolver |
|---|---|---|
| `va-courses-0` | `vccs` | Probes courses.vccs.edu |
| `va-courses-1` | `vccs-ps` | Same + PeopleSoft code mapping |
| `nc-courses-1` | `colleague-nc` | Probes Wake Tech Colleague API |
| `sc-courses-1` | `colleague-sc` | Probes FDTC Colleague API |
| `md-courses-1` | `colleague-md` | Probes PGCC Colleague API |
| `vt-courses-0` | `colleague-vt` | Probes VSC Colleague API |

Banner SSB scrapers (CT, DC, DE, GA, TN, RI) auto-discover terms via `getTerms()` — no `termSystem` needed.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npx tsx scripts/check-scraper-coverage.ts` passes (verified locally)
- [ ] `npx tsx scripts/lib/scraper-matrix.ts --datatype courses` shows `termSystem` on the 6 expected jobs, empty on others
- [ ] Trigger `workflow_dispatch` with `datatype=courses` — `va-courses-1` should no longer fail with "--term is required"
- [ ] Verify resolved terms in the "Resolve terms" step log output

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)