### PR TITLE
Homepage redesign Phase B: real US map (#81)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { getAllStates } from "@/lib/states/registry";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
 import CourseSearchHero from "@/components/CourseSearchHero";
+import USMap from "@/components/USMap";
 
 const STATE_NAMES = getAllStates().map((s) => s.name);
 const STATE_LIST_SENTENCE =
@@ -190,7 +191,7 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* Browse by state — pill fallback (US map ships in Phase B) */}
+      {/* Browse by state — US map + pill fallback */}
       <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 w-full">
         <div className="flex items-center justify-between mb-6">
           <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
@@ -209,29 +210,41 @@ export default function LandingPage() {
             <span>{totalColleges} colleges total</span>
           </div>
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-2">
-          {[...states]
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((s) => (
-              <Link
-                key={s.slug}
-                href={`/${s.slug}`}
-                className="group rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2.5 hover:border-teal-300 dark:hover:border-teal-700 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-all"
-              >
-                <div className="flex items-baseline gap-2">
-                  <span className="font-mono text-[10px] uppercase tracking-[0.15em] text-slate-400 dark:text-slate-500 group-hover:text-teal-600">
-                    {s.slug}
-                  </span>
-                  <span className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
-                    {s.name}
-                  </span>
-                </div>
-                <div className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-                  {s.collegeCount} colleges
-                </div>
-              </Link>
-            ))}
-        </div>
+
+        <USMap />
+
+        <details className="mt-6 group">
+          <summary className="cursor-pointer text-sm text-slate-600 dark:text-slate-400 hover:text-teal-600 select-none inline-flex items-center gap-1">
+            <span className="group-open:hidden">or see all {states.length} as a list</span>
+            <span className="hidden group-open:inline">hide list</span>
+            <svg className="w-3 h-3 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+            </svg>
+          </summary>
+          <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-2">
+            {[...states]
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((s) => (
+                <Link
+                  key={s.slug}
+                  href={`/${s.slug}`}
+                  className="group rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2.5 hover:border-teal-300 dark:hover:border-teal-700 hover:bg-teal-50 dark:hover:bg-teal-900/20 transition-all"
+                >
+                  <div className="flex items-baseline gap-2">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.15em] text-slate-400 dark:text-slate-500 group-hover:text-teal-600">
+                      {s.slug}
+                    </span>
+                    <span className="text-sm font-medium text-slate-900 dark:text-slate-100 truncate">
+                      {s.name}
+                    </span>
+                  </div>
+                  <div className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                    {s.collegeCount} colleges
+                  </div>
+                </Link>
+              ))}
+          </div>
+        </details>
       </section>
 
       {/* Why this exists */}

