### PR TITLE
Fix HTTP 500 on unregistered state routes (#158)

### DIFF
--- a/app/[state]/about/page.tsx
+++ b/app/[state]/about/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
-
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 type Props = {
   params: Promise<{ state: string }>;
 };
@@ -12,7 +12,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   return {
     title: `About — ${config.branding.siteName}`,
     description: `Learn about ${config.branding.siteName} — search courses, check transfer equivalencies, build schedules, and find auditing info for ${config.name} community colleges.`,
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function AboutPage({ params }: Props) {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 
   const faqLd = {

--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -9,7 +9,8 @@ import {
   trimCoursesForClient,
 } from "@/lib/courses";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { subjectName } from "@/lib/subjects";
 import SubjectTermSection from "./SubjectTermSection";
@@ -65,7 +66,7 @@ export function generateStaticParams() {
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { state, id, prefix: rawPrefix } = await props.params;
   const prefix = rawPrefix.toUpperCase();
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const institutions = loadInstitutions(state);
   const institution = institutions.find((i) => i.id === id);
 
@@ -126,7 +127,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 export default async function SubjectPage(props: PageProps) {
   const { state, id, prefix: rawPrefix } = await props.params;
   const prefix = rawPrefix.toUpperCase();
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const institutions = loadInstitutions(state);
   const institution = institutions.find((i) => i.id === id);
 

--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -14,7 +14,8 @@ import type { Metadata } from "next";
 import { loadInstitutions } from "@/lib/institutions";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
 import { getAvailableTerms } from "@/lib/courses";
-import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getInstructorBySlug, getTopInstructors, type InstructorProfile } from "@/lib/instructors";
 import { subjectName } from "@/lib/subjects";
 import type { CourseSection } from "@/lib/types";
@@ -113,7 +114,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const institution = institutions.find((i) => i.id === id);
   if (!institution) return { title: "Not Found" };
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const result = await findInstructor(institution.college_slug, state, slug);
   if (!result) return { title: "Not Found" };
   const { profile, term: resolvedTerm } = result;
@@ -160,7 +161,7 @@ export default async function InstructorPage(props: PageProps) {
   const institution = institutions.find((i) => i.id === id);
   if (!institution) notFound();
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const result = await findInstructor(institution.college_slug, state, slug);
   if (!result) notFound();
   const { profile, term: resolvedTerm } = result;

--- a/app/[state]/college/[id]/opengraph-image.tsx
+++ b/app/[state]/college/[id]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { loadInstitutions } from "@/lib/institutions";
-import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getCourseCount } from "@/lib/courses";
 import { getCurrentTerm } from "@/lib/terms";
 
@@ -25,7 +26,7 @@ export default async function Image({
     return new ImageResponse(<div>Not Found</div>, { ...size });
   }
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const allowed = institution.audit_policy.allowed;
   const currentTerm = await getCurrentTerm(state);
   const courseCount = await getCourseCount(

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -12,7 +12,8 @@ import { getCurrentTerm } from "@/lib/terms";
 import CollegeMap from "./CollegeMap";
 import CollegeTermSection from "./CollegeTermSection";
 import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getTopInstructors } from "@/lib/instructors";
 import type { CourseSection } from "@/lib/types";
 import AdUnit from "@/components/AdUnit";
@@ -36,7 +37,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   if (!institution) return { title: "College Not Found" };
 
   return {
-    title: `${institution.name} — Courses & Transfer Info | Community College Path ${getStateConfig(state).name}`,
+    title: `${institution.name} — Courses & Transfer Info | Community College Path ${requireStateConfig(state).name}`,
     description: `Find out how to audit courses at ${institution.name}. ${
       institution.audit_policy.allowed
         ? "Auditing is available."
@@ -54,7 +55,7 @@ export function generateStaticParams() {
 
 export default async function CollegeDetailPage(props: PageProps) {
   const { state, id } = await props.params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const institutions = loadInstitutions(state);
   const institution = institutions.find((i) => i.id === id);
 

--- a/app/[state]/colleges/page.tsx
+++ b/app/[state]/colleges/page.tsx
@@ -3,8 +3,8 @@ import type { Metadata } from "next";
 import { loadInstitutions } from "@/lib/institutions";
 import { getCourseCount } from "@/lib/courses";
 import { getCurrentTerm } from "@/lib/terms";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
-
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 export const revalidate = 86400; // Revalidate daily so new course imports show up
 
 type Props = {
@@ -17,7 +17,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   return {
     title: `All ${config.collegeCount} ${config.systemName} Colleges — ${config.branding.siteName}`,
     description: `Browse all ${config.name} community colleges — see course counts, transfer data, and campus locations.`,
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function CollegesPage({ params }: Props) {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const institutions = loadInstitutions(state);
 
   // Sort alphabetically

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -4,7 +4,8 @@ import type { Metadata } from "next";
 import { loadInstitutions } from "@/lib/institutions";
 import { loadCourseByCode, loadCoursesBySubject } from "@/lib/courses";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
-import { getStateConfig, getAllStates, isValidState } from "@/lib/states/registry";
+import { getAllStates, isValidState, getStateConfig } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getTransferInfo, getUniversities } from "@/lib/transfer";
 import { subjectName } from "@/lib/subjects";
 import type { CourseSection } from "@/lib/types";
@@ -134,7 +135,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const parsed = parseCode(code);
   if (!parsed) return { title: "Not Found" };
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const currentTerm = await getCurrentTerm(state);
   const sections = await loadCourseByCode(parsed.prefix, parsed.number, currentTerm, state);
 
@@ -195,7 +196,7 @@ export default async function CoursePage(props: PageProps) {
   if (!parsed) notFound();
 
   const { prefix, number } = parsed;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const institutions = loadInstitutions(state);
   const currentTerm = await getCurrentTerm(state);
 

--- a/app/[state]/courses/page.tsx
+++ b/app/[state]/courses/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import CourseSearchClient from "./CourseSearchClient";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { loadInstitutions } from "@/lib/institutions";
 
 type Props = {
@@ -13,7 +14,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   return {
     title: `Find a Course — Search All ${config.collegeCount} ${config.systemName} Colleges | ${config.branding.siteName}`,
     description: `Search for courses across all ${config.collegeCount} ${config.name} community colleges at once. Find the best schedule, location, and format for auditing.`,
@@ -24,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function CoursesPage({ params }: Props) {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 
   const breadcrumbLd = {

--- a/app/[state]/layout.tsx
+++ b/app/[state]/layout.tsx
@@ -2,12 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import Header from "@/components/Header";
-import {
-  getStateConfig,
-  hasPrereqsCoverage,
-  isValidState,
-} from "@/lib/states/registry";
-
+import { hasPrereqsCoverage, isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 type Props = {
   children: React.ReactNode;
   params: Promise<{ state: string }>;
@@ -16,7 +12,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
   if (!isValidState(state)) return {};
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const b = config.branding;
 
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
@@ -46,7 +42,7 @@ export default async function StateLayout({ children, params }: Props) {
   const { state } = await params;
   if (!isValidState(state)) notFound();
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const b = config.branding;
   const baseUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";

--- a/app/[state]/online/page.tsx
+++ b/app/[state]/online/page.tsx
@@ -10,7 +10,8 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { termLabel } from "@/lib/terms";
 import { subjectName } from "@/lib/subjects";
 import { loadOnlineData, onlineQualifies } from "@/lib/online";
@@ -31,7 +32,7 @@ function siteUrl(): string {
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { state } = await props.params;
   if (!isValidState(state)) return { title: "Not Found" };
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const data = await loadOnlineData(state);
   if (!onlineQualifies(data) || !data) return { title: "Not Found" };
 
@@ -69,7 +70,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 export default async function OnlinePage(props: PageProps) {
   const { state } = await props.params;
   if (!isValidState(state)) notFound();
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const data = await loadOnlineData(state);
   if (!onlineQualifies(data) || !data) notFound();
 

--- a/app/[state]/opengraph-image.tsx
+++ b/app/[state]/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from "next/og";
-import { getStateConfig, isValidState } from "@/lib/states/registry";
-
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 export const runtime = "nodejs";
 export const alt = "Community College Path — Community College Course Finder";
 export const size = { width: 1200, height: 630 };
@@ -16,7 +16,7 @@ export default async function Image({
     return new ImageResponse(<div>Not Found</div>, { ...size });
   }
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const b = config.branding;
 
   return new ImageResponse(

--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -5,7 +5,8 @@ import SearchForm from "@/components/SearchForm";
 import StartingSoonCallout from "@/components/StartingSoonCallout";
 import NotifyBanner from "@/components/NotifyBanner";
 import { getNextTerm } from "@/lib/terms";
-import { getStateConfig, getAllStates, isValidState } from "@/lib/states/registry";
+import { getAllStates, isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getArticlesByState, categoryLabel } from "@/lib/blog";
 import { getQualifyingProgramSlugs, getProgramBySlug } from "@/lib/programs";
 import { loadOnlineData, onlineQualifies } from "@/lib/online";
@@ -21,7 +22,7 @@ export function generateStaticParams() {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
   if (!isValidState(state)) return { title: "Not Found" };
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const b = config.branding;
   return {
     title: `${config.name} Community College Course Finder`,
@@ -34,7 +35,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function HomePage({ params }: Props) {
   const { state } = await params;
   if (!isValidState(state)) notFound();
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const nextTerm = await getNextTerm(state);
   const stateArticles = getArticlesByState(state).slice(0, 4);
   const siteUrl =

--- a/app/[state]/plan/page.tsx
+++ b/app/[state]/plan/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import PlannerClient from "./PlannerClient";
 
 type Props = {
@@ -12,7 +13,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   return {
     title: `Semester Planner — ${config.branding.siteName}`,
     description: `Plan your course sequence at ${config.name} community colleges. Automatically maps prerequisites into a semester-by-semester plan so you know exactly what to take and when.`,
@@ -22,7 +23,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function PlanPage({ params }: Props) {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
 
   return (
     <PlannerClient

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -12,7 +12,8 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
 import {
   loadProgramData,
@@ -45,7 +46,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const program = getProgramBySlug(slug);
   if (!program) return { title: "Not Found" };
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const data = await loadProgramData(state, slug);
   if (!data || !qualifies(data)) return { title: "Not Found" };
 
@@ -89,7 +90,7 @@ export default async function ProgramPage(props: PageProps) {
   const data = await loadProgramData(state, slug);
   if (!data || !qualifies(data)) notFound();
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const term = await getCurrentTerm(state);
   const url = siteUrl();
 

--- a/app/[state]/results/page.tsx
+++ b/app/[state]/results/page.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import ResultsContent from "./ResultsContent";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
-
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 type Props = {
   params: Promise<{ state: string }>;
 };
@@ -13,7 +13,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   return {
     title: `Search Results — ${config.branding.siteName}`,
     description: `Community colleges near you in ${config.name} that offer course auditing.`,

--- a/app/[state]/schedule/page.tsx
+++ b/app/[state]/schedule/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import ScheduleClient from "./ScheduleClient";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getUniversities } from "@/lib/transfer";
 import { getAvailableTermsForDisplay } from "@/lib/terms";
 
@@ -14,7 +15,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   return {
     title: `Smart Schedule Builder — ${config.branding.siteName}`,
     description: `Build conflict-free course schedules across all ${config.collegeCount} ${config.name} community colleges. Set your constraints and get personalized schedule suggestions.`,
@@ -24,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function SchedulePage({ params }: Props) {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
 
   // Load available transfer universities and terms for this state
   let universities: { slug: string; name: string }[] = [];

--- a/app/[state]/starting-soon/page.tsx
+++ b/app/[state]/starting-soon/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import StartingSoonClient from "./StartingSoonClient";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import Breadcrumbs from "@/components/Breadcrumbs";
 
 type Props = {
@@ -13,7 +14,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   return {
     title: `Courses Starting Soon — Late-Start Classes | ${config.branding.siteName}`,
     description: `Find late-start courses, mini-sessions, and upcoming classes across all ${config.collegeCount} ${config.name} community colleges. Don't miss registration deadlines.`,
@@ -23,7 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function StartingSoonPage({ params }: Props) {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -14,7 +14,8 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { loadCoursesBySubject, getDistinctSubjects } from "@/lib/courses";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
-import { getStateConfig, isValidState } from "@/lib/states/registry";
+import { isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { subjectName } from "@/lib/subjects";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
@@ -43,7 +44,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   if (!isValidState(state)) return { title: "Not Found" };
 
   const prefix = rawPrefix.toUpperCase();
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const currentTerm = await getCurrentTerm(state);
   const filtered = await loadCoursesBySubject(prefix, currentTerm, state);
 
@@ -145,7 +146,7 @@ export default async function StateSubjectPage(props: PageProps) {
   if (!isValidState(state)) notFound();
 
   const prefix = rawPrefix.toUpperCase();
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   const currentTerm = await getCurrentTerm(state);
   const sections = await loadCoursesBySubject(prefix, currentTerm, state);
   if (sections.length === 0) notFound();

--- a/app/[state]/transfer/page.tsx
+++ b/app/[state]/transfer/page.tsx
@@ -8,7 +8,8 @@ import {
 } from "@/lib/transfer";
 import { loadAllCourses } from "@/lib/courses";
 import { getCurrentTerm } from "@/lib/terms";
-import { getStateConfig, getAllStates } from "@/lib/states/registry";
+import { getAllStates } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import TransferClient from "./TransferClient";
 
 // Render on demand — some states' transfer data exceeds Vercel's ISR size limit
@@ -26,7 +27,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   if (!config.transferSupported) return {};
   return {
     title: `Transfer Course Finder — Which ${config.systemName} Courses Transfer? | ${config.branding.siteName}`,
@@ -38,7 +39,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function TransferPage({ params }: Props) {
   const { state } = await params;
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   if (!config.transferSupported) notFound();
   const universities = await getUniversities(state);
   const defaultUni = universities[0]?.slug || "";

--- a/app/[state]/transfer/to/[universitySlug]/page.tsx
+++ b/app/[state]/transfer/to/[universitySlug]/page.tsx
@@ -9,7 +9,8 @@ import {
   TRANSFER_HUB_MAX_CLIENT_MAPPINGS,
 } from "@/lib/transfer";
 import { loadInstitutions } from "@/lib/institutions";
-import { getStateConfig, getAllStates, isValidState } from "@/lib/states/registry";
+import { getAllStates, isValidState } from "@/lib/states/registry";
+import { requireStateConfig } from "@/lib/states/route-helpers";
 import { subjectName } from "@/lib/subjects";
 import type { TransferMapping } from "@/lib/types";
 import TransferHubClient from "./TransferHubClient";
@@ -65,7 +66,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { state, universitySlug } = await props.params;
   if (!isValidState(state)) return { title: "Not Found" };
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   if (!config.transferSupported) return { title: "Not Found" };
 
   const universities = await getUniversitiesWithCounts(state);
@@ -112,7 +113,7 @@ export default async function TransferHubPage(props: PageProps) {
   const { state, universitySlug } = await props.params;
   if (!isValidState(state)) notFound();
 
-  const config = getStateConfig(state);
+  const config = requireStateConfig(state);
   if (!config.transferSupported) notFound();
 
   const universities = await getUniversitiesWithCounts(state);

--- a/lib/states/route-helpers.ts
+++ b/lib/states/route-helpers.ts
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { getStateConfig, isValidState, type StateConfig } from "./registry";
+
+/**
+ * Server-only wrapper for `getStateConfig` that triggers Next's 404 handler
+ * (HTTP 404, not 500) when the slug isn't a registered state. Use this in
+ * any `app/[state]/**` route component or `generateMetadata` instead of
+ * calling `getStateConfig` directly — the latter throws, which Next renders
+ * as a 500 server-error page.
+ *
+ * Issue #158: prior to this helper, navigating to /<unregistered>/colleges
+ * (or /courses, /plan, /college/[id], etc.) crashed the route with a real
+ * 500 instead of returning a clean 404. Pulled into its own module so
+ * `lib/states/registry.ts` stays Next-agnostic — Node CLI scripts
+ * (scrape-matrix, check-scraper-coverage) import the registry without
+ * dragging in `next/navigation`.
+ */
+export function requireStateConfig(slug: string): StateConfig {
+  if (!isValidState(slug)) notFound();
+  return getStateConfig(slug);
+}


### PR DESCRIPTION
## Diagnosis

Production was returning HTTP **500** on multiple KY routes because KY isn't in the registry. Confirmed via curl:

```
500 /ky/about
500 /ky/colleges
500 /ky/courses
500 /ky/results
500 /ky/plan
500 /ky/schedule
500 /ky/starting-soon
500 /ky/college/foo
500 /ky/college/foo/courses/ENG
```

Some routes already 404'd cleanly (`/ky`, `/ky/transfer`, `/ky/online`, `/ky/subject/...`, `/ky/program/...`, `/ky/course/...`) because they had explicit `isValidState` guards. The 500s were on routes that called `getStateConfig(state)` directly — that throws `Unknown state: "ky"`, which Next renders as a generic server-error page.

## What this PR changes

1. **New helper `lib/states/route-helpers.ts`** exports `requireStateConfig(slug)` — same as `getStateConfig` but calls `notFound()` (clean 404) instead of throwing for unknown slugs.
2. **Mass-replaced `getStateConfig` with `requireStateConfig` in all 20 `[state]` route files.** Each file now imports the helper, and any unknown slug naturally produces a 404.
3. **Kept registry pure.** The `notFound()` call lives in route-helpers, not registry. Node CLI scripts (`scrape-matrix`, `check-scraper-coverage`) keep importing `lib/states/registry.ts` without dragging in `next/navigation`.

One reference at `app/[state]/course/[code]/page.tsx:562` (`config: ReturnType<typeof getStateConfig>`) still uses the original `getStateConfig` for type extraction — that's fine, it's a type-level reference, no value lookup.

## Why this is a P0

`/ky/colleges` and several other `/ky/*` routes were live HTTP 500s for any user who landed on them (e.g. via search engine, bookmark, or guessed URL). Even though KY isn't a marketed state, the registry inconsistency is a real production error.

## Closes #158

## Test plan

- [x] `npx tsc --noEmit` — no new type errors after the patch.
- [x] `npm run build` — route table includes `/[state]/*` routes correctly; structural change is clean.
- [ ] After merge + Vercel deploy: re-curl the 9 confirmed 500 URLs above. Expectation: all return 404 (or other non-500).
- [ ] Spot-check a real registered state (`/va/colleges`) still renders correctly — `requireStateConfig` is a drop-in for the success path.

## Refs
- Filed as #158 (P0).
- Related: #108 (KY phase-2 scraper bootstrap — separate, longer-term work; this PR is the production hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)