### PR TITLE
DE/RI: Banner 8 scrapers use shared SSB term filter (issue #115 phase 2b)

### DIFF
--- a/scripts/de/scrape-banner8.ts
+++ b/scripts/de/scrape-banner8.ts
@@ -14,6 +14,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 type CourseMode = "in-person" | "online" | "hybrid" | "zoom";
 
@@ -424,14 +425,8 @@ async function scrapeCollege(
   const terms = await getAvailableTerms(config.baseUrl, config.prodPath);
   console.log(`  Available terms: ${terms.map((t) => t.description).join(", ")}`);
 
-  // Filter to recent/upcoming terms (skip "Professional Dev" and very old terms)
-  const targetTerms = terms.filter((t) => {
-    const desc = t.description.toLowerCase();
-    if (desc.includes("professional dev")) return false;
-    // Keep terms with year >= 2026
-    const yearMatch = t.description.match(/\b(20\d{2})\b/);
-    if (!yearMatch) return false;
-    return parseInt(yearMatch[1]) >= 2026;
+  const targetTerms = pickRecentSsbTerms(terms, {
+    exclude: (t) => t.description.toLowerCase().includes("professional dev"),
   });
 
   if (targetTerms.length === 0) {

--- a/scripts/lib/resolve-terms.ts
+++ b/scripts/lib/resolve-terms.ts
@@ -77,20 +77,26 @@ export function nextTerm(t: TermInfo): TermInfo {
 }
 
 /**
- * Filter Banner SSB-style terms (objects with a `description` like "Spring 2026"
- * or "Fall Semester 2026") down to those at or after the current calendar term.
+ * Filter Banner-style terms (objects with a human-readable label like
+ * "Spring 2026" or "Fall Semester 2026 17-AUG-2026 - 08-DEC-2026") down to
+ * those at or after the current calendar term.
  *
- * Used by Banner SSB scrapers (DC, CT, GA) in place of hardcoded numeric
- * thresholds like `parseInt(t.code) >= 202620`. Each Banner deployment uses
- * its own season-suffix scheme (DC: 20=SP, CT: 40=SP, GA: 12=SP), so the
- * description string is the only universal denominator across deployments.
+ * Used by both Banner SSB (DC, CT, GA — `description` field) and Banner 8
+ * HTML scrapers (DE — `description`, RI — `name`). Each Banner deployment
+ * uses its own season-suffix scheme in the term *code* (DC: 20=SP, CT: 40=SP,
+ * GA: 12=SP, RI: 10=SP), so the label string is the only universal
+ * denominator across deployments — pass `descriptionOf` when the label
+ * lives on a field other than `description`.
  *
- * Pass an exclude predicate to drop deployment-specific noise (e.g. DE's
+ * Pass an `exclude` predicate to drop deployment-specific noise (e.g. DE's
  * "Professional Dev" entries) without re-implementing the year filter.
+ *
+ * "(View only)" / "(View Only)" entries are dropped by default — they have
+ * no current sections and the data we already have for them is canonical.
  */
-export function pickRecentSsbTerms<T extends { description: string }>(
+export function pickRecentSsbTerms<T>(
   terms: T[],
-  opts: { exclude?: (t: T) => boolean } = {}
+  opts: { exclude?: (t: T) => boolean; descriptionOf?: (t: T) => string } = {}
 ): T[] {
   const cur = currentCalendarTerm();
   const SEASON_RANK: Record<string, number> = { SP: 1, SU: 2, FA: 3 };
@@ -100,11 +106,11 @@ export function pickRecentSsbTerms<T extends { description: string }>(
     fall: "FA",
   };
   const curRank = cur.year * 10 + SEASON_RANK[cur.season];
+  const getDesc =
+    opts.descriptionOf ?? ((t: T) => (t as { description: string }).description);
 
   return terms.filter((t) => {
-    const desc = t.description.toLowerCase();
-    // Banner sites mark expired terms with "(View Only)" — never scrape those,
-    // they have no current sections and the data we already have is canonical.
+    const desc = getDesc(t).toLowerCase();
     if (desc.includes("view only")) return false;
     if (opts.exclude?.(t)) return false;
     const yearMatch = desc.match(/\b(20\d{2})\b/);

--- a/scripts/ri/scrape-banner8.ts
+++ b/scripts/ri/scrape-banner8.ts
@@ -13,6 +13,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 const BASE_URL = "https://bannerweb.ccri.edu/pls/DORA";
 const SLUG = "ccri";
@@ -367,10 +368,9 @@ async function main() {
     const availableTerms = await getAvailableTerms();
     console.log(`  Found ${availableTerms.length} credit terms`);
 
-    // Filter to recent/upcoming non-CWCE credit terms
-    const recentTerms = availableTerms.filter(
-      (t) => parseInt(t.code) >= 202610 && !t.name.includes("View only")
-    );
+    const recentTerms = pickRecentSsbTerms(availableTerms, {
+      descriptionOf: (t) => t.name,
+    });
 
     if (recentTerms.length === 0) {
       console.log("  No recent terms found. Available:", availableTerms.map((t) => `${t.name} (${t.code})`));


### PR DESCRIPTION
Phase 2b of [#115](https://github.com/rohan-c0de/cc-coursemap/issues/115). Phases 1 ([#116](https://github.com/rohan-c0de/cc-coursemap/pull/116)) and 2a ([#117](https://github.com/rohan-c0de/cc-coursemap/pull/117)) handled CUNY and the 3 SSB scrapers. This phase finishes off the two Banner 8 HTML scrapers.

## Problem

Two more hardcoded thresholds:

| State | Filter |
|---|---|
| DE | `year >= 2026 && !description.includes("professional dev")` |
| RI | `code >= 202610 && !name.includes("View only")` |

## Fix

Extends `pickRecentSsbTerms()` to accept an optional `descriptionOf` accessor. RI uses `name` instead of `description` — accessor sidesteps that without a second helper.

```ts
// DE
pickRecentSsbTerms(terms, {
  exclude: (t) => t.description.toLowerCase().includes("professional dev"),
});

// RI
pickRecentSsbTerms(availableTerms, {
  descriptionOf: (t) => t.name,
});
```

## Verification

- RI helper produces the same 3 terms as the existing filter (Spring/Summer/Fall 2026), verified against the live `bwckschd.p_disp_dyn_sched` dropdown end-to-end through the actual scraper path. RI's `getAvailableTerms()` already strips CWCE entries upstream, so the helper never sees them.
- DE module loads and reaches the term-discovery step.
- `tsc --noEmit` clean.
- SSB regression check (CT) — default accessor still picks Fall/Summer/Spring 2026 as before.

## What's left in #115

Just the CI guard against new hardcoded term thresholds/arrays. With phase 2b merged, all 6 scrapers are calendar-relative — the guard becomes a backstop rather than a cleanup tool.