### PR TITLE
MD: declare aggregate-from-courses for prereqs

### DIFF
--- a/lib/states/md/config.ts
+++ b/lib/states/md/config.ts
@@ -150,7 +150,7 @@ const mdConfig: StateConfig = {
       },
     ],
     transfers: [{ scripts: ["scripts/md/scrape-transfer-artsys.ts"], runner: "http" }],
-    // manual-only: prereqs — MD prereq scraper not yet built. Tracked in #105.
+    prereqs: { source: "aggregate-from-courses" },
   },
 };
 


### PR DESCRIPTION
## Summary
Declares `prereqs: { source: "aggregate-from-courses" }` for MD. Course scrape populates `prerequisite_text` on 41.8% of sections (~9k of 21.5k across 12 colleges), so the aggregator has plenty to work with — `data/md/prereqs.json` already exists from a manual run with 2,410 courses.

Combined with #145 (now merged), MD's prereqs.json will refresh on the Sunday cron alongside VA, NC, SC, DC, GA.

Closes #105.

## Test plan
- [x] `npx tsx scripts/check-scraper-coverage.ts` → OK, 18 states × 3 datatypes.
- [x] After #145 merged, `npx tsx scripts/lib/aggregate-prereqs.ts --all` will include MD via registry derivation.
- [ ] After this PR merges, the next Sunday 07:00 UTC cron should aggregate MD and either no-op or open a fresh-data PR if course-side prereq text has shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)