### PR TITLE
NY: derive CUNY term codes from calendar (issue #115 phase 1)

### DIFF
--- a/scripts/lib/resolve-terms.ts
+++ b/scripts/lib/resolve-terms.ts
@@ -33,7 +33,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 // Term arithmetic
 // ---------------------------------------------------------------------------
 
-interface TermInfo {
+export interface TermInfo {
   name: string;      // "Summer 2026"
   code: string;      // "2026SU"
   season: string;    // "SU"
@@ -41,7 +41,7 @@ interface TermInfo {
 }
 
 /** Current calendar-based term (not what's in the DB, what makes sense now). */
-function currentCalendarTerm(): TermInfo {
+export function currentCalendarTerm(): TermInfo {
   const now = new Date();
   const month = now.getMonth() + 1; // 1-12
   const year = now.getFullYear();
@@ -69,7 +69,7 @@ function currentCalendarTerm(): TermInfo {
 }
 
 /** Get the next term after a given term. */
-function nextTerm(t: TermInfo): TermInfo {
+export function nextTerm(t: TermInfo): TermInfo {
   if (t.season === "SP") return { name: `Summer ${t.year}`, code: `${t.year}SU`, season: "SU", year: t.year };
   if (t.season === "SU") return { name: `Fall ${t.year}`, code: `${t.year}FA`, season: "FA", year: t.year };
   // FA → next year SP
@@ -519,7 +519,16 @@ async function main() {
   console.log(JSON.stringify(result));
 }
 
-main().catch((err) => {
-  console.error("Fatal:", err);
-  process.exit(1);
-});
+// Only run the CLI when invoked directly, not when imported by another script
+// (e.g. scrape-cuny.ts re-uses currentCalendarTerm/nextTerm).
+const invokedDirectly =
+  typeof import.meta.url === "string" &&
+  process.argv[1] &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/ny/scrape-cuny.ts
+++ b/scripts/ny/scrape-cuny.ts
@@ -38,6 +38,7 @@
 
 import fs from "fs";
 import path from "path";
+import { currentCalendarTerm, nextTerm, type TermInfo } from "../lib/resolve-terms";
 
 const BASE_URL = "https://globalsearch.cuny.edu/CFGlobalSearchTool";
 const USER_AGENT =
@@ -60,21 +61,42 @@ const CUNY_COLLEGES: Record<string, { code: string; name: string }> = {
   "queensborough-cc": { code: "QCC01", name: "Queensborough CC" },
 };
 
-// CUNY term codes follow PeopleSoft: 1 + YY + season (2=Spring, 6=Summer, 9=Fall).
-// Scrape the 3 active terms visible in the term_value dropdown. When CUNY
-// publishes next year's terms, add them here — the dropdown is parsed only
-// for verification, not as the source of truth, so old codes won't break.
+// CUNY term codes follow PeopleSoft: 1 + YY + season-digit (2=Spring, 6=Summer,
+// 9=Fall). Derived from the calendar so we don't have to edit a hardcoded list
+// every term — at semester rollover the new code is computed automatically.
 interface CunyTerm {
   code: string;
   name: string;
   standard: string;
 }
 
-const CUNY_TERMS: CunyTerm[] = [
-  { code: "1262", name: "2026 Spring Term", standard: "2026SP" },
-  { code: "1266", name: "2026 Summer Term", standard: "2026SU" },
-  { code: "1269", name: "2026 Fall Term", standard: "2026FA" },
-];
+const SEASON_DIGIT: Record<string, string> = { SP: "2", SU: "6", FA: "9" };
+const SEASON_LABEL: Record<string, string> = { SP: "Spring", SU: "Summer", FA: "Fall" };
+
+function toCunyTerm(t: TermInfo): CunyTerm {
+  const digit = SEASON_DIGIT[t.season];
+  if (!digit) throw new Error(`Unsupported season for CUNY: ${t.season}`);
+  return {
+    code: `1${String(t.year % 100).padStart(2, "0")}${digit}`,
+    name: `${t.year} ${SEASON_LABEL[t.season]} Term`,
+    standard: t.code,
+  };
+}
+
+/**
+ * Build the list of CUNY terms to scrape. Returns current + next two calendar
+ * terms (e.g. mid-spring → Spring, Summer, Fall) so registration windows for
+ * upcoming semesters are picked up as soon as they open.
+ */
+function buildCunyTerms(): CunyTerm[] {
+  const cur = currentCalendarTerm();
+  const nxt = nextTerm(cur);
+  const nxtNxt = nextTerm(nxt);
+  return [cur, nxt, nxtNxt].map(toCunyTerm);
+}
+
+// Set by main() when --term <code> is passed; null means "use buildCunyTerms()".
+let activeCunyTerms: CunyTerm[] | null = null;
 
 // ---------------------------------------------------------------------------
 // HTTP session with manual cookie jar
@@ -657,7 +679,8 @@ async function scrapeCollege(slug: string): Promise<number> {
   fs.mkdirSync(outDir, { recursive: true });
 
   let total = 0;
-  for (const term of CUNY_TERMS) {
+  const terms = activeCunyTerms ?? buildCunyTerms();
+  for (const term of terms) {
     console.log(`\n  Term: ${term.name} (${term.code} → ${term.standard})`);
     try {
       const rows = await scrapeCollegeTerm(slug, cuny, term);
@@ -715,20 +738,17 @@ async function main(): Promise<void> {
   }
 
   // Optional single-term scope — useful for quick smoke tests.
-  let termScope: CunyTerm[] = CUNY_TERMS;
   if (termFlag >= 0) {
     const tc = args[termFlag + 1];
-    termScope = CUNY_TERMS.filter((t) => t.code === tc);
-    if (termScope.length === 0) {
+    const all = buildCunyTerms();
+    const match = all.find((t) => t.code === tc);
+    if (!match) {
       console.error(
-        `Unknown term code: ${tc}. Available: ${CUNY_TERMS.map((t) => t.code).join(", ")}`
+        `Unknown term code: ${tc}. Available: ${all.map((t) => t.code).join(", ")}`
       );
       process.exit(1);
     }
-    // Temporarily monkey-patch CUNY_TERMS to the scoped list.
-    // scrapeCollege reads the module-level constant, so we reassign here.
-    CUNY_TERMS.length = 0;
-    CUNY_TERMS.push(...termScope);
+    activeCunyTerms = [match];
   }
 
   let grandTotal = 0;


### PR DESCRIPTION
First slice of [#115](https://github.com/rohan-c0de/cc-coursemap/issues/115) — the only state with a *silent-staleness* failure mode. Other phases (Banner filter de-duplication, CI guard against new hardcoded term arrays) are deferred.

## Problem

`scripts/ny/scrape-cuny.ts` had a hardcoded `CUNY_TERMS` array:

```ts
const CUNY_TERMS = [
  { code: "1262", name: "2026 Spring Term", standard: "2026SP" },
  { code: "1266", name: "2026 Summer Term", standard: "2026SU" },
  { code: "1269", name: "2026 Fall Term", standard: "2026FA" },
];
```

Failure mode: when CUNY opens registration for Spring 2027, the scraper keeps cheerfully running, returns last year's data, and CI is green. No alert fires. Manual edit required to roll forward.

## Fix

CUNY's PeopleSoft term codes are purely algorithmic: `1` + `(year - 2000)` + season-digit (`2`=Spring, `6`=Summer, `9`=Fall). Compute them from the calendar instead of hardcoding.

- Re-uses the existing `currentCalendarTerm()` / `nextTerm()` helpers in `scripts/lib/resolve-terms.ts` (now exported).
- Guards `resolve-terms.ts`' top-level `main()` so the file is safe to import without triggering the CLI.
- Generates current + next 2 terms (e.g. Spring → Spring/Summer/Fall) so newly-opened registration windows are picked up automatically.

## Verification

Derived codes match the old hardcoded values exactly:

```
Spring 2026 → CUNY code 1262 / standard 2026SP
Summer 2026 → CUNY code 1266 / standard 2026SU
Fall 2026 → CUNY code 1269 / standard 2026FA
```

- `npx tsc --noEmit` clean
- `npx tsx scripts/lib/resolve-terms.ts` (CLI) still prints usage as before
- `npx tsx scripts/ny/scrape-cuny.ts --college bmcc --term 9999` rejects with the derived list: `Available: 1262, 1266, 1269`

Behavior is identical today; the difference shows up at the next term boundary, when this code rolls automatically instead of needing a PR.

## Out of scope (other phases of #115)

- De-duplicating the term-filter logic across the 6 Banner/Colleague scrapers (consistency, not staleness)
- A CI check that fails new PRs containing hardcoded term-code arrays