### PR TITLE
Auto-discover catalog IDs for prereq scrapers (fixes #53)

### DIFF
--- a/scripts/ct/scrape-catalog-prereqs.ts
+++ b/scripts/ct/scrape-catalog-prereqs.ts
@@ -18,7 +18,7 @@
  * Output: data/ct/prereqs.json keyed by "${PREFIX} ${NUMBER}".
  *
  * The catalog year rolls over every summer. Re-run once CT State
- * publishes the new catoid. Update CATOID below when that happens.
+ * The catalog ID is auto-discovered at runtime from the catalog dropdown.
  *
  * Usage:
  *   npx tsx scripts/ct/scrape-catalog-prereqs.ts
@@ -27,9 +27,10 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { discoverAcalogCatoid } from "../lib/discover-catalog.js";
 
 const BASE = "https://catalog.ctstate.edu";
-const CATOID = 24;     // CT State 2026-2027 catalog id
+let CATOID = 24;       // fallback — auto-discovered at runtime
 const NAVOID = 2805;   // "Course Descriptions" nav entry
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -213,6 +214,7 @@ async function main() {
 
   console.log("CT State catalog prereq scraper");
   console.log(`  Base: ${BASE}`);
+  CATOID = await discoverAcalogCatoid(BASE, CATOID);
   console.log(`  catoid=${CATOID} navoid=${NAVOID}`);
 
   // --- Phase 1: paginate list, collect coids ---

--- a/scripts/lib/discover-catalog.ts
+++ b/scripts/lib/discover-catalog.ts
@@ -1,0 +1,117 @@
+/**
+ * discover-catalog.ts — auto-discover current catalog IDs for Acalog and
+ * Coursedog so prereq scrapers don't need manual updates each summer.
+ */
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/**
+ * Discover the current (non-archived) Acalog catalog ID by parsing the
+ * `<select name="catalog">` dropdown on the catalog index page.
+ *
+ * Returns the `catoid` of the `selected` option, or the first non-archived
+ * option if none is selected. Falls back to `fallback` on any error.
+ */
+export async function discoverAcalogCatoid(
+  baseUrl: string,
+  fallback: number
+): Promise<number> {
+  try {
+    const resp = await fetch(`${baseUrl}/index.php`, {
+      headers: { "User-Agent": UA },
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const html = await resp.text();
+
+    const optionRe =
+      /<option\s[^>]*value="(\d+)"[^>]*(selected)?[^>]*>([^<]+)/gi;
+    let match;
+    let selectedId: number | null = null;
+    let firstNonArchived: number | null = null;
+
+    while ((match = optionRe.exec(html)) !== null) {
+      const id = parseInt(match[1], 10);
+      const isSelected = !!match[2];
+      const label = match[3];
+      const isArchived = label.includes("[ARCHIVED");
+
+      if (isSelected && !isArchived) {
+        selectedId = id;
+        break;
+      }
+      if (!isArchived && firstNonArchived === null) {
+        firstNonArchived = id;
+      }
+    }
+
+    const catoid = selectedId ?? firstNonArchived;
+    if (catoid !== null) {
+      console.log(`  Auto-discovered Acalog catoid=${catoid} from ${baseUrl}`);
+      return catoid;
+    }
+
+    console.warn(`  No active catalog found at ${baseUrl}, using fallback=${fallback}`);
+    return fallback;
+  } catch (err) {
+    console.warn(
+      `  Acalog discovery failed for ${baseUrl}: ${(err as Error).message}, using fallback=${fallback}`
+    );
+    return fallback;
+  }
+}
+
+/**
+ * Discover the current Coursedog catalog ID by fetching the catalogs API.
+ *
+ * Picks the non-archived catalog with the latest `effectiveStartDate`.
+ * Falls back to `fallback` on any error.
+ */
+export async function discoverCoursedogCatalog(
+  school: string,
+  referer: string,
+  fallback: string
+): Promise<string> {
+  try {
+    const resp = await fetch(
+      `https://app.coursedog.com/api/v1/ca/${school}/catalogs`,
+      {
+        headers: {
+          "User-Agent": UA,
+          Referer: referer,
+          Origin: new URL(referer).origin,
+        },
+      }
+    );
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+
+    const catalogs: Array<{
+      _id: string;
+      displayName: string;
+      archivedAt: number | null;
+      effectiveStartDate?: string;
+    }> = await resp.json();
+
+    const active = catalogs
+      .filter((c) => c.archivedAt === null)
+      .sort((a, b) =>
+        (b.effectiveStartDate ?? "").localeCompare(a.effectiveStartDate ?? "")
+      );
+
+    if (active.length > 0) {
+      const best = active[0];
+      console.log(
+        `  Auto-discovered Coursedog catalog="${best.displayName}" id=${best._id}`
+      );
+      return best._id;
+    }
+
+    console.warn(`  No active Coursedog catalog for ${school}, using fallback=${fallback}`);
+    return fallback;
+  } catch (err) {
+    console.warn(
+      `  Coursedog discovery failed for ${school}: ${(err as Error).message}, using fallback=${fallback}`
+    );
+    return fallback;
+  }
+}

--- a/scripts/ma/scrape-catalog-prereqs-gcc.ts
+++ b/scripts/ma/scrape-catalog-prereqs-gcc.ts
@@ -36,8 +36,9 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { discoverCoursedogCatalog } from "../lib/discover-catalog.js";
 
-const CATALOG_ID = "Tq3vInBCVkfzBa5krhiu";
+let CATALOG_ID = "Tq3vInBCVkfzBa5krhiu"; // fallback — auto-discovered at runtime
 const SCHOOL = "gcc_banner_sql";
 const BASE = `https://app.coursedog.com/api/v1/cm/${SCHOOL}/courses/search/%24filters`;
 const REFERER = "https://catalog.gcc.mass.edu/";
@@ -153,6 +154,7 @@ async function main() {
 
   console.log("GCC Coursedog prereq scraper");
   console.log(`  BASE: ${BASE}`);
+  CATALOG_ID = await discoverCoursedogCatalog(SCHOOL, REFERER, CATALOG_ID);
   console.log(`  catalogId: ${CATALOG_ID}\n`);
 
   // --- Phase 1: discover total count ---

--- a/scripts/ma/scrape-catalog-prereqs-middlesex.ts
+++ b/scripts/ma/scrape-catalog-prereqs-middlesex.ts
@@ -18,7 +18,7 @@
  * A combiner script merges this with GCC's prereqs into data/ma/prereqs.json.
  *
  * The catalog year rolls over every summer. Re-run once Middlesex
- * publishes the new catoid. Update CATOID below when that happens.
+ * The catalog ID is auto-discovered at runtime from the catalog dropdown.
  *
  * Usage:
  *   npx tsx scripts/ma/scrape-catalog-prereqs-middlesex.ts
@@ -27,9 +27,10 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { discoverAcalogCatoid } from "../lib/discover-catalog.js";
 
 const BASE = "https://catalog.middlesex.mass.edu";
-const CATOID = 35;     // Middlesex 2025-2026 catalog id
+let CATOID = 35;       // fallback — auto-discovered at runtime
 const NAVOID = 3331;   // "Course Descriptions" nav entry
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -210,8 +211,9 @@ async function main() {
   const args = process.argv.slice(2);
   const limit = parseInt(args.find((a) => a.startsWith("--limit="))?.split("=")[1] || "0", 10);
 
-  console.log("CT State catalog prereq scraper");
+  console.log("Middlesex CC catalog prereq scraper");
   console.log(`  Base: ${BASE}`);
+  CATOID = await discoverAcalogCatoid(BASE, CATOID);
   console.log(`  catoid=${CATOID} navoid=${NAVOID}`);
 
   // --- Phase 1: paginate list, collect coids ---

--- a/scripts/vt/scrape-catalog-prereqs.ts
+++ b/scripts/vt/scrape-catalog-prereqs.ts
@@ -19,8 +19,7 @@
  *
  * Output: data/vt/prereqs.json keyed by "${PREFIX} ${NUMBER}".
  *
- * The catalog year rolls over every summer. Re-run once CCV publishes the
- * new catoid. Update CATOID below when that happens.
+ * The catalog ID is auto-discovered at runtime from the catalog dropdown.
  *
  * Usage:
  *   npx tsx scripts/vt/scrape-catalog-prereqs.ts
@@ -29,9 +28,10 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { discoverAcalogCatoid } from "../lib/discover-catalog.js";
 
 const BASE = "https://catalog.ccv.edu";
-const CATOID = 17;     // CCV 2026-2027 catalog id
+let CATOID = 17;       // fallback — auto-discovered at runtime
 const NAVOID = 1662;   // "Courses" nav entry
 const UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
@@ -214,6 +214,7 @@ async function main() {
 
   console.log("CCV catalog prereq scraper");
   console.log(`  Base: ${BASE}`);
+  CATOID = await discoverAcalogCatoid(BASE, CATOID);
   console.log(`  catoid=${CATOID} navoid=${NAVOID}`);
 
   // --- Phase 1: paginate list, collect coids ---


### PR DESCRIPTION
## Summary
- New `scripts/lib/discover-catalog.ts` with shared Acalog + Coursedog discovery functions
- VT, CT, MA/Middlesex scrapers auto-discover current `catoid` from the Acalog dropdown
- MA/GCC scraper auto-discovers current catalog from the Coursedog `/catalogs` API
- Each falls back to the hardcoded value if discovery fails (network error, site down)
- No more manual CATOID updates needed each summer

Closes #53

## Test plan
- [x] All 4 discovery functions return correct current catalog IDs
- [x] VT: catoid=17, CT: catoid=24, Middlesex: catoid=35, GCC: Tq3vInBCVkfzBa5krhiu
- [ ] Run one full prereq scraper to confirm end-to-end (e.g. `npx tsx scripts/vt/scrape-catalog-prereqs.ts --limit=5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)