### PR TITLE
SEO phase 3b: FAQPage + HowTo schema, breadcrumb coverage

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -35,9 +35,29 @@ export default async function HomePage({ params }: Props) {
   const config = getStateConfig(state);
   const nextTerm = await getNextTerm(state);
   const stateArticles = getArticlesByState(state).slice(0, 4);
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
+
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: siteUrl },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: config.name,
+        item: `${siteUrl}/${state}`,
+      },
+    ],
+  };
 
   return (
     <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
       {/* Search section */}
       <section id="search" className="py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-2xl mx-auto text-center">

--- a/app/[state]/starting-soon/page.tsx
+++ b/app/[state]/starting-soon/page.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import type { Metadata } from "next";
 import StartingSoonClient from "./StartingSoonClient";
 import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import Breadcrumbs from "@/components/Breadcrumbs";
 
 type Props = {
   params: Promise<{ state: string }>;
@@ -24,15 +24,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function StartingSoonPage({ params }: Props) {
   const { state } = await params;
   const config = getStateConfig(state);
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-      <Link
-        href={`/${state}`}
-        className="text-sm text-teal-600 hover:text-teal-700 mb-6 inline-block"
-      >
-        &larr; Back to search
-      </Link>
+      <Breadcrumbs
+        siteUrl={siteUrl}
+        items={[
+          { name: "Home", href: "/" },
+          { name: config.name, href: `/${state}` },
+          { name: "Starting Soon", href: `/${state}/starting-soon` },
+        ]}
+      />
 
       <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2">
         Courses Starting Soon

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -104,6 +104,29 @@ export default async function BlogPostPage({ params }: Props) {
     ],
   };
 
+  const faqLd = meta.faqs && meta.faqs.length > 0 ? {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: meta.faqs.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  } : null;
+
+  const howToLd = meta.howTo ? {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: meta.howTo.name,
+    description: meta.howTo.description ?? meta.description,
+    step: meta.howTo.steps.map((s, i) => ({
+      "@type": "HowToStep",
+      position: i + 1,
+      name: s.name,
+      text: s.text,
+    })),
+  } : null;
+
   const related = meta.cluster ? getClusterArticles(meta.cluster) : [];
   const stateForCta =
     meta.state && isValidState(meta.state) ? meta.state : null;
@@ -118,6 +141,18 @@ export default async function BlogPostPage({ params }: Props) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
       />
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      )}
+      {howToLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      )}
 
       {/* Back link */}
       <Link

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+export type Crumb = { name: string; href: string };
+
+// Visible breadcrumb trail + matching BreadcrumbList JSON-LD. Server component;
+// no client JS. Last item in `items` is the current page (rendered as text,
+// not a link).
+export default function Breadcrumbs({
+  items,
+  siteUrl,
+  className,
+}: {
+  items: Crumb[];
+  siteUrl: string;
+  className?: string;
+}) {
+  if (items.length === 0) return null;
+  const ld = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: c.name,
+      item: c.href.startsWith("http") ? c.href : `${siteUrl}${c.href}`,
+    })),
+  };
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(ld) }}
+      />
+      <nav
+        aria-label="Breadcrumb"
+        className={
+          className ??
+          "text-sm text-gray-500 dark:text-slate-400 mb-4"
+        }
+      >
+        <ol className="flex flex-wrap items-center gap-1.5">
+          {items.map((c, i) => {
+            const isLast = i === items.length - 1;
+            return (
+              <li key={c.href} className="flex items-center gap-1.5">
+                {i > 0 && (
+                  <span aria-hidden="true" className="text-gray-300 dark:text-slate-600">
+                    /
+                  </span>
+                )}
+                {isLast ? (
+                  <span
+                    aria-current="page"
+                    className="text-gray-700 dark:text-slate-300 truncate max-w-[40ch]"
+                  >
+                    {c.name}
+                  </span>
+                ) : (
+                  <Link
+                    href={c.href}
+                    className="hover:text-teal-600 dark:hover:text-teal-400 transition-colors truncate max-w-[40ch]"
+                  >
+                    {c.name}
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    </>
+  );
+}

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -1,3 +1,11 @@
+export type FaqEntry = { q: string; a: string };
+export type HowToStep = { name: string; text: string };
+export type HowToSpec = {
+  name: string;
+  description?: string;
+  steps: HowToStep[];
+};
+
 export type ArticleMeta = {
   slug: string;
   title: string;
@@ -9,6 +17,10 @@ export type ArticleMeta = {
   tags: string[];
   cluster?: string; // optional cluster ID for hub/spoke linking
   clusterRole?: "hub" | "spoke";
+  // Optional rich-result inputs. Emitted as schema.org FAQPage / HowTo JSON-LD
+  // when present. Opt-in per article — keeps thin/inferred FAQs out of search.
+  faqs?: FaqEntry[];
+  howTo?: HowToSpec;
 };
 
 export const CATEGORIES: Record<string, string> = {
@@ -79,6 +91,24 @@ export const articles: ArticleMeta[] = [
     tags: ["seniors", "tuition-waiver", "auditing", "free-classes"],
     cluster: "senior-waivers-guide",
     clusterRole: "hub",
+    faqs: [
+      {
+        q: "Which states offer free community college classes for seniors?",
+        a: "Several states waive community college tuition for senior residents, including Virginia (60+), North Carolina (65+), South Carolina (60+), and the District of Columbia (65+). Age thresholds, residency rules, and what's actually covered (auditing vs credit) vary by state.",
+      },
+      {
+        q: "What does \"space permitting\" mean for senior tuition waivers?",
+        a: "It means seniors register after credit-seeking students. If a class is already full when senior registration opens, you cannot enroll. Popular gen-ed and online sections fill fastest; niche electives, morning sections, and late-start courses tend to have more availability.",
+      },
+      {
+        q: "Does a senior tuition waiver cover credits or just auditing?",
+        a: "It depends on the state. North Carolina's waiver covers auditing only — no grade, no credit. Virginia waives tuition for auditing but charges a reduced rate for credit enrollment. Always confirm with the college before you register.",
+      },
+      {
+        q: "Are there income limits for senior tuition waivers?",
+        a: "Some states impose income caps. Virginia, for example, requires taxable income below roughly $29,000 for the credit-bearing waiver — auditing is free regardless. Most other states do not have an income test, but residency is always required.",
+      },
+    ],
   },
   {
     slug: "virginia-senior-citizens-community-college-free-tuition",
@@ -393,6 +423,22 @@ export const articles: ArticleMeta[] = [
     state: "pa",
     author: "Community College Path",
     tags: ["transfer", "pennsylvania", "penn-state", "pitt", "temple", "pa-trac", "ccp"],
+    cluster: "transfer-credit-guide",
+    clusterRole: "spoke",
+  },
+
+  // --- Cluster A spoke: MA MassTransfer ---
+  {
+    slug: "massachusetts-community-college-transfer-credit-guide",
+    title:
+      "How Massachusetts Community College Transfer Credit Actually Works: A MassTransfer Student's Guide",
+    description:
+      "MA has 46k+ published transfer mappings via MassTransfer — but at UMass Amherst, more than half come back as elective credit. Here's how to read MassTransfer before you register.",
+    date: "2026-05-02",
+    category: "state-system-explainers",
+    state: "ma",
+    author: "Community College Path",
+    tags: ["transfer", "massachusetts", "masscc", "masstransfer", "umass"],
     cluster: "transfer-credit-guide",
     clusterRole: "spoke",
   },


### PR DESCRIPTION
## Summary

Round out structured-data coverage for rich-result eligibility, and fill the two BreadcrumbList JSON-LD gaps the audit found. Pure additive — no changes to existing schemas.

- **FAQPage / HowTo on blog posts** — `ArticleMeta` gains optional `faqs` and `howTo` fields; `app/blog/[slug]/page.tsx` emits matching JSON-LD only when present. Opt-in per article so we don't ship inferred or low-quality FAQs to Google.
- **Hand-curated FAQs on the senior-waivers hub** — 4 questions the article already answers in prose. This PR ships one rich-result-eligible page; the rest get FAQs as part of phase 5 content work.
- **`components/Breadcrumbs.tsx`** — server-rendered, no client JS. Renders the visible trail and emits matching BreadcrumbList JSON-LD from a single source.
- **Coverage fills** — `/[state]` root gets BreadcrumbList JSON-LD (top of hierarchy, no visible UI needed); `/[state]/starting-soon` gets both visible breadcrumbs and JSON-LD (replaces a one-off back link).

Most other state routes (course, college, subject, transfer hub, blog) already had inline breadcrumb JSON-LD + visible UI from earlier work — those are unchanged.

## Test plan

- [x] `/va` HTML contains BreadcrumbList JSON-LD with Home → Virginia
- [x] `/va/starting-soon` contains both JSON-LD AND `<nav aria-label="Breadcrumb">` visible UI rendering "Home / Virginia / Starting Soon"
- [x] `/blog/free-community-college-classes-for-seniors` emits FAQPage JSON-LD with all 4 question/answer pairs
- [x] Blog posts without `faqs` data emit no FAQPage script (verified via missing `@type":"FAQPage"`)
- [x] No new client JS added (Breadcrumbs is a server component)
- [ ] After merge: validate the senior-waivers article in [Google Rich Results Test](https://search.google.com/test/rich-results) and confirm FAQ eligibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)