### PR TITLE
Fix MD scrape-banner-ssb: default to all colleges when no flag given

### DIFF
--- a/scripts/md/scrape-banner-ssb.ts
+++ b/scripts/md/scrape-banner-ssb.ts
@@ -444,10 +444,10 @@ async function main() {
     }
     targets = [[slug, baseUrl]];
   } else {
-    console.log("Usage:");
-    console.log("  npx tsx scripts/md/scrape-banner-ssb.ts --college harford");
-    console.log("  npx tsx scripts/md/scrape-banner-ssb.ts --all");
-    process.exit(0);
+    // Default: scrape all Banner SSB colleges. Matches scrape-banner8.ts and
+    // scrape-custom.ts so the unified scheduled-scrape workflow can invoke
+    // this script with --no-import alone.
+    targets = Object.entries(BANNER_COLLEGES);
   }
 
   for (const [slug, baseUrl] of targets) {


### PR DESCRIPTION
## Summary

- `scripts/md/scrape-banner-ssb.ts` required `--college <slug>` or `--all` and printed usage otherwise, but the unified scheduled-scrape workflow invokes every script with only `--no-import [--term <t>]`.
- Result: Harford and Montgomery have been silently skipped on every cron tick since the workflow was unified. First surfaced as the `md-courses-0` failure in [run 25235408577](https://github.com/rohan-c0de/cc-coursemap/actions/runs/25235408577).
- Fix: in the no-flag branch, default to all colleges — matches the convention already used by [scrape-banner8.ts:480-483](../blob/main/scripts/md/scrape-banner8.ts#L480-L483) and [scrape-custom.ts:558-560](../blob/main/scripts/md/scrape-custom.ts#L558-L560).

## Test plan

- [x] Local: `npx tsx scripts/md/scrape-banner-ssb.ts --no-import` enters scrape mode (`=== Scraping harford ===`, 3 terms found, sections being fetched). Pre-fix, this exited with usage.
- [ ] After merge: manually trigger the scheduled-scrape workflow with `datatype=courses`, confirm `md-courses-0` succeeds and the uploaded artifact contains data for `harford` and `montgomery` (not just CCBC).
- [ ] After the next merged scheduled-scrape PR lands MD data: load `/md` on prod, search a Harford or Montgomery course, confirm sections render.

## Out of scope

- VA `scrape-vccs` 0-section silent failure + 60-min job timeout.
- VA `scrape-peoplesoft` 100% `page.waitForFunction` timeout rate.
- Lint/CI guardrail to ensure every scraper handles the workflow's `--no-import`-only invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)