### PR TITLE
Hotfix: TS null-check breaking Vercel build

### DIFF
--- a/scripts/lib/scrape-collegetransfer.ts
+++ b/scripts/lib/scrape-collegetransfer.ts
@@ -153,7 +153,7 @@ export async function scrapeCollegeTransfer(
       throw new Error(`OData API HTTP ${resp!.status}: ${resp!.statusText}`);
     }
 
-    const data: ODataResponse = await resp.json();
+    const data: ODataResponse = await resp!.json();
     const batch = data.value;
 
     if (batch.length === 0) break;


### PR DESCRIPTION
## Summary
- Production has been failing every Vercel build for ~1 hour. Type-check error at [scripts/lib/scrape-collegetransfer.ts:156](scripts/lib/scrape-collegetransfer.ts:156): `resp` is typed `Response | null` (introduced by PR #84's retry loop), and line 156 was missed when adding `!` non-null assertions.
- Lines 152-153 already use `resp!`; this just brings line 156 in line with them.

## Test plan
- [x] `npm run build` passes locally
- [ ] Vercel preview build goes green