--- a/components/USMap.tsx
+++ b/components/USMap.tsx
@@ -1,0 +1,73 @@
+import { feature } from "topojson-client";
+import { geoPath } from "d3-geo";
+import type { FeatureCollection, Geometry } from "geojson";
+import topology from "us-atlas/states-albers-10m.json";
+import { getAllStates } from "@/lib/states/registry";
+
+// us-atlas topology has states pre-projected to Albers USA in a ~975×610 frame.
+// geoPath() with no projection treats coordinates as already-screen coords.
+const path = geoPath();
+
+type StateProps = { name: string };
+
+export default function USMap() {
+  const states = getAllStates();
+  const byName = new Map(
+    states.map((s) => [s.name, { slug: s.slug, count: s.collegeCount }]),
+  );
+
+  // topojson types are loose; cast to a typed FeatureCollection for our use.
+  const fc = feature(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    topology as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (topology as any).objects.states,
+  ) as unknown as FeatureCollection<Geometry, StateProps>;
+
+  return (
+    <div className="relative w-full">
+      <svg
+        viewBox="0 0 975 610"
+        className="w-full h-auto"
+        role="img"
+        aria-label={`Map of US states. ${states.length} active, click to browse a state.`}
+      >
+        <g>
+          {fc.features.map((f, i) => {
+            const d = path(f) || "";
+            const name = f.properties?.name ?? "";
+            const active = byName.get(name);
+            const key = `${name}-${i}`;
+            if (active) {
+              return (
+                <a
+                  key={key}
+                  href={`/${active.slug}`}
+                  aria-label={`${name}: ${active.count} colleges. Click to browse.`}
+                >
+                  <path
+                    d={d}
+                    className="fill-teal-500 hover:fill-teal-600 stroke-white cursor-pointer transition-colors"
+                    strokeWidth={1}
+                  >
+                    <title>{`${name} — ${active.count} colleges · click to browse`}</title>
+                  </path>
+                </a>
+              );
+            }
+            return (
+              <path
+                key={key}
+                d={d}
+                className="fill-slate-300/60 dark:fill-slate-700/60 stroke-white dark:stroke-slate-900"
+                strokeWidth={1}
+              >
+                <title>{`${name} — coming soon`}</title>
+              </path>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,11 @@
         "@next/mdx": "^16.2.2",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.101.1",
+        "@types/d3-geo": "^3.1.0",
         "@types/mdx": "^2.0.13",
+        "@types/topojson-client": "^3.1.5",
         "cheerio": "^1.2.0",
+        "d3-geo": "^3.1.1",
         "leaflet": "^1.9.4",
         "next": "16.2.1",
         "next-themes": "^0.4.6",
@@ -22,6 +25,8 @@
         "react-dom": "19.2.4",
         "react-leaflet": "^5.0.0",
         "resend": "^6.10.0",
+        "topojson-client": "^3.1.0",
+        "us-atlas": "^3.0.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -2279,6 +2284,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2307,7 +2321,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -2390,6 +2403,25 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -3622,6 +3654,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3710,6 +3748,30 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5458,6 +5520,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -8912,6 +8983,20 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -9335,6 +9420,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/us-atlas": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/us-atlas/-/us-atlas-3.0.1.tgz",
+      "integrity": "sha512-wEIZCq0ImPvGblTd8gZMqNNCPkQshugMUG/8nkSWXb02+XqNFREg9atHOKP9w6prLZTpqcLhSvdBW81MkV3/0Q==",
+      "license": "ISC"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
     "@next/mdx": "^16.2.2",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.101.1",
+    "@types/d3-geo": "^3.1.0",
     "@types/mdx": "^2.0.13",
+    "@types/topojson-client": "^3.1.5",
     "cheerio": "^1.2.0",
+    "d3-geo": "^3.1.1",
     "leaflet": "^1.9.4",
     "next": "16.2.1",
     "next-themes": "^0.4.6",
@@ -42,6 +45,8 @@
     "react-dom": "19.2.4",
     "react-leaflet": "^5.0.0",
     "resend": "^6.10.0",
+    "topojson-client": "^3.1.0",
+    "us-atlas": "^3.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Second of three PRs for #81. Phase A merged in #88.

## What's in this PR

- **`components/USMap.tsx`** — server component that loads `us-atlas`'s pre-projected `states-albers-10m.json` via `topojson-client` + `d3-geo`, and renders an SVG map of all 51 states+DC.
- Active states (from `getAllStates()`) fill **teal-500** with hover lift to **teal-600**, native `<title>` tooltip showing college count, click navigates to `/{slug}`. Inactive states render dimmed (`slate-300/60` light, `slate-700/60` dark).
- **`app/page.tsx`** — swaps the pill-grid placeholder for `<USMap />`, keeps the pill grid inside `<details>` as the a11y/list fallback (also useful for screen readers and small viewports).
- Adds deps: `us-atlas`, `topojson-client`, `d3-geo` (+ types).

## Verification

- `tsc --noEmit` clean.
- DOM has 51 state paths + 17 anchors (one per active state) — matches the registry.
- Click on a teal state → navigates to `/{slug}`.
- Renders cleanly at desktop, light + dark mode.

## Tradeoffs

- **No leader-line callouts** for the small NE states (CT/RI/DE/DC/etc). They're still clickable on the map (just small targets) and fully accessible via the `<details>` list fallback. We can add callouts in a follow-up if the small-target friction is real in usage.
- **Native `<title>` tooltips** instead of a styled hover popover. Faster to ship and works without a client component; we can upgrade later if needed.
- Used SVG `<a>` elements (not `next/link`) — `next/link` doesn't render correctly as an SVG child in Next 16. Means each state click is a full page nav, which is fine for landing-page bounces.

## Out of scope (Phase C)

- Vercel `request.geo.region` auto-detect for the search-bar state pill.

## Test plan

- [ ] Load `/` — map renders with 17 East Coast states in teal.
- [ ] Hover a teal state → tooltip shows "{State} — {N} colleges · click to browse".
- [ ] Click a teal state → lands on `/{slug}`.
- [ ] Hover a gray state → tooltip shows "{State} — coming soon".
- [ ] Click "or see all 17 as a list" → expands the pill-grid fallback.
- [ ] Toggle dark mode → map and chrome remain legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)