### PR TITLE
SEO phase 2: bidirectional blog ↔ state linking

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -6,6 +6,7 @@ import StartingSoonCallout from "@/components/StartingSoonCallout";
 import NotifyBanner from "@/components/NotifyBanner";
 import { getNextTerm } from "@/lib/terms";
 import { getStateConfig, getAllStates, isValidState } from "@/lib/states/registry";
+import { getArticlesByState, categoryLabel } from "@/lib/blog";
 
 type Props = {
   params: Promise<{ state: string }>;
@@ -32,6 +33,7 @@ export default async function HomePage({ params }: Props) {
   if (!isValidState(state)) notFound();
   const config = getStateConfig(state);
   const nextTerm = await getNextTerm(state);
+  const stateArticles = getArticlesByState(state).slice(0, 4);
 
   return (
     <div>
@@ -199,6 +201,47 @@ export default async function HomePage({ params }: Props) {
           </p>
         </div>
       </section>
+
+      {/* Related guides — blog posts tagged for this state */}
+      {stateArticles.length > 0 && (
+        <section className="py-12 px-4 sm:px-6 lg:px-8">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-slate-100 mb-2 text-center">
+              {config.name} Guides
+            </h2>
+            <p className="text-center text-sm text-gray-600 dark:text-slate-400 mb-8">
+              Plain-English explainers for {config.name} students.
+            </p>
+            <div className="grid sm:grid-cols-2 gap-4">
+              {stateArticles.map((article) => (
+                <Link
+                  key={article.slug}
+                  href={`/blog/${article.slug}`}
+                  className="group rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 transition hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-sm"
+                >
+                  <span className="inline-block rounded-full bg-gray-100 dark:bg-slate-700 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:text-slate-400">
+                    {categoryLabel(article.category)}
+                  </span>
+                  <h3 className="mt-2 font-semibold text-gray-900 dark:text-slate-100 group-hover:text-teal-600 transition-colors">
+                    {article.title}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-slate-400 line-clamp-2">
+                    {article.description}
+                  </p>
+                </Link>
+              ))}
+            </div>
+            <p className="text-center text-sm text-gray-500 dark:text-slate-400 mt-6">
+              <Link
+                href="/blog"
+                className="text-teal-600 hover:text-teal-700 transition-colors"
+              >
+                Browse all guides &rarr;
+              </Link>
+            </p>
+          </div>
+        </section>
+      )}
 
       {/* Explore other states */}
       <section className="py-12 px-4 sm:px-6 lg:px-8">

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -8,6 +8,8 @@ import {
   stateLabel,
 } from "@/lib/blog";
 import RelatedArticles from "@/components/blog/RelatedArticles";
+import StateToolsCTA from "@/components/blog/StateToolsCTA";
+import { isValidState } from "@/lib/states/registry";
 import AdUnit from "@/components/AdUnit";
 import Link from "next/link";
 
@@ -103,6 +105,8 @@ export default async function BlogPostPage({ params }: Props) {
   };
 
   const related = meta.cluster ? getClusterArticles(meta.cluster) : [];
+  const stateForCta =
+    meta.state && isValidState(meta.state) ? meta.state : null;
 
   return (
     <article className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
@@ -152,10 +156,16 @@ export default async function BlogPostPage({ params }: Props) {
         </p>
       </header>
 
+      {/* State tools CTA — shown only on state-tagged posts */}
+      {stateForCta && <StateToolsCTA state={stateForCta} variant="top" />}
+
       {/* MDX content */}
       <div className="prose prose-gray prose-lg max-w-none prose-headings:text-gray-900 dark:prose-headings:text-slate-100 prose-a:text-teal-600 dark:prose-a:text-teal-400 prose-a:no-underline hover:prose-a:underline prose-strong:text-gray-900 dark:prose-strong:text-slate-100">
         <Post />
       </div>
+
+      {/* State tools CTA at the foot — also state-only */}
+      {stateForCta && <StateToolsCTA state={stateForCta} variant="bottom" />}
 
       {/* End-of-article ad */}
       <div className="my-10">

--- a/components/blog/StateToolsCTA.tsx
+++ b/components/blog/StateToolsCTA.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { getStateConfig } from "@/lib/states/registry";
+
+interface StateToolsCTAProps {
+  state: string;
+  variant: "top" | "bottom";
+}
+
+export default function StateToolsCTA({ state, variant }: StateToolsCTAProps) {
+  const config = getStateConfig(state);
+  const headline =
+    variant === "top"
+      ? `Looking up ${config.name} community college courses?`
+      : `Use the ${config.name} tools`;
+  const subhead =
+    variant === "top"
+      ? `Skip to the search and transfer tools for ${config.systemName} colleges.`
+      : `Search ${config.systemName} courses, look up transfer credit, or build a schedule.`;
+
+  return (
+    <aside
+      className={`not-prose rounded-xl border border-teal-200 dark:border-teal-800 bg-teal-50/60 dark:bg-teal-900/20 px-5 py-4 ${
+        variant === "top" ? "mb-8" : "mt-10"
+      }`}
+    >
+      <p className="text-sm font-semibold text-teal-900 dark:text-teal-200">
+        {headline}
+      </p>
+      <p className="mt-1 text-sm text-teal-800 dark:text-teal-300">{subhead}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Link
+          href={`/${state}`}
+          className="inline-flex items-center rounded-md bg-teal-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-teal-700 transition-colors"
+        >
+          {`Find ${config.name} courses →`}
+        </Link>
+        {config.transferSupported && (
+          <Link
+            href={`/${state}/transfer`}
+            className="inline-flex items-center rounded-md border border-teal-600 bg-white dark:bg-transparent px-3 py-1.5 text-xs font-medium text-teal-700 dark:text-teal-300 hover:bg-teal-50 dark:hover:bg-teal-900/40 transition-colors"
+          >
+            {`${config.name} transfer lookup →`}
+          </Link>
+        )}
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the SEO work (after [#130](https://github.com/rohan-c0de/cc-coursemap/pull/130)). Phase 1 was about labels and freshness; this phase is about internal-link authority flow between the two parts of the site that should be feeding each other but weren't.

- **State landing pages** ([app/[state]/page.tsx](app/[state]/page.tsx)): when one or more blog posts have frontmatter `state: "<this state>"`, render a "{State} Guides" section above "Explore Other States" with up to 4 article cards. Hidden when no posts match. Uses the existing `getArticlesByState()` helper. 12 states currently have tagged posts (ct, dc, de, ga, md, nc, nj, ny, pa, sc, tn, va).
- **Blog post layout** ([app/blog/[slug]/page.tsx](app/blog/[slug]/page.tsx)): when an article declares a state (16 of 34 articles do), render a small teal CTA box both above and below the article body linking to `/{state}` and `/{state}/transfer`. New reusable component: [components/blog/StateToolsCTA.tsx](components/blog/StateToolsCTA.tsx). Posts with `state: null` (general explainers like "Direct Match vs Elective Credit") render unchanged.

The result is bidirectional: state-name searches that land on `/va` now have a clear path into the explainer content, and blog readers learning about Virginia transfer have a one-click route into the actual tool. Internal anchor text also explicitly tells Google what each linked page is about.

## Test plan
- [x] `npx tsc --noEmit` clean for the touched files (pre-existing test-file errors unrelated)
- [x] Local dev: `/va` renders "Virginia Guides" section with 2 cards (the 2 VA-tagged articles), links resolve
- [x] Local dev: `/ma` (no tagged articles) — section is hidden, no empty container
- [x] Local dev: `/blog/virginia-community-college-transfer-guaranteed-admission` — top + bottom CTA cards render with correct labels ("Find Virginia courses →", "Virginia transfer lookup →")
- [x] Local dev: `/blog/prerequisite-chains-why-four-semester-plans-take-six` (state: null) — no CTA renders
- [ ] After merge + Vercel deploy: `curl https://communitycollegepath.com/va | grep -c "/blog/"` should return ≥2
- [ ] After merge + Vercel deploy: visit a state-tagged blog post and confirm both CTAs render

## What this still doesn't do (Phase 3, optional)
Transfer-row schema is still deferred. The right `Course` / `isRelatedTo` shape isn't a proven Google rich-result, so it's worth running the spike on one URL before rolling out — see the original plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)