### PR TITLE
VA: recognize PeopleSoft's new no-results modal (#98)

### DIFF
--- a/scripts/va/scrape-peoplesoft.ts
+++ b/scripts/va/scrape-peoplesoft.ts
@@ -242,6 +242,7 @@ async function searchSubject(page: Page, subjectLabel: string, collegeSlug: stri
 
     await page.click("#VX_CLSRCH_WRK2_SEARCH_BTN");
 
+    let modalNoResults = false;
     try {
       await page.waitForFunction(
         () => {
@@ -250,10 +251,22 @@ async function searchSubject(page: Page, subjectLabel: string, collegeSlug: stri
             text.includes("Class Nbr") ||
             text.includes("No results") ||
             text.includes("no classes found") ||
-            text.includes("exceeds the maximum")
+            text.includes("exceeds the maximum") ||
+            // 2026-05: PS upgrade moved the no-results state into a modal
+            // dialog with text "The search returns no results that match
+            // the criteria specified." Issue #98 evidence in
+            // data/va/ps-discovery/search-timeout-brcc-*.html.
+            text.includes("search returns no results")
           );
         },
         { timeout: SEARCH_WAIT }
+      );
+      // PS responded — circuit breaker is for "search is systemically
+      // broken," not for "this subject has no classes." Reset before we
+      // dismiss the modal (which strips the no-results text from the DOM).
+      consecutiveSearchFailures = 0;
+      modalNoResults = await page.evaluate(() =>
+        (document.body?.innerText || "").includes("search returns no results")
       );
     } catch (waitErr) {
       // Issue #98: post-click page never produced any of the four marker
@@ -274,15 +287,14 @@ async function searchSubject(page: Page, subjectLabel: string, collegeSlug: stri
     await sleep(1500);
     await dismissModal(page);
 
+    if (modalNoResults) return false;
+
     const bodyText = await page.evaluate(() => document.body?.innerText || "");
     if (bodyText.includes("No results") || bodyText.includes("no classes found")) {
-      consecutiveSearchFailures = 0;
       return false;
     }
 
-    const ok = bodyText.includes("Class Nbr");
-    if (ok) consecutiveSearchFailures = 0;
-    return ok;
+    return bodyText.includes("Class Nbr");
   } catch (err) {
     consecutiveSearchFailures++;
     console.error(


### PR DESCRIPTION
## The actual fix

#147 instrumented the search-timeout failure mode and dumped HTML + screenshots from the next run. The screenshot tells the whole story:

> **"The search returns no results that match the criteria specified."**

PeopleSoft replaced inline no-results text with a modal dialog. Our marker check had `text.includes("No results")` (capital N), so the lowercase "no results" in the new modal text never matched, `waitForFunction` timed out for every subject, and the circuit breaker we just shipped fired.

## What this PR changes

`scripts/va/scrape-peoplesoft.ts` `searchSubject()`:
- Adds `"search returns no results"` to the marker list `waitForFunction` watches for. That's the most distinctive substring of the new modal text and avoids false positives.
- Captures whether that string is visible *before* calling `dismissModal()` (the modal is gone after dismissal), so the function can short-circuit cleanly.
- Resets the consecutive-failure counter as soon as `waitForFunction` succeeds. The counter exists to detect "PS is systemically broken," not "this subject has no classes" — those are different signals.

`dismissModal()` is unchanged; it already finds `pt_modalMask` + the "OK" button (verified in the captured HTML).

Closes #98.

## Verification path

After merge: `gh workflow run scheduled-scrape.yml -f datatype=courses` and watch the va-courses-1 matrix entry. Expectation:
- waitForFunction resolves quickly (no 20s wait per subject).
- BRCC's Spring 2026 returns ~0 sections (most accurate — Spring is current/closing). Summer 2026 + Fall 2026 should return real data.
- The auto-PR's diff should show course-row changes for VA.

If the data lands but is sparse, that's the second-order issue: "Show Open Classes Only" is checked-by-default in the new PS UI, which excludes filled/closed sections. That's a separate enhancement (toggle the filter off before searching) — out of scope for #98.

## Refs
- Issue #98
- Predecessor: PR #147 (instrumentation that made this diagnosis possible)
- Evidence: `data/va/ps-discovery/search-timeout-brcc-*.{html,png}` (in artifact of run 25267774441)

🤖 Generated with [Claude Code](https://claude.com/claude-code)