### PR TITLE
SEO phase 3c: course→subject link, more-state-guides on blog

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -339,9 +339,12 @@ export default async function CoursePage(props: PageProps) {
 
         {/* Header */}
         <div className="mb-8">
-          <p className="text-sm font-medium text-teal-600 dark:text-teal-400 mb-1">
+          <Link
+            href={`/${state}/subject/${prefix.toLowerCase()}`}
+            className="text-sm font-medium text-teal-600 dark:text-teal-400 mb-1 inline-block hover:underline"
+          >
             {subjectName(prefix)}
-          </p>
+          </Link>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
             {prefix} {number}
             <span className="font-normal text-gray-500 dark:text-slate-400 text-2xl ml-2">

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   stateLabel,
 } from "@/lib/blog";
 import RelatedArticles from "@/components/blog/RelatedArticles";
+import MoreStateGuides from "@/components/blog/MoreStateGuides";
 import StateToolsCTA from "@/components/blog/StateToolsCTA";
 import { isValidState } from "@/lib/states/registry";
 import AdUnit from "@/components/AdUnit";
@@ -209,6 +210,16 @@ export default async function BlogPostPage({ params }: Props) {
 
       {/* Related articles */}
       <RelatedArticles articles={related} currentSlug={slug} />
+
+      {/* More guides for this state — only on state-tagged posts.
+          Excludes cluster siblings already shown above. */}
+      {stateForCta && (
+        <MoreStateGuides
+          state={stateForCta}
+          currentSlug={slug}
+          excludeSlugs={related.map((a) => a.slug)}
+        />
+      )}
     </article>
   );
 }

--- a/components/blog/MoreStateGuides.tsx
+++ b/components/blog/MoreStateGuides.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { getArticlesByState, categoryLabel, stateLabel } from "@/lib/blog";
+
+// Renders up to N other state-tagged guides on a state-tagged blog post.
+// Excludes the current article and any articles already shown by the
+// cluster-based RelatedArticles component (avoids duplicate cards).
+export default function MoreStateGuides({
+  state,
+  currentSlug,
+  excludeSlugs = [],
+  limit = 4,
+}: {
+  state: string;
+  currentSlug: string;
+  excludeSlugs?: string[];
+  limit?: number;
+}) {
+  const exclude = new Set([currentSlug, ...excludeSlugs]);
+  const others = getArticlesByState(state)
+    .filter((a) => !exclude.has(a.slug))
+    .slice(0, limit);
+  if (others.length === 0) return null;
+
+  return (
+    <div className="mt-12 border-t border-gray-200 dark:border-slate-700 pt-8">
+      <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-slate-100">
+        More {stateLabel(state)} guides
+      </h2>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {others.map((article) => (
+          <Link
+            key={article.slug}
+            href={`/blog/${article.slug}`}
+            className="group rounded-lg border border-gray-200 dark:border-slate-700 p-4 transition hover:border-teal-300 dark:hover:border-teal-600 hover:bg-teal-50/50 dark:hover:bg-teal-900/20"
+          >
+            <span className="mb-1 inline-block rounded-full bg-gray-100 dark:bg-slate-700 px-2.5 py-0.5 text-xs font-medium text-gray-600 dark:text-slate-400">
+              {categoryLabel(article.category)}
+            </span>
+            <h3 className="mt-1 text-sm font-semibold text-gray-900 dark:text-slate-100 group-hover:text-teal-700 dark:group-hover:text-teal-400">
+              {article.title}
+            </h3>
+            <p className="mt-1 text-xs text-gray-500 dark:text-slate-400 line-clamp-2">
+              {article.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Audit-driven cross-linking improvements. Most internal-linking work was already done in earlier phases (course pages link to peer courses + colleges; subject pages list top courses; college pages link to system siblings; blog posts cluster-link). Two real gaps remained, both fixed here:

- **Course page subject is now a link** — e.g., the "English" label on `/va/course/eng-111` now links to `/va/subject/eng` (the state-wide subject hub). Tightens the topical pyramid: course → state subject → state hub.
- **`MoreStateGuides` on state-tagged blog posts** — new server component pulling other articles tagged with the same state, excluding the current article and cluster siblings already shown by `RelatedArticles`. Silent on general (state=null) posts, silent when no other state articles exist.

The plan also mentioned `next/image` migration. Audit showed only two raw `<img>` tags in the codebase (account dashboard + user menu, both OAuth provider avatars on external URLs that can't be Next-optimized and already have valid eslint disables). Nothing to migrate.

## Test plan

- [x] `/va/course/eng-111` renders `<a href="/va/subject/eng">` on the subject label
- [x] `/blog/virginia-senior-citizens-community-college-free-tuition` shows a "More Virginia guides" section linking to the VA GAA article
- [x] `/blog/free-community-college-classes-for-seniors` (state=null) emits no `MoreStateGuides` section
- [x] Server-rendered, no new client JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)