### PR TITLE
Bump scheduled-scrape job timeout 60 → 120 min (unblock #98 evidence capture)

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -85,7 +85,10 @@ jobs:
     needs: plan
     if: needs.plan.outputs.empty == 'false'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 120 (not 60) so VA's vccs + peoplesoft jobs have headroom while #98
+    # selector-drift instrumentation captures evidence. Other states finish
+    # well under 60 — this is the worst-case ceiling, not the budget.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}


### PR DESCRIPTION
## Summary

Raise the shared scrape job's `timeout-minutes` from 60 to 120 in `.github/workflows/scheduled-scrape.yml`.

## Why

VA's two courses jobs (`va-courses-0` running `scrape-vccs.ts` across 23 VCCS colleges, and `va-courses-1` running `scrape-peoplesoft.ts` + `enrich-peoplesoft.ts`) have been hitting the 60-minute ceiling on every scheduled run since 2026-04-29, returning `conclusion=cancelled` with no useful logs.

Run history confirms the regression — earlier April runs of `va-courses-0` exited with `failure` (i.e. the scraper completed within the budget and surfaced an error), but starting around 2026-04-27 the conclusion flipped to `cancelled` (the job was killed mid-run):

| Run | `va-courses-0` | `va-courses-1` |
|---|---|---|
| 2026-04-24 | failure | success |
| 2026-04-27 | failure | cancelled |
| 2026-04-29 | cancelled | cancelled |
| 2026-05-01 (×2) | cancelled | cancelled |

Each cancelled job ran for **exactly 60m 15s** before termination, matching the `timeout-minutes: 60` ceiling.

This timeout is also blocking #98's debugging path — the HTML-capture instrumentation added in #129 can't write its evidence file if the job is killed mid-run, so we have no captured selectors to actually patch.

## What did NOT change

- Per-run cost for healthy states is unchanged. Only states that exceed 60 min pay anything more. Other states' courses jobs finish in well under 60 min today.
- No matrix structure changes; no per-state config changes.
- This does not fix the underlying VA slow-down — it just gives the next scheduled run room to either complete or fail loudly with #129's captured evidence.

## Verification

- Lint / build not affected (workflow YAML only).
- Confirm in next scheduled `courses` cron tick (Mon 2026-05-04 06:00 UTC): `va-courses-0` and `va-courses-1` should complete with `success` or `failure` rather than `cancelled`. If `failure`, #129's HTML evidence should be in the artifacts and we can act on #98 directly.

## Refs

- Unblocks #98 (VA PeopleSoft selector drift)
- Refs #124 (courses health umbrella, currently shows VA jobs as failed/cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)