### PR TITLE
Add per-tick scraper health monitor (issue #120)

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -238,3 +238,72 @@ jobs:
       - name: No-op summary
         if: steps.diff.outputs.broken == 'false' && steps.diff.outputs.changed == '0'
         run: echo "No changes vs. main — nothing to PR."
+
+      # ----------------------------------------------------------------------
+      # Health monitor (issue #120) — runs every tick, never gated on diff.
+      # Classifies every (state × declared scraper) pair as healthy/empty/failed
+      # and keeps a rolling issue per datatype so silence is never the answer.
+      # ----------------------------------------------------------------------
+      - name: Run health check
+        id: health
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx tsx scripts/lib/check-scrape-health.ts \
+            --datatype "${{ needs.plan.outputs.datatype }}" \
+            --run-id "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
+            --data-dir data \
+            --status-out /tmp/health.json
+          echo "all_healthy=$(jq -r '.allHealthy' /tmp/health.json)" >> "$GITHUB_OUTPUT"
+          # Persist markdown body via env to avoid GITHUB_OUTPUT multiline quoting issues.
+          {
+            echo 'body<<HEALTH_BODY_EOF'
+            jq -r '.markdown' /tmp/health.json
+            echo 'HEALTH_BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update rolling health issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DT: ${{ needs.plan.outputs.datatype }}
+          BODY: ${{ steps.health.outputs.body }}
+          ALL_HEALTHY: ${{ steps.health.outputs.all_healthy }}
+        run: |
+          set -e
+          title="Scraper health — ${DT}"
+          # Find existing issue (open or closed) by exact title match.
+          existing=$(gh issue list \
+            --search "in:title \"${title}\"" \
+            --state all \
+            --limit 5 \
+            --json number,state,title \
+            --jq ".[] | select(.title == \"${title}\") | .number" \
+            | head -n 1)
+
+          printf '%s\n' "$BODY" > /tmp/issue-body.md
+
+          if [ -z "$existing" ]; then
+            # First run for this datatype — only file an issue if there's
+            # something to report. All-healthy on first tick stays silent.
+            if [ "$ALL_HEALTHY" = "true" ]; then
+              echo "First run for '${title}', all healthy — not opening an issue."
+              exit 0
+            fi
+            gh issue create \
+              --title "${title}" \
+              --body-file /tmp/issue-body.md \
+              --label "scraper-health,automated"
+            exit 0
+          fi
+
+          # Existing issue: always update the body so it reflects the latest tick.
+          gh issue edit "$existing" --body-file /tmp/issue-body.md
+
+          # Close on green, reopen on red. gh handles the no-op cases gracefully.
+          state=$(gh issue view "$existing" --json state --jq .state)
+          if [ "$ALL_HEALTHY" = "true" ] && [ "$state" = "OPEN" ]; then
+            gh issue close "$existing" --comment "All declared ${DT} scrapers healthy on the latest tick. Closing — will reopen automatically if a future tick regresses."
+          elif [ "$ALL_HEALTHY" = "false" ] && [ "$state" = "CLOSED" ]; then
+            gh issue reopen "$existing" --comment "Reopening — at least one ${DT} scraper is failing or producing empty output."
+          fi

--- a/scripts/lib/check-scrape-health.ts
+++ b/scripts/lib/check-scrape-health.ts
@@ -1,0 +1,334 @@
+/**
+ * check-scrape-health.ts
+ *
+ * Per-cron-tick health check for scheduled scraping (issue #120).
+ *
+ * Runs in the `aggregate` job of scheduled-scrape.yml after the matrix
+ * completes. For the cron's datatype, classifies every (state × scraper)
+ * pair declared in the registry as:
+ *
+ *   ✅ healthy  — matrix job succeeded AND expected output exists / non-empty
+ *   ⚠️ empty    — matrix job succeeded but output is missing or empty
+ *   ❌ failed   — matrix job exited non-zero (or never ran)
+ *
+ * Two outputs:
+ *   - Markdown report on stdout (rolling-issue body, Actions log)
+ *   - JSON status to --status-out (read by the workflow to decide whether
+ *     to open/update/close the rolling issue)
+ *
+ * The website is only useful if the data is current. Anything that lets
+ * the cron run without producing fresh data must surface as ⚠️ or ❌.
+ *
+ * Usage (from the aggregate job):
+ *   npx tsx scripts/lib/check-scrape-health.ts \
+ *     --datatype courses \
+ *     --run-id "$GITHUB_RUN_ID" \
+ *     --repo "$GITHUB_REPOSITORY" \
+ *     --data-dir data \
+ *     --status-out /tmp/health.json
+ */
+
+import { existsSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { getAllStates } from "../../lib/states/registry";
+import type { ScrapeJob, ScraperCoverage } from "../../lib/states/registry";
+
+type DataType = "courses" | "transfers" | "prereqs";
+type Status = "healthy" | "empty" | "failed";
+
+interface JobResult {
+  state: string;
+  datatype: DataType;
+  jobIndex: number; // matrix entry index within (state, datatype)
+  scripts: string[];
+  conclusion: string | null; // "success", "failure", "cancelled", or null if missing
+  status: Status;
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function arg(name: string, required = true): string {
+  const i = process.argv.indexOf(`--${name}`);
+  if (i < 0 || !process.argv[i + 1]) {
+    if (required) {
+      console.error(`Missing required --${name}`);
+      process.exit(2);
+    }
+    return "";
+  }
+  return process.argv[i + 1];
+}
+
+const datatype = arg("datatype") as DataType;
+const runId = arg("run-id");
+const repo = arg("repo");
+const dataDir = arg("data-dir", false) || "data";
+const statusOut = arg("status-out", false);
+
+if (!["courses", "transfers", "prereqs"].includes(datatype)) {
+  console.error(`Invalid --datatype: ${datatype}`);
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Registry → declared jobs
+// ---------------------------------------------------------------------------
+
+function jobsFor(scrapers: ScraperCoverage, dt: DataType): ScrapeJob[] {
+  if (dt === "courses") return scrapers.courses ?? [];
+  if (dt === "transfers") return scrapers.transfers ?? [];
+  const p = scrapers.prereqs;
+  // `aggregate-from-courses` states have no separate scrape job; nothing to
+  // schedule and so nothing to check here.
+  if (!p || !Array.isArray(p)) return [];
+  return p;
+}
+
+interface DeclaredJob {
+  state: string;
+  jobIndex: number;
+  scripts: string[];
+  matrixId: string;
+}
+
+function collectDeclaredJobs(): DeclaredJob[] {
+  const out: DeclaredJob[] = [];
+  for (const cfg of getAllStates()) {
+    if (!cfg.scrapers) continue;
+    const jobs = jobsFor(cfg.scrapers, datatype);
+    jobs.forEach((job, i) => {
+      out.push({
+        state: cfg.slug,
+        jobIndex: i,
+        scripts: job.scripts,
+        matrixId: `${cfg.slug}-${datatype}-${i}`,
+      });
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Actions per-job result lookup
+// ---------------------------------------------------------------------------
+
+interface GhJob {
+  name: string;
+  conclusion: string | null;
+}
+
+function fetchRunJobs(): GhJob[] {
+  // gh CLI paginates automatically with --paginate; cap output via jq.
+  // Workflow runs with large matrices can have 100+ jobs, so paginate.
+  try {
+    const out = execSync(
+      `gh api --paginate "/repos/${repo}/actions/runs/${runId}/jobs" --jq '.jobs[] | {name, conclusion}'`,
+      { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 }
+    );
+    // --jq with one object per line; wrap into an array.
+    return out
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l) as GhJob);
+  } catch (err) {
+    console.error("Failed to fetch run jobs from gh API:", err);
+    return [];
+  }
+}
+
+/**
+ * Find the matrix-entry job for a given declared scraper job.
+ *
+ * GitHub Actions names matrix-entry jobs `<job-id> (<matrix-value>, ...)`.
+ * Our matrix has multiple keys (id, state, datatype, runner, scripts,
+ * termSystem) so the displayed name varies — but the unique `id` field
+ * (e.g. `va-courses-0`) always appears. Match by substring.
+ */
+function findJobConclusion(matrixId: string, jobs: GhJob[]): string | null {
+  const hit = jobs.find((j) => j.name.includes(matrixId));
+  return hit?.conclusion ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Per-datatype output checks
+// ---------------------------------------------------------------------------
+
+function checkCoursesOutput(state: string): { ok: boolean; detail: string } {
+  const dir = join(dataDir, state, "courses");
+  if (!existsSync(dir)) {
+    return { ok: false, detail: "no courses directory" };
+  }
+  const colleges = readdirSync(dir).filter((entry) => {
+    const full = join(dir, entry);
+    return statSync(full).isDirectory();
+  });
+  if (colleges.length === 0) {
+    return { ok: false, detail: "no college subdirectories" };
+  }
+  // Look for at least one non-trivial JSON file across the colleges.
+  // "Non-trivial" = >100 bytes (an empty array is "[]" = 2 bytes; a single
+  // section is well over 100). Catches both "no file written" and "wrote
+  // [] because parser saw a login redirect."
+  const collegesWithData: string[] = [];
+  for (const college of colleges) {
+    const collegeDir = join(dir, college);
+    const files = readdirSync(collegeDir).filter((f) => f.endsWith(".json"));
+    const hasData = files.some((f) => {
+      const sz = statSync(join(collegeDir, f)).size;
+      return sz > 100;
+    });
+    if (hasData) collegesWithData.push(college);
+  }
+  if (collegesWithData.length === 0) {
+    return {
+      ok: false,
+      detail: `${colleges.length} college dir(s) but all course files <100 bytes`,
+    };
+  }
+  if (collegesWithData.length < colleges.length) {
+    return {
+      ok: true,
+      detail: `${collegesWithData.length}/${colleges.length} colleges have data`,
+    };
+  }
+  return {
+    ok: true,
+    detail: `${collegesWithData.length} college(s) with data`,
+  };
+}
+
+function checkSingleFileOutput(
+  state: string,
+  filename: string
+): { ok: boolean; detail: string } {
+  const path = join(dataDir, state, filename);
+  if (!existsSync(path)) {
+    return { ok: false, detail: `${filename} missing` };
+  }
+  const size = statSync(path).size;
+  if (size <= 100) {
+    return { ok: false, detail: `${filename} is empty (${size} bytes)` };
+  }
+  return { ok: true, detail: `${filename} present (${size} bytes)` };
+}
+
+function checkOutput(
+  state: string,
+  scripts: string[]
+): { ok: boolean; detail: string } {
+  if (datatype === "courses") return checkCoursesOutput(state);
+  if (datatype === "transfers")
+    return checkSingleFileOutput(state, "transfer-equiv.json");
+  if (datatype === "prereqs") return checkSingleFileOutput(state, "prereqs.json");
+  return { ok: false, detail: `unknown datatype ${datatype}` };
+}
+
+// ---------------------------------------------------------------------------
+// Classification + reporting
+// ---------------------------------------------------------------------------
+
+function classify(declared: DeclaredJob, conclusion: string | null): JobResult {
+  if (conclusion === null) {
+    return {
+      state: declared.state,
+      datatype,
+      jobIndex: declared.jobIndex,
+      scripts: declared.scripts,
+      conclusion,
+      status: "failed",
+      detail: "matrix job not found in workflow run (registry/matrix mismatch)",
+    };
+  }
+  if (conclusion !== "success") {
+    return {
+      state: declared.state,
+      datatype,
+      jobIndex: declared.jobIndex,
+      scripts: declared.scripts,
+      conclusion,
+      status: "failed",
+      detail: `matrix job conclusion=${conclusion}`,
+    };
+  }
+  const out = checkOutput(declared.state, declared.scripts);
+  return {
+    state: declared.state,
+    datatype,
+    jobIndex: declared.jobIndex,
+    scripts: declared.scripts,
+    conclusion,
+    status: out.ok ? "healthy" : "empty",
+    detail: out.detail,
+  };
+}
+
+function emoji(s: Status): string {
+  return s === "healthy" ? "✅" : s === "empty" ? "⚠️" : "❌";
+}
+
+function renderMarkdown(results: JobResult[]): string {
+  const counts = {
+    healthy: results.filter((r) => r.status === "healthy").length,
+    empty: results.filter((r) => r.status === "empty").length,
+    failed: results.filter((r) => r.status === "failed").length,
+  };
+  const lines: string[] = [];
+  lines.push(`# Scraper health — ${datatype}`);
+  lines.push("");
+  lines.push(
+    `**${counts.healthy} healthy · ${counts.empty} empty · ${counts.failed} failed** (of ${results.length} declared)`
+  );
+  lines.push("");
+  lines.push(`Workflow run: https://github.com/${repo}/actions/runs/${runId}`);
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push("");
+
+  // Group: failures first, then empty, then healthy.
+  const order: Status[] = ["failed", "empty", "healthy"];
+  for (const status of order) {
+    const group = results.filter((r) => r.status === status);
+    if (group.length === 0) continue;
+    lines.push(`## ${emoji(status)} ${status} (${group.length})`);
+    lines.push("");
+    lines.push("| State | Scripts | Detail |");
+    lines.push("| --- | --- | --- |");
+    for (const r of group) {
+      const scripts = r.scripts.map((s) => `\`${s}\``).join("<br>");
+      lines.push(`| \`${r.state}\` | ${scripts} | ${r.detail} |`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const declared = collectDeclaredJobs();
+const ghJobs = fetchRunJobs();
+const results = declared.map((d) => classify(d, findJobConclusion(d.matrixId, ghJobs)));
+
+const md = renderMarkdown(results);
+console.log(md);
+
+if (statusOut) {
+  const counts = {
+    healthy: results.filter((r) => r.status === "healthy").length,
+    empty: results.filter((r) => r.status === "empty").length,
+    failed: results.filter((r) => r.status === "failed").length,
+  };
+  const allHealthy = counts.empty === 0 && counts.failed === 0;
+  writeFileSync(
+    statusOut,
+    JSON.stringify(
+      { datatype, allHealthy, counts, results, markdown: md },
+      null,
+      2
+    )
+  );
+}


### PR DESCRIPTION
Closes [#120](https://github.com/rohan-c0de/cc-coursemap/issues/120).

## What this fixes

The scheduled-scrape workflow was only loud about hard job failures and >50% row drops on existing files. Several silent-failure modes — empty output, missed terms, scrapers returning `[]` because a session expired — slipped past CI without notice. The website is only useful if the data is current, so silence has to mean "definitely fine," not "no idea."

## Verification on real data

Running the monitor against the **2026-04-29 transfers cron** (run 25106134426) immediately surfaced two pre-existing silent failures:

```
=== Scraper health — transfers ===
12 healthy · 2 empty · 2 failed (of 16 declared)

❌ failed (2)
  sc — matrix job conclusion=failure
  tn — matrix job not found in workflow run (registry/matrix mismatch from #112)

⚠️ empty (2)
  dc — transfer-equiv.json is empty (3 bytes)
  me — transfer-equiv.json is empty (3 bytes)
```

DC and ME have had `[]` transfer files on main this whole time — this monitor would have flagged them on the very first tick they went empty.

## How it works

**Health check** ([scripts/lib/check-scrape-health.ts](scripts/lib/check-scrape-health.ts)). After every cron tick, for every (state × declared scraper) pair in the registry:

- ✅ **healthy** — matrix job succeeded AND expected output exists / non-empty (>100 bytes)
- ⚠️ **empty** — matrix job succeeded but output is missing or trivially small
- ❌ **failed** — matrix job exited non-zero (or never ran — registry/matrix mismatch)

Output paths are convention-driven by datatype:
- `courses` → `data/{state}/courses/{college}/*.json` (any non-empty file across colleges)
- `transfers` → `data/{state}/transfer-equiv.json`
- `prereqs` → `data/{state}/prereqs.json`

**Rolling issue per datatype** (in scheduled-scrape.yml). One issue per cron — \`Scraper health — courses\`, \`— transfers\`, \`— prereqs\`:
- First tick all-green → stays silent.
- First tick with issues → opens the rolling issue with a labeled summary.
- Subsequent ticks → edit the same issue body so it always reflects the latest tick.
- Goes green → closes with a comment.
- Regresses → reopens with a comment.

So failures are tracked without inbox spam, and you can mute one datatype's issue while leaving the others active.

## Coverage

Catches every silent-failure mode discussed in #120 across all three datatypes (courses, transfers, prereqs):

| Failure | Caught? |
|---|---|
| Scraper script crashes / non-zero exit | ✅ matrix job conclusion |
| Scraper "succeeds" but output empty / `[]` | ✅ size check |
| State declares a scraper that never ran | ✅ matrix-id lookup |
| Per-college subset broken (e.g. 1 of 7 CUNY colleges) | ✅ per-college file walk for courses |
| File drops below 50% of prior count | ✅ existing `broken` check (kept) |

## Follow-up

After merge: DC and ME transfer scrapers need investigation — they're producing `[]` and have been for a while. That's a separate issue / PR; this one is about *learning* about it, not fixing it.