### PR TITLE
ci: blog integrity check (registered slug ↔ MDX file)

### DIFF
--- a/.github/workflows/blog-integrity.yml
+++ b/.github/workflows/blog-integrity.yml
@@ -1,0 +1,22 @@
+name: Blog integrity
+
+on:
+  pull_request:
+    paths:
+      - "content/blog/**"
+      - "scripts/check-blog-mdx.ts"
+      - ".github/workflows/blog-integrity.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run check:blog-mdx

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:scrapers": "tsx scripts/check-scraper-coverage.ts",
     "check:scraper-terms": "tsx scripts/check-scraper-term-hardcoding.ts",
     "check:data": "tsx scripts/check-data-integrity.ts",
+    "check:blog-mdx": "tsx scripts/check-blog-mdx.ts",
     "scrape": "tsx scripts/scrape-vccs.ts",
     "scrape:college": "tsx scripts/scrape-vccs.ts --college",
     "discover:ps": "tsx scripts/discover-ps-responses.ts",

--- a/scripts/check-blog-mdx.ts
+++ b/scripts/check-blog-mdx.ts
@@ -1,0 +1,56 @@
+/**
+ * Blog content integrity check.
+ *
+ * For every article registered in `content/blog/index.ts`, verifies that
+ * the matching `<slug>.mdx` file exists. Also flags orphan MDX files
+ * present on disk but missing from the index.
+ *
+ * Why this matters: `app/blog/[slug]/page.tsx` calls
+ * `generateStaticParams()` from the index, so every registered slug gets
+ * a route + sitemap entry. The page body is then loaded via
+ * `import('@/content/blog/${slug}.mdx')` — if the file is missing, the
+ * import throws and the route falls into `catch { notFound() }`,
+ * producing a 404 in prod that the build does not flag. PR #156 fixed
+ * one such silent miss; this check prevents the next one.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { articles } from "../content/blog/index";
+
+const ROOT = resolve(__dirname, "..");
+const BLOG_DIR = resolve(ROOT, "content/blog");
+const errors: string[] = [];
+
+const registeredSlugs = new Set(articles.map((a) => a.slug));
+
+for (const article of articles) {
+  const path = resolve(BLOG_DIR, `${article.slug}.mdx`);
+  if (!existsSync(path)) {
+    errors.push(
+      `Missing MDX for registered slug "${article.slug}" — expected at content/blog/${article.slug}.mdx`
+    );
+  }
+}
+
+const onDiskMdx = readdirSync(BLOG_DIR)
+  .filter((f) => f.endsWith(".mdx"))
+  .map((f) => f.replace(/\.mdx$/, ""));
+
+for (const slug of onDiskMdx) {
+  if (!registeredSlugs.has(slug)) {
+    errors.push(
+      `Orphan MDX at content/blog/${slug}.mdx — slug not registered in content/blog/index.ts`
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Blog integrity check failed:");
+  for (const e of errors) console.error("  -", e);
+  process.exit(1);
+}
+
+console.log(
+  `OK: ${articles.length} registered slugs all match an MDX file; no orphans.`
+);


### PR DESCRIPTION
## Summary

Follow-up to [#156](https://github.com/rohan-c0de/cc-coursemap/pull/156). Adds CI that catches the class of bug behind that fix: a blog slug registered in `content/blog/index.ts` whose `.mdx` body was never committed produces a 404 in prod, but the build does not fail and nothing surfaces it locally if the file exists on the author's filesystem.

The check enforces both directions:

- **Missing MDX**: every registered slug must have a matching `content/blog/<slug>.mdx`. (This is what #156 fixed — caught here it would have been a CI failure on the PR that registered the article, not a 404 in prod.)
- **Orphan MDX**: every `.mdx` on disk must be registered in `content/blog/index.ts`. (Without this, a deployed file would have no sitemap entry and no metadata — a dark URL.)

Modeled on the existing [scripts/check-registry-integrity.ts](scripts/check-registry-integrity.ts) and [.github/workflows/registry-integrity.yml](.github/workflows/registry-integrity.yml). New script: `npm run check:blog-mdx`. New workflow runs on PRs that touch `content/blog/**` or the script itself.

## Merge order

**This PR's CI fails until #156 merges**, by design — that's the demonstration the check works against the existing bug. Merge order:

1. Merge [#156](https://github.com/rohan-c0de/cc-coursemap/pull/156) first (ships the missing MA MDX).
2. Rebase this PR on main (or just push an empty commit to retrigger CI). Check turns green.
3. Merge.

## Test plan
- [x] Local: with the MA MDX missing, `npm run check:blog-mdx` exits 1 and prints the missing slug
- [x] Local: with an extra orphan MDX file, the same check prints the orphan and exits 1
- [ ] After #156 merges and this rebases: CI green
- [ ] Future PR that registers a slug without an MDX file: this workflow fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)