### PR TITLE
fix: ship missing MA transfer-credit blog MDX (404 on /blog/massachusetts-…)

### DIFF
--- a/content/blog/massachusetts-community-college-transfer-credit-guide.mdx
+++ b/content/blog/massachusetts-community-college-transfer-credit-guide.mdx
@@ -1,0 +1,101 @@
+Massachusetts has 15 community colleges — from Bunker Hill in Boston to Berkshire in the Berkshires — and a state-run transfer database (MassTransfer) that publishes equivalencies into 13 different state and UMass receiving institutions. On paper, MA has one of the most generous transfer infrastructures in the country: about 46,000 published course mappings, all in one place, all updated by the state. In practice, whether your specific course actually counts toward your degree is more complicated — and the published data shows exactly where the gaps are.
+
+If you're at any MassCC college and planning to transfer, here's what MassTransfer is, what it isn't, and how to use it without ending up with credits that don't move you toward graduation.
+
+## What MassTransfer is
+
+MassTransfer is a Commonwealth-run equivalency database. Unlike states where each university publishes its own transfer table independently (Pennsylvania, for example), Massachusetts maintains a single source of truth covering all 15 community colleges paired with the nine state universities, four UMass campuses, and a few specialized institutions like Mass Maritime and MassArt.
+
+The coverage is uniform — that's the unusual part. Even the colleges with locked-down internal scheduling systems (Massasoit, Cape Cod, QCC, Roxbury, MassBay) appear in MassTransfer alongside the bigger ones. If you take a course at any MA community college, you can look up exactly how it maps at any of the receiving institutions.
+
+That density is real. But density does not equal direct match.
+
+## The number that surprises people
+
+For every receiving university in MassTransfer, the database tags each mapping as either a direct course-to-course match or as elective credit. The split varies dramatically by institution:
+
+- **Bridgewater State University:** 4,501 mappings, 62% as elective credit
+- **University of Massachusetts at Amherst:** 5,294 mappings, 54% as elective credit
+- **Worcester State University:** 5,841 mappings, 53% as elective credit
+- **Framingham State University:** 3,451 mappings, 68% as elective credit
+- **University of Massachusetts at Lowell:** 1,820 mappings, 21% as elective credit
+- **Massachusetts Maritime Academy:** 476 mappings, under 1% as elective credit
+
+Read that again. At the most popular transfer destination in the state — UMass Amherst — more than half of the published equivalencies come back as elective credit, not as a direct match to a specific UMass course. At Framingham State, it's two out of three.
+
+This is the trap. A student looks up their course, sees a green checkmark on MassTransfer, and assumes it counts. The credit transfers. But [the difference between a direct match and elective credit](/blog/what-direct-match-vs-elective-credit-means) determines whether you've moved closer to graduating or just added hours to your transcript.
+
+## Why the elective-credit rate is so high at some schools
+
+The pattern in the data is consistent: the more selective and faculty-controlled the receiving institution, the more often community college courses get redirected to elective credit even when the content lines up.
+
+- **UMass Lowell** (21% elective) has a smaller equivalency table overall — the courses they map at all, they tend to map directly. Their faculty have signed off on each one.
+- **Mass Maritime** (under 1% elective) is highly specialized — they only map courses that fit their narrow program structure, but when they do, those are the named equivalents.
+- **Bridgewater, Framingham, Worcester State** — the comprehensive state universities — accept a much broader range of courses but reserve their own course slots more aggressively, especially for major requirements.
+
+The practical takeaway: dense coverage at a school is not the same as friendly coverage. Lowell publishes fewer mappings but more of them count. Bridgewater publishes thousands but the majority just stack up as electives.
+
+## How to read a MassTransfer entry
+
+When you look up your community college course in MassTransfer, the entry will show you something like:
+
+```
+Berkshire CC: ENG 101 (English Composition I, 3 cr)
+→ UMass Amherst: ENGLWRIT 112 (College Writing, 3 cr)
+```
+
+That's a direct match. ENGLWRIT 112 satisfies UMass's general education writing requirement, so your Berkshire course does too.
+
+Compare that to:
+
+```
+Berkshire CC: AHS 150 (Introduction to Nutrition, 3 cr)
+→ Bridgewater State: Health Elective (3 cr)
+```
+
+The credits transfer. But "Health Elective" is a generic bucket — it doesn't satisfy any specific Bridgewater requirement. If you don't need a free elective in your degree plan, you've burned a course slot.
+
+The rule: if the receiving column shows a real course number (`ENGLWRIT 112`, `BIOL 121`, `MATH 131`), it's a direct match. If it shows something generic — `Elective`, `Free Elective`, `1XX`, or just a category name like `Health Elective` — it's elective credit only.
+
+## How MassTransfer relates to MassTransfer Pathways
+
+A quick disambiguation that trips up a lot of students: MassTransfer (the equivalency database) is not the same as MassTransfer Pathways (the structured degree program).
+
+- **MassTransfer (equivalency)** = the course-by-course lookup table this whole article is about.
+- **MassTransfer Pathways (A2B)** = a set of associate degrees designed so that all 60+ credits transfer as a block to a partnering UMass or state university program in your major. Complete the Pathway with a 2.5+ GPA and you get guaranteed admission and full junior standing.
+
+If you're committed to a major and a destination, the Pathway program is almost always the better play than course-by-course planning. Fewer surprises, fewer elective-credit landmines, fewer credits to retake.
+
+But if you're undecided, switching majors mid-stream, or transferring to a school that isn't in the Pathway list, you're back in equivalency-table territory — and the elective-credit risk is real.
+
+<ProductCallout
+  text="Community College Path's transfer lookup pulls directly from the MassTransfer dataset so you can see direct match vs elective credit for each course at each receiving university — before you register."
+  feature="transfer"
+  label="Check MA Transfer Equivalencies"
+/>
+
+## Three checks before you register
+
+1. **Pick the destination first.** A course that's a direct match at UMass Lowell can be elective credit at UMass Amherst. The same course at the same community college, two different outcomes. Choose your destination before you choose your courses, not after.
+2. **Look up each course individually.** Don't trust degree-plan summaries. Pull the MassTransfer entry for the exact course code you're considering and read the receiving column.
+3. **If you're aiming at a Pathway, follow the Pathway exactly.** A2B programs only deliver their guarantees if you complete the prescribed course list with the prescribed grade minimums. Substituting one course for another usually breaks the guarantee.
+
+For courses that come back as elective credit, ask yourself: do I actually need elective credits in my degree, or am I going to need to retake the named version of this course at the four-year level anyway? If it's the second one, find a different community college course that maps directly.
+
+## Where the data is thinnest
+
+MassTransfer covers public Massachusetts colleges and universities thoroughly. It does not cover:
+
+- **Private universities** in Massachusetts (Boston University, Northeastern, Tufts, Boston College, Brandeis, etc.) — each runs its own transfer evaluation, usually with smaller credit acceptance. Boston-area privates frequently cap accepted transfer credit at 60 hours and re-evaluate technical or upper-division courses individually.
+- **Out-of-state public universities** — you'll need to submit transcripts for case-by-case evaluation. Expect the receiving institution to ask for syllabi for any STEM or major-required course.
+- **Highly specialized programs** — nursing, allied health, engineering at UMass Lowell, business at UMass Amherst Isenberg — often have additional restrictions even when the MassTransfer equivalency shows a direct match. A course can be a direct match for general purposes and still need to be retaken inside the major. Always check with the receiving department, not just the equivalency table.
+
+If your destination falls into any of these buckets, MassTransfer gets you part of the way and you'll need to follow up with the receiving institution's transfer office. Build that follow-up into your planning timeline — three weeks before registration, not three days.
+
+## The bottom line
+
+Massachusetts gives transfer students more raw equivalency data than almost any other state. That's a genuine asset. But the data shows — clearly, by the numbers — that even with dense coverage, more than half of the published mappings to the most popular destinations are elective credit, not direct match.
+
+Use MassTransfer as a planning tool, not a guarantee. Look up each course. Read the receiving column carefully. Prefer Pathway programs when they fit your major. And before you commit to a course, [check whether it transfers as a direct match to a specific course at your target university or whether it just becomes elective credit](/blog/comparing-transfer-credit-across-universities).
+
+Search and plan your MA community college courses at [Community College Path Massachusetts](/ma). The transfer lookup shows you the MassTransfer outcome for each course, at each receiving university, before you register.


