### PR TITLE
SC transfer scrapers: dedupe before writing (fixes #79)

### DIFF
--- a/scripts/sc/scrape-transfer-clemson.ts
+++ b/scripts/sc/scrape-transfer-clemson.ts
@@ -189,11 +189,22 @@ async function main() {
   // Filter out NCT (not college transferable) entries — they add noise
   const transferable = allMappings.filter((m) => !m.no_credit);
 
-  console.log(`\nTotal: ${allMappings.length} equivalencies, ${transferable.length} transferable`);
+  // Dedupe: iterating 16 colleges can produce identical equivalencies
+  const seen = new Set<string>();
+  const deduped = transferable.filter((m) => {
+    const key = `${m.cc_prefix}|${m.cc_number}|${m.university}|${m.univ_course}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 
-  if (transferable.length > 0) {
+  const dupeCount = transferable.length - deduped.length;
+  console.log(`\nTotal: ${allMappings.length} equivalencies, ${transferable.length} transferable`);
+  if (dupeCount > 0) console.log(`Removed ${dupeCount} duplicates → ${deduped.length} unique`);
+
+  if (deduped.length > 0) {
     const outPath = path.join(process.cwd(), "data", "sc", "transfer-equiv.json");
-    fs.writeFileSync(outPath, JSON.stringify(transferable, null, 2) + "\n");
+    fs.writeFileSync(outPath, JSON.stringify(deduped, null, 2) + "\n");
     console.log(`Written to ${outPath}`);
   }
 }

--- a/scripts/sc/scrape-transfer-universities.ts
+++ b/scripts/sc/scrape-transfer-universities.ts
@@ -291,10 +291,21 @@ async function main() {
     a.cc_course.localeCompare(b.cc_course) || a.university.localeCompare(b.university)
   );
 
-  fs.writeFileSync(outPath, JSON.stringify(merged, null, 2) + "\n");
+  // Dedupe: multiple sources can produce identical equivalencies
+  const seen = new Set<string>();
+  const deduped = merged.filter((m) => {
+    const key = `${m.cc_prefix}|${m.cc_number}|${m.university}|${m.univ_course}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const dupeCount = merged.length - deduped.length;
+  fs.writeFileSync(outPath, JSON.stringify(deduped, null, 2) + "\n");
   console.log(
     `\nMerged: ${kept.length} existing + ${transferable.length} new = ${merged.length} total`
   );
+  if (dupeCount > 0) console.log(`Removed ${dupeCount} duplicates → ${deduped.length} unique`);
   console.log(`Written to ${outPath}`);
 }
 


### PR DESCRIPTION
## Summary
- Adds a Set-based dedupe pass (keyed on `cc_prefix|cc_number|university|univ_course`) to both `scrape-transfer-clemson.ts` and `scrape-transfer-universities.ts` before writing to disk
- Logs duplicate count when any are removed; no-op when data is already unique
- Existing `data/sc/transfer-equiv.json` (7693 rows) verified 100% unique — this prevents future bloat from overlapping scrape targets

Closes #79

## Test plan
- [ ] Run `npx tsx scripts/sc/scrape-transfer-clemson.ts --no-import` and verify output row count matches unique count
- [ ] Run `npx tsx scripts/sc/scrape-transfer-universities.ts --no-import` and verify deduped output
- [ ] Confirm no regressions in existing transfer-equiv.json data

🤖 Generated with [Claude Code](https://claude.com/claude-code)