### PR TITLE
SC: harden transfer scraper against transient connect timeouts (#99)

### DIFF
--- a/scripts/sc/scrape-transfer-universities.ts
+++ b/scripts/sc/scrape-transfer-universities.ts
@@ -73,15 +73,33 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-async function fetchJSON<T = unknown>(url: string): Promise<T> {
-  const resp = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
-    },
-  });
-  if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${url}`);
-  return resp.json() as Promise<T>;
+// Issue #99: USC's banner.onecarolina.sc.edu host occasionally drops a TCP
+// connect from the GH Actions runner. undici's default fetch has a 10s
+// connect timeout and no retry, so a single SYN drop killed the whole job
+// on 4/26 + 4/29. Retry with linear backoff and an explicit 30s signal.
+async function fetchJSON<T = unknown>(url: string, attempts = 4): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const resp = await fetch(url, {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+        },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status} for ${url}`);
+      return (await resp.json()) as T;
+    } catch (e) {
+      lastErr = e;
+      if (i < attempts - 1) {
+        const delay = 2_000 * (i + 1);
+        console.warn(`    ⚠ fetch attempt ${i + 1}/${attempts} failed (${(e as Error).message}); retrying in ${delay}ms`);
+        await sleep(delay);
+      }
+    }
+  }
+  throw lastErr;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,10 +283,30 @@ async function main() {
     process.exit(1);
   }
 
+  // Isolate per-university failures (#99): one university's transient host
+  // failure must not blackhole the rest. Retry exhaustion in fetchJSON still
+  // throws here; we log + continue rather than aborting the merge step.
   const newMappings: TransferMapping[] = [];
+  const succeededUniversities: UniversityConfig[] = [];
+  const failures: { university: string; error: string }[] = [];
   for (const univ of targets) {
-    const mappings = await scrapeUniversity(univ);
-    newMappings.push(...mappings);
+    try {
+      const mappings = await scrapeUniversity(univ);
+      newMappings.push(...mappings);
+      succeededUniversities.push(univ);
+    } catch (e) {
+      const msg = (e as Error).message;
+      console.error(`\n  ✗ ${univ.name} failed: ${msg}\n  Continuing to next university; existing rows preserved.`);
+      failures.push({ university: univ.name, error: msg });
+    }
+  }
+
+  if (failures.length === targets.length) {
+    console.error(`\nAll ${targets.length} universities failed. Aborting before write to avoid wiping existing data.`);
+    process.exit(1);
+  }
+  if (failures.length > 0) {
+    console.warn(`\n⚠ ${failures.length}/${targets.length} universities failed; their prior rows are kept untouched.`);
   }
 
   // Filter out no-credit entries
@@ -281,8 +319,9 @@ async function main() {
     existing = JSON.parse(fs.readFileSync(outPath, "utf8"));
   }
 
-  // Remove old entries for universities we just scraped
-  const scrapedSlugs = new Set(targets.map((t) => t.slug));
+  // Remove old entries only for universities that SUCCEEDED — failed
+  // universities keep their prior rows so a transient outage doesn't wipe data.
+  const scrapedSlugs = new Set(succeededUniversities.map((t) => t.slug));
   const kept = existing.filter((m) => !scrapedSlugs.has(m.university));
 
   const merged = [...kept, ...transferable];


### PR DESCRIPTION
## Diagnosis

Pulled the failing run logs (`gh run view 25106134426 --job=73567840439 --log`):

```
=== University of South Carolina (usc) ===
  Found 17 SC technical colleges
  Aiken Technical College...
TypeError: fetch failed
  [cause]: ConnectTimeoutError: Connect Timeout Error
           (attempted address: banner.onecarolina.sc.edu:443, timeout: 10000ms)
  code: 'UND_ERR_CONNECT_TIMEOUT'
```

- Failed scraper: `scripts/sc/scrape-transfer-universities.ts` (clemson finished cleanly in the same job).
- Failed at the very first `getEquivalencies()` call inside the USC loop.
- Host `banner.onecarolina.sc.edu` is up and fast right now (`time_total=0.18s`, code 200) — it was reachable on the 5/2 cron that succeeded.
- No commits to the script in weeks (last touch: #79 dedupe fix). This isn't a regression; it's long-standing fragility.
- One bad request killed USC + USC Upstate + CofC for the whole run because the main loop has no per-university try/catch.

## What this PR changes

1. **`fetchJSON` retries with backoff.** Previously 10s default connect timeout, no retry. Now 4 attempts with 2s/4s/6s linear backoff and an explicit `AbortSignal.timeout(30_000)`.

2. **Per-university failure isolation.** `main()` now wraps each university in its own try/catch. A failure logs + continues; the run completes with whatever data did land.

3. **Merge step preserves data on partial failure.** Previously the merge step removed all existing rows for every targeted university before writing — meaning a USC transient failure would wipe USC's prior data. Now only universities that *succeeded* get their existing rows replaced; failed universities keep prior data untouched.

4. **Abort before write if every university failed.** Prevents an all-empty merge from clobbering everything.

## Why no instrument-first PR

Unlike #98 where we couldn't see the post-click HTML, here the failure is unambiguous — full stack trace, host, exact timeout duration in the log. Direct fix is appropriate.

Closes #99.

## Test plan

- [x] Script parses + rejects unknown university arg.
- [x] No new type errors.
- [ ] After merge: next transfer cron (Wed/Sat 10:00 UTC) or `gh workflow run scheduled-scrape.yml -f datatype=transfers` should land green for SC. If a connect timeout recurs, `fetchJSON` retries silently or fails over per-university.

## Refs
- Failed run: 25106134426 (4/29)
- Last green: 25250153933 (5/2)
- Files: `scripts/sc/scrape-transfer-universities.ts:76-103, 286-336`

🤖 Generated with [Claude Code](https://claude.com/claude-code)