### PR DESCRIPTION
## Summary

`/blog/massachusetts-community-college-transfer-credit-guide` is currently a 404 in prod. The article was registered in [content/blog/index.ts:460](content/blog/index.ts#L460) (so `generateStaticParams()`, the sitemap, and the blog index all expose the URL) but the actual MDX body was never committed — it has been sitting untracked locally. At build time on Vercel, `import('@/content/blog/${slug}.mdx')` throws, falls into the `catch { notFound() }` branch in [app/blog/[slug]/page.tsx:58-63](app/blog/[slug]/page.tsx#L58-L63), and Next renders a 404.

This PR commits the MDX as authored (101 lines, finished article — intro, MassTransfer explainer, the elective-credit-rate breakdown by receiving university, internal links to two related blog posts and to `/ma`).

## Test plan
- [x] Locally `/blog/massachusetts-community-college-transfer-credit-guide` rendered fine before this PR (because the file existed locally) — that's why the bug wasn't caught
- [ ] After merge + Vercel deploy: `curl -s -o /dev/null -w "%{http_code}\n" https://communitycollegepath.com/blog/massachusetts-community-college-transfer-credit-guide` should return 200
- [ ] Spot-check the article renders with article header, body, and the "Use the Massachusetts tools" CTA (from PR #131, since `state: "ma"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)