### PR TITLE
Enforce per-datatype scraper coverage in check:scrapers (#111)

### DIFF
--- a/lib/states/dc/config.ts
+++ b/lib/states/dc/config.ts
@@ -64,7 +64,7 @@ const dcConfig: StateConfig = {
   },
   scrapers: {
     courses: [{ scripts: ["scripts/dc/scrape-banner.ts"], runner: "http" }],
-    // transfers intentionally omitted — see `transferSupported` comment above.
+    // manual-only: transfers — DC has no in-state CC→4yr articulation pipeline; see `transferSupported` comment above.
     prereqs: { source: "aggregate-from-courses" },
   },
 };

--- a/lib/states/md/config.ts
+++ b/lib/states/md/config.ts
@@ -150,6 +150,7 @@ const mdConfig: StateConfig = {
       },
     ],
     transfers: [{ scripts: ["scripts/md/scrape-transfer-artsys.ts"], runner: "http" }],
+    // manual-only: prereqs — MD prereq scraper not yet built. Tracked in #105.
   },
 };
 

--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -61,7 +61,8 @@ const meConfig: StateConfig = {
   },
   scrapers: {
     courses: [{ scripts: ["scripts/me/scrape-mccs.ts"], runner: "playwright" }],
-    // transfers intentionally omitted — see `transferSupported` comment above.
+    // manual-only: transfers — CT.Net has zero in-state targets for ME; MaineStreet PeopleSoft scraper is the real fix. See `transferSupported` comment above.
+    // manual-only: prereqs — ME prereq scraper not yet built. Tracked in #106.
   },
 };
 

