### PR TITLE
Add term-hardcoding CI guard + clean up 4 more scrapers (issue #115 phase 3)

### DIFF
--- a/.github/workflows/scraper-coverage.yml
+++ b/.github/workflows/scraper-coverage.yml
@@ -21,3 +21,4 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run check:scrapers
+      - run: npm run check:scraper-terms

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "check:registry": "tsx scripts/check-registry-integrity.ts",
     "check:scrapers": "tsx scripts/check-scraper-coverage.ts",
+    "check:scraper-terms": "tsx scripts/check-scraper-term-hardcoding.ts",
     "scrape": "tsx scripts/scrape-vccs.ts",
     "scrape:college": "tsx scripts/scrape-vccs.ts --college",
     "discover:ps": "tsx scripts/discover-ps-responses.ts",

--- a/scripts/check-scraper-term-hardcoding.ts
+++ b/scripts/check-scraper-term-hardcoding.ts
@@ -1,0 +1,138 @@
+/**
+ * Term-hardcoding guard (issue #115 phase 3).
+ *
+ * Scans per-state scraper files (`scripts/{state}/**\/*.ts`) for the kinds of
+ * hardcoded term references that put the cron at risk of silent staleness:
+ *
+ *   - Numeric term-code thresholds  (e.g. `code >= 202620`, `parseInt(t.code) >= 202610`)
+ *   - Hardcoded year thresholds     (e.g. `parseInt(yearMatch[1]) >= 2026`)
+ *   - Literal term-code arrays      (e.g. `{ code: "1262", ... }` of CUNY/PeopleSoft term codes)
+ *
+ * Each of these is calendar-relative work the scraper should derive from
+ * `currentCalendarTerm()` / `pickRecentSsbTerms()` in `scripts/lib/resolve-terms.ts`,
+ * not bake into the source. When a hardcoded value drifts past its real-world
+ * meaning the scraper fails silently — it returns the wrong term's data with
+ * no error, no alert, no change in CI status.
+ *
+ * Background: the original three offenders (CUNY in scripts/ny, the SSB
+ * thresholds in scripts/{ct,dc,ga}, the Banner 8 thresholds in
+ * scripts/{de,ri}) were cleaned up in PRs #116, #117, and #118. This guard
+ * exists so the next contributor can't reintroduce the pattern by accident.
+ *
+ * Opt-out: add a `// term-hardcode-allowed: <reason>` marker on the same
+ * line for legitimate one-off uses (e.g. school-specific code mappings that
+ * really are deployment-pinned). The reason is required and shows up in the
+ * git blame so future readers know why the exemption exists.
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const ROOT = resolve(__dirname, "..");
+const SCRIPTS_DIR = join(ROOT, "scripts");
+const ALLOW_MARKER = "term-hardcode-allowed:";
+
+// State directories under scripts/ — anything else (lib/, top-level scripts/*.ts)
+// is out of scope. State scrapers are where the staleness risk lives.
+function listStateScraperFiles(): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(SCRIPTS_DIR)) {
+    const full = join(SCRIPTS_DIR, entry);
+    if (!statSync(full).isDirectory()) continue;
+    if (entry === "lib") continue;
+    walk(full, out);
+  }
+  return out;
+}
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, out);
+    else if (entry.endsWith(".ts")) out.push(full);
+  }
+}
+
+interface Finding {
+  file: string;
+  line: number;
+  text: string;
+  kind: string;
+}
+
+// Banner term codes are 6 digits starting with `20` (e.g. 202620, 202712).
+// CUNY/PeopleSoft codes are 4 digits starting with `1` (e.g. 1262, 1269).
+// Year thresholds are 4 digits starting with `20` (e.g. 2026).
+const PATTERNS: { regex: RegExp; kind: string }[] = [
+  // `code >= 202610`, `parseInt(t.code) >= 202620`, etc.
+  { regex: /\bcode\s*\)?\s*>=\s*20\d{4}\b/, kind: "banner-term-code threshold" },
+  // `>= 2026` in a comparison (year threshold). Constrained to digit forms
+  // that look like academic years to avoid matching unrelated numerics.
+  { regex: />=\s*20[2-9]\d\b/, kind: "year threshold" },
+  // Literal term-code values in object/property form: `code: "1262"`,
+  // `code: "202610"`, `termCode: "2262"`. Catches hardcoded term arrays
+  // like the old CUNY_TERMS.
+  { regex: /\b(?:code|termCode|term)\s*:\s*["'](?:1\d{3}|20\d{4}|2\d{3})["']/, kind: "literal term code" },
+];
+
+function scan(file: string): Finding[] {
+  const found: Finding[] = [];
+  const src = readFileSync(file, "utf8");
+  const lines = src.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+
+    // Strip line comments before pattern matching so we don't flag examples
+    // in JSDoc / `//` comments — but keep the original for the allow marker
+    // check, which sits after the code.
+    const codePart = raw.replace(/\/\/.*$/, "");
+    if (raw.includes(ALLOW_MARKER)) continue;
+    // Block-comment lines: skip if the line looks comment-only.
+    if (/^\s*\*/.test(raw) || /^\s*\/\*/.test(raw)) continue;
+
+    for (const { regex, kind } of PATTERNS) {
+      if (regex.test(codePart)) {
+        found.push({ file, line: i + 1, text: raw.trim(), kind });
+        break;
+      }
+    }
+  }
+  return found;
+}
+
+const files = listStateScraperFiles();
+const findings: Finding[] = [];
+for (const file of files) findings.push(...scan(file));
+
+if (findings.length > 0) {
+  console.error(
+    `\nFound ${findings.length} hardcoded term reference(s) in state scrapers.\n`
+  );
+  console.error(
+    `These risk silent staleness at term rollover — the scraper succeeds`
+  );
+  console.error(
+    `but returns last term's data, with no alert. Use the helpers in`
+  );
+  console.error(`scripts/lib/resolve-terms.ts (currentCalendarTerm,`);
+  console.error(`nextTerm, pickRecentSsbTerms) instead.\n`);
+  console.error(
+    `If a hardcoded value is genuinely required (e.g. a school's`
+  );
+  console.error(
+    `deployment-pinned code mapping), add a same-line marker:`
+  );
+  console.error(`  // term-hardcode-allowed: <reason>\n`);
+
+  for (const f of findings) {
+    const rel = relative(ROOT, f.file);
+    console.error(`  ${rel}:${f.line}  [${f.kind}]`);
+    console.error(`    ${f.text}`);
+  }
+  console.error("");
+  process.exit(1);
+}
+
+console.log(`OK — no hardcoded term references in ${files.length} scraper files.`);

