### PR TITLE
VA PS: bump scrape job timeout to 200 min so all 3 terms finish (#98)

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -85,10 +85,12 @@ jobs:
     needs: plan
     if: needs.plan.outputs.empty == 'false'
     runs-on: ubuntu-latest
-    # 120 (not 60) so VA's vccs + peoplesoft jobs have headroom while #98
-    # selector-drift instrumentation captures evidence. Other states finish
-    # well under 60 — this is the worst-case ceiling, not the budget.
-    timeout-minutes: 120
+    # 200 (not 60 or 120) so VA's PeopleSoft scrape can finish all three
+    # terms (Spring/Summer/Fall) end-to-end. Run 25268053426 verified
+    # the PS scraper produces ~24k sections for the first two terms in
+    # ~120 min; Fall iteration adds ~60 min. Other states finish well
+    # under 60 — this is the worst-case ceiling, not the budget.
+    timeout-minutes: 200
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}


### PR DESCRIPTION
## What this PR does

Bumps `timeout-minutes` for the scheduled-scrape `scrape` matrix job from 120 to 200.

## Why

Run [25268053426](https://github.com/rohan-c0de/cc-coursemap/actions/runs/25268053426) (the verification run after #148 merged) proved the VA PeopleSoft scraper is fixed:

- **24,446 sections scraped across all 23 VA colleges** for Spring 2026 + Summer 2026.
  - NOVA: 6,377 sections
  - TCC: 3,585
  - Reynolds: 1,385
  - Germanna: 1,309
  - …
- No search-timeout dumps in the artifact (modal-recognition fix from #148 working).
- Job cancelled at the 120-min mark before Fall 2026 iteration completed.

Fall 2026 is the most important term (open registration window). Losing it would defeat the point of fixing the scraper. Empirical timing: ~120 min for two terms, extrapolated ~60 min more for the third, plus a small buffer → 200 min.

## Why this is safe for other states

- Every other state in the matrix finishes well under 60 min today; this raises the worst-case ceiling, not the budget.
- The fail-fast circuit breaker added in #147 still aborts at ~100s if PS (or any other scraper) is systemically broken — so a stuck job won't run for 200 min, only legitimate long-running jobs will.

## Closes #98

Once this lands and the next courses cron fires (or via `gh workflow run scheduled-scrape.yml -f datatype=courses`), VA PS data for all three terms should land in an auto-PR.

## Test plan

- [x] Yaml change is valid.
- [ ] After merge: trigger workflow_dispatch, watch va-courses-1 complete (not cancel) within ~180 min, and produce `2026FA.json` files alongside the existing `2026SP.json` / `2026SU.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)