### PR TITLE
TN: wire transfer + prereq scrapers into scheduled-scrape

### DIFF
--- a/lib/states/tn/config.ts
+++ b/lib/states/tn/config.ts
@@ -77,8 +77,8 @@ const tnConfig: StateConfig = {
   },
   scrapers: {
     courses: [{ scripts: ["scripts/tn/scrape-banner-ssb.ts"], runner: "http" }],
-    // transfers: TN has scripts under scripts/tn/transfer/ but none wired to cron yet.
-    // prereqs: scrape-catalog-prereqs.ts exists but is not scheduled.
+    transfers: [{ scripts: ["scripts/tn/transfer/scrape-all.ts"], runner: "http" }],
+    prereqs: [{ scripts: ["scripts/tn/scrape-catalog-prereqs.ts"], runner: "http" }],
   },
 };
 


### PR DESCRIPTION
## Summary
- Declares `scripts/tn/transfer/scrape-all.ts` and `scripts/tn/scrape-catalog-prereqs.ts` in `lib/states/tn/config.ts` so the unified scheduled-scrape workflow picks them up. Both scripts already existed but were not on cron.
- Removes the two TODO comments that called this out.

Closes #103.

## Test plan
- [x] `npx tsx scripts/check-scraper-coverage.ts` → "Scraper-coverage OK — 18 states accounted for."
- [x] Confirmed `getStateConfig('tn').scrapers` now exposes `transfers` + `prereqs` jobs.
- [ ] After merge, watch the next scheduled-scrape transfer run (Wed/Sat 10:00 UTC) and prereq run (Sun 07:00 UTC) for TN green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)