--- a/scripts/de/scrape-banner-ssb.ts
+++ b/scripts/de/scrape-banner-ssb.ts
@@ -15,6 +15,7 @@
 
 import fs from "fs";
 import path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 const PAGE_SIZE = 500;
 const BASE_URL = "https://banner.dtcc.edu";
@@ -514,19 +515,14 @@ async function main() {
     return;
   }
 
-  // Filter to recent/upcoming terms (2026+)
-  // "View Only" terms still have data — they're just past the registration window
-  const targetTerms = terms.filter((t) => {
-    const desc = t.description.toLowerCase();
-    // Skip continuing education or non-credit terms
-    if (desc.includes("continuing ed") || desc.includes("non-credit"))
-      return false;
-    // Extract year from description
-    const yearMatch = t.description.match(/\b(20\d{2})\b/);
-    if (yearMatch) return parseInt(yearMatch[1]) >= 2026;
-    // Fallback: code-based year
-    const codeYear = parseInt(t.code.substring(0, 4));
-    return codeYear >= 2026;
+  // Keep View Only entries: this scraper backfills past terms whose
+  // sections are still considered canonical.
+  const targetTerms = pickRecentSsbTerms(terms, {
+    includeViewOnly: true,
+    exclude: (t) => {
+      const desc = t.description.toLowerCase();
+      return desc.includes("continuing ed") || desc.includes("non-credit");
+    },
   });
 
   if (targetTerms.length === 0) {

--- a/scripts/lib/resolve-terms.ts
+++ b/scripts/lib/resolve-terms.ts
@@ -96,7 +96,17 @@ export function nextTerm(t: TermInfo): TermInfo {
  */
 export function pickRecentSsbTerms<T>(
   terms: T[],
-  opts: { exclude?: (t: T) => boolean; descriptionOf?: (t: T) => string } = {}
+  opts: {
+    exclude?: (t: T) => boolean;
+    descriptionOf?: (t: T) => string;
+    /**
+     * If true, keep "(View Only)" entries instead of dropping them.
+     * Default false. Set true for sites that intentionally re-scrape past
+     * terms (e.g. backfill scenarios where past sections are still valid
+     * to refresh).
+     */
+    includeViewOnly?: boolean;
+  } = {}
 ): T[] {
   const cur = currentCalendarTerm();
   const SEASON_RANK: Record<string, number> = { SP: 1, SU: 2, FA: 3 };
@@ -111,7 +121,7 @@ export function pickRecentSsbTerms<T>(
 
   return terms.filter((t) => {
     const desc = getDesc(t).toLowerCase();
-    if (desc.includes("view only")) return false;
+    if (!opts.includeViewOnly && desc.includes("view only")) return false;
     if (opts.exclude?.(t)) return false;
     const yearMatch = desc.match(/\b(20\d{2})\b/);
     const seasonKey = Object.keys(SEASON_FROM_DESC).find((s) => desc.includes(s));

--- a/scripts/ma/scrape-banner-ssb.ts
+++ b/scripts/ma/scrape-banner-ssb.ts
@@ -11,6 +11,7 @@
 
 import fs from "fs";
 import path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 const BASE_URL = "https://ban.hcc.edu";
 const COLLEGE_SLUG = "hcc";
@@ -310,12 +311,8 @@ async function main() {
   console.log("Fetching available terms...");
   const terms = await getTerms();
 
-  // Filter to recent/upcoming terms, skip non-credit and view-only
-  const targetTerms = terms.filter((t) => {
-    const desc = t.description.toLowerCase();
-    if (desc.includes("view only") || desc.includes("noncredit")) return false;
-    const yearMatch = t.description.match(/\b(20\d{2})\b/);
-    return yearMatch ? parseInt(yearMatch[1]) >= 2026 : false;
+  const targetTerms = pickRecentSsbTerms(terms, {
+    exclude: (t) => t.description.toLowerCase().includes("noncredit"),
   });
 
   console.log(`Found ${targetTerms.length} target terms:`, targetTerms.map((t) => t.description));

--- a/scripts/md/scrape-banner-ssb.ts
+++ b/scripts/md/scrape-banner-ssb.ts
@@ -14,6 +14,7 @@
 
 import fs from "fs";
 import path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 const PAGE_SIZE = 500;
 
@@ -343,11 +344,7 @@ async function scrapeCollege(slug: string, baseUrl: string): Promise<void> {
   console.log("Fetching available terms...");
   const terms = await getTerms(baseUrl);
 
-  // Filter to recent/upcoming terms
-  const targetTerms = terms.filter((t) => {
-    const code = parseInt(t.code);
-    return code >= 202620;
-  });
+  const targetTerms = pickRecentSsbTerms(terms);
 
   console.log(
     `Found ${targetTerms.length} target terms:`,

--- a/scripts/md/scrape-banner8.ts
+++ b/scripts/md/scrape-banner8.ts
@@ -14,6 +14,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
 
 type CourseMode = "in-person" | "online" | "hybrid" | "zoom";
 
@@ -424,14 +425,8 @@ async function scrapeCollege(
   const terms = await getAvailableTerms(config.baseUrl, config.prodPath);
   console.log(`  Available terms: ${terms.map((t) => t.description).join(", ")}`);
 
-  // Filter to recent/upcoming terms (skip "Professional Dev" and very old terms)
-  const targetTerms = terms.filter((t) => {
-    const desc = t.description.toLowerCase();
-    if (desc.includes("professional dev")) return false;
-    // Keep terms with year >= 2026
-    const yearMatch = t.description.match(/\b(20\d{2})\b/);
-    if (!yearMatch) return false;
-    return parseInt(yearMatch[1]) >= 2026;
+  const targetTerms = pickRecentSsbTerms(terms, {
+    exclude: (t) => t.description.toLowerCase().includes("professional dev"),
   });
 
   if (targetTerms.length === 0) {

--- a/scripts/va/enrich-peoplesoft.ts
+++ b/scripts/va/enrich-peoplesoft.ts
@@ -35,12 +35,15 @@ import * as path from "path";
 
 const PS_BASE = "https://ps-sis.vccs.edu";
 
-// Term name → PS term code + file code (mirrors scrape-peoplesoft.ts)
+// Term name → PS term code + file code (mirrors scrape-peoplesoft.ts).
+// VCCS PeopleSoft term IDs (2262, 2263, ...) are opaque internal IDs assigned
+// by VCCS; they are not derivable from the calendar. This mapping table is
+// the authoritative source — extend it when VCCS publishes new term IDs.
 const PS_TERM_MAP: Record<string, { code: string; file: string }> = {
-  "Spring 2026": { code: "2262", file: "2026SP" },
-  "Summer 2026": { code: "2263", file: "2026SU" },
-  "Fall 2026":   { code: "2264", file: "2026FA" },
-  "Spring 2027": { code: "2272", file: "2027SP" },
+  "Spring 2026": { code: "2262", file: "2026SP" }, // term-hardcode-allowed: opaque VCCS PS term ID
+  "Summer 2026": { code: "2263", file: "2026SU" }, // term-hardcode-allowed: opaque VCCS PS term ID
+  "Fall 2026":   { code: "2264", file: "2026FA" }, // term-hardcode-allowed: opaque VCCS PS term ID
+  "Spring 2027": { code: "2272", file: "2027SP" }, // term-hardcode-allowed: opaque VCCS PS term ID
 };
 
 // Accept --term "Summer 2026" (human-readable, matching scrape-peoplesoft.ts)


### PR DESCRIPTION
Final phase of [#115](https://github.com/rohan-c0de/cc-coursemap/issues/115). Phases 1–2b ([#116](https://github.com/rohan-c0de/cc-coursemap/pull/116), [#117](https://github.com/rohan-c0de/cc-coursemap/pull/117), [#118](https://github.com/rohan-c0de/cc-coursemap/pull/118)) cleaned up the scrapers I had surveyed by hand. This PR adds the CI backstop and surfaces the four I missed.

## What's new

**1. Term-hardcoding guard.** New `scripts/check-scraper-term-hardcoding.ts`, wired into the existing `scraper-coverage.yml` workflow. Scans `scripts/{state}/**/*.ts` for:

- Numeric term-code thresholds (`code >= 202620`, `parseInt(t.code) >= 202610`)
- Year thresholds (`parseInt(yearMatch[1]) >= 2026`)
- Literal term-code arrays (`{ code: "1262", ... }`)

**2. Opt-out marker.** Same-line `// term-hardcode-allowed: <reason>` for legitimate exceptions. The reason is required and shows up in git blame.

**3. Four more cleanups, courtesy of the guard.** When I ran the guard for the first time it caught four scrapers I hadn't manually surveyed:
  - `de/scrape-banner-ssb.ts` (separate from the `banner8` one)
  - `ma/scrape-banner-ssb.ts`
  - `md/scrape-banner-ssb.ts`
  - `md/scrape-banner8.ts`

All use the same SSB/Banner 8 pattern as the previously-cleaned scrapers — converted to `pickRecentSsbTerms()`, verified against each site's live `getTerms` endpoint.

**4. One legitimate exception.** `scripts/va/enrich-peoplesoft.ts` has a `PS_TERM_MAP` with VCCS PeopleSoft term IDs like `2262` / `2263`. These are opaque internal IDs assigned by VCCS — not derivable from the calendar. Each line gets a `// term-hardcode-allowed: opaque VCCS PS term ID` marker.

## Helper change

`pickRecentSsbTerms()` gains an `includeViewOnly` option. Default is still `false` (drop View Only), but DE-banner-ssb passes `true` because it intentionally re-scrapes past-but-still-canonical terms.

## Verification

- `npx tsx scripts/check-scraper-term-hardcoding.ts` → `OK — no hardcoded term references in 96 scraper files.`
- Regression test: synthetic file with `code: "1262"` + `parseInt(t.code) >= 202610` → guard exits non-zero ✓
- Live `getTerms` probes for the 4 newly-refactored sites all produce sensible term lists.
- `tsc --noEmit` clean.

## Wraps #115

After merge, every state course scraper in the repo is calendar-relative, and the CI prevents new ones from regressing. The original time bomb (NY/CUNY) and the latent bugs surfaced along the way (DC/CT scraping `(View Only)` terms, four more scrapers I had missed in the manual sweep) are all closed.