### PR TITLE
VA PS scraper: instrument selector drift, capture HTML evidence (#98)

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -140,6 +140,11 @@ jobs:
           done
 
       - name: Upload scraped data
+        # Run even when the scrape step failed so any diagnostic dumps the
+        # script wrote (e.g. data/va/ps-discovery/drift-*.html for issue #98)
+        # reach the workflow run page. By default GitHub skips remaining
+        # steps after a failure unless `if: always()` is set.
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: scrape-${{ matrix.id }}

--- a/scripts/va/enrich-peoplesoft.ts
+++ b/scripts/va/enrich-peoplesoft.ts
@@ -63,6 +63,11 @@ const INTER_SEARCH_DELAY = 2000; // ms between subject searches
 const MAX_RETRIES = 2;
 
 const DATA_DIR = path.join(process.cwd(), "data", "va", "courses");
+const PS_DISCOVERY_DIR = path.join(process.cwd(), "data", "va", "ps-discovery");
+
+// Cap drift dumps per run so a multi-college mismatch doesn't fill the
+// artifact with hundreds of near-identical HTML pages. See issue #98.
+let driftDumpsRemaining = 5;
 
 // Load institution codes
 const PS_CODES: Record<string, string> = JSON.parse(
@@ -160,6 +165,47 @@ function parseArgs(): {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Save the current PeopleSoft page HTML + a screenshot to data/va/ps-discovery/
+ * so a human can inspect the new DOM scheme after the workflow uploads
+ * `data/va/` as an artifact. Capped per run via `driftDumpsRemaining`.
+ *
+ * Used when extractPageSections() returns sections whose CRNs were caught by
+ * the body-text regex but whose instructor DOM lookups all returned null —
+ * that combination means PeopleSoft renamed the result-card element IDs and
+ * the position-indexed `HTMLAREA5$N` selectors no longer match. See issue #98.
+ */
+async function dumpDriftEvidence(
+  page: Page,
+  context: { college: string; subject: string; matchCount: number }
+): Promise<void> {
+  if (driftDumpsRemaining <= 0) return;
+  driftDumpsRemaining--;
+
+  if (!fs.existsSync(PS_DISCOVERY_DIR)) {
+    fs.mkdirSync(PS_DISCOVERY_DIR, { recursive: true });
+  }
+
+  const stem = `enrich-drift-${context.college}-${context.subject}-${Date.now()}`;
+  try {
+    fs.writeFileSync(
+      path.join(PS_DISCOVERY_DIR, `${stem}.html`),
+      await page.content()
+    );
+    await page.screenshot({
+      path: path.join(PS_DISCOVERY_DIR, `${stem}.png`),
+      fullPage: true,
+    });
+    console.error(
+      `   🚨 SELECTOR DRIFT: ${context.college}/${context.subject} — ` +
+        `extracted ${context.matchCount} CRN(s) but 0 had instructor info. ` +
+        `Saved evidence to data/va/ps-discovery/${stem}.{html,png}`
+    );
+  } catch (e) {
+    console.error(`   ⚠ Failed to save drift evidence: ${(e as Error).message}`);
+  }
 }
 
 function readCourseJson(slug: string): CourseSection[] {
@@ -535,12 +581,15 @@ async function enrichCollege(
       // Extract from all pages
       let pageNum = 0;
       let totalExtracted = 0;
+      let pageInstructorsFound = 0;
 
       do {
         pageNum++;
         const psSections = await extractPageSections(page);
 
         for (const ps of psSections) {
+          if (ps.instructor) pageInstructorsFound++;
+
           const idx = crnToIndex.get(ps.classNbr);
           if (idx === undefined) continue;
 
@@ -556,6 +605,23 @@ async function enrichCollege(
             sections[idx].seats_open = ps.isOpen ? 1 : 0;
             stats.enrichedStatus++;
           }
+        }
+
+        // Drift guard: psSections came from regex on body text, so a non-zero
+        // length means PS rendered real results. If NONE of those rows pulled
+        // an instructor name from the HTMLAREA5 lookup, the position-indexed
+        // selectors are broken (issue #98). Dump evidence and warn — we don't
+        // throw here because enrich is secondary; let the run complete so the
+        // summary JSON captures the warning across all colleges.
+        if (psSections.length > 0 && pageInstructorsFound === 0) {
+          await dumpDriftEvidence(page, {
+            college: slug,
+            subject,
+            matchCount: psSections.length,
+          });
+          stats.errors.push(
+            `Selector drift on ${subject} page ${pageNum}: ${psSections.length} CRNs extracted, 0 instructors`
+          );
         }
 
         totalExtracted += psSections.length;

--- a/scripts/va/scrape-peoplesoft.ts
+++ b/scripts/va/scrape-peoplesoft.ts
@@ -26,6 +26,12 @@ const SEARCH_WAIT = 20_000;
 const INTER_SEARCH_DELAY = 2000;
 const MAX_RETRIES = 2;
 const DATA_DIR = path.join(process.cwd(), "data", "va", "courses");
+const PS_DISCOVERY_DIR = path.join(process.cwd(), "data", "va", "ps-discovery");
+
+// Cap drift dumps per run so a multi-college mismatch doesn't fill the
+// artifact with hundreds of near-identical HTML pages. The first 5
+// captures are more than enough evidence to identify the new DOM scheme.
+let driftDumpsRemaining = 5;
 
 // Term name → PS term code mapping
 const TERM_CODES: Record<string, string> = {
@@ -293,6 +299,47 @@ async function extractPageCards(page: Page): Promise<RawCard[]> {
   });
 }
 
+/**
+ * Save the current PeopleSoft page HTML + a screenshot to data/va/ps-discovery/
+ * so a human can inspect the new DOM scheme after the workflow uploads
+ * `data/va/` as an artifact. Capped per run via `driftDumpsRemaining`.
+ *
+ * Used when the page contains "Class Nbr" matches (= PS returned real
+ * results) but extractPageCards() found 0 cards. That combination means
+ * PeopleSoft renamed the result-card element IDs and our position-
+ * indexed selectors no longer match — see issue #98.
+ */
+async function dumpDriftEvidence(
+  page: Page,
+  context: { college: string; subject: string; matchCount: number; cardCount: number }
+): Promise<void> {
+  if (driftDumpsRemaining <= 0) return;
+  driftDumpsRemaining--;
+
+  if (!fs.existsSync(PS_DISCOVERY_DIR)) {
+    fs.mkdirSync(PS_DISCOVERY_DIR, { recursive: true });
+  }
+
+  const stem = `drift-${context.college}-${context.subject}-${Date.now()}`;
+  try {
+    fs.writeFileSync(
+      path.join(PS_DISCOVERY_DIR, `${stem}.html`),
+      await page.content()
+    );
+    await page.screenshot({
+      path: path.join(PS_DISCOVERY_DIR, `${stem}.png`),
+      fullPage: true,
+    });
+    console.error(
+      `    🚨 SELECTOR DRIFT: ${context.college}/${context.subject} — ` +
+        `page text contains ${context.matchCount} CRN(s) but extractPageCards found ${context.cardCount}. ` +
+        `Saved evidence to data/va/ps-discovery/${stem}.{html,png}`
+    );
+  } catch (e) {
+    console.error(`    ⚠ Failed to save drift evidence: ${(e as Error).message}`);
+  }
+}
+
 async function goToNextPage(page: Page): Promise<boolean> {
   try {
     const nextLink = page.locator("#VX_RSLT_NAV_WK_SEARCH_CONDITION2");
@@ -549,6 +596,33 @@ async function scrapeCollege(
 
       while (true) {
         const cards = await extractPageCards(page);
+
+        // Drift guard: searchSubject() above already confirmed the page text
+        // contains "Class Nbr" before we got here, so an empty cards array
+        // means the result-card DOM IDs no longer match our selectors. Dump
+        // evidence and fail fast — see issue #98.
+        if (cards.length === 0) {
+          const matchCount = await page.evaluate(() => {
+            const text = document.body?.innerText || "";
+            return (text.match(/Class Nbr (\d+)/g) || []).length;
+          });
+          if (matchCount > 0) {
+            await dumpDriftEvidence(page, {
+              college: slug,
+              subject: prefix,
+              matchCount,
+              cardCount: 0,
+            });
+            throw new Error(
+              `Selector drift: ${slug}/${prefix} page contains ${matchCount} "Class Nbr" matches ` +
+                `but extractPageCards returned 0. Likely PeopleSoft DOM-id rename. ` +
+                `Evidence saved to data/va/ps-discovery/. See issue #98.`
+            );
+          }
+          // No CRNs in body text either — PS legitimately returned no results
+          // for this subject. Fall through to next-page check (will exit loop).
+        }
+
         for (const card of cards) {
           const section = rawCardToSection(card, slug, fileTermCode);
           if (section) {


### PR DESCRIPTION
Closes the diagnostic gap on issue #98 — the VA PeopleSoft scraper has been red on every cron for ~2 weeks but produces no actionable evidence.

## Smoking-gun evidence already in the repo

`data/va/ps-enrichment-summary.json` (last successful manual run, 2026-03-29) shows:
- NOVA matched **3,471 of 4,489** sections in the page text
- Enriched **0 instructors and 0 statuses**

CRN extraction (regex on body text) works. Field extraction (DOM lookup by `win0divVX_RSLT_NAV_WK_HTMLAREA$N`) silent-fails. Almost certainly PeopleSoft renamed the result-card element IDs in a UI update, and our position-indexed selectors no longer match. The latest health-check (#124) shows both scrape + enrich legs as `cancelled` — the scraper hits the 60-minute job timeout while extracting nothing.

## Why diagnostic-first, not selector-fix-first

I can't reach `ps-sis.vccs.edu` from this environment to verify the new DOM scheme. Patching selectors blind risks writing wrong fields (e.g. instructor name pulled from the wrong card) to Supabase — worse than no data per CLAUDE.md ("Student data never runs through prod with fake values"). The 5% schema-validation reject and 50% change-detection abort wouldn't catch field-level wrongness.

So this PR makes the failure loud and captures evidence; a Phase B PR patches selectors with the captured HTML in hand.

## Changes

| File | Change |
|---|---|
| `scripts/va/scrape-peoplesoft.ts` | `dumpDriftEvidence()` helper. When `extractPageCards()` returns 0 cards but the page text contains "Class Nbr" matches (= PS rendered real results), save HTML + full-page screenshot to `data/va/ps-discovery/drift-{college}-{subject}-{ts}.{html,png}` and **throw** a clear "Selector drift" error. Capped at 5 dumps per run; failing fast also lets the matrix job finish in seconds instead of hitting the 60-min timeout. |
| `scripts/va/enrich-peoplesoft.ts` | Same dump helper (prefixed `enrich-drift-`) but **warn-only** instead of throw, so the run completes and the summary JSON captures drift across every college. Signal: `psSections.length > 0 && pageInstructorsFound === 0` (non-zero CRNs, zero instructor extractions). |
| `.github/workflows/scheduled-scrape.yml` | Add `if: always()` to the Upload-scraped-data step. Without this, GitHub skips the upload when the scrape step fails — exactly when we need the evidence most. |

## What happens on the next cron tick

1. Scheduled-scrape fires (Mon/Wed/Fri 06:00 UTC for courses).
2. VA `playwright` matrix entry navigates to PS, runs first subject search, gets a results page that the parser can't read.
3. First mismatched subject dumps HTML + screenshot to `data/va/ps-discovery/`, throws `Selector drift: ...`, matrix job fails fast (a few minutes vs the previous 60-min timeout).
4. Workflow run page shows the failed step with the error message.
5. `Upload scraped data` step runs anyway thanks to `if: always()`, attaching `scrape-{matrix.id}` artifact containing the dumps.
6. Download the artifact, inspect the HTML, identify the new DOM scheme. Open Phase B PR with the patched selectors and a regression test against the captured HTML (modeled on #127's fixture pattern).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 197/197 (no test changes; existing suite still green)
- [ ] CI green on this PR
- [ ] Manual `workflow_dispatch` of `scheduled-scrape.yml` with `datatype=courses` after merge — expect VA leg to fail fast with diagnostic artifact

## Out of scope (Phase B)

- Patch the selectors with what we learn from the artifact.
- Add fixture-based regression test (`scripts/va/__tests__/scrape-peoplesoft.test.ts`) using both known-good and the captured known-broken HTML.
- VA VCCS HTTP leg (`scrape-vccs.ts`) is also showing cancelled in #124 but is likely a cascade from the playwright leg's hang — diagnose separately if it stays red after this lands.

https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V97ab5rrgf4mm9wcZuCAeC)_