### PR TITLE
MA: wire scrapers into scheduled-scrape

### DIFF
--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -1,11 +1,5 @@
 import type { StateConfig } from "../registry";
 
-// manual-only: MA has rich scraper coverage (scrape-banner-ssb, scrape-banner8,
-// scrape-colleague, scrape-masstransfer, two per-college prereq scrapers) but nothing
-// is wired to cron yet. Intentional — 6 of 15 colleges are scrapable and we want to
-// confirm the long tail is stable before cron'ing. MassTransfer is weekly-ish-stable
-// and could be scheduled first.
-
 const maConfig: StateConfig = {
   slug: "ma",
   name: "Massachusetts",
@@ -57,6 +51,25 @@ const maConfig: StateConfig = {
       "MassCC course search",
       "Massachusetts Community Colleges",
       "Massachusetts community college schedule",
+    ],
+  },
+  scrapers: {
+    courses: [
+      {
+        scripts: ["scripts/ma/scrape-banner-ssb.ts", "scripts/ma/scrape-banner8.ts"],
+        runner: "http",
+      },
+      { scripts: ["scripts/ma/scrape-colleague.ts"], runner: "playwright" },
+    ],
+    transfers: [{ scripts: ["scripts/ma/scrape-masstransfer.ts"], runner: "http" }],
+    prereqs: [
+      {
+        scripts: [
+          "scripts/ma/scrape-catalog-prereqs-gcc.ts",
+          "scripts/ma/scrape-catalog-prereqs-middlesex.ts",
+        ],
+        runner: "http",
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Removes the `manual-only` marker from `lib/states/ma/config.ts` and declares MA's existing scrapers in `StateConfig.scrapers`.
- Two course jobs (http for Banner SSB + Banner 8, playwright for Colleague), one transfer job (MassTransfer ~46k mappings), one prereq job (GCC + Middlesex catalog).

Closes #101.

## Test plan
- [x] `npx tsx scripts/check-scraper-coverage.ts` → OK, 18 states.
- [x] Matrix builder emits two MA course rows (http + playwright), one transfer row, one prereq row.
- [ ] After merge, watch the next scheduled-scrape course (Mon/Wed/Fri 06:00 UTC), transfer (Wed/Sat 10:00 UTC), and prereq (Sun 07:00 UTC) runs for MA green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)