--- a/lib/states/pa/config.ts
+++ b/lib/states/pa/config.ts
@@ -52,8 +52,8 @@ const paConfig: StateConfig = {
     ],
   },
   scrapers: {
-    // PA has no scheduled course scraper today — PASSHE / state-system
-    // public course search is inconsistent across 14 colleges.
+    // manual-only: courses — PASSHE / state-system public course search
+    // is inconsistent across 14 colleges; no unified scraper. Tracked in #100.
     transfers: [
       { scripts: ["scripts/pa/scrape-transfer.ts"], runner: "http" },
       { scripts: ["scripts/pa/scrape-pitt-tes.ts"], runner: "http" },

--- a/scripts/check-scraper-coverage.ts
+++ b/scripts/check-scraper-coverage.ts
@@ -1,30 +1,52 @@
 /**
- * Scraper-coverage integrity check (issue #59).
+ * Scraper-coverage integrity check (issues #59, #111).
  *
- * For every state in `getAllStates()`:
- *   - If `scrapers` is populated, verify every declared script path exists.
- *   - If `scrapers` is omitted entirely, require a `manual-only:` marker
- *     in the config file explaining why (so the gap is intentional, not
- *     accidental drift).
+ * For every state in `getAllStates()`, every data type in
+ * {courses, transfers, prereqs} must be either:
+ *   - declared in `scrapers.<datatype>` (a non-empty job array, or
+ *     `{ source: "aggregate-from-courses" }` for prereqs), OR
+ *   - explicitly opted out via a marker comment in the config file:
+ *       `// manual-only: <datatype> — <reason>`           (per-datatype)
+ *     or, when `scrapers` is omitted entirely:
+ *       `// manual-only: <reason>`                         (blanket)
  *
- * Fails the PR if any slug is silently missing coverage. Same shape as
- * scripts/check-registry-integrity.ts.
+ * Also verifies every declared script path resolves on disk — a typo
+ * silently breaks the unified scheduled-scrape workflow at runtime.
  */
 
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { getAllStates, type StateConfig } from "../lib/states/registry";
+import { getAllStates, type ScraperCoverage } from "../lib/states/registry";
 
 const ROOT = resolve(__dirname, "..");
+const DATATYPES = ["courses", "transfers", "prereqs"] as const;
+type Datatype = (typeof DATATYPES)[number];
+
 const errors: string[] = [];
 
 function err(slug: string, msg: string) {
   errors.push(`[${slug}] ${msg}`);
 }
 
-function jobsFromCoverage(cfg: StateConfig): string[] {
-  const scrapers = cfg.scrapers;
-  if (!scrapers) return [];
+function isDeclared(scrapers: ScraperCoverage | undefined, dt: Datatype): boolean {
+  if (!scrapers) return false;
+  const entry = scrapers[dt];
+  if (!entry) return false;
+  if (Array.isArray(entry)) return entry.length > 0;
+  // prereqs can be `{ source: "aggregate-from-courses" }`
+  return entry.source === "aggregate-from-courses";
+}
+
+function hasDatatypeMarker(source: string, dt: Datatype): boolean {
+  return new RegExp(`manual-only:\\s*${dt}\\b`, "i").test(source);
+}
+
+function hasBlanketMarker(source: string): boolean {
+  // A `manual-only:` whose next non-whitespace token is NOT a datatype keyword.
+  return /manual-only:(?!\s*(?:courses|transfers|prereqs)\b)/i.test(source);
+}
+
+function declaredScriptPaths(scrapers: ScraperCoverage): string[] {
   const paths: string[] = [];
   for (const job of scrapers.courses ?? []) paths.push(...job.scripts);
   for (const job of scrapers.transfers ?? []) paths.push(...job.scripts);
@@ -42,25 +64,24 @@ for (const cfg of getAllStates()) {
     continue;
   }
 
-  const hasScrapers = !!cfg.scrapers;
-  if (!hasScrapers) {
-    // Omitting `scrapers` is fine if the config is explicit about why.
-    const source = readFileSync(configPath, "utf8");
-    if (!/manual-only:/i.test(source)) {
-      err(
-        slug,
-        `config has no \`scrapers\` field and no \`manual-only: <reason>\` marker. Either declare scrapers or explain the gap — see issue #59.`
-      );
-    }
-    continue;
+  const source = readFileSync(configPath, "utf8");
+  const blanket = !cfg.scrapers && hasBlanketMarker(source);
+
+  for (const dt of DATATYPES) {
+    if (isDeclared(cfg.scrapers, dt)) continue;
+    if (blanket) continue;
+    if (hasDatatypeMarker(source, dt)) continue;
+    err(
+      slug,
+      `${dt} is neither declared in \`scrapers.${dt}\` nor marked \`// manual-only: ${dt} — <reason>\` in config. See issue #111.`
+    );
   }
 
-  // Script paths must resolve. A typo here silently breaks the unified
-  // scheduled-scrape workflow (PR 2) at runtime, so catch it now.
-  for (const script of jobsFromCoverage(cfg)) {
-    const abs = resolve(ROOT, script);
-    if (!existsSync(abs)) {
-      err(slug, `declared scraper script "${script}" does not exist`);
+  if (cfg.scrapers) {
+    for (const script of declaredScriptPaths(cfg.scrapers)) {
+      if (!existsSync(resolve(ROOT, script))) {
+        err(slug, `declared scraper script "${script}" does not exist`);
+      }
     }
   }
 }
@@ -72,11 +93,11 @@ if (errors.length > 0) {
     `\n${errors.length} issue(s) across ${getAllStates().length} registered state(s).`
   );
   console.error(
-    "\nEvery state must either declare `scrapers` in its StateConfig or include a `manual-only:` comment explaining the gap. See issue #59."
+    "\nEvery state × {courses, transfers, prereqs} must either be declared in `scrapers` or carry a `manual-only:` marker. See issues #59 and #111."
   );
   process.exit(1);
 }
 
 console.log(
-  `Scraper-coverage OK — ${getAllStates().length} states accounted for.`
+  `Scraper-coverage OK — ${getAllStates().length} states × ${DATATYPES.length} datatypes accounted for.`
 );


### PR DESCRIPTION
## Summary

Tightens `scripts/check-scraper-coverage.ts` so per-datatype gaps in `StateConfig.scrapers` can't slip through silently. Closes #111.

## Why

Today the check is all-or-nothing: a state passes if either every datatype is declared OR `scrapers` is omitted entirely with a file-level `// manual-only:` marker. Partial-coverage states (DC declares `courses` + `prereqs` but no `transfers`; PA declares `transfers` + `prereqs` but no `courses`) are silent gaps. The new check enforces an explicit decision for every (state × datatype) pair.

## Marker convention

Two flavors of `// manual-only:`:

1. **Blanket** — `// manual-only: <reason>` at the top of a config whose `scrapers` field is fully omitted. Already used by MA, NJ, NH, WV (Phase-1 or not-yet-cron'd states). Behavior unchanged.
2. **Per-datatype** *(new)* — `// manual-only: courses — <reason>` (or `transfers` / `prereqs`) inside the `scrapers: {}` block, opting just that datatype out.

The check's regex is anchored to the `manual-only:` literal followed by a datatype keyword, so prose like "intentionally omitted" no longer counts — every gap must be explicit.

## States updated

Five gaps surfaced by the new check; each maps to a known open issue and gets a marker that references it:

| State | Datatype | Marker reason | Tracking |
|---|---|---|---|
| `dc` | transfers | No in-state CC→4yr articulation pipeline | (per #133 / #122) |
| `me` | transfers | CT.Net has zero in-state targets; MaineStreet PS scraper is real fix | (per #133 / #122) |
| `me` | prereqs | Scraper not yet built | #106 |
| `md` | prereqs | Scraper not yet built | #105 |
| `pa` | courses | PASSHE inconsistent across 14 colleges; no unified scraper | #100 |

Each marker preserves the existing explanatory prose and just adds the keyword the check looks for.

## Verification

- `npm run check:scrapers` → `Scraper-coverage OK — 18 states × 3 datatypes accounted for.`
- `npm run lint` → 0 errors (unchanged warning baseline).
- `.github/workflows/scraper-coverage.yml` already runs `npm run check:scrapers` on changes to `lib/states/**` and the script itself, so the stronger check is automatically wired into CI for future PRs.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: try a sanity-check by tearing out one `manual-only:` marker locally and running `npm run check:scrapers` — should fail with the per-datatype error message.

Closes #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)