### PR TITLE
SEO phase 4a: programs/majors hub (~88 new pSEO pages)

### DIFF
--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -1,0 +1,260 @@
+/**
+ * Programs / majors hub page. e.g. `/va/program/nursing` lists every VCCS
+ * college offering ≥5 sections in nursing-program prefixes (NUR, NURS, NSG,
+ * RNS, ADN). Targets queries like "nursing programs Virginia community
+ * college".
+ *
+ * Threshold-gated to avoid thin pSEO — see `qualifies()` in lib/programs.
+ * ISR: 7 days, same as subject/course pages. Sitemap (programs partition)
+ * lists only qualifying (state, program) pairs.
+ */
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { getCurrentTerm, termLabel } from "@/lib/terms";
+import {
+  loadProgramData,
+  qualifies,
+  getProgramBySlug,
+  PROGRAMS,
+} from "@/lib/programs";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+export const revalidate = 604800; // 7 days
+
+type PageProps = {
+  params: Promise<{ state: string; slug: string }>;
+};
+
+export async function generateStaticParams() {
+  // On-demand ISR: sitemap drives discovery, no upfront generation
+  return [];
+}
+
+function siteUrl() {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"
+  );
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { state, slug } = await props.params;
+  if (!isValidState(state)) return { title: "Not Found" };
+  const program = getProgramBySlug(slug);
+  if (!program) return { title: "Not Found" };
+
+  const config = getStateConfig(state);
+  const data = await loadProgramData(state, slug);
+  if (!data || !qualifies(data)) return { title: "Not Found" };
+
+  const term = await getCurrentTerm(state);
+  const title = `${program.name} Programs at ${config.name} Community Colleges`;
+  const description = `${data.totalColleges} ${config.systemName} colleges offer ${program.name.toLowerCase()} coursework — ${data.totalSections} sections across ${data.totalUniqueCourses} courses for ${termLabel(term)}. Compare colleges and transfer options.`;
+  const canonical = `${siteUrl()}/${state}/program/${slug}`;
+
+  return {
+    title,
+    description,
+    keywords: [
+      `${program.name.toLowerCase()} programs ${config.name}`,
+      `${program.name.toLowerCase()} community college ${config.name}`,
+      `${config.systemName} ${program.name.toLowerCase()}`,
+      `${program.name.toLowerCase()} degree ${config.name}`,
+      ...config.branding.metaKeywords,
+    ],
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      siteName: config.branding.siteName,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default async function ProgramPage(props: PageProps) {
+  const { state, slug } = await props.params;
+  if (!isValidState(state)) notFound();
+  const program = getProgramBySlug(slug);
+  if (!program) notFound();
+
+  const data = await loadProgramData(state, slug);
+  if (!data || !qualifies(data)) notFound();
+
+  const config = getStateConfig(state);
+  const term = await getCurrentTerm(state);
+  const url = siteUrl();
+
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${program.name} programs at ${config.name} community colleges`,
+    description: data.program.description,
+    numberOfItems: data.colleges.length,
+    url: `${url}/${state}/program/${slug}`,
+    itemListElement: data.colleges.slice(0, 25).map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "CollegeOrUniversity",
+        name: c.collegeName,
+        url: `${url}/${state}/college/${c.collegeId}`,
+      },
+    })),
+  };
+
+  // Other programs offered in this state (for cross-linking footer)
+  const otherProgramSlugs = PROGRAMS.filter((p) => p.slug !== slug).map(
+    (p) => p.slug
+  );
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Breadcrumbs
+          siteUrl={url}
+          items={[
+            { name: "Home", href: "/" },
+            { name: config.name, href: `/${state}` },
+            { name: "Programs", href: `/${state}` },
+            {
+              name: program.name,
+              href: `/${state}/program/${slug}`,
+            },
+          ]}
+        />
+
+        <header className="mb-8">
+          <p className="text-sm font-medium text-teal-600 dark:text-teal-400 mb-1">
+            {config.name} Community Colleges
+          </p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
+            {program.name} Programs
+          </h1>
+          <p className="text-gray-600 dark:text-slate-400 mt-3 leading-relaxed">
+            {program.description}
+          </p>
+          <p className="text-sm text-gray-500 dark:text-slate-400 mt-3">
+            {data.totalColleges}{" "}
+            {data.totalColleges === 1 ? "college" : "colleges"} &middot;{" "}
+            {data.totalSections} sections &middot; {data.totalUniqueCourses}{" "}
+            unique courses &middot; {termLabel(term)}
+          </p>
+        </header>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+            Colleges offering {program.name}
+          </h2>
+          <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-900">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-gray-50 dark:bg-slate-800 text-xs uppercase tracking-wider text-gray-500 dark:text-slate-400">
+                <tr>
+                  <th className="px-4 py-2.5 font-medium">College</th>
+                  <th className="px-4 py-2.5 font-medium text-right">
+                    Sections
+                  </th>
+                  <th className="px-4 py-2.5 font-medium text-right">Courses</th>
+                  <th className="px-4 py-2.5 font-medium text-right">Online</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-slate-700">
+                {data.colleges.map((c) => (
+                  <tr
+                    key={c.collegeCode}
+                    className="hover:bg-gray-50 dark:hover:bg-slate-800"
+                  >
+                    <td className="px-4 py-2.5">
+                      <Link
+                        href={`/${state}/college/${c.collegeId}`}
+                        className="font-medium text-teal-600 dark:text-teal-400 hover:underline"
+                      >
+                        {c.collegeName}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-gray-900 dark:text-slate-100">
+                      {c.sectionCount}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-gray-600 dark:text-slate-400">
+                      {c.uniqueCourses}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-gray-600 dark:text-slate-400">
+                      {c.onlineCount > 0 ? c.onlineCount : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {data.sampleCourses.length > 0 && (
+          <section className="mb-10">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+              Common {program.name} courses
+            </h2>
+            <ul className="grid sm:grid-cols-2 gap-2">
+              {data.sampleCourses.map((c) => (
+                <li key={`${c.prefix}-${c.number}`}>
+                  <Link
+                    href={`/${state}/course/${c.prefix.toLowerCase()}-${c.number.toLowerCase()}`}
+                    className="block rounded-lg border border-gray-200 dark:border-slate-700 px-3 py-2 hover:border-teal-300 dark:hover:border-teal-600 transition"
+                  >
+                    <span className="font-mono text-sm font-medium text-teal-600 dark:text-teal-400">
+                      {c.prefix} {c.number}
+                    </span>
+                    <span className="ml-2 text-sm text-gray-700 dark:text-slate-300">
+                      {c.title}
+                    </span>
+                    <span className="ml-2 text-xs text-gray-500 dark:text-slate-400">
+                      ({c.sectionCount}{" "}
+                      {c.sectionCount === 1 ? "section" : "sections"})
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+            Other programs in {config.name}
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {otherProgramSlugs.map((s) => {
+              const p = getProgramBySlug(s)!;
+              return (
+                <Link
+                  key={s}
+                  href={`/${state}/program/${s}`}
+                  className="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1 text-sm text-gray-700 dark:text-slate-300 hover:border-teal-300 dark:hover:border-teal-600 transition"
+                >
+                  {p.name}
+                </Link>
+              );
+            })}
+          </div>
+          <p className="text-xs text-gray-500 dark:text-slate-400 mt-2">
+            Some programs may not be offered at every college — pages render
+            only when the program meets a coverage threshold for the state.
+          </p>
+        </section>
+      </div>
+    </>
+  );
+}
+

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -9,6 +9,7 @@ const SITEMAP_IDS = [
   "state-subjects",
   "transfer",
   "instructors",
+  "programs",
   "blog",
 ];
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,6 +12,7 @@ import {
 import { getInstructorSitemapEntries } from "@/lib/instructors";
 import { getCurrentTerm } from "@/lib/terms";
 import { getUniversitiesWithCounts } from "@/lib/transfer";
+import { getQualifyingProgramSlugs } from "@/lib/programs";
 
 // Thin-content guard: keep in sync with the /[state]/transfer/to/[slug] page.
 const MIN_TRANSFER_HUB_COUNT = 10;
@@ -24,6 +25,7 @@ const SITEMAP_IDS = [
   "state-subjects",
   "transfer",
   "instructors",
+  "programs",
   "blog",
 ] as const;
 type SitemapId = (typeof SITEMAP_IDS)[number];
@@ -272,6 +274,28 @@ async function buildInstructors(): Promise<MetadataRoute.Sitemap> {
   return out;
 }
 
+async function buildPrograms(): Promise<MetadataRoute.Sitemap> {
+  const url = baseUrl();
+  const out: MetadataRoute.Sitemap = [];
+  for (const state of getAllStates()) {
+    try {
+      const stateLastMod = lastModifiedForState(state.slug);
+      const slugs = await getQualifyingProgramSlugs(state.slug);
+      for (const slug of slugs) {
+        out.push({
+          url: `${url}/${state.slug}/program/${slug}`,
+          changeFrequency: "weekly",
+          priority: 0.75,
+          lastModified: stateLastMod,
+        });
+      }
+    } catch {
+      // skip state if program data loading fails
+    }
+  }
+  return out;
+}
+
 async function buildBlog(): Promise<MetadataRoute.Sitemap> {
   const url = baseUrl();
   return [
@@ -307,6 +331,8 @@ export default async function sitemap({
       return buildTransfer();
     case "instructors":
       return buildInstructors();
+    case "programs":
+      return buildPrograms();
     case "blog":
       return buildBlog();
     default:

--- a/lib/programs/index.ts
+++ b/lib/programs/index.ts
@@ -1,0 +1,173 @@
+/**
+ * Program-page data layer. Aggregates per-college sections for a program
+ * (from the registry) in a given state and current term. Threshold-gated:
+ * a program qualifies for its own page only if PROGRAM_MIN_COLLEGES colleges
+ * each offer at least PROGRAM_MIN_SECTIONS sections in the program prefixes.
+ *
+ * Keep thresholds tight to avoid thin-content pSEO. Same discipline as
+ * sitemap.ts (≥3, ≥5, ≥10 thresholds elsewhere).
+ */
+
+import { loadCoursesBySubject } from "@/lib/courses";
+import { getCurrentTerm } from "@/lib/terms";
+import { loadInstitutions } from "@/lib/institutions";
+import { PROGRAMS, getProgramBySlug, type ProgramDef } from "./registry";
+import type { CourseSection } from "@/lib/types";
+
+export { PROGRAMS, getProgramBySlug };
+export type { ProgramDef };
+
+// Thin-content thresholds. Both must hold for a program page to render.
+export const PROGRAM_MIN_COLLEGES = 3;
+export const PROGRAM_MIN_SECTIONS = 5;
+
+export type ProgramCollegeRow = {
+  collegeCode: string;
+  collegeName: string;
+  collegeId: string;
+  sectionCount: number;
+  uniqueCourses: number;
+  onlineCount: number;
+};
+
+export type ProgramData = {
+  program: ProgramDef;
+  matchedPrefixes: string[];
+  totalSections: number;
+  totalUniqueCourses: number;
+  totalColleges: number;
+  totalOnline: number;
+  colleges: ProgramCollegeRow[];
+  // Sample of representative courses for an ItemList block.
+  sampleCourses: {
+    prefix: string;
+    number: string;
+    title: string;
+    sectionCount: number;
+  }[];
+};
+
+/**
+ * Pull every section across program candidate prefixes for a state+term.
+ * Returns null if no data found at all (used for notFound discrimination).
+ * Caller decides if the result clears the threshold via `qualifies()`.
+ */
+export async function loadProgramData(
+  state: string,
+  programSlug: string
+): Promise<ProgramData | null> {
+  const program = getProgramBySlug(programSlug);
+  if (!program) return null;
+
+  const term = await getCurrentTerm(state);
+  const institutions = loadInstitutions(state);
+  const sectionsPerPrefix = await Promise.all(
+    program.prefixes.map(async (p) => ({
+      prefix: p,
+      sections: await loadCoursesBySubject(p, term, state),
+    }))
+  );
+
+  const all: CourseSection[] = sectionsPerPrefix.flatMap((x) => x.sections);
+  if (all.length === 0) return null;
+
+  const matchedPrefixes = sectionsPerPrefix
+    .filter((x) => x.sections.length > 0)
+    .map((x) => x.prefix);
+
+  // Aggregate by college
+  const byCollege = new Map<string, CourseSection[]>();
+  for (const s of all) {
+    if (!byCollege.has(s.college_code)) byCollege.set(s.college_code, []);
+    byCollege.get(s.college_code)!.push(s);
+  }
+
+  const colleges: ProgramCollegeRow[] = [];
+  for (const [code, secs] of byCollege) {
+    const inst = institutions.find(
+      (i) => i.college_slug === code || i.id === code
+    );
+    if (!inst) continue; // skip orphaned college codes
+    const uniqueCourses = new Set(
+      secs.map((s) => `${s.course_prefix} ${s.course_number}`)
+    ).size;
+    const onlineCount = secs.filter(
+      (s) => s.mode === "online" || s.mode === "zoom"
+    ).length;
+    colleges.push({
+      collegeCode: code,
+      collegeName: inst.name,
+      collegeId: inst.id,
+      sectionCount: secs.length,
+      uniqueCourses,
+      onlineCount,
+    });
+  }
+  // Sort by section count descending, then name
+  colleges.sort(
+    (a, b) =>
+      b.sectionCount - a.sectionCount ||
+      a.collegeName.localeCompare(b.collegeName)
+  );
+
+  // Sample courses across the program — top by section count
+  const courseMap = new Map<string, { title: string; count: number }>();
+  for (const s of all) {
+    const key = `${s.course_prefix} ${s.course_number}`;
+    const existing = courseMap.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      courseMap.set(key, { title: s.course_title, count: 1 });
+    }
+  }
+  const sampleCourses = [...courseMap.entries()]
+    .map(([key, v]) => {
+      const [prefix, number] = key.split(" ");
+      return {
+        prefix,
+        number,
+        title: v.title,
+        sectionCount: v.count,
+      };
+    })
+    .sort((a, b) => b.sectionCount - a.sectionCount)
+    .slice(0, 12);
+
+  return {
+    program,
+    matchedPrefixes,
+    totalSections: all.length,
+    totalUniqueCourses: courseMap.size,
+    totalColleges: colleges.length,
+    totalOnline: all.filter((s) => s.mode === "online" || s.mode === "zoom")
+      .length,
+    colleges,
+    sampleCourses,
+  };
+}
+
+export function qualifies(data: ProgramData): boolean {
+  if (data.totalColleges < PROGRAM_MIN_COLLEGES) return false;
+  const eligibleColleges = data.colleges.filter(
+    (c) => c.sectionCount >= PROGRAM_MIN_SECTIONS
+  );
+  return eligibleColleges.length >= PROGRAM_MIN_COLLEGES;
+}
+
+/**
+ * Sitemap helper — for a state, return the slugs of all programs whose page
+ * should be indexed. Calls loadProgramData per program; relies on the cache
+ * inside loadCoursesBySubject so repeat calls during a sitemap build are
+ * cheap.
+ */
+export async function getQualifyingProgramSlugs(
+  state: string
+): Promise<string[]> {
+  const out: string[] = [];
+  for (const program of PROGRAMS) {
+    const data = await loadProgramData(state, program.slug);
+    if (data && qualifies(data)) out.push(program.slug);
+  }
+  return out;
+}

--- a/lib/programs/registry.ts
+++ b/lib/programs/registry.ts
@@ -1,0 +1,112 @@
+/**
+ * Curated program → course-prefix mapping for the programs/majors hub
+ * (`/[state]/program/[slug]`). Each program lists candidate course prefixes;
+ * the page filters to whichever prefixes actually have data in the target
+ * state. State-by-state prefix variation is handled here, not at call sites.
+ *
+ * Add a program by appending to PROGRAMS. The slug becomes the URL segment;
+ * use kebab-case lower. To add a new prefix variant, append to that program's
+ * `prefixes` — it's a superset, no harm done if a state lacks it.
+ */
+
+export type ProgramDef = {
+  slug: string;
+  name: string;
+  // 1-2 sentence description used for meta description and page intro.
+  description: string;
+  // Candidate course prefixes. Match is OR — any prefix in this list counts
+  // toward program coverage. Variants across state systems are intentional
+  // (e.g. NUR, NURS, NSG all map to Nursing).
+  prefixes: string[];
+};
+
+export const PROGRAMS: ProgramDef[] = [
+  {
+    slug: "nursing",
+    name: "Nursing",
+    description:
+      "Compare nursing programs across community colleges in this state. ADN, LPN, and pre-nursing pathways with section counts and transfer details.",
+    prefixes: ["NUR", "NURS", "NSG", "RNS", "ADN"],
+  },
+  {
+    slug: "business-administration",
+    name: "Business Administration",
+    description:
+      "Business administration courses across community colleges in this state, covering management, accounting, marketing, and economics.",
+    prefixes: ["BUS", "MGT", "MGMT", "MKT", "MKTG", "ACC", "ACCT", "ECO", "ECON", "FIN"],
+  },
+  {
+    slug: "computer-science",
+    name: "Computer Science",
+    description:
+      "Computer science and IT pathways at community colleges in this state. Programming, networking, cybersecurity, and transfer-track CS courses.",
+    prefixes: ["CSC", "CSCI", "CSE", "CIS", "CIT", "ITN", "ITP", "ITE", "COMP"],
+  },
+  {
+    slug: "accounting",
+    name: "Accounting",
+    description:
+      "Accounting programs at community colleges in this state. Financial accounting, managerial accounting, and CPA-track coursework.",
+    prefixes: ["ACC", "ACCT", "ACG"],
+  },
+  {
+    slug: "early-childhood-education",
+    name: "Early Childhood Education",
+    description:
+      "Early childhood education programs at community colleges in this state. Coursework for child-care, preschool, and elementary-track teachers.",
+    prefixes: ["ECE", "EDU", "CHD", "CD", "CHFD"],
+  },
+  {
+    slug: "criminal-justice",
+    name: "Criminal Justice",
+    description:
+      "Criminal justice programs at community colleges in this state. Law-enforcement, corrections, and pre-law pathways.",
+    prefixes: ["CRJ", "CJ", "CJU", "ADJ", "LGL", "PLS"],
+  },
+  {
+    slug: "liberal-arts",
+    name: "Liberal Arts",
+    description:
+      "Liberal-arts transfer programs at community colleges in this state. English, history, philosophy, and the social sciences for university transfer.",
+    prefixes: ["ENG", "ENGL", "HIS", "HIST", "PHI", "PHIL"],
+  },
+  {
+    slug: "engineering",
+    name: "Engineering",
+    description:
+      "Engineering and pre-engineering programs at community colleges in this state. Calculus, physics, and intro engineering for transfer to four-year programs.",
+    prefixes: ["EGR", "ENGR", "ENGE", "EGT"],
+  },
+  {
+    slug: "biology",
+    name: "Biology",
+    description:
+      "Biology coursework across community colleges in this state. Anatomy, microbiology, and pre-health science transfer pathways.",
+    prefixes: ["BIO", "BIOL"],
+  },
+  {
+    slug: "psychology",
+    name: "Psychology",
+    description:
+      "Psychology programs at community colleges in this state. Intro psych, abnormal, developmental, and transfer-track coursework for four-year programs.",
+    prefixes: ["PSY", "PSYC"],
+  },
+  {
+    slug: "welding",
+    name: "Welding Technology",
+    description:
+      "Welding technology programs at community colleges in this state. Career-track training for AWS-certified welders.",
+    prefixes: ["WEL", "WLD", "WLDG"],
+  },
+  {
+    slug: "automotive-technology",
+    name: "Automotive Technology",
+    description:
+      "Automotive technology programs at community colleges in this state. ASE-aligned coursework for technicians and service writers.",
+    prefixes: ["AUT", "AUTO", "AUMT", "ATR"],
+  },
+];
+
+export function getProgramBySlug(slug: string): ProgramDef | undefined {
+  return PROGRAMS.find((p) => p.slug === slug);
+}


### PR DESCRIPTION
## Summary

Net-new programmatic pages targeting high-intent queries the site doesn't currently match — "nursing programs Virginia community college", "criminal justice NCCCS", "welding programs in NH". The underlying course data already exists; this PR turns it into indexable major/program landing pages.

- **`lib/programs/registry.ts`** — 12 curated programs, each mapped to a list of candidate course prefixes. State-by-state prefix variation (NUR vs NURS vs NSG for nursing) handled in one place; states without a particular prefix are silently filtered.
- **`lib/programs/index.ts`** — data layer. `loadProgramData()` aggregates sections across candidate prefixes for a state, joins to institutions for college names, builds a college list + sample courses. `qualifies()` enforces the thin-content threshold: ≥3 colleges each offering ≥5 sections.
- **`app/[state]/program/[slug]/page.tsx`** — server-rendered (no client JS). Threshold-gated → `notFound()` for non-qualifying combos. `ItemList` JSON-LD with `CollegeOrUniversity` entries. ISR `revalidate=604800` (7d), same as subject/course pages.
- **Sitemap** — new `programs` partition. Only emits qualifying state×program pairs. Robots.txt updated.

Pages render only when the data is rich enough — same discipline as the existing `≥3` / `≥5` / `≥10` thresholds elsewhere.

## Impact

`/sitemap/programs.xml` emits 88 URLs across 18 states (avg ~5 programs per state). Combined with rich-result eligibility (ItemList) and tight internal linking (each program page links to college detail pages + sample courses + sibling programs), this is the largest net-new indexable surface added since SEO phase 1.

## Test plan

- [x] `/va/program/nursing` renders 18 college rows with H1, breadcrumbs, ItemList JSON-LD, Title "Nursing Programs at Virginia Community Colleges"
- [x] `/va/program/welding` qualifies and renders
- [x] `/va/program/foo-bar-not-real` → notFound (404 page rendered)
- [x] `/sitemap/programs.xml` returns valid XML with 88 entries
- [x] Threshold logic — programs that don't have ≥3 qualifying colleges in a state silently skip (sitemap gate)
- [ ] After merge: spot-check one program page in production for each of NC, MA, NH (states with smaller course coverage) and confirm thin-content gate is working as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)