### PR TITLE
Add API route contract tests (P1 of test-coverage plan)

### DIFF
--- a/app/api/[state]/prereqs/chain/route.ts
+++ b/app/api/[state]/prereqs/chain/route.ts
@@ -11,7 +11,7 @@ type RouteContext = { params: Promise<{ state: string }> };
  * AND-of-OR groups: outer array = AND (all required), inner array = OR
  * (pick one). A flat `children` array is also provided for backward compat.
  */
-interface ChainNode {
+export interface ChainNode {
   course: string;
   text: string;        // Human-readable prereq description for THIS course
   children: ChainNode[];
@@ -40,7 +40,7 @@ function loadPrereqs(
  * Parse prereq text into AND-of-OR groups.
  * "ACC 101 and (BUS 107 or CIS 107)" → [["ACC 101"], ["BUS 107","CIS 107"]]
  */
-function parsePrereqGroups(text: string, courses: string[]): string[][] {
+export function parsePrereqGroups(text: string, courses: string[]): string[][] {
   if (courses.length === 0) return [];
   if (courses.length === 1) return [courses];
 
@@ -89,7 +89,7 @@ function parsePrereqGroups(text: string, courses: string[]): string[][] {
  * Returns both a flat `children` array (backward compat) and a `groups`
  * array that preserves AND-of-OR structure from the prereq text.
  */
-function buildChain(
+export function buildChain(
   course: string,
   prereqs: Map<string, { text: string; courses: string[] }>,
   visited: Set<string>,

--- a/app/api/__tests__/account-delete.route.test.ts
+++ b/app/api/__tests__/account-delete.route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getUserMock = vi.fn();
+const deleteUserMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: getUserMock },
+  })),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getServiceClient: vi.fn(() => ({
+    auth: { admin: { deleteUser: deleteUserMock } },
+  })),
+}));
+
+import { DELETE } from "../account/delete/route";
+
+beforeEach(() => {
+  getUserMock.mockReset();
+  deleteUserMock.mockReset();
+});
+
+describe("DELETE /api/account/delete", () => {
+  it("returns 401 when the request has no authenticated user", async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: null }, error: null });
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+    expect(deleteUserMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when getUser surfaces an auth error", async () => {
+    getUserMock.mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: "JWT expired" },
+    });
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+    expect(deleteUserMock).not.toHaveBeenCalled();
+  });
+
+  it("calls service-role deleteUser with the authenticated user's id", async () => {
+    getUserMock.mockResolvedValueOnce({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+    deleteUserMock.mockResolvedValueOnce({ error: null });
+
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    expect(deleteUserMock).toHaveBeenCalledWith("user-123");
+    expect(await res.json()).toEqual({ success: true });
+  });
+
+  it("returns 500 when the service-role deletion fails", async () => {
+    getUserMock.mockResolvedValueOnce({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
+    deleteUserMock.mockResolvedValueOnce({
+      error: { message: "Supabase admin error" },
+    });
+
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when an unexpected exception is thrown", async () => {
+    getUserMock.mockRejectedValueOnce(new Error("network down"));
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+  });
+
+  it("never invokes deleteUser before getUser succeeds (auth-gate ordering)", async () => {
+    // Belt-and-suspenders: the entire 401 case must skip service-role calls.
+    // This guards the security-critical invariant that admin deletion
+    // cannot happen without a verified user.
+    getUserMock.mockResolvedValueOnce({ data: { user: null }, error: null });
+    await DELETE();
+    expect(deleteUserMock).toHaveBeenCalledTimes(0);
+  });
+});

--- a/app/api/__tests__/courses-search.route.test.ts
+++ b/app/api/__tests__/courses-search.route.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock all heavy dependencies before importing the route. `vi.mock` is
+// hoisted so this runs before the route module is evaluated.
+vi.mock("@/lib/courses-search", () => ({
+  searchCoursesAcrossColleges: vi.fn(),
+}));
+vi.mock("@/lib/institutions", () => ({
+  loadInstitutions: vi.fn(() => []),
+}));
+vi.mock("@/lib/terms", () => ({
+  getCurrentTerm: vi.fn(async () => "2026SP"),
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 99 })),
+  getClientKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+import { GET } from "../[state]/courses/search/route";
+import { searchCoursesAcrossColleges } from "@/lib/courses-search";
+import { rateLimit } from "@/lib/rate-limit";
+
+const searchMock = vi.mocked(searchCoursesAcrossColleges);
+const rateLimitMock = vi.mocked(rateLimit);
+
+function makeRequest(state: string, query: Record<string, string>): {
+  req: NextRequest;
+  ctx: { params: Promise<{ state: string }> };
+} {
+  const url = new URL(`http://localhost/api/${state}/courses/search`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return {
+    req: new NextRequest(url),
+    ctx: { params: Promise.resolve({ state }) },
+  };
+}
+
+beforeEach(() => {
+  searchMock.mockReset();
+  searchMock.mockResolvedValue({
+    courses: [],
+    totalCourses: 0,
+    totalSections: 0,
+    totalColleges: 0,
+  });
+  rateLimitMock.mockReset();
+  rateLimitMock.mockReturnValue({ allowed: true, remaining: 99 });
+});
+
+describe("GET /api/[state]/courses/search", () => {
+  it("returns 404 for an unknown state", async () => {
+    const { req, ctx } = makeRequest("xx", { q: "ENG 111" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when q is missing", async () => {
+    const { req, ctx } = makeRequest("va", {});
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.any(String) });
+  });
+
+  it("returns 400 when q is shorter than 2 chars", async () => {
+    const { req, ctx } = makeRequest("va", { q: "a" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an unknown timeOfDay value", async () => {
+    const { req, ctx } = makeRequest("va", { q: "ENG 111", timeOfDay: "midnight" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when the rate limiter denies the request", async () => {
+    rateLimitMock.mockReturnValueOnce({ allowed: false, remaining: 0 });
+    const { req, ctx } = makeRequest("va", { q: "ENG 111" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps limit to 100 when callers pass a larger value", async () => {
+    const { req, ctx } = makeRequest("va", { q: "ENG 111", limit: "999" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    // searchCoursesAcrossColleges receives `limit` as the 5th positional arg.
+    expect(searchMock.mock.calls[0][4]).toBe(100);
+  });
+
+  it("clamps negative limit to 1", async () => {
+    const { req, ctx } = makeRequest("va", { q: "ENG 111", limit: "-5" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    expect(searchMock.mock.calls[0][4]).toBe(1);
+  });
+
+  it("falls back to default limit (10) when parseInt yields 0 or NaN", async () => {
+    // `parseInt("0") || 10` short-circuits to 10 because 0 is falsy. Same
+    // happens for non-numeric input. This documents that quirk.
+    const { req, ctx } = makeRequest("va", { q: "ENG 111", limit: "0" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    expect(searchMock.mock.calls[0][4]).toBe(10);
+  });
+
+  it("parses comma-separated days param", async () => {
+    const { req, ctx } = makeRequest("va", { q: "ENG 111", days: "M,W,F" });
+    await GET(req, ctx);
+    // 4th positional arg is the filters object.
+    expect(searchMock.mock.calls[0][3]).toMatchObject({ days: ["M", "W", "F"] });
+  });
+
+  it("falls back to the legacy single 'day' param when 'days' is missing", async () => {
+    const { req, ctx } = makeRequest("va", { q: "ENG 111", day: "Tu" });
+    await GET(req, ctx);
+    expect(searchMock.mock.calls[0][3]).toMatchObject({ days: ["Tu"] });
+  });
+
+  it("forwards the state slug to searchCoursesAcrossColleges", async () => {
+    const { req, ctx } = makeRequest("nc", { q: "BIO" });
+    await GET(req, ctx);
+    expect(searchMock.mock.calls[0][6]).toBe("nc");
+  });
+
+  it("returns 200 with the search result body on a valid request", async () => {
+    searchMock.mockResolvedValueOnce({
+      courses: [{ prefix: "ENG", number: "111" } as never],
+      totalCourses: 1,
+      totalSections: 5,
+      totalColleges: 3,
+    });
+    const { req, ctx } = makeRequest("va", { q: "ENG 111" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalSections).toBe(5);
+    expect(body.totalColleges).toBe(3);
+  });
+});

--- a/app/api/__tests__/prereqs-chain.route.test.ts
+++ b/app/api/__tests__/prereqs-chain.route.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// `fs` is mocked so we can inject controlled prereq fixtures without
+// touching the real data/{state}/prereqs.json files. The route reads
+// process.cwd()/data/{state}/prereqs.json synchronously via fs.readFileSync.
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    default: { ...actual, readFileSync: vi.fn() },
+    readFileSync: vi.fn(),
+  };
+});
+
+import fs from "fs";
+import {
+  GET,
+  parsePrereqGroups,
+  buildChain,
+} from "../[state]/prereqs/chain/route";
+
+const readFileSyncMock = vi.mocked(fs.readFileSync);
+
+function makeRequest(state: string, course?: string): {
+  req: NextRequest;
+  ctx: { params: Promise<{ state: string }> };
+} {
+  const url = new URL(`http://localhost/api/${state}/prereqs/chain`);
+  if (course !== undefined) url.searchParams.set("course", course);
+  return {
+    req: new NextRequest(url),
+    ctx: { params: Promise.resolve({ state }) },
+  };
+}
+
+beforeEach(() => {
+  readFileSyncMock.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// parsePrereqGroups — pure function, no I/O. This was the highest-value
+// target identified in the test-coverage analysis: a buggy AND/OR parser
+// silently misclassifies required prereqs as optional, blocking enrollment.
+// ---------------------------------------------------------------------------
+
+describe("parsePrereqGroups", () => {
+  it("returns an empty array when there are no courses", () => {
+    expect(parsePrereqGroups("", [])).toEqual([]);
+  });
+
+  it("wraps a single course in a single AND group", () => {
+    expect(parsePrereqGroups("ENG 111", ["ENG 111"])).toEqual([["ENG 111"]]);
+  });
+
+  it("treats two AND-joined courses as separate AND groups", () => {
+    expect(
+      parsePrereqGroups("ACC 101 and BUS 107", ["ACC 101", "BUS 107"])
+    ).toEqual([["ACC 101"], ["BUS 107"]]);
+  });
+
+  it("groups OR-alternatives inside parens as a single AND group with multiple ORs", () => {
+    const result = parsePrereqGroups(
+      "ACC 101 and (BUS 107 or CIS 107)",
+      ["ACC 101", "BUS 107", "CIS 107"]
+    );
+    expect(result).toEqual([["ACC 101"], ["BUS 107", "CIS 107"]]);
+  });
+
+  it("does not split on 'and' when it appears inside parentheses", () => {
+    // "(MATH 101 and MATH 102)" should be treated as a single chunk, so the
+    // two MATH courses end up in the same OR group, not separate AND groups.
+    const result = parsePrereqGroups(
+      "PHYS 101 and (MATH 101 and MATH 102)",
+      ["PHYS 101", "MATH 101", "MATH 102"]
+    );
+    expect(result).toEqual([["PHYS 101"], ["MATH 101", "MATH 102"]]);
+  });
+
+  it("places unassigned courses in their own AND group", () => {
+    // If the text doesn't mention a course at all, fall back to including it
+    // as a standalone requirement so it is not silently dropped from the tree.
+    const result = parsePrereqGroups("ENG 111", ["ENG 111", "MTH 161"]);
+    expect(result).toContainEqual(["ENG 111"]);
+    expect(result).toContainEqual(["MTH 161"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildChain — recursive tree builder; depth-cap and visited-set guard
+// against runaway recursion on cyclic catalogs.
+// ---------------------------------------------------------------------------
+
+describe("buildChain", () => {
+  it("returns a node with empty children for an unknown course", () => {
+    const tree = buildChain("UNKNOWN 999", new Map(), new Set(), 0);
+    expect(tree.course).toBe("UNKNOWN 999");
+    expect(tree.children).toEqual([]);
+  });
+
+  it("walks one level of prerequisites", () => {
+    const prereqs = new Map<string, { text: string; courses: string[] }>([
+      ["ENG 112", { text: "ENG 111", courses: ["ENG 111"] }],
+    ]);
+    const tree = buildChain("ENG 112", prereqs, new Set(), 0);
+    expect(tree.children).toHaveLength(1);
+    expect(tree.children[0].course).toBe("ENG 111");
+  });
+
+  it("stops recursing when depth exceeds 6 (cycle protection)", () => {
+    // Build a 10-deep linear chain. The depth cap should halt expansion at 6
+    // even without an explicit cycle.
+    const prereqs = new Map<string, { text: string; courses: string[] }>();
+    for (let i = 0; i < 10; i++) {
+      prereqs.set(`X ${i}`, { text: `X ${i + 1}`, courses: [`X ${i + 1}`] });
+    }
+    const tree = buildChain("X 0", prereqs, new Set(), 0);
+    let node = tree;
+    let depth = 0;
+    while (node.children.length > 0) {
+      node = node.children[0];
+      depth++;
+    }
+    // Each recursive call increments depth before testing >= 6, so the deepest
+    // populated node we reach is the one whose recursion call still had
+    // depth < 6 — i.e. depth 6 from the root.
+    expect(depth).toBeLessThanOrEqual(6);
+  });
+
+  it("does not infinite-loop on a circular prereq definition", () => {
+    const prereqs = new Map<string, { text: string; courses: string[] }>([
+      ["A 1", { text: "B 1", courses: ["B 1"] }],
+      ["B 1", { text: "A 1", courses: ["A 1"] }],
+    ]);
+    // If this throws or hangs, the test runner times out — which counts as
+    // a failure. So just calling it is the assertion.
+    const tree = buildChain("A 1", prereqs, new Set(), 0);
+    expect(tree.course).toBe("A 1");
+  });
+
+  it("attaches AND-of-OR groups when text has alternatives", () => {
+    const prereqs = new Map<string, { text: string; courses: string[] }>([
+      [
+        "PHYS 101",
+        {
+          text: "MATH 101 and (CHEM 101 or CHEM 102)",
+          courses: ["MATH 101", "CHEM 101", "CHEM 102"],
+        },
+      ],
+    ]);
+    const tree = buildChain("PHYS 101", prereqs, new Set(), 0);
+    expect(tree.groups).toBeDefined();
+    expect(tree.groups!.length).toBe(2);
+    // Second AND group has two OR alternatives.
+    expect(tree.groups![1].length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET handler — input validation + fs error handling
+// ---------------------------------------------------------------------------
+
+describe("GET /api/[state]/prereqs/chain", () => {
+  it("returns 404 for an unknown state", async () => {
+    const { req, ctx } = makeRequest("xx", "ENG 111");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when the course query param is missing", async () => {
+    const { req, ctx } = makeRequest("va");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the state has no prereqs.json", async () => {
+    readFileSyncMock.mockImplementationOnce(() => {
+      throw new Error("ENOENT");
+    });
+    const { req, ctx } = makeRequest("va", "ENG 111");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the prereq tree when the data is loadable", async () => {
+    readFileSyncMock.mockImplementationOnce(() =>
+      JSON.stringify({
+        "ENG 112": { text: "ENG 111", courses: ["ENG 111"] },
+      })
+    );
+    const { req, ctx } = makeRequest("va", "ENG 112");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.course).toBe("ENG 112");
+    expect(body.children[0].course).toBe("ENG 111");
+  });
+
+  it("sets a Cache-Control header on success", async () => {
+    readFileSyncMock.mockImplementationOnce(() =>
+      JSON.stringify({ "ENG 111": { text: "", courses: [] } })
+    );
+    const { req, ctx } = makeRequest("va", "ENG 111");
+    const res = await GET(req, ctx);
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+});

--- a/app/api/__tests__/schedule-build.route.test.ts
+++ b/app/api/__tests__/schedule-build.route.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/schedule", () => ({
+  generateSchedules: vi.fn(),
+}));
+vi.mock("@/lib/transfer-scoped", () => ({
+  buildTransferLookupForSubjects: vi.fn(),
+}));
+vi.mock("@/lib/institutions", () => ({
+  loadInstitutions: vi.fn(() => []),
+}));
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 19 })),
+  getClientKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+
+import { POST } from "../[state]/schedule/build/route";
+import { generateSchedules } from "@/lib/schedule";
+import { rateLimit } from "@/lib/rate-limit";
+
+const generateMock = vi.mocked(generateSchedules);
+const rateLimitMock = vi.mocked(rateLimit);
+
+function makeRequest(state: string, body: unknown): {
+  req: Request;
+  ctx: { params: Promise<{ state: string }> };
+} {
+  return {
+    req: new Request(`http://localhost/api/${state}/schedule/build`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    ctx: { params: Promise.resolve({ state }) },
+  };
+}
+
+const validBody = {
+  subjects: ["ENG 111"],
+  daysAvailable: ["M", "W", "F"],
+  maxCourses: 2,
+};
+
+beforeEach(() => {
+  generateMock.mockReset();
+  generateMock.mockResolvedValue({
+    schedules: [],
+    meta: {
+      candidateSections: 0,
+      candidateCourses: 0,
+      combinationsEvaluated: 0,
+      timeTakenMs: 1,
+    },
+  });
+  rateLimitMock.mockReset();
+  rateLimitMock.mockReturnValue({ allowed: true, remaining: 19 });
+});
+
+describe("POST /api/[state]/schedule/build", () => {
+  it("returns 404 for an unknown state", async () => {
+    const { req, ctx } = makeRequest("xx", validBody);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+    expect(generateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    rateLimitMock.mockReturnValueOnce({ allowed: false, remaining: 0 });
+    const { req, ctx } = makeRequest("va", validBody);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when subjects array is missing", async () => {
+    const { req, ctx } = makeRequest("va", { daysAvailable: ["M"], maxCourses: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when subjects is empty", async () => {
+    const { req, ctx } = makeRequest("va", { ...validBody, subjects: [] });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when a subject is not a string", async () => {
+    const { req, ctx } = makeRequest("va", { ...validBody, subjects: [123] });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when daysAvailable is missing", async () => {
+    const { req, ctx } = makeRequest("va", { subjects: ["ENG 111"], maxCourses: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when daysAvailable contains an invalid day code", async () => {
+    const { req, ctx } = makeRequest("va", { ...validBody, daysAvailable: ["Mo"] });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when maxCourses is outside 1-5", async () => {
+    const { req, ctx } = makeRequest("va", { ...validBody, maxCourses: 6 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with the schedule result on a valid request", async () => {
+    const { req, ctx } = makeRequest("va", validBody);
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    expect(generateMock).toHaveBeenCalledOnce();
+    const body = await res.json();
+    expect(body.meta).toBeDefined();
+  });
+
+  it("forwards the state slug to generateSchedules", async () => {
+    const { req, ctx } = makeRequest("nc", validBody);
+    await POST(req, ctx);
+    // generateSchedules signature: (request, institutions, state, ...)
+    expect(generateMock.mock.calls[0][2]).toBe("nc");
+  });
+
+  it("returns 500 when the body cannot be parsed as JSON", async () => {
+    const req = new Request("http://localhost/api/va/schedule/build", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const ctx = { params: Promise.resolve({ state: "va" }) };
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/__tests__/transfer-lookup.route.test.ts
+++ b/app/api/__tests__/transfer-lookup.route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/transfer", () => ({
+  buildTransferLookup: vi.fn(),
+  getUniversities: vi.fn(),
+}));
+
+beforeEach(async () => {
+  // Module-level `cachedResponses` persists across imports of the route
+  // module — so a previous test's data would leak into the next via cache.
+  // Reset modules to give each test a fresh route + fresh cache.
+  vi.resetModules();
+  const transfer = await import("@/lib/transfer");
+  vi.mocked(transfer.buildTransferLookup).mockReset();
+  vi.mocked(transfer.getUniversities).mockReset();
+});
+
+function makeRequest(state: string): {
+  req: NextRequest;
+  ctx: { params: Promise<{ state: string }> };
+} {
+  return {
+    req: new NextRequest(`http://localhost/api/${state}/transfer/lookup`),
+    ctx: { params: Promise.resolve({ state }) },
+  };
+}
+
+describe("GET /api/[state]/transfer/lookup", () => {
+  it("returns 404 for an unknown state", async () => {
+    const { GET } = await import("../[state]/transfer/lookup/route");
+    const { req, ctx } = makeRequest("xx");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when the underlying transfer load throws", async () => {
+    const transfer = await import("@/lib/transfer");
+    vi.mocked(transfer.buildTransferLookup).mockRejectedValueOnce(new Error("db down"));
+    const { GET } = await import("../[state]/transfer/lookup/route");
+    const { req, ctx } = makeRequest("va");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(500);
+  });
+
+  it("returns the lookup + universities payload on success", async () => {
+    const transfer = await import("@/lib/transfer");
+    vi.mocked(transfer.buildTransferLookup).mockResolvedValueOnce({
+      "ENG-111": [{ university: "vt", type: "direct", course: "ENGL 1105" }],
+    });
+    vi.mocked(transfer.getUniversities).mockResolvedValueOnce([
+      { slug: "vt", name: "Virginia Tech" },
+    ]);
+
+    const { GET } = await import("../[state]/transfer/lookup/route");
+    const { req, ctx } = makeRequest("va");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.lookup["ENG-111"]).toBeDefined();
+    expect(body.universities[0].slug).toBe("vt");
+  });
+
+  it("does NOT leak one state's data into another (cache is keyed per state)", async () => {
+    const transfer = await import("@/lib/transfer");
+    vi.mocked(transfer.buildTransferLookup).mockImplementation(async (state?: string) => ({
+      [`${state}-COURSE`]: [{ university: "uni", type: "direct" as const, course: "X" }],
+    }));
+    vi.mocked(transfer.getUniversities).mockImplementation(async (state?: string) => [
+      { slug: `${state}-uni`, name: `${state} university` },
+    ]);
+
+    const { GET } = await import("../[state]/transfer/lookup/route");
+
+    const va = makeRequest("va");
+    const vaRes = await GET(va.req, va.ctx);
+    const vaBody = await vaRes.json();
+
+    const nc = makeRequest("nc");
+    const ncRes = await GET(nc.req, nc.ctx);
+    const ncBody = await ncRes.json();
+
+    // Critical: NC must NOT receive VA's lookup keys.
+    expect(vaBody.lookup["va-COURSE"]).toBeDefined();
+    expect(vaBody.lookup["nc-COURSE"]).toBeUndefined();
+    expect(ncBody.lookup["nc-COURSE"]).toBeDefined();
+    expect(ncBody.lookup["va-COURSE"]).toBeUndefined();
+  });
+
+  it("serves the cached response on a repeat call without re-loading", async () => {
+    const transfer = await import("@/lib/transfer");
+    vi.mocked(transfer.buildTransferLookup).mockResolvedValue({});
+    vi.mocked(transfer.getUniversities).mockResolvedValue([]);
+
+    const { GET } = await import("../[state]/transfer/lookup/route");
+    const a = makeRequest("va");
+    await GET(a.req, a.ctx);
+    const b = makeRequest("va");
+    await GET(b.req, b.ctx);
+
+    expect(vi.mocked(transfer.buildTransferLookup)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(transfer.getUniversities)).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

P1 from the test-coverage plan. Builds on the Vitest infrastructure shipped in #125. **50 new tests across the 5 highest-traffic / highest-risk API routes**, focused on input validation, state-routing safety, and the security-critical service-role flow — not on re-testing the underlying lib helpers (which have their own P0 tests).

| Route | Tests | What's covered |
|---|---|---|
| `GET /api/[state]/courses/search` | 12 | state 404, q-length, invalid `timeOfDay`, rate-limit 429, `limit` clamping (incl. the `parseInt('0') \|\| 10` quirk — documented as a test rather than fixed because it's pre-existing behavior), `days`/`day` param parity, state forwarding. |
| `POST /api/[state]/schedule/build` | 11 | state 404, rate-limit, body validation (subjects array of strings, `daysAvailable` enum, `maxCourses` 1–5), malformed-JSON 500, state forwarding. |
| `GET /api/[state]/prereqs/chain` | 14 | route-level: state 404, missing `?course=`, missing data file, `Cache-Control`. Plus **direct unit tests on the now-exported `parsePrereqGroups` and `buildChain`** — paren-depth AND/OR splitting, depth-cap protection, circular-prereq termination, AND-of-OR group attachment. This is the test the original plan called out as the highest-value gap. |
| `GET /api/[state]/transfer/lookup` | 5 | state 404, 500 on backend failure, **cross-state cache-key isolation** (regression guard against one state's mappings leaking into another's response), repeat-call cache hit. |
| `DELETE /api/account/delete` | 6 | 401 on no user / auth error, 200 on successful service-role delete with the right user id forwarded, 500 on delete failure or thrown exception, and a belt-and-suspenders assertion that `deleteUser` is never called when `getUser` returns null (the security-critical invariant). |

## Notes on approach

- **Mocking via `vi.mock`** at module level for all heavy deps: `searchCoursesAcrossColleges`, `generateSchedules`, `buildTransferLookup`/`getUniversities`, both Supabase clients, and `fs.readFileSync`. Route handlers are imported and called directly with a constructed `Request`/`NextRequest`; this is fast (~2s for the whole suite) and lets us pin down validation branches deterministically.
- **Module-level state isolation** for the transfer-lookup route: `vi.resetModules()` in `beforeEach` so the in-memory `cachedResponses` map gets a fresh start per test.
- **Non-handler exports from `route.ts`** are ignored by Next's App Router. `parsePrereqGroups`, `buildChain`, and `ChainNode` are now exported from `app/api/[state]/prereqs/chain/route.ts` for unit-test access — no runtime change.

## Test plan

- [x] `npm run test:run` — 152 / 152 pass locally (102 P0 + 50 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [ ] CI green on this PR

## Follow-ups (not in scope)

- **P1 — Scraper parsing fixture tests** (start with VA): closes the "1000-byte plausible-looking garbage passes the health check" gap.
- **P2 — `npm run check:data`**: pre-merge referential integrity (prereqs reference real courses, no duplicate CRNs).
- **P2 — One Playwright e2e flow** on Vercel previews.

https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC)_