### PR TITLE
Add VA VCCS scraper fixture tests (P1 of test-coverage plan)

### DIFF
--- a/scripts/va/__fixtures__/course-page-empty.html
+++ b/scripts/va/__fixtures__/course-page-empty.html
@@ -1,0 +1,19 @@
+<!--
+  Drift fixture #2: a course page with no `div#schedule` at all.
+
+  This simulates the symptoms of an auth-wall login redirect or an error
+  page being returned in place of the real catalog. scrapeSections() must
+  return an empty array rather than producing junk rows from whatever
+  HTML happens to be present.
+-->
+<html>
+<body>
+  <div class="credits">3 credits</div>
+  <div class="endtext">No schedule available for this course.</div>
+
+  <main>
+    <h1>Page not found</h1>
+    <p>The course you requested could not be located. Please <a href="/login">sign in</a> to continue.</p>
+  </main>
+</body>
+</html>

--- a/scripts/va/__fixtures__/course-page-happy.html
+++ b/scripts/va/__fixtures__/course-page-happy.html
@@ -1,0 +1,85 @@
+<!--
+  Synthetic VCCS course page fixture for scrapeSections() tests.
+
+  Mirrors the structure of a real courses.vccs.edu course detail page:
+  https://courses.vccs.edu/colleges/<slug>/courses/ENG111-CollegeCompositionI
+
+  The selectors here match the ones in scripts/va/scrape-vccs.ts. If the
+  upstream site's DOM changes, those tests should start failing — but in
+  practice that's caught at scrape time by the empty-output health check
+  rather than here. These fixtures are about regressing the parser, not
+  drift detection.
+-->
+<html>
+<body>
+  <div class="credits">3 credits</div>
+
+  <div class="endtext">
+    Designed to help students develop college-level writing skills.
+    Prerequisite: Placement into <a href="/courses/ENF003">ENF 003</a> or higher.
+    Lecture 3 hours per week.
+  </div>
+
+  <div id="schedule">
+    <!-- Past term — should be ignored when targetTerm is "Spring 2026" -->
+    <div class="card">
+      <div class="card-header">
+        <a class="card-link"><h4>Fall 2025</h4></a>
+      </div>
+      <table class="table">
+        <tbody>
+          <tr class="vevent">
+            <td>99999</td>
+            <td>001</td>
+            <td>3</td>
+            <td><div class="days"><span class="s">M</span></div></td>
+            <td><div class="times">9:00 AM - 9:50 AM</div></td>
+            <td>08/26/2025</td>
+            <td>Annandale</td>
+            <td><span title="In-Person Course">P</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Target term — both rows should parse -->
+    <div class="card">
+      <div class="card-header">
+        <a class="card-link"><h4>Spring 2026 ➔</h4></a>
+      </div>
+      <table class="table">
+        <tbody>
+          <!-- In-person, MWF morning -->
+          <tr class="vevent">
+            <td>70056</td>
+            <td>001</td>
+            <td>3</td>
+            <td>
+              <div class="days">
+                <span class="s">M</span>
+                <span class="s">W</span>
+                <span class="s">F</span>
+              </div>
+            </td>
+            <td><div class="times">9:00 AM - 9:50 AM</div></td>
+            <td>01/12/2026</td>
+            <td>Annandale</td>
+            <td><span title="In-Person Course">P</span></td>
+          </tr>
+          <!-- Online async, TBA times, no days -->
+          <tr class="vevent">
+            <td>70057</td>
+            <td>002</td>
+            <td>3</td>
+            <td><div class="days"></div></td>
+            <td><div class="times">TBA</div></td>
+            <td>01/12/2026</td>
+            <td>Distance Learning</td>
+            <td><span title="Worldwide Online">WW</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/va/__fixtures__/course-page-no-target-term.html
+++ b/scripts/va/__fixtures__/course-page-no-target-term.html
@@ -1,0 +1,31 @@
+<!--
+  Drift fixture #1: a course page whose only schedule card is for a term
+  that does NOT match the caller's targetTerm. scrapeSections() must
+  return an empty array — not silently produce stale rows for an old term.
+-->
+<html>
+<body>
+  <div class="credits">3 credits</div>
+  <div id="schedule">
+    <div class="card">
+      <div class="card-header">
+        <a class="card-link"><h4>Fall 2024</h4></a>
+      </div>
+      <table class="table">
+        <tbody>
+          <tr class="vevent">
+            <td>50001</td>
+            <td>001</td>
+            <td>3</td>
+            <td><div class="days"><span class="s">Tu</span><span class="s">Th</span></div></td>
+            <td><div class="times">2:00 PM - 3:15 PM</div></td>
+            <td>08/26/2024</td>
+            <td>Annandale</td>
+            <td><span title="In-Person Course">P</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/va/__tests__/scrape-vccs.test.ts
+++ b/scripts/va/__tests__/scrape-vccs.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from "vitest";
+import * as cheerio from "cheerio";
+import fs from "fs";
+import path from "path";
+
+import {
+  termToCode,
+  termMatchesTarget,
+  parseMode,
+  parseTimes,
+  parseDays,
+  parsePrerequisites,
+  scrapeSections,
+} from "../scrape-vccs";
+
+// ---------------------------------------------------------------------------
+// Helpers — pure, no I/O
+// ---------------------------------------------------------------------------
+
+describe("termToCode", () => {
+  it.each([
+    ["Spring 2026", "2026SP"],
+    ["Summer 2026", "2026SU"],
+    ["Fall 2026", "2026FA"],
+    ["spring 2026", "2026SP"], // case-insensitive
+  ])("converts %j -> %s", (input, expected) => {
+    expect(termToCode(input)).toBe(expected);
+  });
+
+  it("falls back to compacted whitespace for unrecognised formats", () => {
+    expect(termToCode("Winter 2026")).toBe("Winter2026");
+  });
+});
+
+describe("termMatchesTarget", () => {
+  it("matches identical terms after stripping decorations", () => {
+    // Real VCCS pages append a glyph like "Spring 2026 ➔" to the heading.
+    expect(termMatchesTarget("Spring 2026 ➔", "Spring 2026")).toBe(true);
+  });
+
+  it("rejects different seasons of the same year", () => {
+    expect(termMatchesTarget("Fall 2026", "Spring 2026")).toBe(false);
+  });
+
+  it("rejects same season different year", () => {
+    expect(termMatchesTarget("Spring 2025", "Spring 2026")).toBe(false);
+  });
+});
+
+describe("parseMode", () => {
+  it("classifies online (WW) regardless of title", () => {
+    expect(parseMode("WW", "")).toBe("online");
+    expect(parseMode("X", "Worldwide Online")).toBe("online");
+  });
+
+  it("classifies hybrid (HY)", () => {
+    expect(parseMode("HY", "")).toBe("hybrid");
+    expect(parseMode("X", "Hybrid Course")).toBe("hybrid");
+  });
+
+  it("classifies zoom-style synchronous-remote", () => {
+    expect(parseMode("CV", "")).toBe("zoom");
+    expect(parseMode("X", "Interactive Video")).toBe("zoom");
+    expect(parseMode("X", "Zoom Meeting")).toBe("zoom");
+  });
+
+  it("defaults to in-person", () => {
+    expect(parseMode("P", "In-Person Course")).toBe("in-person");
+    expect(parseMode("", "")).toBe("in-person");
+  });
+});
+
+describe("parseTimes", () => {
+  it("returns TBA for empty / TBA / null-equivalent input", () => {
+    expect(parseTimes("")).toEqual(["TBA", "TBA"]);
+    expect(parseTimes("TBA")).toEqual(["TBA", "TBA"]);
+    expect(parseTimes("tba")).toEqual(["TBA", "TBA"]);
+  });
+
+  it("normalises 'a.m.' / 'p.m.' to AM/PM", () => {
+    expect(parseTimes("9:00 a.m. - 9:50 a.m.")).toEqual([
+      "9:00 AM",
+      "9:50 AM",
+    ]);
+    expect(parseTimes("1:00 p.m. - 2:15 p.m.")).toEqual([
+      "1:00 PM",
+      "2:15 PM",
+    ]);
+  });
+
+  it("handles different dash characters", () => {
+    expect(parseTimes("9:00 AM – 9:50 AM")).toEqual(["9:00 AM", "9:50 AM"]);
+    expect(parseTimes("9:00 AM — 9:50 AM")).toEqual(["9:00 AM", "9:50 AM"]);
+  });
+
+  it("collapses non-breaking spaces", () => {
+    expect(parseTimes("9:00 AM - 9:50 AM")).toEqual([
+      "9:00 AM",
+      "9:50 AM",
+    ]);
+  });
+
+  it("returns TBA when only one side parses", () => {
+    expect(parseTimes("0:00 AM - 9:50 AM")).toEqual(["TBA", "TBA"]);
+    expect(parseTimes("12:00 AM - 12:00 AM")).toEqual(["TBA", "TBA"]);
+  });
+
+  it("returns TBA when there is no dash", () => {
+    expect(parseTimes("9:00 AM")).toEqual(["TBA", "TBA"]);
+  });
+});
+
+describe("parseDays", () => {
+  it("joins active day spans with a single space", () => {
+    const $ = cheerio.load(
+      `<div class="days">
+        <span class="s">M</span>
+        <span class="s">W</span>
+        <span class="s">F</span>
+      </div>`
+    );
+    expect(parseDays($, $("div.days"))).toBe("M W F");
+  });
+
+  it("returns empty string when there are no active spans", () => {
+    const $ = cheerio.load('<div class="days"></div>');
+    expect(parseDays($, $("div.days"))).toBe("");
+  });
+});
+
+describe("parsePrerequisites", () => {
+  it("extracts text and linked course codes", () => {
+    const $ = cheerio.load(`
+      <div class="endtext">
+        Foundation course.
+        Prerequisite: <a href="/courses/MTH161">MTH 161</a> or
+        <a href="/courses/MTH162">MTH 162</a>.
+      </div>
+    `);
+    const result = parsePrerequisites($);
+    expect(result.text).toContain("MTH 161");
+    expect(result.courses).toEqual(expect.arrayContaining(["MTH 161", "MTH 162"]));
+  });
+
+  it("also catches unlinked course codes mentioned in the text", () => {
+    const $ = cheerio.load(`
+      <div class="endtext">
+        Prerequisite: ENG 111 or equivalent placement.
+      </div>
+    `);
+    const result = parsePrerequisites($);
+    expect(result.courses).toContain("ENG 111");
+  });
+
+  it("returns null/[] when no prerequisite block is present", () => {
+    const $ = cheerio.load(`
+      <div class="endtext">A standalone course with no prereqs.</div>
+    `);
+    expect(parsePrerequisites($)).toEqual({ text: null, courses: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scrapeSections — fixture-driven; the highest-value test, since this
+// guards against a parser regression silently writing junk to data/.
+// ---------------------------------------------------------------------------
+
+function fixture(name: string): string {
+  return fs.readFileSync(
+    path.join(__dirname, "..", "__fixtures__", name),
+    "utf-8"
+  );
+}
+
+describe("scrapeSections", () => {
+  it("parses two sections from the happy-path fixture for the target term", () => {
+    const html = fixture("course-page-happy.html");
+    const sections = scrapeSections(
+      html,
+      "nova",
+      "ENG",
+      "111",
+      "College Composition I",
+      "Spring 2026"
+    );
+    expect(sections).toHaveLength(2);
+  });
+
+  it("extracts identity + schedule fields for an in-person section", () => {
+    const html = fixture("course-page-happy.html");
+    const sections = scrapeSections(
+      html,
+      "nova",
+      "ENG",
+      "111",
+      "College Composition I",
+      "Spring 2026"
+    );
+    const inPerson = sections.find((s) => s.crn === "70056")!;
+    expect(inPerson).toMatchObject({
+      college_code: "nova",
+      term: "2026SP",
+      course_prefix: "ENG",
+      course_number: "111",
+      course_title: "College Composition I",
+      credits: 3,
+      crn: "70056",
+      days: "M W F",
+      start_time: "9:00 AM",
+      end_time: "9:50 AM",
+      campus: "Annandale",
+      mode: "in-person",
+    });
+  });
+
+  it("classifies a WW section as online with TBA times and no days", () => {
+    const html = fixture("course-page-happy.html");
+    const sections = scrapeSections(
+      html,
+      "nova",
+      "ENG",
+      "111",
+      "College Composition I",
+      "Spring 2026"
+    );
+    const online = sections.find((s) => s.crn === "70057")!;
+    expect(online.mode).toBe("online");
+    expect(online.start_time).toBe("TBA");
+    expect(online.end_time).toBe("TBA");
+    expect(online.days).toBe("");
+  });
+
+  it("attaches per-course prerequisites to every section", () => {
+    const html = fixture("course-page-happy.html");
+    const sections = scrapeSections(
+      html,
+      "nova",
+      "ENG",
+      "111",
+      "College Composition I",
+      "Spring 2026"
+    );
+    expect(sections.every((s) => s.prerequisite_courses.includes("ENF 003"))).toBe(true);
+    expect(sections[0].prerequisite_text).toContain("ENF 003");
+  });
+
+  it("ignores sections from non-matching term cards", () => {
+    const html = fixture("course-page-happy.html");
+    const sections = scrapeSections(
+      html,
+      "nova",
+      "ENG",
+      "111",
+      "College Composition I",
+      "Spring 2026"
+    );
+    // The fixture has a Fall 2025 card with CRN 99999. It should NOT appear
+    // when the caller asks for Spring 2026 — this is the silent-staleness
+    // guard.
+    expect(sections.find((s) => s.crn === "99999")).toBeUndefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Drift cases — degenerate inputs that the scraper sometimes encounters
+  // (auth-wall redirect, stale term page). Parser must return [] rather
+  // than emit junk rows that would slip past schema validation.
+  // ---------------------------------------------------------------------------
+
+  it("returns [] when no schedule card matches the requested term", () => {
+    const html = fixture("course-page-no-target-term.html");
+    const sections = scrapeSections(
+      html,
+      "nova",
+      "ENG",
+      "111",
+      "College Composition I",
+      "Spring 2026"
+    );
+    expect(sections).toEqual([]);
+  });
+
+  it("returns [] when the page has no schedule div at all (auth wall / 404 surrogate)", () => {
+    const html = fixture("course-page-empty.html");
+    const sections = scrapeSections(
+      html,
+      "nova",
+      "ENG",
+      "111",
+      "College Composition I",
+      "Spring 2026"
+    );
+    expect(sections).toEqual([]);
+  });
+
+  it("returns [] when handed empty / whitespace HTML", () => {
+    expect(scrapeSections("", "nova", "ENG", "111", "x", "Spring 2026")).toEqual([]);
+    expect(scrapeSections("   \n  ", "nova", "ENG", "111", "x", "Spring 2026")).toEqual([]);
+  });
+});

--- a/scripts/va/scrape-vccs.ts
+++ b/scripts/va/scrape-vccs.ts
@@ -35,7 +35,7 @@ const ALL_SLUGS = [
 // Helpers
 // ---------------------------------------------------------------------------
 
-function termToCode(termName: string): string {
+export function termToCode(termName: string): string {
   const match = termName.match(/^(Spring|Summer|Fall)\s+(\d{4})$/i);
   if (!match) return termName.replace(/\s+/g, "");
   const season = match[1].toLowerCase();
@@ -44,13 +44,13 @@ function termToCode(termName: string): string {
   return `${year}${codes[season] || season.toUpperCase()}`;
 }
 
-function termMatchesTarget(termName: string, targetTerm: string): boolean {
+export function termMatchesTarget(termName: string, targetTerm: string): boolean {
   // "Spring 2026 ➔" should match target "Spring 2026"
   const clean = termName.replace(/[^\w\s]/g, "").trim();
   return termToCode(clean) === termToCode(targetTerm);
 }
 
-function parseMode(modeCode: string, modeTitle: string): "in-person" | "online" | "hybrid" | "zoom" {
+export function parseMode(modeCode: string, modeTitle: string): "in-person" | "online" | "hybrid" | "zoom" {
   const code = modeCode.trim().toUpperCase();
   const title = modeTitle.trim().toLowerCase();
   if (code === "WW" || title.includes("online")) return "online";
@@ -59,7 +59,7 @@ function parseMode(modeCode: string, modeTitle: string): "in-person" | "online" 
   return "in-person";
 }
 
-function parseTimes(timeStr: string): [string, string] {
+export function parseTimes(timeStr: string): [string, string] {
   if (!timeStr || timeStr.trim() === "" || timeStr.toLowerCase().includes("tba")) {
     return ["TBA", "TBA"];
   }
@@ -81,7 +81,7 @@ function parseTimes(timeStr: string): [string, string] {
   return [start, end];
 }
 
-function parseDays($: cheerio.CheerioAPI, daysDiv: cheerio.Cheerio<AnyNode>): string {
+export function parseDays($: cheerio.CheerioAPI, daysDiv: cheerio.Cheerio<AnyNode>): string {
   const active: string[] = [];
   daysDiv.find("span.s").each((_, el) => {
     const t = $(el).text().trim();
@@ -95,7 +95,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 /** Extract prerequisite info from the course description area */
-function parsePrerequisites($: cheerio.CheerioAPI): {
+export function parsePrerequisites($: cheerio.CheerioAPI): {
   text: string | null;
   courses: string[];
 } {
@@ -153,7 +153,7 @@ async function fetchPage(url: string): Promise<string> {
 // Types
 // ---------------------------------------------------------------------------
 
-interface CourseSection {
+export interface CourseSection {
   college_code: string;
   term: string;
   course_prefix: string;
@@ -242,7 +242,7 @@ async function getCoursePages(subjectUrl: string, prefix: string): Promise<{ pre
 // Step 3: Scrape sections from a course page for the target term
 // ---------------------------------------------------------------------------
 
-function scrapeSections(
+export function scrapeSections(
   html: string,
   slug: string,
   coursePrefix: string,
@@ -440,7 +440,11 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("Fatal:", err);
-  process.exit(1);
-});
+// Only invoke main() when this file is the CLI entry point. Importing it
+// from tests must be a no-op so vitest doesn't trigger a live scrape.
+if (process.argv[1]?.includes("scrape-vccs")) {
+  main().catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

P1 — VA VCCS scraper fixture tests. Establishes the per-state scraper-test pattern that closes the gap between **"scraper produced 1000 bytes of plausible-looking garbage"** and "data was rejected at import time." Schema validation + change-detection catch gross failures (zero rows, malformed shape, >50% drop). These tests catch parser regressions on input that still **looks** structurally valid.

**31 new tests, 183 total** (152 prior + 31 here). Uses the same Vitest infrastructure shipped in #125.

## Changes

- **`scripts/va/scrape-vccs.ts`** — added `export` to 7 pure helpers (`termToCode`, `termMatchesTarget`, `parseMode`, `parseTimes`, `parseDays`, `parsePrerequisites`, `scrapeSections`) plus the `CourseSection` interface. No runtime change. Also wrapped the top-level `main()` in an entry-point guard so importing the file from a test doesn't trigger a real live scrape.
- **`scripts/va/__fixtures__/`** — 3 synthesized HTML fixtures:
  - `course-page-happy.html` — 2-section Spring 2026 + 1-section Fall 2025. Covers in-person and `WW` (online) modes plus per-course prereqs.
  - `course-page-no-target-term.html` — only-Fall-2024 page; parser must return `[]` rather than emit stale rows for the wrong term.
  - `course-page-empty.html` — no schedule div at all (auth-wall / 404 surrogate); parser must return `[]` rather than parse junk from noise.
- **`scripts/va/__tests__/scrape-vccs.test.ts`** — 31 tests. Covers helper behaviour at the unit level + `scrapeSections` end-to-end against fixtures.

## Test plan

- [x] `npm run test:run` — 183/183 pass locally
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [ ] CI green on this PR

## Notes

- **Fixtures are synthesized**, not captured from a live scrape. They mirror the selectors `scrapeSections` reads. This is sufficient for guarding against parser regressions; "site changed without us noticing" is a different concern that the scraper-time empty-output health check (`scripts/lib/check-scrape-health.ts`) catches.
- **Easy follow-up:** swap a fixture file for a real `curl`-captured HTML page and the tests update with no test-logic changes.
- **Fan-out template:** the same `__tests__/` + `__fixtures__/` layout works unchanged for NC Banner, MA Banner8, NY CUNY, and the other scraper families. Each one is its own incremental PR.

## What's still queued

- **P2 — `npm run check:data`**: pre-merge referential integrity (prereqs reference real courses, no duplicate CRNs).
- **P2 — One Playwright e2e flow** on Vercel previews.
- Fan out scraper fixture tests to the other 17 states.

https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC)_