### PR TITLE
SEO phase 1: structured data + sitemap freshness

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -130,9 +130,13 @@ export default async function CollegeDetailPage(props: PageProps) {
   const stateAbbr = state.toUpperCase();
   const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "EducationalOrganization",
+    "@type": "CollegeOrUniversity",
     name: institution.name,
     url: `${siteUrl}/${state}/college/${institution.id}`,
+    parentOrganization: {
+      "@type": "EducationalOrganization",
+      name: config.systemName,
+    },
     address: {
       "@type": "PostalAddress",
       addressRegion: stateAbbr,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,8 +63,42 @@ export default async function LandingPage() {
       ? region
       : null;
 
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
+  const searchState = geoState ?? "va";
+  const orgLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Community College Path",
+    url: siteUrl,
+    logo: `${siteUrl}/icon`,
+    description: `A free national community college course finder, transfer guide, and schedule builder covering ${STATE_LIST_SENTENCE}.`,
+  };
+  const websiteLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Community College Path",
+    url: siteUrl,
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${siteUrl}/${searchState}/courses?q={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  };
+
   return (
     <div className="min-h-screen flex flex-col bg-white dark:bg-slate-900">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(orgLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteLd) }}
+      />
       {/* Header */}
       <header className="border-b border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-900/80 backdrop-blur sticky top-0 z-30">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex items-center justify-between">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,3 +1,5 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import type { MetadataRoute } from "next";
 import { getAllStates } from "@/lib/states/registry";
 import { loadInstitutions } from "@/lib/institutions";
@@ -14,6 +16,55 @@ import { getUniversitiesWithCounts } from "@/lib/transfer";
 // Thin-content guard: keep in sync with the /[state]/transfer/to/[slug] page.
 const MIN_TRANSFER_HUB_COUNT = 10;
 
+// Latest mtime across a state's per-college course files. Course JSON has no
+// per-record scraped_at, so the file mtime is the freshness proxy — it bumps
+// every time the scheduled scraper rewrites the file. Computed once per state.
+function lastModifiedForState(stateSlug: string): Date | undefined {
+  const root = join(process.cwd(), "data", stateSlug, "courses");
+  if (!existsSync(root)) return undefined;
+  let latest = 0;
+  for (const college of readdirSync(root)) {
+    const dir = join(root, college);
+    let stat;
+    try {
+      stat = statSync(dir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const m = statSync(join(dir, file)).mtimeMs;
+        if (m > latest) latest = m;
+      } catch {
+        // skip unreadable file
+      }
+    }
+  }
+  return latest > 0 ? new Date(latest) : undefined;
+}
+
+// Latest mtime across one college's course files.
+function lastModifiedForCollege(
+  stateSlug: string,
+  collegeSlug: string
+): Date | undefined {
+  const dir = join(process.cwd(), "data", stateSlug, "courses", collegeSlug);
+  if (!existsSync(dir)) return undefined;
+  let latest = 0;
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const m = statSync(join(dir, file)).mtimeMs;
+      if (m > latest) latest = m;
+    } catch {
+      // skip unreadable file
+    }
+  }
+  return latest > 0 ? new Date(latest) : undefined;
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl =
     process.env.NEXT_PUBLIC_SITE_URL ||
