### PR TITLE
Wire MA scrapers into scheduled-scrape cron matrix (#101)

### DIFF
--- a/scripts/ma/scrape-colleague.ts
+++ b/scripts/ma/scrape-colleague.ts
@@ -14,9 +14,9 @@
  *   stcc        studentwebsvr.stcc.edu:9016
  *
  * Usage:
- *   npx tsx scripts/ma/scrape-colleague.ts --college bhcc
+ *   npx tsx scripts/ma/scrape-colleague.ts                              # default: all 3 colleges
+ *   npx tsx scripts/ma/scrape-colleague.ts --college bhcc               # one college
  *   npx tsx scripts/ma/scrape-colleague.ts --college bhcc --term "Fall 2026"
- *   npx tsx scripts/ma/scrape-colleague.ts --all
  */
 
 import * as fs from "fs";
@@ -649,15 +649,12 @@ async function main() {
   const args = process.argv.slice(2);
   const collegeFlag = args.indexOf("--college");
   const termFlag = args.indexOf("--term");
-  const allFlag = args.includes("--all");
 
   const termName = termFlag >= 0 ? args[termFlag + 1] : "Fall 2026";
 
   let targets: [string, string][];
 
-  if (allFlag) {
-    targets = Object.entries(COLLEAGUE_COLLEGES);
-  } else if (collegeFlag >= 0) {
+  if (collegeFlag >= 0) {
     const slug = args[collegeFlag + 1];
     const baseUrl = COLLEAGUE_COLLEGES[slug];
     if (!baseUrl) {
@@ -669,13 +666,9 @@ async function main() {
     }
     targets = [[slug, baseUrl]];
   } else {
-    console.log("Usage:");
-    console.log("  npx tsx scripts/ma/scrape-colleague.ts --college bhcc");
-    console.log(
-      '  npx tsx scripts/ma/scrape-colleague.ts --college bhcc --term "Fall 2026"'
-    );
-    console.log("  npx tsx scripts/ma/scrape-colleague.ts --all");
-    process.exit(0);
+    // Default to all colleges (matches MD #132 pattern; required for cron).
+    // Pass --college <slug> for one-off local runs.
+    targets = Object.entries(COLLEAGUE_COLLEGES);
   }
 
   console.log(`Scraping ${targets.length} MA college(s) for ${termName}...\n`);


### PR DESCRIPTION
## Summary

Promotes Massachusetts from manual-only to fully cron-wired. MA had 6-of-15-college coverage sitting behind a blanket `// manual-only:` marker since 2026-04. Coverage hasn't moved (the SSO-gated 9 are tracked separately as future work), but waiting longer doesn't help — the wired 6 stay fresher with cron'd cycles than with manual-cycle reminders.

Closes #101.

## Changes

- **`lib/states/ma/config.ts`** — drop the blanket `manual-only:` marker; declare 4 matrix entries:
  | Datatype | Runner | Scripts | Colleges |
  |---|---|---|---|
  | courses | http | `scrape-banner-ssb.ts`, `scrape-banner8.ts` | hcc, gcc, middlesex |
  | courses | playwright | `scrape-colleague.ts` | berkshire, bhcc, stcc |
  | transfers | http | `scrape-masstransfer.ts` | all 15 (state-run source) |
  | prereqs | http | `scrape-catalog-prereqs-gcc.ts` + `scrape-catalog-prereqs-middlesex.ts` | gcc, middlesex |

- **`scripts/ma/scrape-colleague.ts`** — default to all 3 Colleague colleges when called with no flags. Matches the convention from MD #132 — required because the cron runner just invokes scripts as-is, no flags injected. The `--college <slug>` flag still works for one-off local runs.

## Why these grouping choices

- The two http course scrapers (HCC SSB + GCC/Middlesex Banner 8) are fast and share no state, so co-locating in one runner is cheaper than splitting across matrix entries.
- The Colleague scraper is Playwright (browser-based) — different runner kind, so it's its own matrix entry. Aligns with MD's pattern.
- Both prereq scrapers self-merge into `data/ma/prereqs.json` with collision handling. Running them sequentially in one matrix entry preserves both sources without races.
- MassTransfer is one source covering all 15 senders × 14 receivers, so a single matrix entry is correct.

## Verification

- `npm run check:scrapers` → **OK — 18 states × 3 datatypes accounted for**
- `npx tsx scripts/lib/scraper-matrix.ts --datatype courses` → MA contributes `ma-courses-0` (http) + `ma-courses-1` (playwright)
- `npx tsx scripts/lib/scraper-matrix.ts --datatype transfers` → `ma-transfers-0`
- `npx tsx scripts/lib/scraper-matrix.ts --datatype prereqs` → `ma-prereqs-0`
- `npx tsx scripts/check-scraper-term-hardcoding.ts` → no hardcoded term refs
- `npm run lint` → 0 errors

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: next scheduled `transfers` cron tick (Wed/Sat 10:00 UTC) should include `ma-transfers-0` and produce a non-empty `data/ma/transfer-equiv.json` artifact.
- [ ] Next scheduled `courses` cron tick (Mon/Wed/Fri 06:00 UTC) should include both MA courses jobs and produce data for hcc, gcc, middlesex, berkshire, bhcc, stcc.
- [ ] Health monitor issue updates to reflect MA's new declared coverage.

## Out of scope

- The 9 SSO-gated MA colleges (Massasoit, Cape Cod, QCC, Roxbury, MassBay, etc.) — separate scraper work, not in this PR.
- Term-system resolution for MA — Colleague defaults to "Fall 2026" (hardcoded string default, not flagged by the term-hardcoding guard since it's not a Banner code or numeric threshold). When the catalog rolls forward, that default needs to update — best handled in a follow-up that wires `termSystem` for MA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)