### PR TITLE
Remove DC + ME transfer scrapers from scheduled cron matrix

### DIFF
--- a/lib/states/dc/config.ts
+++ b/lib/states/dc/config.ts
@@ -20,13 +20,15 @@ const dcConfig: StateConfig = {
       "DC residents aged 65+ may attend UDC Community College with tuition and fees waived, space permitting. Degree-seeking seniors pay half tuition.",
   },
 
-  // No in-state transfer data yet. CollegeTransfer.Net's DC dataset for
-  // UDC contains only out-of-state long-tail entries (Midlands Tech,
-  // Wilmington University, Weber State, etc.) which are not real
-  // articulation pathways and have been dropped per the in-state-only
-  // rule. UDC's own catalog publishes its 4-year articulations through
-  // a different channel; flip back to true once an in-state DC scraper
-  // lands.
+  // DC has no in-state CC→4yr articulation pipeline at all. UDC publishes
+  // four articulation PDFs (all to MD/VA schools, dropped by the in-state
+  // rule), and the Consortium of Universities arrangement is cross-
+  // registration, not course-equivalency. UDC's 1,453 CollegeTransfer.Net
+  // entries target zero DC institutions. The dc-transfers cron job was
+  // therefore removed from `scrapers` below in 2026-05; if a structured
+  // in-state source ever appears, re-add the cron entry and flip this
+  // back to true. The scraper script `scripts/dc/scrape-transfer.ts` is
+  // retained for manual use.
   transferSupported: false,
   popularCourses: [],
   defaultZip: "20001",
@@ -62,7 +64,7 @@ const dcConfig: StateConfig = {
   },
   scrapers: {
     courses: [{ scripts: ["scripts/dc/scrape-banner.ts"], runner: "http" }],
-    transfers: [{ scripts: ["scripts/dc/scrape-transfer.ts"], runner: "http" }],
+    // transfers intentionally omitted — see `transferSupported` comment above.
     prereqs: { source: "aggregate-from-courses" },
   },
 };

--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -20,15 +20,19 @@ const meConfig: StateConfig = {
       "Maine law allows residents aged 65+ to audit credit courses at Maine Community College System institutions tuition-free on a space-available basis.",
   },
 
-  // 2026-04: enabled after `scripts/me/scrape-transfer.ts` populated
-  // `data/me/transfer-equiv.json` with mappings from CollegeTransfer.Net
-  // (MCCS institution ids 1079/1331/1602/1603/1605/1829/3657). Initial
-  // No in-state transfer data yet. CollegeTransfer.Net's ME dataset
-  // contains only out-of-state long-tail entries (Weber State, Univ of
-  // Alaska, Utah Valley, etc.) which are not real articulation pathways
-  // and have been dropped per the in-state-only rule. UMaine / USM
-  // receiving institutions publish via their own portals; flip back to
-  // true once an in-state ME scraper lands.
+  // CollegeTransfer.Net is the wrong source for ME: across the 4 MCCS
+  // colleges that fit under the free-tier API quota (CMCC/EMCC/KVCC/NMCC),
+  // 1,649 raw equivalencies target zero in-state institutions. The
+  // authoritative in-state source is UMaine's MaineStreet Transfer
+  // Equivalency Guest portal at
+  // https://mainestreetcs.maine.edu/psp/CSPRDG/EMPLOYEE/SA/c/UM_SA.UM_TRNSFER_GUEST.GBL
+  // — PeopleSoft, no login required, ~49 (MCCS-sender × UMS-receiver)
+  // pairs. Building that scraper is tracked separately. Until then, the
+  // me-transfers cron job is removed from `scrapers` below (2026-05) so
+  // empty output stops being flagged as a regression. Flip
+  // `transferSupported` back to true once a MaineStreet scraper lands.
+  // The CT.Net script `scripts/me/scrape-transfer.ts` is retained for
+  // manual use if the in-state rule is ever relaxed.
   transferSupported: false,
   popularCourses: ["ENG 101", "MAT 101", "BIO 101", "PSY 101", "HIS 101", "SOC 101"],
   defaultZip: "04101",
@@ -57,7 +61,7 @@ const meConfig: StateConfig = {
   },
   scrapers: {
     courses: [{ scripts: ["scripts/me/scrape-mccs.ts"], runner: "playwright" }],
-    transfers: [{ scripts: ["scripts/me/scrape-transfer.ts"], runner: "http" }],
+    // transfers intentionally omitted — see `transferSupported` comment above.
   },
 };
 

