### PR TITLE
DC/CT/GA: shared SSB term filter (issue #115 phase 2a)

### DIFF
--- a/scripts/ct/scrape-banner.ts
+++ b/scripts/ct/scrape-banner.ts
@@ -7,6 +7,7 @@
 
 import fs from "fs";
 import path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 const BASE_URL = "https://reg-prod.ec.ct.edu";
 const COLLEGE_SLUG = "ct-state";
@@ -296,11 +297,7 @@ async function main() {
   console.log("Fetching available terms...");
   const terms = await getTerms();
 
-  // Filter to recent/upcoming terms
-  const targetTerms = terms.filter((t) => {
-    const code = parseInt(t.code);
-    return code >= 202640; // Spring 2026+
-  });
+  const targetTerms = pickRecentSsbTerms(terms);
 
   console.log(`Found ${targetTerms.length} target terms:`, targetTerms.map((t) => t.description));
 

--- a/scripts/dc/scrape-banner.ts
+++ b/scripts/dc/scrape-banner.ts
@@ -7,6 +7,7 @@
 
 import fs from "fs";
 import path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 const BASE_URL = "https://reg-prod.ec.udc.edu";
 const COLLEGE_SLUG = "udc-cc";
@@ -303,11 +304,7 @@ async function main() {
   console.log("Fetching available terms...");
   const terms = await getTerms();
 
-  // Filter to recent/upcoming terms
-  const targetTerms = terms.filter((t) => {
-    const code = parseInt(t.code);
-    return code >= 202620; // Spring 2026+
-  });
+  const targetTerms = pickRecentSsbTerms(terms);
 
   console.log(`Found ${targetTerms.length} target terms:`, targetTerms.map((t) => t.description));
 

--- a/scripts/ga/scrape-banner-ssb.ts
+++ b/scripts/ga/scrape-banner-ssb.ts
@@ -19,6 +19,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 import fs from "fs";
 import path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 const PAGE_SIZE = 500;
 
@@ -382,12 +383,7 @@ async function scrapeCollege(slug: string, baseUrl: string): Promise<number> {
     return 0;
   }
 
-  // Filter to recent/upcoming terms
-  // TCSG fiscal year codes: Fall 2026 = 202712, Spring 2026 = 202614
-  const targetTerms = terms.filter((t) => {
-    const code = parseInt(t.code);
-    return code >= 202612;
-  });
+  const targetTerms = pickRecentSsbTerms(terms);
 
   if (targetTerms.length === 0) {
     console.log(`  No recent terms found. Available: ${terms.map((t) => `${t.description} (${t.code})`).join(", ")}`);

--- a/scripts/lib/resolve-terms.ts
+++ b/scripts/lib/resolve-terms.ts
@@ -76,6 +76,46 @@ export function nextTerm(t: TermInfo): TermInfo {
   return { name: `Spring ${t.year + 1}`, code: `${t.year + 1}SP`, season: "SP", year: t.year + 1 };
 }
 
+/**
+ * Filter Banner SSB-style terms (objects with a `description` like "Spring 2026"
+ * or "Fall Semester 2026") down to those at or after the current calendar term.
+ *
+ * Used by Banner SSB scrapers (DC, CT, GA) in place of hardcoded numeric
+ * thresholds like `parseInt(t.code) >= 202620`. Each Banner deployment uses
+ * its own season-suffix scheme (DC: 20=SP, CT: 40=SP, GA: 12=SP), so the
+ * description string is the only universal denominator across deployments.
+ *
+ * Pass an exclude predicate to drop deployment-specific noise (e.g. DE's
+ * "Professional Dev" entries) without re-implementing the year filter.
+ */
+export function pickRecentSsbTerms<T extends { description: string }>(
+  terms: T[],
+  opts: { exclude?: (t: T) => boolean } = {}
+): T[] {
+  const cur = currentCalendarTerm();
+  const SEASON_RANK: Record<string, number> = { SP: 1, SU: 2, FA: 3 };
+  const SEASON_FROM_DESC: Record<string, string> = {
+    spring: "SP",
+    summer: "SU",
+    fall: "FA",
+  };
+  const curRank = cur.year * 10 + SEASON_RANK[cur.season];
+
+  return terms.filter((t) => {
+    const desc = t.description.toLowerCase();
+    // Banner sites mark expired terms with "(View Only)" — never scrape those,
+    // they have no current sections and the data we already have is canonical.
+    if (desc.includes("view only")) return false;
+    if (opts.exclude?.(t)) return false;
+    const yearMatch = desc.match(/\b(20\d{2})\b/);
+    const seasonKey = Object.keys(SEASON_FROM_DESC).find((s) => desc.includes(s));
+    if (!yearMatch || !seasonKey) return false;
+    const season = SEASON_FROM_DESC[seasonKey];
+    const rank = parseInt(yearMatch[1]) * 10 + SEASON_RANK[season];
+    return rank >= curRank;
+  });
+}
+
 /** Get the term before a given term. */
 function prevTerm(t: TermInfo): TermInfo {
   if (t.season === "FA") return { name: `Summer ${t.year}`, code: `${t.year}SU`, season: "SU", year: t.year };


### PR DESCRIPTION
Phase 2a of [#115](https://github.com/rohan-c0de/cc-coursemap/issues/115). Phase 1 ([#116](https://github.com/rohan-c0de/cc-coursemap/pull/116)) handled CUNY's hardcoded term array. This phase de-duplicates the term-filter logic in the 3 Banner SSB scrapers.

## Problem

Each SSB scraper had its own hardcoded numeric threshold for "which terms are recent enough to scrape":

| State | Filter | Meaning |
|---|---|---|
| DC | `code >= 202620` | Spring 2026+ |
| CT | `code >= 202640` | Spring 2026+ |
| GA | `code >= 202612` | Fall 2025+ |

Three different formats because each Banner deployment uses its own season-suffix scheme (DC: `20`=Spring, CT: `40`=Spring, GA: `12`=Fall). No shared arithmetic possible across the codes themselves.

Side issue surfaced while investigating: the existing filters let through `(View Only)` entries that have no current sections — wasted scrape work on each cron run.

## Fix

Added `pickRecentSsbTerms()` to `scripts/lib/resolve-terms.ts`. Every Banner SSB deployment exposes a human description (`"Spring 2026"`, `"Fall Semester 2026 17-AUG-2026 - 08-DEC-2026"`, etc.), so the helper parses year + season from the description and compares against `currentCalendarTerm()`. Calendar-relative, deployment-agnostic.

Also drops `(View Only)` entries by default — they're never the right scrape target.

## Verification

Helper output against the 3 live `getTerms` endpoints (today, 2026-04-29):

```
=== CT (17 total) ===   →  Fall 2026, Summer 2026, Spring 2026
=== DC (20 total) ===   →  Fall 2026, Summer 2026
=== GA (20 total) ===   →  Fall/Summer/Spring Semester 2026
```

vs. previous behavior:
- **CT:** old filter also kept `WFD/CE 2026-2027 (View Only)` — wasted scrape, now dropped.
- **DC:** old filter also kept `Spring 2026 (View Only)` (DC's spring semester ended early) — wasted scrape, now dropped.
- **GA:** identical (GA's threshold was already tuned correctly).

`tsc --noEmit` clean. All three scrapers load and parse args without error.

## Out of scope

- DE / RI use a different scraper (Banner 8 self-serve, HTML-scraped) — different shape, will need its own pass if worth doing.
- VT (Colleague) already uses `resolve-terms.ts`'s probe path.
- CI guard against new hardcoded thresholds is the remaining item in #115.