### PR TITLE
Fix HTTP 500 on unregistered state routes — proxy validation (#158)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,8 +1,9 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { updateSession } from "@/lib/supabase/middleware";
+import { isValidState } from "@/lib/states/registry";
 
 /**
- * Next.js proxy (formerly "middleware"). Two jobs, routed by path:
+ * Next.js proxy (formerly "middleware"). Three jobs, routed by path:
  *
  *   1. AUTH ROUTES (/account, /api/account, /auth)
  *      Refresh the Supabase session cookie via `updateSession`.
@@ -18,11 +19,19 @@ import { updateSession } from "@/lib/supabase/middleware";
  *      check in the proxy runs before streaming starts. See Next.js docs:
  *      "Status Codes" under loading.js.
  *
+ *   3. UNREGISTERED STATE ROUTES (/<unknown-2-letter>/*)
+ *      Issue #158: requests like /ky/colleges or /xx/courses were rendering
+ *      as HTTP 500 even after page-level `notFound()` guards landed in
+ *      #163, because `app/loading.tsx` streams the Suspense boundary
+ *      before the layout/page-level notFound() runs — same locking
+ *      problem as branch #2. Validate the state slug here, before
+ *      streaming starts.
+ *
  * CRITICAL: Neither branch touches cookies for public pages. The auth branch
- * is scoped by the matcher to auth-only paths. The course branch just does
- * regex validation + a static 404 response. This preserves ISR edge caching
- * (`cache-control: public, s-maxage=…`) for the ~200 prerendered routes —
- * any cookie access on a public page forces
+ * is scoped by the matcher to auth-only paths. The course/state branches
+ * just do validation + a static 404 response. This preserves ISR edge
+ * caching (`cache-control: public, s-maxage=…`) for the ~200 prerendered
+ * routes — any cookie access on a public page forces
  * `cache-control: private, no-cache, no-store` and kills the cache.
  */
 
@@ -35,6 +44,10 @@ const COURSE_CODE_RE = /^[A-Z]{2,5}-[A-Z0-9-]{1,10}$/;
 // whatever the URL path segment is (validated against the regex below after
 // uppercasing).
 const COURSE_PATH_RE = /^\/([a-z]{2})\/course\/([^/]+)\/?$/;
+
+// Top-level `/<state>/...` capture for unknown-state validation. Two
+// lowercase letters at the start of the path; everything after is anything.
+const STATE_PATH_RE = /^\/([a-z]{2})(\/.*)?$/;
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -50,6 +63,24 @@ export async function proxy(request: NextRequest) {
       // Rewrite to the global 404 page. Using `rewrite` (not `redirect`)
       // keeps the URL in the address bar and produces a 404 status —
       // exactly what Google wants for dropping the URL from its index.
+      return new NextResponse(null, { status: 404 });
+    }
+    // Course code looks well-formed; let the route handle it (the page
+    // also validates against the scraped catalog and may still 404).
+    return NextResponse.next();
+  }
+
+  // -------------------------------------------------------------------------
+  // Unregistered-state validation — issue #158. Catches /<unknown-2-letter>/*
+  // requests before app/loading.tsx starts streaming, locking the response
+  // at 500. Skip auth paths (handled below) — the regex already excludes
+  // them since their first segment is >2 letters (account, api, auth, blog,
+  // etc.).
+  // -------------------------------------------------------------------------
+  const stateMatch = pathname.match(STATE_PATH_RE);
+  if (stateMatch) {
+    const stateSlug = stateMatch[1];
+    if (!isValidState(stateSlug)) {
       return new NextResponse(null, { status: 404 });
     }
     return NextResponse.next();
@@ -69,5 +100,13 @@ export const config = {
     "/auth/:path*",
     // Course detail routes — need URL format validation
     "/:state/course/:code",
+    // Top-level state segment — validate slug before stream starts (#158).
+    // The `[a-z]{2}` constraint matches only 2-letter top segments. None of
+    // the non-state routes (api, auth, blog, account, colleges, privacy,
+    // sitemap, robots, mockup, _next, favicon, icon) is exactly 2 lowercase
+    // letters, so this matcher is naturally exclusive — it only fires on
+    // state slugs (valid or invalid).
+    "/:state([a-z]{2})/:path*",
+    "/:state([a-z]{2})",
   ],
 };


### PR DESCRIPTION
## Why #163 wasn't enough

#163 added page-level `notFound()` guards in layout/pages, but production verification (curl after deploy `dpl_9aKCEtAhdqKGXppFXi2qPewKFnJw`) showed `/ky/colleges` and 8 other KY routes still returning **HTTP 500**. The response body even contained `NEXT_HTTP_ERROR_FALLBACK;404` — meaning `notFound()` IS firing, but the HTTP status couldn't be changed.

**Root cause:** `app/loading.tsx` is a top-level Suspense boundary that starts streaming immediately. Once streaming begins, the response status is locked at whatever Next has emitted — `notFound()` can only set the body, not the status. This is the exact pattern documented in `proxy.ts` for the course-code validation:

> *"once the response body starts streaming (which happens the moment `loading.tsx`'s Suspense boundary renders), the status code is locked at 200 and `notFound()` can only set the body, not the status. Doing the format check in the proxy runs before streaming starts."*

## What this PR does

Adds a third branch to `proxy.ts` mirroring the existing course-code pattern: validate the state slug before streaming starts; return a real `NextResponse(null, { status: 404 })` for unknown slugs.

The matcher `/:state([a-z]{2})/:path*` is naturally exclusive — none of the non-state top segments (api/auth/blog/account/colleges/privacy/sitemap/mockup/_next/etc.) is exactly 2 lowercase letters. So the proxy only runs on actual state slugs (valid or invalid).

## Verification (local dev)

```
404 /ky/colleges   (was 500)
404 /ky/courses    (was 500)
404 /ky/about      (was 500)
404 /ky/plan       (was 500)
404 /ky/college/foo (was 500)
404 /zz            (any unknown 2-letter slug)
404 /xx/colleges
200 /va/colleges   (valid state, unchanged)
200 /va/courses    (valid state, unchanged)
```

Page-level guards from #163 stay in (defense in depth) — they don't conflict and they're correct hygiene for the route components.

## Closes #158 (for real)

## Test plan

- [x] Local `npm run dev` — KY/zz/xx 404, VA 200.
- [ ] After merge + Vercel deploy: re-curl the 9 KY routes from the original audit; all should return 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)