### PR TITLE
Fix HTTP 500 on unregistered state routes — proxy matcher v2 (#158)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -73,9 +73,9 @@ export async function proxy(request: NextRequest) {
   // -------------------------------------------------------------------------
   // Unregistered-state validation — issue #158. Catches /<unknown-2-letter>/*
   // requests before app/loading.tsx starts streaming, locking the response
-  // at 500. Skip auth paths (handled below) — the regex already excludes
-  // them since their first segment is >2 letters (account, api, auth, blog,
-  // etc.).
+  // at 500. Only fires when the first segment is exactly 2 lowercase letters
+  // (none of the non-state top routes — api, auth, blog, account, colleges,
+  // privacy, sitemap, robots, mockup — is exactly 2 chars).
   // -------------------------------------------------------------------------
   const stateMatch = pathname.match(STATE_PATH_RE);
   if (stateMatch) {
@@ -83,30 +83,41 @@ export async function proxy(request: NextRequest) {
     if (!isValidState(stateSlug)) {
       return new NextResponse(null, { status: 404 });
     }
+    // Valid state — let the route render. Don't fall through to the auth
+    // branch (state pages don't need session refresh, and updateSession
+    // touches cookies which kills ISR caching).
     return NextResponse.next();
   }
 
   // -------------------------------------------------------------------------
-  // Auth session refresh — only for auth-dependent paths (see matcher).
+  // Auth session refresh — only for auth-dependent paths.
   // -------------------------------------------------------------------------
-  return await updateSession(request);
+  if (
+    pathname.startsWith("/account") ||
+    pathname.startsWith("/api/account") ||
+    pathname.startsWith("/auth")
+  ) {
+    return await updateSession(request);
+  }
+
+  // Everything else (e.g. /blog, /colleges, /privacy, /api/* non-account
+  // routes) — pass through unchanged. Critically, no cookie access here so
+  // ISR edge caching stays intact.
+  return NextResponse.next();
 }
 
 export const config = {
+  // Single broad matcher that catches the auth, course, and state-slug
+  // branches above. The proxy function itself filters by pathname; doing
+  // the filtering in code avoids path-to-regexp quirks (the `:state([a-z]{2})`
+  // form silently failed to match in production on Next 16, even though
+  // Next docs say the syntax is supported — see #158/#164 history).
+  //
+  // Static assets (`/_next/*`, image generators, favicon, etc.) are
+  // excluded so the proxy doesn't run on every chunk request. Everything
+  // else falls through quickly via `NextResponse.next()` when no branch
+  // matches.
   matcher: [
-    // Auth routes — need session refresh
-    "/account/:path*",
-    "/api/account/:path*",
-    "/auth/:path*",
-    // Course detail routes — need URL format validation
-    "/:state/course/:code",
-    // Top-level state segment — validate slug before stream starts (#158).
-    // The `[a-z]{2}` constraint matches only 2-letter top segments. None of
-    // the non-state routes (api, auth, blog, account, colleges, privacy,
-    // sitemap, robots, mockup, _next, favicon, icon) is exactly 2 lowercase
-    // letters, so this matcher is naturally exclusive — it only fires on
-    // state slugs (valid or invalid).
-    "/:state([a-z]{2})/:path*",
-    "/:state([a-z]{2})",
+    "/((?!_next/|favicon\\.ico|icon$|apple-icon$|robots\\.txt$|sitemap\\.xml$|sitemap/).*)",
   ],
 };


### PR DESCRIPTION
## Why #164 wasn't enough

#164's matcher `/:state([a-z]{2})/...` silently failed to match in production on Next 16, even though Next docs say the regex-constraint syntax is supported. Verified post-deploy:

- `x-matched-path: /[state]/colleges` (the page handler ran, not the proxy)
- HTTP status 200 with `NEXT_HTTP_ERROR_FALLBACK;404` body — same streaming-lock symptom as before, just stuck at 200 instead of 500 because the page-level `notFound()` from #163 prevents the throw

So the situation went 500 → 200 (still wrong) instead of 500 → 404.

## What this PR does

Replaces the constrained matchers with a single broad matcher that only excludes static-asset paths (`/_next/`, favicon, robots, sitemap, etc.). The proxy code itself filters by pathname, which avoids path-to-regexp quirks. Tiny per-request overhead in exchange for a matcher that actually fires.

The auth branch (`/account`, `/api/account`, `/auth`) is now gated explicitly inside the proxy code rather than relying on the matcher, so it stays mutually exclusive with the new state branch.

## Verified locally

```
404 /ky/colleges, /ky/courses, /ky/about, /ky/college/foo
404 /zz, /zz/colleges          (any unknown 2-letter slug)
200 /va/colleges, /va/courses  (valid state)
200 /, /blog, /colleges        (non-state public routes)
```

## Closes #158 (third time's the charm)

## Test plan

- [x] Local `npm run dev` — KY/zz routes 404; valid state and public routes 200.
- [ ] After merge + Vercel deploy: re-curl the 9 KY routes — all should return 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)