### PR TITLE
Homepage redesign Phase C: Vercel geo auto-detect for state pill (#81)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { getAllStates } from "@/lib/states/registry";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
@@ -45,12 +46,22 @@ const GRID_BG_STYLE = {
   backgroundSize: "32px 32px",
 };
 
-export default function LandingPage() {
+export default async function LandingPage() {
   const states = getAllStates();
   const totalColleges = states.reduce((sum, s) => sum + s.collegeCount, 0);
   const stateOptions = states
     .map((s) => ({ slug: s.slug, name: s.name, abbr: s.slug.toUpperCase() }))
     .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Vercel populates x-vercel-ip-country-region with the US state code (e.g. "VA").
+  // Fall through to null in local dev or when the header is missing.
+  const h = await headers();
+  const region = h.get("x-vercel-ip-country-region")?.toLowerCase() ?? null;
+  const country = h.get("x-vercel-ip-country") ?? null;
+  const geoState =
+    country === "US" && region && states.some((s) => s.slug === region)
+      ? region
+      : null;
 
   return (
     <div className="min-h-screen flex flex-col bg-white dark:bg-slate-900">
@@ -102,7 +113,7 @@ export default function LandingPage() {
           </div>
 
           <div className="mt-10 relative">
-            <CourseSearchHero states={stateOptions} />
+            <CourseSearchHero states={stateOptions} geoState={geoState} />
           </div>
         </div>
       </section>

--- a/components/CourseSearchHero.tsx
+++ b/components/CourseSearchHero.tsx
@@ -7,7 +7,13 @@ type StateOption = { slug: string; name: string; abbr: string };
 
 const LS_KEY = "ccp:lastState";
 
-export default function CourseSearchHero({ states }: { states: StateOption[] }) {
+export default function CourseSearchHero({
+  states,
+  geoState,
+}: {
+  states: StateOption[];
+  geoState: string | null;
+}) {
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [selectedState, setSelectedState] = useState<string | null>(null);
@@ -16,14 +22,20 @@ export default function CourseSearchHero({ states }: { states: StateOption[] }) 
   const [needsState, setNeedsState] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
 
-  // Hydrate selected state: localStorage first, fall back to none.
+  // Hydrate selected state: a previously-chosen value in localStorage wins
+  // (manual choice = highest priority), then geo auto-detect, else nothing.
   useEffect(() => {
     const stored = typeof window !== "undefined" ? localStorage.getItem(LS_KEY) : null;
     if (stored && states.some((s) => s.slug === stored)) {
       setSelectedState(stored);
       setIsAuto(false);
+      return;
     }
-  }, [states]);
+    if (geoState && states.some((s) => s.slug === geoState)) {
+      setSelectedState(geoState);
+      setIsAuto(true);
+    }
+  }, [states, geoState]);
 
   // Close picker on outside click.
   useEffect(() => {


### PR DESCRIPTION
Final PR for #81. Phases A (#88) and B (#90) merged.

## What's in this PR

- **`app/page.tsx`** — reads `x-vercel-ip-country` and `x-vercel-ip-country-region` (auto-populated by Vercel on every request). When country is US and the region maps to a covered state slug, passes it to `CourseSearchHero` as `geoState`.
- **`components/CourseSearchHero.tsx`** — accepts new `geoState` prop. Hydration priority is now: localStorage manual pick → geo auto-detect (with "auto" tag) → no selection. Manual choice always wins so we never overwrite a deliberate pick.

## Verification

- `tsc --noEmit` clean.
- Local dev with no headers → no geoState, picker shows "select your state" (no regression).
- Local dev with simulated headers (`curl -H 'x-vercel-ip-country: US' -H 'x-vercel-ip-country-region: VA' /`) → RSC payload contains `"geoState":"va"`, hero seeds the Virginia pill on first load.
- Unknown region or non-US country → falls through to null cleanly.

## Behavior

| Scenario | Pill state |
|---|---|
| First visit from VA, US | Virginia (with "auto" tag) |
| First visit from CA (not covered yet) | "select your state" prompt |
| Returning visitor who picked NC | North Carolina (no auto tag — manual choice wins) |
| Local dev / non-Vercel host | "select your state" prompt |

## Trade-off

Reading headers makes the homepage dynamic (was static before). For a small page that's renders fast on Vercel's edge, it's a fine trade for the personalization. If TTFB regresses we can revisit by moving the geo read into a tiny edge route + cookie set by middleware, but the simple path is worth shipping first.

## Test plan

- [ ] Load `/` — page renders normally.
- [ ] In dev tools, inspect the search hero — pill is empty (no Vercel header in dev).
- [ ] On Vercel preview, load `/` from a covered-state IP — pill auto-fills with state name + "auto" tag.
- [ ] Pick a different state → "auto" tag goes away.
- [ ] Reload → manually-picked state persists, doesn't get overwritten by geo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)