### PR TITLE
Add check:data referential integrity script (P2)

### DIFF
--- a/.github/workflows/data-integrity.yml
+++ b/.github/workflows/data-integrity.yml
@@ -1,0 +1,22 @@
+name: Data integrity
+
+on:
+  pull_request:
+    paths:
+      - "data/**"
+      - "scripts/check-data-integrity.ts"
+      - ".github/workflows/data-integrity.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run check:data

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check:registry": "tsx scripts/check-registry-integrity.ts",
     "check:scrapers": "tsx scripts/check-scraper-coverage.ts",
     "check:scraper-terms": "tsx scripts/check-scraper-term-hardcoding.ts",
+    "check:data": "tsx scripts/check-data-integrity.ts",
     "scrape": "tsx scripts/scrape-vccs.ts",
     "scrape:college": "tsx scripts/scrape-vccs.ts --college",
     "discover:ps": "tsx scripts/discover-ps-responses.ts",

--- a/scripts/__tests__/check-data-integrity.test.ts
+++ b/scripts/__tests__/check-data-integrity.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCourseSet,
+  findDuplicateCrns,
+  findOrphanPrereqs,
+  findOrphanTransferMappings,
+} from "../check-data-integrity";
+
+describe("buildCourseSet", () => {
+  it("returns 'PREFIX NUMBER' keys for every section", () => {
+    const set = buildCourseSet([
+      { course_prefix: "ENG", course_number: "111", crn: "1" },
+      { course_prefix: "MTH", course_number: "161", crn: "2" },
+    ]);
+    expect(set.has("ENG 111")).toBe(true);
+    expect(set.has("MTH 161")).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it("deduplicates the same course offered multiple times", () => {
+    const set = buildCourseSet([
+      { course_prefix: "ENG", course_number: "111", crn: "1" },
+      { course_prefix: "ENG", course_number: "111", crn: "2" },
+      { course_prefix: "ENG", course_number: "111", crn: "3" },
+    ]);
+    expect(set.size).toBe(1);
+  });
+
+  it("skips rows missing prefix or number", () => {
+    const set = buildCourseSet([
+      { course_prefix: "", course_number: "111", crn: "1" },
+      { course_prefix: "ENG", course_number: "", crn: "2" },
+      { course_prefix: "ENG", course_number: "111", crn: "3" },
+    ]);
+    expect(set.size).toBe(1);
+  });
+});
+
+describe("findDuplicateCrns", () => {
+  it("returns empty when every CRN is unique", () => {
+    const dups = findDuplicateCrns([
+      { course_prefix: "ENG", course_number: "111", crn: "1" },
+      { course_prefix: "ENG", course_number: "111", crn: "2" },
+    ]);
+    expect(dups).toEqual([]);
+  });
+
+  it("reports a CRN that appears twice with count 2", () => {
+    const dups = findDuplicateCrns([
+      { course_prefix: "ENG", course_number: "111", crn: "70056" },
+      { course_prefix: "ENG", course_number: "111", crn: "70056" },
+    ]);
+    expect(dups).toEqual([{ crn: "70056", count: 2 }]);
+  });
+
+  it("reports separate counts for separate duplicate CRNs", () => {
+    const dups = findDuplicateCrns([
+      { course_prefix: "ENG", course_number: "111", crn: "A" },
+      { course_prefix: "ENG", course_number: "111", crn: "A" },
+      { course_prefix: "ENG", course_number: "111", crn: "A" },
+      { course_prefix: "ENG", course_number: "111", crn: "B" },
+      { course_prefix: "ENG", course_number: "111", crn: "B" },
+      { course_prefix: "ENG", course_number: "111", crn: "C" },
+    ]);
+    expect(dups).toEqual(
+      expect.arrayContaining([
+        { crn: "A", count: 3 },
+        { crn: "B", count: 2 },
+      ])
+    );
+    expect(dups.find((d) => d.crn === "C")).toBeUndefined();
+  });
+
+  it("ignores rows with empty CRN", () => {
+    const dups = findDuplicateCrns([
+      { course_prefix: "ENG", course_number: "111", crn: "" },
+      { course_prefix: "ENG", course_number: "111", crn: "" },
+    ]);
+    expect(dups).toEqual([]);
+  });
+});
+
+describe("findOrphanPrereqs", () => {
+  const courseSet = new Set(["ENG 111", "MTH 161", "BIO 101"]);
+
+  it("flags a key whose course is not in the catalog", () => {
+    const { orphanKeys, orphanRefs } = findOrphanPrereqs(
+      { "ENG 999": { text: "ENG 111", courses: ["ENG 111"] } },
+      courseSet
+    );
+    expect(orphanKeys).toEqual(["ENG 999"]);
+    expect(orphanRefs).toEqual([]);
+  });
+
+  it("flags a reference to a course not in the catalog", () => {
+    const { orphanKeys, orphanRefs } = findOrphanPrereqs(
+      { "ENG 111": { text: "RDG 100", courses: ["RDG 100"] } },
+      courseSet
+    );
+    expect(orphanKeys).toEqual([]);
+    expect(orphanRefs).toEqual([{ from: "ENG 111", to: "RDG 100" }]);
+  });
+
+  it("does not flag entries fully contained in the catalog", () => {
+    const result = findOrphanPrereqs(
+      { "MTH 161": { text: "ENG 111", courses: ["ENG 111"] } },
+      courseSet
+    );
+    expect(result.orphanKeys).toEqual([]);
+    expect(result.orphanRefs).toEqual([]);
+  });
+
+  it("handles multiple referenced courses per entry", () => {
+    const { orphanRefs } = findOrphanPrereqs(
+      {
+        "BIO 101": {
+          text: "ENG 111 and RDG 100",
+          courses: ["ENG 111", "RDG 100", "MTH 161"],
+        },
+      },
+      courseSet
+    );
+    expect(orphanRefs).toEqual([{ from: "BIO 101", to: "RDG 100" }]);
+  });
+});
+
+describe("findOrphanTransferMappings", () => {
+  const courseSet = new Set(["ENG 111", "MTH 161"]);
+
+  it("returns empty when every CC course is in the catalog", () => {
+    const orphans = findOrphanTransferMappings(
+      [
+        { cc_prefix: "ENG", cc_number: "111" },
+        { cc_prefix: "MTH", cc_number: "161" },
+      ],
+      courseSet
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  it("flags rows whose CC course is missing from the catalog", () => {
+    const orphans = findOrphanTransferMappings(
+      [
+        { cc_prefix: "ENG", cc_number: "111" }, // present
+        { cc_prefix: "VCCS", cc_number: "Course Number" }, // legitimate header row
+        { cc_prefix: "ACC", cc_number: "111" }, // not in catalog
+      ],
+      courseSet
+    );
+    expect(orphans).toHaveLength(2);
+  });
+
+  it("ignores rows missing prefix or number rather than treating them as orphans", () => {
+    const orphans = findOrphanTransferMappings(
+      [
+        { cc_prefix: "", cc_number: "111" },
+        { cc_prefix: "ENG", cc_number: "" },
+      ],
+      courseSet
+    );
+    expect(orphans).toEqual([]);
+  });
+});

--- a/scripts/check-data-integrity.ts
+++ b/scripts/check-data-integrity.ts
@@ -1,0 +1,345 @@
+/**
+ * Data integrity check.
+ *
+ * Pre-merge guard against silent data corruption that the import-time
+ * validators in scripts/lib/supabase-import.ts (schema + change-detection)
+ * can't catch.
+ *
+ * Errors (fail CI):
+ *   - A course JSON file under data/{state}/courses/** fails to parse,
+ *     or its contents aren't an array. Nothing else in CI today catches
+ *     a corrupt or truncated catalog file before merge.
+ *
+ * Warnings (informational, don't fail CI):
+ *   - Duplicate CRNs within (state, college, term). CRNs are unique by
+ *     definition, so duplicates signal a scraper double-counting bug.
+ *     Today this is warn-only because ~880 pre-existing dupes exist
+ *     across MD/SC/VA/ME — promote to error in a follow-up once the
+ *     underlying scrapers are deduplicated.
+ *   - Prereq entries / references whose course key is absent from the
+ *     state's scraped catalog. Often legitimate (developmental courses,
+ *     historical course numbers, courses not offered this term).
+ *   - Transfer mappings whose CC course is absent from the catalog —
+ *     transfer tables intentionally cover historical and cross-system
+ *     course numbers, so this is a stat, not a gate.
+ *
+ * Usage:
+ *   npm run check:data
+ *   npm run check:data -- --state va        # scope to one state
+ *   npm run check:data -- --verbose          # show example rows per category
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { getAllStates } from "../lib/states/registry";
+
+// ---------------------------------------------------------------------------
+// Types — narrow shapes loaded from disk (full schemas live in lib/schemas.ts)
+// ---------------------------------------------------------------------------
+
+interface SectionRow {
+  course_prefix: string;
+  course_number: string;
+  crn: string;
+}
+
+interface PrereqEntry {
+  text: string;
+  courses: string[];
+}
+
+type PrereqMap = Record<string, PrereqEntry>;
+
+interface TransferRow {
+  cc_prefix: string;
+  cc_number: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for unit testing
+// ---------------------------------------------------------------------------
+
+/** Build the set of "PREFIX NUMBER" keys present in a state's catalog. */
+export function buildCourseSet(sections: SectionRow[]): Set<string> {
+  const set = new Set<string>();
+  for (const s of sections) {
+    if (!s.course_prefix || !s.course_number) continue;
+    set.add(`${s.course_prefix} ${s.course_number}`);
+  }
+  return set;
+}
+
+/** Find CRN values that appear more than once in the same (college, term). */
+export function findDuplicateCrns(
+  sections: SectionRow[]
+): Array<{ crn: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const s of sections) {
+    if (!s.crn) continue;
+    counts.set(s.crn, (counts.get(s.crn) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .filter(([, n]) => n > 1)
+    .map(([crn, count]) => ({ crn, count }));
+}
+
+/**
+ * Find prereq map entries that reference courses not in the catalog. Returns
+ * keys whose entire prereq references are orphans, plus a flat list of every
+ * orphan reference so callers can report counts.
+ */
+export function findOrphanPrereqs(
+  prereqs: PrereqMap,
+  courseSet: Set<string>
+): {
+  orphanKeys: string[];
+  orphanRefs: Array<{ from: string; to: string }>;
+} {
+  const orphanKeys: string[] = [];
+  const orphanRefs: Array<{ from: string; to: string }> = [];
+
+  for (const [key, entry] of Object.entries(prereqs)) {
+    if (!courseSet.has(key)) {
+      orphanKeys.push(key);
+    }
+    for (const ref of entry.courses) {
+      if (!courseSet.has(ref)) {
+        orphanRefs.push({ from: key, to: ref });
+      }
+    }
+  }
+
+  return { orphanKeys, orphanRefs };
+}
+
+/** Transfer rows whose CC course doesn't exist in the state's catalog. */
+export function findOrphanTransferMappings(
+  transfers: TransferRow[],
+  courseSet: Set<string>
+): TransferRow[] {
+  const orphans: TransferRow[] = [];
+  for (const t of transfers) {
+    if (!t.cc_prefix || !t.cc_number) continue;
+    const key = `${t.cc_prefix} ${t.cc_number}`;
+    if (!courseSet.has(key)) orphans.push(t);
+  }
+  return orphans;
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem walking
+// ---------------------------------------------------------------------------
+
+const ROOT = resolve(__dirname, "..");
+
+function readJsonOrNull<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Read every courses/{college}/{term}.json file for a state. */
+function loadAllSections(state: string): SectionRow[] {
+  const coursesDir = resolve(ROOT, `data/${state}/courses`);
+  if (!existsSync(coursesDir)) return [];
+  const all: SectionRow[] = [];
+
+  for (const college of readdirSync(coursesDir)) {
+    const collegeDir = join(coursesDir, college);
+    if (!statSync(collegeDir).isDirectory()) continue;
+    for (const file of readdirSync(collegeDir)) {
+      if (!file.endsWith(".json")) continue;
+      const rows = readJsonOrNull<SectionRow[]>(join(collegeDir, file));
+      if (Array.isArray(rows)) all.push(...rows);
+    }
+  }
+  return all;
+}
+
+/** Same, but partition by (college, term) — needed for duplicate-CRN scoping. */
+function loadSectionsByGroup(state: string): Map<string, SectionRow[]> {
+  const coursesDir = resolve(ROOT, `data/${state}/courses`);
+  const groups = new Map<string, SectionRow[]>();
+  if (!existsSync(coursesDir)) return groups;
+
+  for (const college of readdirSync(coursesDir)) {
+    const collegeDir = join(coursesDir, college);
+    if (!statSync(collegeDir).isDirectory()) continue;
+    for (const file of readdirSync(collegeDir)) {
+      if (!file.endsWith(".json")) continue;
+      const rows = readJsonOrNull<SectionRow[]>(join(collegeDir, file));
+      if (!Array.isArray(rows)) continue;
+      groups.set(`${college}/${file.replace(/\.json$/, "")}`, rows);
+    }
+  }
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry
+// ---------------------------------------------------------------------------
+
+interface Finding {
+  level: "error" | "warn";
+  state: string;
+  category: string;
+  detail: string;
+}
+
+function checkState(state: string, verbose: boolean): Finding[] {
+  const findings: Finding[] = [];
+  const coursesDir = resolve(ROOT, `data/${state}/courses`);
+
+  // 1. ERROR: every courses/**/*.json file must parse and be an array.
+  if (existsSync(coursesDir)) {
+    for (const college of readdirSync(coursesDir)) {
+      const collegeDir = join(coursesDir, college);
+      if (!statSync(collegeDir).isDirectory()) continue;
+      for (const file of readdirSync(collegeDir)) {
+        if (!file.endsWith(".json")) continue;
+        const fullPath = join(collegeDir, file);
+        try {
+          const parsed = JSON.parse(readFileSync(fullPath, "utf8"));
+          if (!Array.isArray(parsed)) {
+            findings.push({
+              level: "error",
+              state,
+              category: "malformed-course-file",
+              detail: `data/${state}/courses/${college}/${file} is not an array`,
+            });
+          }
+        } catch (e) {
+          findings.push({
+            level: "error",
+            state,
+            category: "malformed-course-file",
+            detail: `data/${state}/courses/${college}/${file} failed to parse: ${(e as Error).message}`,
+          });
+        }
+      }
+    }
+  }
+
+  const allSections = loadAllSections(state);
+  const courseSet = buildCourseSet(allSections);
+
+  // 2. WARN: duplicate CRNs within (college, term). Eventually error-level
+  //    once the existing scraper dupes in MD/SC/VA/ME are cleaned up.
+  for (const [group, rows] of loadSectionsByGroup(state)) {
+    const dups = findDuplicateCrns(rows);
+    if (dups.length > 0) {
+      const sample =
+        verbose
+          ? ` (e.g. ${dups.slice(0, 3).map((d) => `${d.crn}×${d.count}`).join(", ")})`
+          : "";
+      findings.push({
+        level: "warn",
+        state,
+        category: "duplicate-crn",
+        detail: `${group}: ${dups.length} duplicate CRN(s)${sample}`,
+      });
+    }
+  }
+
+  // 2. Prereq map — orphan keys + refs (informational).
+  const prereqs = readJsonOrNull<PrereqMap>(
+    resolve(ROOT, `data/${state}/prereqs.json`)
+  );
+  if (prereqs && courseSet.size > 0) {
+    const { orphanKeys, orphanRefs } = findOrphanPrereqs(prereqs, courseSet);
+    if (orphanKeys.length > 0) {
+      const sample =
+        verbose && orphanKeys.length > 0
+          ? ` (e.g. ${orphanKeys.slice(0, 3).join(", ")})`
+          : "";
+      findings.push({
+        level: "warn",
+        state,
+        category: "orphan-prereq-keys",
+        detail: `${orphanKeys.length} prereq entries for courses not in this term's catalog${sample}`,
+      });
+    }
+    if (orphanRefs.length > 0) {
+      const sample =
+        verbose && orphanRefs.length > 0
+          ? ` (e.g. ${orphanRefs.slice(0, 3).map((r) => `${r.from}→${r.to}`).join(", ")})`
+          : "";
+      findings.push({
+        level: "warn",
+        state,
+        category: "orphan-prereq-refs",
+        detail: `${orphanRefs.length} prereq references to courses not in this term's catalog${sample}`,
+      });
+    }
+  }
+
+  // 3. Transfer mappings — CC side absent from catalog (informational).
+  const transfers = readJsonOrNull<TransferRow[]>(
+    resolve(ROOT, `data/${state}/transfer-equiv.json`)
+  );
+  if (Array.isArray(transfers) && courseSet.size > 0) {
+    const orphans = findOrphanTransferMappings(transfers, courseSet);
+    if (orphans.length > 0) {
+      const sample =
+        verbose && orphans.length > 0
+          ? ` (e.g. ${orphans.slice(0, 3).map((t) => `${t.cc_prefix} ${t.cc_number}`).join(", ")})`
+          : "";
+      findings.push({
+        level: "warn",
+        state,
+        category: "orphan-transfer-mappings",
+        detail: `${orphans.length} transfer mappings reference CC courses not in the catalog${sample}`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const stateIdx = args.indexOf("--state");
+  const targetState = stateIdx >= 0 ? args[stateIdx + 1] : null;
+  const verbose = args.includes("--verbose");
+
+  const states = targetState
+    ? getAllStates().filter((s) => s.slug === targetState)
+    : getAllStates();
+
+  if (states.length === 0) {
+    console.error(`Unknown state: ${targetState}`);
+    process.exit(2);
+  }
+
+  const all: Finding[] = [];
+  for (const { slug } of states) {
+    all.push(...checkState(slug, verbose));
+  }
+
+  const errors = all.filter((f) => f.level === "error");
+  const warnings = all.filter((f) => f.level === "warn");
+
+  if (errors.length > 0) {
+    console.error(`\nErrors (${errors.length}):`);
+    for (const f of errors) console.error(`  [${f.state}] ${f.category}: ${f.detail}`);
+  }
+
+  if (warnings.length > 0) {
+    console.log(`\nWarnings (${warnings.length}):`);
+    for (const f of warnings) console.log(`  [${f.state}] ${f.category}: ${f.detail}`);
+    if (!verbose) console.log(`\n  (run with --verbose to see example rows)`);
+  }
+
+  console.log(
+    `\nData integrity scan: ${states.length} state(s), ${errors.length} error(s), ${warnings.length} warning(s).`
+  );
+
+  if (errors.length > 0) process.exit(1);
+}
+
+if (process.argv[1]?.includes("check-data-integrity")) {
+  main();
+}


### PR DESCRIPTION
## Summary

P2 — pre-merge data integrity script. Mirrors the existing `check:registry` / `check:scrapers` / `check:scraper-terms` pattern. Catches data corruption that import-time validation in `scripts/lib/supabase-import.ts` misses.

| Level | Check | Notes |
|---|---|---|
| **ERROR** | `data/{state}/courses/**/*.json` parses + is an array | Catches a corrupt or truncated catalog file before merge. Nothing in CI today looks at these per-college files individually — `check:registry` validates only top-level data files. |
| WARN | Duplicate CRNs within `(college, term)` | **880 pre-existing dupes on `main` today** across MD (458), SC (362), VA (59), ME (1). E.g. `ART 100 / CRN 69849` in `va/escc/2026SU` appears 3× as identical rows — real scraper double-counting. Filed as warn-only here so this PR doesn't jam every future data PR; promoting to error after the underlying scrapers are deduplicated is a follow-up. |
| WARN | Orphan prereq entries / references | Often legitimate — developmental courses, historical course numbers, courses not offered this term. Useful as a stat (47 warnings total across all states), not as a gate. |
| WARN | Transfer mappings whose CC course is absent from catalog | Same caveat — transfer tables intentionally cover historical and cross-system course numbers. |

Run with `--verbose` to see example rows per warning category. `--state <slug>` scopes to one state.

## Files

- **`scripts/check-data-integrity.ts`** — new script with exported pure helpers (`buildCourseSet`, `findDuplicateCrns`, `findOrphanPrereqs`, `findOrphanTransferMappings`).
- **`scripts/__tests__/check-data-integrity.test.ts`** — 14 unit tests on the helpers.
- **`.github/workflows/data-integrity.yml`** — runs `check:data` on PRs that touch `data/**` or the script itself, plus on pushes to `main`.
- **`package.json`** — adds `"check:data"` next to the existing `check:*` scripts.

## Test plan

- [x] `npm run test:run` — **197 / 197** pass locally (183 prior + 14 new)
- [x] `npm run check:data` — runs against all 18 states; **0 errors**, 47 warnings (all pre-existing data quirks)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [ ] CI green on this PR

## Follow-ups (not in scope)

- Fix the underlying scraper double-counting in MD/SC/VA/ME, then promote `duplicate-crn` from warn to error.
- **P2 — Playwright e2e flow** on Vercel previews (the remaining queued plan item).
- Fan out scraper fixture tests to the other states (NC Banner, MA Banner8, NY CUNY, etc.).

https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC)_