### PR TITLE
Homepage redesign Phase A: search-first hero + new sections (#81)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,10 +2,10 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "auditmap-dev",
-      "runtimeExecutable": "/bin/bash",
-      "runtimeArgs": ["/Users/rohanupalekar/claudecode/auditmap-virginia/.claude/start-dev.sh"],
-      "port": 3007
+      "name": "cc-coursemap-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
     }
   ]
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { getAllStates } from "@/lib/states/registry";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
+import CourseSearchHero from "@/components/CourseSearchHero";
 
 const STATE_NAMES = getAllStates().map((s) => s.name);
 const STATE_LIST_SENTENCE =
@@ -11,8 +12,8 @@ const STATE_LIST_SENTENCE =
     : `${STATE_NAMES.slice(0, -1).join(", ")}, and ${STATE_NAMES[STATE_NAMES.length - 1]}`;
 
 export const metadata: Metadata = {
-  title: "Community College Path — Your Community College Course Finder",
-  description: `Search courses, plan transfers, and build schedules across community colleges in ${STATE_LIST_SENTENCE}.`,
+  title: "Community College Path — Find any community college course in one search",
+  description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
   keywords: [
     "community college courses",
     "CC course finder",
@@ -23,206 +24,285 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: "Community College Path — Course Finder & Transfer Guide",
-    description: `Search courses, plan transfers, and build schedules across community colleges in ${STATE_LIST_SENTENCE}.`,
+    description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
     type: "website",
     url: "/",
   },
   twitter: {
     card: "summary_large_image",
     title: "Community College Path — Course Finder & Transfer Guide",
-    description: `Search courses, plan transfers, and build schedules across community colleges in ${STATE_LIST_SENTENCE}.`,
+    description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
   },
   alternates: {
     canonical: "/",
   },
 };
 