--- a/scripts/dc/scrape-transfer.ts
+++ b/scripts/dc/scrape-transfer.ts
@@ -1,6 +1,14 @@
 /**
  * scrape-transfer.ts
  *
+ * **Status: manual-only — removed from the scheduled-scrape cron matrix
+ * in 2026-05.** UDC's 1,453 CollegeTransfer.Net equivalencies target
+ * zero DC institutions, so the in-state-only rule strips everything to
+ * an empty array on every run. Kept in the repo as documentation of
+ * how to query CT.Net's UDC dataset, and in case the in-state rule is
+ * ever revisited for DC. See `lib/states/dc/config.ts` for the
+ * decision context.
+ *
  * Scrapes transfer equivalency data for UDC Community College (DC's only
  * community college program, part of the University of the District of
  * Columbia) from CollegeTransfer.Net's public OData v2 API.

--- a/scripts/me/scrape-transfer.ts
+++ b/scripts/me/scrape-transfer.ts
@@ -1,6 +1,16 @@
 /**
  * scrape-transfer.ts
  *
+ * **Status: manual-only — removed from the scheduled-scrape cron matrix
+ * in 2026-05.** Across the 4 MCCS colleges that fit under the
+ * CollegeTransfer.Net free-tier quota in a single run, 1,649 raw
+ * equivalencies target zero in-state institutions, so the in-state
+ * rule strips everything to an empty array. The authoritative in-state
+ * source is UMaine's MaineStreet Transfer Equivalency Guest portal
+ * (`https://mainestreetcs.maine.edu/psp/CSPRDG/EMPLOYEE/SA/c/UM_SA.UM_TRNSFER_GUEST.GBL`)
+ * — a PeopleSoft scraper for that is tracked separately. This script is
+ * retained for manual use if the in-state rule is ever relaxed.
+ *
  * Scrapes transfer equivalency data for Maine's 7 MCCS (Maine Community
  * College System) schools from CollegeTransfer.Net's public OData v2 API.
  *


### PR DESCRIPTION
## Summary

Both DC and ME transfer scrapers have been silently producing empty `[]` files on every cron tick, flagged as ⚠️ empty in the rolling [Scraper health — transfers](https://github.com/rohan-c0de/cc-coursemap/issues/123) issue.

**Root cause is structural, not a bug.** Probed the CollegeTransfer.Net OData API directly:
- **DC (UDC, source ID 990):** 1,453 outgoing equivalencies — **0 target a DC institution.** UDC publishes only 4 articulation PDFs (all to MD/VA), and the Consortium of Universities is cross-registration, not equivalency. There is no in-state CC→4yr articulation pipeline in DC.
- **ME (4 MCCS colleges fit under one quota window):** 1,649 raw equivalencies — **0 target a ME institution.** The authoritative in-state source is UMaine's [MaineStreet Transfer Equivalency Guest portal](https://mainestreetcs.maine.edu/psp/CSPRDG/EMPLOYEE/SA/c/UM_SA.UM_TRNSFER_GUEST.GBL) (PeopleSoft, no login). Building that scraper is real work — Playwright across ~49 (sender × receiver) pairs — and is tracked as future work.

The in-state-only rule (per `feedback_in_state_transfers_only` memory) is correct. CollegeTransfer.Net is just the wrong source for these two states.

## What changed

- `lib/states/dc/config.ts` — drop `transfers` from `scrapers`; rewrite the `transferSupported: false` comment to capture the structural reason.
- `lib/states/me/config.ts` — same; the comment also points at the MaineStreet PeopleSoft path as the real fix.
- `scripts/dc/scrape-transfer.ts` and `scripts/me/scrape-transfer.ts` — added a "Status: manual-only" header so anyone running them locally understands why they were pulled from cron.

## What did NOT change

- `transferSupported: false` was already set on both states, so the UI is unchanged — the transfer feature has been correctly hidden for DC/ME all along.
- The scraper scripts are retained for manual invocation if the in-state rule is ever revisited.
- The empty `data/{dc,me}/transfer-equiv.json` files stay (required by `check-registry-integrity.ts`).

## Verification

- [x] `npm run check:scrapers` — passes (per-datatype gaps within a populated `scrapers` field are allowed).
- [x] `npx tsx scripts/check-registry-integrity.ts` — passes.
- [x] `npx tsx scripts/lib/scraper-matrix.ts --datatype transfers` — DC and ME no longer in the include list (12 states remain).
- [x] `npm run lint` — 0 errors.
- [ ] After merge: next scheduled `transfers` cron tick (Wed/Sat 10:00 UTC) should report all-healthy and auto-close issue #123.

## Out of scope (follow-up)

Build the MaineStreet PeopleSoft scraper for ME so transfer functionality can be turned back on for Maine. (DC has no equivalent — leave disabled.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)