### PR TITLE
SEO phase 4d: /[state]/online landing page

### DIFF
--- a/app/[state]/online/page.tsx
+++ b/app/[state]/online/page.tsx
@@ -1,0 +1,209 @@
+/**
+ * Online community college courses landing page (phase 4d).
+ *
+ * Targets queries like "online classes [state] community college". Lists
+ * every college in the state offering online sections this term, with
+ * total counts and top subjects. Threshold-gated — see ONLINE_MIN_*
+ * in lib/online.
+ */
+
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { termLabel } from "@/lib/terms";
+import { subjectName } from "@/lib/subjects";
+import { loadOnlineData, onlineQualifies } from "@/lib/online";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+export const revalidate = 604800; // 7 days
+
+type PageProps = {
+  params: Promise<{ state: string }>;
+};
+
+function siteUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"
+  );
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { state } = await props.params;
+  if (!isValidState(state)) return { title: "Not Found" };
+  const config = getStateConfig(state);
+  const data = await loadOnlineData(state);
+  if (!onlineQualifies(data) || !data) return { title: "Not Found" };
+
+  const title = `Online Community College Courses in ${config.name} (${termLabel(data.term)})`;
+  const description = `Find ${data.totalSections} online sections across ${data.totalColleges} ${config.systemName} colleges for ${termLabel(data.term)}. ${data.totalUniqueCourses} unique courses available online — compare schedules and transfer options.`;
+  const canonical = `${siteUrl()}/${state}/online`;
+
+  return {
+    title,
+    description,
+    keywords: [
+      `online community college ${config.name}`,
+      `online classes ${config.name} community college`,
+      `${config.systemName} online courses`,
+      `distance learning ${config.name}`,
+      `online associate degree ${config.name}`,
+      ...config.branding.metaKeywords,
+    ],
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      siteName: config.branding.siteName,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default async function OnlinePage(props: PageProps) {
+  const { state } = await props.params;
+  if (!isValidState(state)) notFound();
+  const config = getStateConfig(state);
+  const data = await loadOnlineData(state);
+  if (!onlineQualifies(data) || !data) notFound();
+
+  const url = siteUrl();
+  const itemListLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `Online community college courses in ${config.name}`,
+    description: `${data.totalSections} online sections across ${data.totalColleges} ${config.systemName} colleges for ${termLabel(data.term)}.`,
+    numberOfItems: data.colleges.length,
+    url: `${url}/${state}/online`,
+    itemListElement: data.colleges.slice(0, 25).map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "CollegeOrUniversity",
+        name: c.collegeName,
+        url: `${url}/${state}/college/${c.collegeId}`,
+      },
+    })),
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListLd) }}
+      />
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Breadcrumbs
+          siteUrl={url}
+          items={[
+            { name: "Home", href: "/" },
+            { name: config.name, href: `/${state}` },
+            { name: "Online Courses", href: `/${state}/online` },
+          ]}
+        />
+
+        <header className="mb-8">
+          <p className="text-sm font-medium text-teal-600 dark:text-teal-400 mb-1">
+            {config.name} Community Colleges
+          </p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
+            Online Courses
+          </h1>
+          <p className="text-gray-600 dark:text-slate-400 mt-3 leading-relaxed max-w-3xl">
+            {data.totalSections} online sections across {data.totalColleges}{" "}
+            {config.systemName} colleges for {termLabel(data.term)}.{" "}
+            {data.totalUniqueCourses} unique courses delivered fully online or
+            via Zoom — same credits, same transfer eligibility as in-person
+            sections.
+          </p>
+        </header>
+
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+            Colleges with online courses
+          </h2>
+          <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-900">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-gray-50 dark:bg-slate-800 text-xs uppercase tracking-wider text-gray-500 dark:text-slate-400">
+                <tr>
+                  <th className="px-4 py-2.5 font-medium">College</th>
+                  <th className="px-4 py-2.5 font-medium text-right">
+                    Online sections
+                  </th>
+                  <th className="px-4 py-2.5 font-medium text-right">
+                    Unique courses
+                  </th>
+                  <th className="px-4 py-2.5 font-medium">Top subjects</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-slate-700">
+                {data.colleges.map((c) => (
+                  <tr
+                    key={c.collegeCode}
+                    className="hover:bg-gray-50 dark:hover:bg-slate-800"
+                  >
+                    <td className="px-4 py-2.5">
+                      <Link
+                        href={`/${state}/college/${c.collegeId}`}
+                        className="font-medium text-teal-600 dark:text-teal-400 hover:underline"
+                      >
+                        {c.collegeName}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-gray-900 dark:text-slate-100 font-medium">
+                      {c.sectionCount}
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-gray-600 dark:text-slate-400">
+                      {c.uniqueCourses}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-600 dark:text-slate-400 text-xs">
+                      {c.topSubjects.join(", ")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {data.subjects.length > 0 && (
+          <section className="mb-10">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+              Online subjects
+            </h2>
+            <ul className="grid sm:grid-cols-2 gap-2">
+              {data.subjects.slice(0, 30).map((s) => (
+                <li key={s.prefix}>
+                  <Link
+                    href={`/${state}/subject/${s.prefix.toLowerCase()}`}
+                    className="flex items-baseline justify-between rounded-lg border border-gray-200 dark:border-slate-700 px-3 py-2 hover:border-teal-300 dark:hover:border-teal-600 transition"
+                  >
+                    <span>
+                      <span className="font-mono text-sm font-medium text-teal-600 dark:text-teal-400">
+                        {s.prefix}
+                      </span>
+                      <span className="ml-2 text-sm text-gray-700 dark:text-slate-300">
+                        {subjectName(s.prefix)}
+                      </span>
+                    </span>
+                    <span className="text-xs text-gray-500 dark:text-slate-400 shrink-0 ml-2">
+                      {s.sectionCount} sections &middot; {s.collegeCount}{" "}
+                      {s.collegeCount === 1 ? "college" : "colleges"}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,6 +13,7 @@ import { getInstructorSitemapEntries } from "@/lib/instructors";
 import { getCurrentTerm } from "@/lib/terms";
 import { getUniversitiesWithCounts } from "@/lib/transfer";
 import { getQualifyingProgramSlugs } from "@/lib/programs";
+import { loadOnlineData, onlineQualifies } from "@/lib/online";
 
 // Thin-content guard: keep in sync with the /[state]/transfer/to/[slug] page.
 const MIN_TRANSFER_HUB_COUNT = 10;
@@ -113,6 +114,20 @@ async function buildCore(): Promise<MetadataRoute.Sitemap> {
         priority: 0.85,
         lastModified: stateLastMod,
       });
+    }
+    // Online courses landing — only when threshold met
+    try {
+      const od = await loadOnlineData(s);
+      if (onlineQualifies(od)) {
+        entries.push({
+          url: `${url}/${s}/online`,
+          changeFrequency: "weekly",
+          priority: 0.85,
+          lastModified: stateLastMod,
+        });
+      }
+    } catch {
+      // skip if online data load fails
     }
   }
   return entries;

--- a/lib/online.ts
+++ b/lib/online.ts
@@ -1,0 +1,177 @@
+/**
+ * Data layer for the /[state]/online landing page (phase 4d). Focused
+ * query that pulls only online + zoom sections for the current term —
+ * smaller and faster than loadAllCourses, since most catalogs are 60–80%
+ * in-person.
+ */
+
+import { supabase } from "@/lib/supabase";
+import { loadInstitutions } from "@/lib/institutions";
+import { getCurrentTerm } from "@/lib/terms";
+
+// Threshold for the page to render at all. Same discipline as the
+// programs page (≥3 colleges, ≥10 online sections each).
+export const ONLINE_MIN_COLLEGES = 3;
+export const ONLINE_MIN_SECTIONS_PER_COLLEGE = 10;
+
+// Threshold for a row in the per-subject table to render. Keeps thin
+// rows (1–2 sections) out.
+export const ONLINE_MIN_SECTIONS_PER_SUBJECT = 5;
+
+type OnlineRow = {
+  college_code: string;
+  course_prefix: string;
+  course_number: string;
+  course_title: string;
+  mode: string;
+};
+
+export type OnlineCollegeRow = {
+  collegeCode: string;
+  collegeId: string;
+  collegeName: string;
+  sectionCount: number;
+  uniqueCourses: number;
+  topSubjects: string[];
+};
+
+export type OnlineSubjectRow = {
+  prefix: string;
+  sectionCount: number;
+  collegeCount: number;
+  uniqueCourses: number;
+};
+
+export type OnlineData = {
+  totalSections: number;
+  totalColleges: number;
+  totalUniqueCourses: number;
+  colleges: OnlineCollegeRow[];
+  subjects: OnlineSubjectRow[];
+  term: string;
+};
+
+async function loadOnlineSections(
+  state: string,
+  term: string
+): Promise<OnlineRow[]> {
+  const { count, error: countErr } = await supabase
+    .from("courses")
+    .select("id", { count: "exact", head: true })
+    .eq("state", state)
+    .eq("term", term)
+    .in("mode", ["online", "zoom"]);
+  if (countErr || !count) return [];
+
+  const PAGE = 1000;
+  const pages = Math.ceil(count / PAGE);
+  const out: OnlineRow[] = [];
+  for (let i = 0; i < pages; i++) {
+    const { data, error } = await supabase
+      .from("courses")
+      .select("college_code, course_prefix, course_number, course_title, mode")
+      .eq("state", state)
+      .eq("term", term)
+      .in("mode", ["online", "zoom"])
+      .range(i * PAGE, i * PAGE + PAGE - 1);
+    if (error) continue;
+    out.push(...(data ?? []));
+  }
+  return out;
+}
+
+export async function loadOnlineData(state: string): Promise<OnlineData | null> {
+  const term = await getCurrentTerm(state);
+  const rows = await loadOnlineSections(state, term);
+  if (rows.length === 0) return null;
+  const institutions = loadInstitutions(state);
+
+  const byCollege = new Map<string, OnlineRow[]>();
+  for (const r of rows) {
+    if (!byCollege.has(r.college_code)) byCollege.set(r.college_code, []);
+    byCollege.get(r.college_code)!.push(r);
+  }
+
+  const colleges: OnlineCollegeRow[] = [];
+  for (const [code, secs] of byCollege) {
+    const inst = institutions.find(
+      (i) => i.college_slug === code || i.id === code
+    );
+    if (!inst) continue;
+
+    const uniq = new Set(
+      secs.map((s) => `${s.course_prefix} ${s.course_number}`)
+    );
+    const subjectCounts = new Map<string, number>();
+    for (const s of secs) {
+      subjectCounts.set(
+        s.course_prefix,
+        (subjectCounts.get(s.course_prefix) ?? 0) + 1
+      );
+    }
+    const topSubjects = [...subjectCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 4)
+      .map(([p]) => p);
+
+    colleges.push({
+      collegeCode: code,
+      collegeId: inst.id,
+      collegeName: inst.name,
+      sectionCount: secs.length,
+      uniqueCourses: uniq.size,
+      topSubjects,
+    });
+  }
+  colleges.sort(
+    (a, b) =>
+      b.sectionCount - a.sectionCount ||
+      a.collegeName.localeCompare(b.collegeName)
+  );
+
+  const subjectMap = new Map<
+    string,
+    { sections: number; colleges: Set<string>; courses: Set<string> }
+  >();
+  for (const r of rows) {
+    const entry = subjectMap.get(r.course_prefix) ?? {
+      sections: 0,
+      colleges: new Set<string>(),
+      courses: new Set<string>(),
+    };
+    entry.sections += 1;
+    entry.colleges.add(r.college_code);
+    entry.courses.add(`${r.course_prefix} ${r.course_number}`);
+    subjectMap.set(r.course_prefix, entry);
+  }
+  const subjects: OnlineSubjectRow[] = [...subjectMap.entries()]
+    .filter(([, v]) => v.sections >= ONLINE_MIN_SECTIONS_PER_SUBJECT)
+    .map(([prefix, v]) => ({
+      prefix,
+      sectionCount: v.sections,
+      collegeCount: v.colleges.size,
+      uniqueCourses: v.courses.size,
+    }))
+    .sort((a, b) => b.sectionCount - a.sectionCount);
+
+  const totalUniqueCourses = new Set(
+    rows.map((r) => `${r.course_prefix} ${r.course_number}`)
+  ).size;
+
+  return {
+    totalSections: rows.length,
+    totalColleges: colleges.length,
+    totalUniqueCourses,
+    colleges,
+    subjects,
+    term,
+  };
+}
+
+export function onlineQualifies(data: OnlineData | null): boolean {
+  if (!data) return false;
+  const eligible = data.colleges.filter(
+    (c) => c.sectionCount >= ONLINE_MIN_SECTIONS_PER_COLLEGE
+  );
+  return eligible.length >= ONLINE_MIN_COLLEGES;
+}


### PR DESCRIPTION
## Summary

Net-new programmatic page targeting "online classes [state] community college" queries — currently zero coverage. Lists every college in the state offering online or zoom-delivered sections this term, with top subjects per college and a state-wide subject breakdown.

- **`lib/online.ts`** — focused supabase query (state + term + mode in `online`/`zoom`). Smaller than `loadAllCourses` since most catalogs are 60–80% in-person. Aggregates by college and by subject. Threshold: ≥3 colleges with ≥10 online sections each.
- **`app/[state]/online/page.tsx`** — server-rendered, no client JS. ItemList JSON-LD for top 25 colleges. Internal links to college detail pages and state subject pages. Breadcrumbs. ISR `revalidate=604800` (7d).
- **Sitemap** — gated entry in `core` partition, only included when `onlineQualifies()` returns true.

## Phase 4c skipped

Investigation showed `/[state]/transfer/compare` doesn't exist as a route — "compare" is an interactive view-mode tab inside the transfer client. A static comparison page would risk duplicate content with the existing `/[state]/transfer` hub and per-university `/transfer/to/[slug]` hubs. Those already provide the indexable transfer surface.

## Test plan

- [x] `/va/online` renders 24 college rows with online section counts and top subjects
- [x] Page emits ItemList JSON-LD for the top 25 colleges
- [x] Breadcrumbs render: Home / Virginia / Online Courses
- [x] Subject list links to `/[state]/subject/[prefix]` pages
- [x] No new client JS
- [ ] After merge: confirm sitemap includes `/online` entries for all 18 states (or only qualifying ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)