+const GRID_BG_STYLE = {
+  backgroundImage:
+    "linear-gradient(rgba(13,148,136,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(13,148,136,0.06) 1px, transparent 1px)",
+  backgroundSize: "32px 32px",
+};
+
 export default function LandingPage() {
   const states = getAllStates();
   const totalColleges = states.reduce((sum, s) => sum + s.collegeCount, 0);
+  const stateOptions = states
+    .map((s) => ({ slug: s.slug, name: s.name, abbr: s.slug.toUpperCase() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <div className="min-h-screen flex flex-col bg-white dark:bg-slate-900">
-      {/* Minimal header */}
-      <header className="border-b border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <div className="w-8 h-8 bg-teal-600 rounded-lg flex items-center justify-center">
-              <span className="text-white font-bold text-xs">CCP</span>
+      {/* Header */}
+      <header className="border-b border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur sticky top-0 z-30">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2 group">
+            <div className="w-9 h-9 bg-teal-600 rounded-lg flex items-center justify-center">
+              <span className="text-white font-mono font-semibold text-xs">CCP</span>
             </div>
-            <span className="text-xl font-semibold text-gray-900 dark:text-slate-100">
+            <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Community College <span className="text-teal-600">Path</span>
             </span>
-          </div>
-          <div className="flex items-center gap-4">
+          </Link>
+          <nav className="flex items-center gap-5">
             <Link
               href="/colleges"
-              className="text-sm text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors"
+              className="hidden sm:inline text-sm text-slate-600 dark:text-slate-400 hover:text-teal-600 transition-colors"
             >
-              All Colleges
+              All colleges
             </Link>
             <Link
               href="/blog"
-              className="text-sm text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors"
+              className="hidden sm:inline text-sm text-slate-600 dark:text-slate-400 hover:text-teal-600 transition-colors"
             >
               Blog
             </Link>
             <UserMenu />
             <ThemeToggle />
-          </div>
+          </nav>
         </div>
       </header>
 
       {/* Hero */}
-      <section className="py-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-teal-50 to-white dark:from-teal-950/50 dark:to-slate-900">
-        <div className="max-w-3xl mx-auto text-center">
-          <h1 className="text-4xl sm:text-5xl font-bold text-gray-900 dark:text-slate-100 mb-4">
-            Your Community College Course Finder
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-slate-400 max-w-2xl mx-auto">
-            Search courses, plan transfers, and build schedules — across{" "}
-            <span className="font-semibold text-gray-900 dark:text-slate-100">
-              {totalColleges} colleges
-            </span>{" "}
-            in{" "}
-            <span className="font-semibold text-gray-900 dark:text-slate-100">
-              {states.length} states
+      <section className="relative overflow-hidden" style={GRID_BG_STYLE}>
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 pb-20 sm:pt-24 sm:pb-28">
+          <div className="text-center">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-teal-100 dark:bg-teal-900/40 text-teal-800 dark:text-teal-200 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.2em]">
+              ✓ {totalColleges} colleges · {states.length} states · always free
             </span>
-            .
-          </p>
-          <Link
-            href="/colleges"
-            className="inline-flex items-center gap-1.5 mt-4 text-sm font-medium text-teal-600 hover:text-teal-700 transition-colors"
-          >
-            Browse all colleges
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
-            </svg>
-          </Link>
+            <h1 className="mt-6 text-4xl sm:text-6xl lg:text-[64px] font-semibold leading-[1.05] tracking-[-0.025em] text-slate-900 dark:text-slate-100">
+              Find any community college course in{" "}
+              <span className="text-teal-600 dark:text-teal-400">one search.</span>
+            </h1>
+            <p className="mt-6 text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto">
+              Search courses, look up transfer credits, and build a schedule —
+              without bouncing between five state websites.
+            </p>
+          </div>
+
+          <div className="mt-10 relative">
+            <CourseSearchHero states={stateOptions} />
+          </div>
         </div>
       </section>
 
-      {/* State cards */}
-      <section className="py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-5xl mx-auto">
-          <h2 className="text-sm font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wider text-center mb-8">
-            Choose your state
-          </h2>
-          <div className="grid md:grid-cols-3 gap-6">
-            {states.map((config) => (
+      {/* Three task cards */}
+      <section className="bg-slate-50 dark:bg-slate-800/40 border-y border-slate-200 dark:border-slate-800">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-8">
+            what you can do
+          </div>
+          <div className="grid sm:grid-cols-3 gap-4">
+            {[
+              {
+                num: "01",
+                title: "Search any course",
+                body: "One search across every college in your state — by code, subject, or what you're trying to learn.",
+                href: "/colleges",
+                cta: "Start searching",
+                icon: (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                  />
+                ),
+              },
+              {
+                num: "02",
+                title: "Check what transfers",
+                body: "Pick your CC and your target university. See which courses count, which don't, and what they map to.",
+                href: "/va/transfer",
+                cta: "Look up transfers",
+                icon: (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"
+                  />
+                ),
+              },
+              {
+                num: "03",
+                title: "Build a schedule",
+                body: "Drag classes onto a weekly grid, see conflicts immediately, and export when you're ready to register.",
+                href: "/va/schedule",
+                cta: "Open the planner",
+                icon: (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5"
+                  />
+                ),
+              },
+            ].map((card) => (
               <Link
-                key={config.slug}
-                href={`/${config.slug}`}
-                className="group rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 shadow-sm hover:shadow-md hover:border-teal-300 transition-all"
+                key={card.num}
+                href={card.href}
+                className="group rounded-2xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6 hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-md transition-all"
               >
-                <h3 className="text-2xl font-bold text-gray-900 dark:text-slate-100 group-hover:text-teal-600 transition-colors">
-                  {config.name}
+                <div className="flex items-center justify-between">
+                  <div className="w-11 h-11 rounded-xl bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300 flex items-center justify-center">
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.75} viewBox="0 0 24 24">
+                      {card.icon}
+                    </svg>
+                  </div>
+                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500">
+                    {card.num}
+                  </span>
+                </div>
+                <h3 className="mt-5 text-lg font-semibold text-slate-900 dark:text-slate-100">
+                  {card.title}
                 </h3>
-                <p className="text-sm text-gray-500 dark:text-slate-400 mt-1">
-                  {config.systemName} &mdash; {config.collegeCount} colleges
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                  {card.body}
                 </p>
-
-                <div className="flex flex-wrap gap-2 mt-4">
-                  {config.seniorWaiver && (
-                    <span className="inline-flex items-center rounded-full bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 px-2.5 py-0.5 text-xs font-medium text-green-700">
-                      Free for {config.seniorWaiver.ageThreshold}+
-                    </span>
-                  )}
-                  {config.transferSupported && (
-                    <span className="inline-flex items-center rounded-full bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 px-2.5 py-0.5 text-xs font-medium text-blue-700">
-                      Transfer Data
-                    </span>
-                  )}
-                </div>
-
-                <div className="mt-6 text-sm font-medium text-teal-600 group-hover:text-teal-700">
-                  Explore {config.name} &rarr;
-                </div>
+                <span className="mt-5 inline-flex items-center gap-1 text-sm font-medium text-teal-700 dark:text-teal-400 group-hover:gap-2 transition-all">
+                  {card.cta}
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+                  </svg>
+                </span>
               </Link>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Features */}
-      <section className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-slate-800">
-        <div className="max-w-5xl mx-auto">
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-slate-100 text-center mb-12">
-            What You Can Do
-          </h2>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
-            <div className="text-center">
-              <div className="w-12 h-12 bg-teal-100 dark:bg-teal-900/30 text-teal-700 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-                </svg>
+      {/* Browse by state — pill fallback (US map ships in Phase B) */}
+      <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 w-full">
+        <div className="flex items-center justify-between mb-6">
+          <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+            browse by state
+          </div>
+          <div className="flex items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="w-3 h-3 rounded-sm bg-teal-500" />
+              {states.length} live
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="w-3 h-3 rounded-sm bg-slate-300 dark:bg-slate-700" />
+              coming soon
+            </span>
+            <span className="text-slate-400 dark:text-slate-600">·</span>
+            <span>{totalColleges} colleges total</span>
+          </div>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-2">
+          {[...states]
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((s) => (
+              <Link
+                key={s.slug}
+                href={`/${s.slug}`}
+                className="group rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2.5 hover:border-teal-300 dark:hover:border-teal-700 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-all"
+              >
+                <div className="flex items-baseline gap-2">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.15em] text-slate-400 dark:text-slate-500 group-hover:text-teal-600">
+                    {s.slug}
+                  </span>
+                  <span className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
+                    {s.name}
+                  </span>
+                </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                  {s.collegeCount} colleges
+                </div>
+              </Link>
+            ))}
+        </div>
+      </section>
+
+      {/* Why this exists */}
+      <section className="bg-slate-900 dark:bg-black text-white">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+          <div className="grid lg:grid-cols-2 gap-10 lg:gap-16">
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-teal-300 mb-5">
+                why this exists
               </div>
-              <h3 className="font-semibold text-gray-900 dark:text-slate-100 mb-1">
-                Search Courses
-              </h3>
-              <p className="text-sm text-gray-600 dark:text-slate-400">
-                Search across all colleges at once by subject, keyword, or
-                course number.
-              </p>
+              <h2 className="text-3xl sm:text-4xl font-semibold leading-tight tracking-[-0.02em]">
+                The state systems weren&apos;t built to talk to each other.
+              </h2>
             </div>
-            <div className="text-center">
-              <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900/30 text-blue-700 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
-                </svg>
-              </div>
-              <h3 className="font-semibold text-gray-900 dark:text-slate-100 mb-1">
-                Transfer Lookup
-              </h3>
-              <p className="text-sm text-gray-600 dark:text-slate-400">
-                See which courses transfer to your target university before you
-                enroll.
+            <div className="space-y-5 text-slate-300 leading-relaxed">
+              <p>
+                Every state runs its own community-college portal, with its own
+                login, its own course numbers, and its own ideas about what counts
+                toward a transfer degree. If you&apos;re trying to take a class
+                across a state line — or just compare two colleges in the same
+                system — you end up with five tabs open and a spreadsheet.
               </p>
-            </div>
-            <div className="text-center">
-              <div className="w-12 h-12 bg-purple-100 dark:bg-purple-900/30 text-purple-700 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
-                </svg>
-              </div>
-              <h3 className="font-semibold text-gray-900 dark:text-slate-100 mb-1">
-                Schedule Builder
-              </h3>
-              <p className="text-sm text-gray-600 dark:text-slate-400">
-                Build a weekly schedule across multiple colleges and courses.
+              <p>
+                Community College Path pulls all of it into one place. Free, no
+                account required, refreshed weekly straight from each college&apos;s
+                registrar.
               </p>
-            </div>
-            <div className="text-center">
-              <div className="w-12 h-12 bg-green-100 dark:bg-green-900/30 text-green-700 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
+              <div className="grid grid-cols-3 gap-6 pt-6 border-t border-slate-800">
+                <div>
+                  <div className="text-3xl font-semibold text-teal-300">
+                    {totalColleges}
+                  </div>
+                  <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-400 mt-1">
+                    colleges
+                  </div>
+                </div>
+                <div>
+                  <div className="text-3xl font-semibold text-teal-300">
+                    {states.length}
+                  </div>
+                  <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-400 mt-1">
+                    states
+                  </div>
+                </div>
+                <div>
+                  <div className="text-3xl font-semibold text-teal-300">weekly</div>
+                  <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-400 mt-1">
+                    data refresh
+                  </div>
+                </div>
               </div>
-              <h3 className="font-semibold text-gray-900 dark:text-slate-100 mb-1">
-                Starting Soon
-              </h3>
-              <p className="text-sm text-gray-600 dark:text-slate-400">
-                Find late-start and mini-session courses still open for
-                registration.
-              </p>
             </div>
           </div>
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="mt-auto border-t border-gray-200 dark:border-slate-700 py-8 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-gray-500 dark:text-slate-400">
-          <p>&copy; {new Date().getFullYear()} Community College Path</p>
+      <footer className="mt-auto border-t border-slate-200 dark:border-slate-700 py-8 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-slate-500 dark:text-slate-400">
+          <p className="font-mono uppercase tracking-[0.15em]">
+            © {new Date().getFullYear()} · A free public tool
+          </p>
           <div className="flex gap-4">
             <Link href="/colleges" className="hover:text-teal-600 transition-colors">
-              All Colleges
+              All colleges
             </Link>
             <Link href="/blog" className="hover:text-teal-600 transition-colors">
               Blog
             </Link>
             <Link href="/privacy" className="hover:text-teal-600 transition-colors">
-              Privacy Policy
+              Privacy
             </Link>
           </div>
         </div>

--- a/components/CourseSearchHero.tsx
+++ b/components/CourseSearchHero.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+type StateOption = { slug: string; name: string; abbr: string };
+
+const LS_KEY = "ccp:lastState";
+
+export default function CourseSearchHero({ states }: { states: StateOption[] }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [selectedState, setSelectedState] = useState<string | null>(null);
+  const [isAuto, setIsAuto] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [needsState, setNeedsState] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  // Hydrate selected state: localStorage first, fall back to none.
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem(LS_KEY) : null;
+    if (stored && states.some((s) => s.slug === stored)) {
+      setSelectedState(stored);
+      setIsAuto(false);
+    }
+  }, [states]);
+
+  // Close picker on outside click.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [pickerOpen]);
+
+  const pickState = (slug: string) => {
+    setSelectedState(slug);
+    setIsAuto(false);
+    localStorage.setItem(LS_KEY, slug);
+    setPickerOpen(false);
+    setNeedsState(false);
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedState) {
+      setNeedsState(true);
+      setPickerOpen(true);
+      return;
+    }
+    const q = query.trim();
+    const params = q ? `?q=${encodeURIComponent(q)}` : "";
+    router.push(`/${selectedState}/courses${params}`);
+  };
+
+  const current = selectedState ? states.find((s) => s.slug === selectedState) : null;
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      <form onSubmit={onSubmit} className="relative">
+        <div
+          className="flex items-center gap-2 rounded-2xl border border-ink-300/60 dark:border-slate-700 bg-white dark:bg-slate-800 pl-5 pr-2 py-2 focus-within:border-teal-600 focus-within:ring-4 focus-within:ring-teal-100 dark:focus-within:ring-teal-900/40 transition-all"
+          style={{
+            boxShadow:
+              "0 1px 0 rgba(15,23,42,0.04), 0 8px 24px -8px rgba(13,148,136,0.35)",
+          }}
+        >
+          <svg
+            className="w-5 h-5 text-slate-400 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
+          </svg>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={'Try "ENG 111", "intro biology", or "does this transfer to GMU"…'}
+            className="flex-1 min-w-0 py-2 bg-transparent text-base text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:outline-none"
+            aria-label="Search courses"
+          />
+          <button
+            type="submit"
+            className="inline-flex items-center gap-1.5 rounded-xl bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 text-sm font-medium transition-colors"
+          >
+            Search
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+            </svg>
+          </button>
+        </div>
+      </form>
+
+      {/* State filter pill row */}
+      <div className="mt-4 flex flex-wrap items-center justify-center gap-2 text-sm" ref={pickerRef}>
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+          searching in
+        </span>
+
+        {current ? (
+          <button
+            type="button"
+            onClick={() => setPickerOpen((o) => !o)}
+            className="inline-flex items-center gap-1.5 rounded-full bg-teal-50 dark:bg-teal-900/30 border border-teal-200 dark:border-teal-800 px-3 py-1 text-teal-800 dark:text-teal-200 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
+            </svg>
+            <span className="font-medium">{current.name}</span>
+            {isAuto && (
+              <span className="font-mono text-[9px] uppercase tracking-[0.15em] bg-teal-200/60 dark:bg-teal-800/60 px-1.5 py-0.5 rounded">
+                auto
+              </span>
+            )}
+            <span aria-hidden>▾</span>
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setPickerOpen((o) => !o)}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 transition-colors ${
+              needsState
+                ? "border-teal-600 bg-teal-50 text-teal-800 dark:bg-teal-900/30 dark:text-teal-200 ring-2 ring-teal-200 dark:ring-teal-900/40"
+                : "border-dashed border-slate-400 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:border-teal-600 hover:text-teal-700"
+            }`}
+          >
+            {needsState ? "pick a state to search ▾" : "select your state ▾"}
+          </button>
+        )}
+
+        <span className="text-slate-400 dark:text-slate-600">·</span>
+
+        <button
+          type="button"
+          onClick={() => setPickerOpen((o) => !o)}
+          className="inline-flex items-center gap-1 rounded-full border border-dashed border-slate-300 dark:border-slate-700 px-3 py-1 text-slate-500 dark:text-slate-400 hover:border-teal-600 hover:text-teal-700 transition-colors"
+        >
+          all {states.length} states
+        </button>
+
+        {pickerOpen && (
+          <div className="absolute z-20 mt-2 max-w-xl w-full left-1/2 -translate-x-1/2 top-full rounded-xl border border-ink-300/60 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-xl p-3">
+            <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mb-2 px-1">
+              choose a state
+            </div>
+            <div className="grid grid-cols-3 sm:grid-cols-4 gap-1">
+              {states.map((s) => (
+                <button
+                  key={s.slug}
+                  type="button"
+                  onClick={() => pickState(s.slug)}
+                  className={`text-left rounded-lg px-2 py-1.5 text-sm hover:bg-teal-50 dark:hover:bg-teal-900/30 hover:text-teal-700 dark:hover:text-teal-200 transition-colors ${
+                    s.slug === selectedState
+                      ? "bg-teal-50 dark:bg-teal-900/30 text-teal-800 dark:text-teal-200"
+                      : "text-slate-700 dark:text-slate-200"
+                  }`}
+                >
+                  <span className="font-mono text-[10px] uppercase tracking-[0.15em] text-slate-400 dark:text-slate-500 mr-1.5">
+                    {s.abbr}
+                  </span>
+                  {s.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Popular searches */}
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400 mr-1">
+          popular searches
+        </span>
+        {[
+          "Does ENG 111 transfer to GMU?",
+          "prereqs for BIO 256",
+          "online math, summer 2026",
+          "free college if I'm 65+",
+        ].map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setQuery(s)}
+            className="rounded-full border border-ink-300/60 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-1 text-xs text-slate-600 dark:text-slate-300 hover:border-teal-600 hover:text-teal-700 transition-colors"
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
First of three PRs for #81 (Teal Modern v2 homepage redesign).

## What's in this PR

- **Grid-texture hero** with badge pill (`221 colleges · 17 states · always free`), 64px semibold headline with teal accent on "one search.", and the new visual search bar.
- **State-pill picker** (`components/CourseSearchHero.tsx`) — persists choice to `localStorage`, prompts inline when no state is selected (no surprise fallback-to-VA), pre-fills query from "popular searches" chips.
- **Three numbered task cards** — Search any course / Check what transfers / Build a schedule, each linking to the existing destination.
- **Dark "why this exists" section** with the colleges / states / weekly-refresh stats row.
- **State pill grid** in place of the map — placeholder for Phase B.
- Misc: fixed `.claude/launch.json` which was still pointing at the legacy `auditmap-virginia` repo.

## Verification

- `tsc --noEmit` clean, no console/server errors.
- Empty submit → picker opens with "pick a state to search" prompt highlighted in teal.
- Pick VA + type `ENG 111` + submit → routes to `/va/courses?q=ENG%20111`.
- Renders cleanly at desktop + mobile, light + dark mode.

## Out of scope (later PRs)

- **Phase B:** real US map SVG via `us-atlas`/`topojson-client`.
- **Phase C:** Vercel `request.geo.region` auto-detection (the "auto" tag slot is already wired in).
- Actual course-keyword search backend (per the issue, the bar is visual + navigates to `/{state}/courses`).

## Test plan

- [ ] Load `/` — hero, search bar, three cards, state grid, dark section, footer all render.
- [ ] Submit search with no state selected → picker opens, prompt is highlighted.
- [ ] Pick a state → submit empty → goes to `/{state}/courses`.
- [ ] Pick a state → submit with query → goes to `/{state}/courses?q=…`.
- [ ] Reload page → previously-picked state is remembered.
- [ ] Toggle dark mode → all sections legible.
- [ ] Mobile viewport → search bar, picker, and cards stack cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)