@@ -26,16 +77,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   for (const state of getAllStates()) {
     const s = state.slug;
+    const stateLastMod = lastModifiedForState(s);
     entries.push(
-      { url: `${baseUrl}/${s}`, changeFrequency: "weekly", priority: 1 },
-      { url: `${baseUrl}/${s}/courses`, changeFrequency: "weekly", priority: 0.9 },
-      { url: `${baseUrl}/${s}/colleges`, changeFrequency: "weekly", priority: 0.9 },
-      { url: `${baseUrl}/${s}/starting-soon`, changeFrequency: "daily", priority: 0.85 },
+      { url: `${baseUrl}/${s}`, changeFrequency: "weekly", priority: 1, lastModified: stateLastMod },
+      { url: `${baseUrl}/${s}/courses`, changeFrequency: "weekly", priority: 0.9, lastModified: stateLastMod },
+      { url: `${baseUrl}/${s}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: stateLastMod },
+      { url: `${baseUrl}/${s}/starting-soon`, changeFrequency: "daily", priority: 0.85, lastModified: stateLastMod },
       { url: `${baseUrl}/${s}/about`, changeFrequency: "monthly", priority: 0.6 },
       // /results and /schedule are noindexed (client-side interactive tools)
     );
     if (state.transferSupported) {
-      entries.push({ url: `${baseUrl}/${s}/transfer`, changeFrequency: "weekly" as const, priority: 0.85 });
+      entries.push({ url: `${baseUrl}/${s}/transfer`, changeFrequency: "weekly" as const, priority: 0.85, lastModified: stateLastMod });
     }
   }
 
@@ -48,10 +100,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const currentTerm = await getCurrentTerm(state.slug);
 
     for (const inst of institutions) {
+      const collegeLastMod = lastModifiedForCollege(state.slug, inst.college_slug);
       collegePages.push({
         url: `${baseUrl}/${state.slug}/college/${inst.id}`,
         changeFrequency: "weekly" as const,
         priority: 0.7,
+        lastModified: collegeLastMod,
       });
 
       // Subject pages (pSEO) — only include if ≥3 sections to avoid thin content
@@ -71,6 +125,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
               url: `${baseUrl}/${state.slug}/college/${inst.id}/courses/${prefix.toLowerCase()}`,
               changeFrequency: "weekly" as const,
               priority: 0.6,
+              lastModified: collegeLastMod,
             });
           }
         }
@@ -88,6 +143,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   for (const state of getAllStates()) {
     try {
       const currentTerm = await getCurrentTerm(state.slug);
+      const stateLastMod = lastModifiedForState(state.slug);
       // Single 2-column scan instead of full row catalog (~9 MB → ~50 KB).
       const { codes, subjectSectionCounts } = await getSitemapCourseIndex(
         currentTerm,
@@ -100,6 +156,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           url: `${baseUrl}/${state.slug}/course/${key}`,
           changeFrequency: "weekly" as const,
           priority: 0.7,
+          lastModified: stateLastMod,
         });
       }
 
@@ -110,6 +167,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             url: `${baseUrl}/${state.slug}/subject/${prefix.toLowerCase()}`,
             changeFrequency: "weekly" as const,
             priority: 0.65,
+            lastModified: stateLastMod,
           });
         }
       }
@@ -124,6 +182,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   for (const state of getAllStates()) {
     if (!state.transferSupported) continue;
     try {
+      const stateLastMod = lastModifiedForState(state.slug);
       const universities = await getUniversitiesWithCounts(state.slug);
       for (const u of universities) {
         if (u.totalCount < MIN_TRANSFER_HUB_COUNT) continue;
@@ -131,6 +190,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           url: `${baseUrl}/${state.slug}/transfer/to/${u.slug}`,
           changeFrequency: "weekly" as const,
           priority: 0.8,
+          lastModified: stateLastMod,
         });
       }
     } catch {
@@ -144,6 +204,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   for (const state of getAllStates()) {
     try {
       const currentTerm = await getCurrentTerm(state.slug);
+      const stateLastMod = lastModifiedForState(state.slug);
       const instructorEntries = await getInstructorSitemapEntries(
         currentTerm,
         state.slug
@@ -153,6 +214,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           url: `${baseUrl}/${state.slug}/college/${entry.collegeId}/instructor/${entry.slug}`,
           changeFrequency: "weekly" as const,
           priority: 0.6,
+          lastModified: stateLastMod,
         });
       }
     } catch {


### PR DESCRIPTION
## Summary

The audit prompt that started this work assumed an SSR problem. I verified with `curl -A Googlebot` against prod that there isn't one — `/va`, `/va/transfer`, and the blog posts all serve real SSRed content. The actual SEO gaps were elsewhere. This is phase 1 of three (each its own PR).

- **Homepage** ([app/page.tsx](app/page.tsx)): no structured data before. Now emits `Organization` + `WebSite` with `SearchAction` (eligible for Google sitelinks search box).
- **College pages** ([app/[state]/college/[id]/page.tsx](app/[state]/college/[id]/page.tsx)): already emitted `EducationalOrganization`. Upgraded to `CollegeOrUniversity` (more specific subtype) and added `parentOrganization` so the state system (e.g. VCCS) is part of the entity graph.
- **Sitemap** ([app/sitemap.ts](app/sitemap.ts)): only blog posts had `<lastmod>` (~30 URLs). State hubs, course pages, college pages, subject pages, transfer hubs, and instructor pages now derive `lastModified` from the mtime of the per-college course JSON, which the scheduled scraper rewrites on every run. Result: ~46k of ~46.3k URLs carry a `<lastmod>` after this change.

Phase 2 (bidirectional blog ↔ state linking) and phase 3 (transfer-row schema spike) will follow in their own PRs per the project's phased-PR pattern.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — no new warnings in the 3 touched files (pre-existing scraper warnings unchanged)
- [x] Local dev: `curl localhost:3000/` — verified 2 valid JSON-LD blocks (Organization, WebSite/SearchAction) parse as JSON
- [x] Local dev: `curl localhost:3000/va/college/nova` — verified 3 JSON-LD blocks (WebSite from layout, CollegeOrUniversity with parentOrganization, BreadcrumbList)
- [x] Local dev: `curl localhost:3000/sitemap.xml | grep -c "<lastmod>"` returns 46170 (was ~30)
- [ ] After merge + Vercel deploy: paste live `/`, `/va/college/nova` JSON-LD into [Google Rich Results Test](https://search.google.com/test/rich-results) — must show no errors
- [ ] After merge + Vercel deploy: `curl https://communitycollegepath.com/sitemap.xml | grep -c lastmod` should be similarly large

🤖 Generated with [Claude Code](https://claude.com/claude-code)