### PR TITLE
NJ: add course scrapers for 12 colleges (10 Colleague + 2 Banner SSB) (#166)

### DIFF
--- a/lib/states/nj/config.ts
+++ b/lib/states/nj/config.ts
@@ -1,42 +1,31 @@
 import type { StateConfig } from "../registry";
 
-// manual-only: NJ has a transfer scraper (scripts/nj/scrape-transfer.ts from NJTransfer.org)
-// but no public-accessible course-scheduling system — Colleague Self-Service is auth-gated
-// at most NJ colleges. No prereq coverage yet. Revisit once a course scraper is viable.
-
-// NJ community colleges predominantly use Ellucian Colleague Self-Service
-// for course scheduling. The public Self-Service JSON REST API endpoints
-// vary by college but follow a common URL pattern:
-//   https://<host>/Student/Courses/Search
-//
-// Transfer equivalency data is centralized at NJTransfer.org, a state-mandated
-// CGI database maintained by the NJ Transfer consortium. This is the primary
-// source for CC-to-university transfer mappings.
-//
-// The 18 community colleges are coordinated by the New Jersey Council of
-// County Colleges (NJCCC). Some former independent colleges have merged
-// under the Rowan College umbrella but retain separate campuses and codes.
-
+// Colleague Self-Service base URLs (no /Student suffix — appended by courseDiscoveryUrl).
+// 10 confirmed publicly accessible for scraping; 6 deferred colleges kept for discovery links.
 const COLLEAGUE_SELF_SERVICE_URLS: Record<string, string> = {
-  "atlantic-cape": "https://ssb.atlantic.edu/Student",
-  "bergen": "https://selfservice.bergen.edu/Student",
-  "brookdale": "https://selfservice.brookdalecc.edu/Student",
-  "camden": "https://selfservice.camdencc.edu/Student",
-  "ccm": "https://selfservice.ccm.edu/Student",
-  "essex": "https://selfservice.essex.edu/Student",
-  "hccc": "https://selfservice.hccc.edu/Student",
-  "mercer": "https://selfservice.mccc.edu/Student",
-  "middlesex": "https://selfservice.middlesexcc.edu/Student",
-  "ocean": "https://selfservice.ocean.edu/Student",
-  "passaic": "https://selfservice.pccc.edu/Student",
-  "rvcc": "https://selfservice.raritanval.edu/Student",
-  "rcbc": "https://selfservice.rcbc.edu/Student",
-  "rcsj-cumberland": "https://selfservice.rcsj.edu/Student",
-  "rcsj-gloucester": "https://selfservice.rcsj.edu/Student",
-  "salem": "https://selfservice.salemcc.edu/Student",
-  "sussex": "https://selfservice.sussex.edu/Student",
-  "ucnj": "https://selfservice.ucc.edu/Student",
-  "warren": "https://selfservice.warren.edu/Student",
+  "atlantic-cape": "https://acccdtsfss22.atlantic.edu",
+  "bergen": "https://selfservice.bergen.edu",
+  "brookdale": "https://selfservice.brookdalecc.edu",
+  "camden": "https://selfservice.camdencc.edu",
+  "ccm": "https://titansdirect.ccm.edu",
+  "hccc": "https://libertylink.hccc.edu",
+  "mercer": "https://mercer-ss.colleague.elluciancloud.com",
+  "middlesex": "https://middlesexcollege-ss.colleague.elluciancloud.com",
+  "ocean": "https://selfservice.ocean.edu",
+  "passaic": "https://eselfservice.pccc.edu",
+  "rcbc": "https://selfservice2019.rcbc.edu",
+  "rcsj-cumberland": "https://selfservice.rcsj.edu",
+  "rcsj-gloucester": "https://selfservice.rcsj.edu",
+  "salem": "https://selfservice.salemcc.edu",
+  "sussex": "https://selfservice.sussex.edu",
+  "ucnj": "https://ucc-ss.colleague.elluciancloud.com",
+  "warren": "https://selfservice.warren.edu",
+};
+
+// Banner SSB base URLs (essex, rvcc use Banner instead of Colleague)
+const BANNER_SSB_URLS: Record<string, string> = {
+  "essex": "https://bannerprod.essex.edu",
+  "rvcc": "https://reg-prod.ec.raritanval.edu",
 };
 
 const njConfig: StateConfig = {
@@ -70,15 +59,26 @@ const njConfig: StateConfig = {
   defaultZipCity: "New Brunswick",
 
   courseDiscoveryUrl: (collegeSlug: string, _prefix: string, _number: string) => {
-    // Most NJ CCs use Ellucian Colleague Self-Service. Link to the
-    // college's course search page when available.
+    const bannerUrl = BANNER_SSB_URLS[collegeSlug];
+    if (bannerUrl) return `${bannerUrl}/StudentRegistrationSsb/ssb/classSearch/classSearch`;
     const ssUrl = COLLEAGUE_SELF_SERVICE_URLS[collegeSlug];
-    return ssUrl ? `${ssUrl}/Courses/Search` : "https://www.njcommunitycolleges.org";
+    return ssUrl ? `${ssUrl}/Student/Courses/Search` : "https://www.njcommunitycolleges.org";
   },
 
   collegeCoursesUrl: (collegeSlug: string) => {
+    const bannerUrl = BANNER_SSB_URLS[collegeSlug];
+    if (bannerUrl) return `${bannerUrl}/StudentRegistrationSsb/ssb/classSearch/classSearch`;
     const ssUrl = COLLEAGUE_SELF_SERVICE_URLS[collegeSlug];
-    return ssUrl ? `${ssUrl}/Courses` : "https://www.njcommunitycolleges.org";
+    return ssUrl ? `${ssUrl}/Student/Courses` : "https://www.njcommunitycolleges.org";
+  },
+
+  scrapers: {
+    courses: [
+      { scripts: ["scripts/nj/scrape-colleague.ts"], runner: "playwright", termSystem: "colleague-nj" },
+      { scripts: ["scripts/nj/scrape-banner-ssb.ts"], runner: "http" },
+    ],
+    transfers: [{ scripts: ["scripts/nj/scrape-transfer.ts"], runner: "http" }],
+    prereqs: { source: "aggregate-from-courses" },
   },
 
   branding: {

--- a/scripts/lib/resolve-terms.ts
+++ b/scripts/lib/resolve-terms.ts
@@ -525,6 +525,7 @@ const COLLEAGUE_SAMPLES: Record<string, string> = {
   sc: "https://selfservice.fdtc.edu",        // Florence-Darlington Tech
   md: "https://selfservice.pgcc.edu",        // Prince George's CC
   vt: "https://selfservice.vsc.edu",         // Vermont State Colleges (CCV + VTSU)
+  nj: "https://selfservice.bergen.edu",      // Bergen Community College
 };
 
 // ---------------------------------------------------------------------------
@@ -538,7 +539,7 @@ async function main() {
 
   if (!system) {
     console.error("Usage: npx tsx scripts/lib/resolve-terms.ts --system <system>");
-    console.error("Systems: vccs, vccs-ps, colleague-nc, colleague-sc, colleague-md, colleague-vt, banner");
+    console.error("Systems: vccs, vccs-ps, colleague-nc, colleague-sc, colleague-md, colleague-vt, colleague-nj, banner");
     process.exit(1);
   }
 
@@ -562,6 +563,9 @@ async function main() {
       break;
     case "colleague-vt":
       result = await resolveColleague(COLLEAGUE_SAMPLES.vt || COLLEAGUE_SAMPLES.nc);
+      break;
+    case "colleague-nj":
+      result = await resolveColleague(COLLEAGUE_SAMPLES.nj || COLLEAGUE_SAMPLES.nc);
       break;
     case "banner":
       result = await resolveBanner();

--- a/scripts/nj/scrape-banner-ssb.ts
+++ b/scripts/nj/scrape-banner-ssb.ts
@@ -1,0 +1,498 @@
+/**
+ * scrape-banner-ssb.ts
+ *
+ * Scrapes course section data from NJ community colleges that use
+ * Ellucian Banner 9/10 Student Registration SSB REST API.
+ *
+ * Usage:
+ *   npx tsx scripts/nj/scrape-banner-ssb.ts --college essex
+ *   npx tsx scripts/nj/scrape-banner-ssb.ts --all
+ */
+
+import fs from "fs";
+import path from "path";
+import { pickRecentSsbTerms } from "../lib/resolve-terms";
+
+const PAGE_SIZE = 500;
+
+// NJ colleges using Banner SSB (2 confirmed publicly accessible)
+const BANNER_COLLEGES: Record<string, string> = {
+  "essex": "https://bannerprod.essex.edu",
+  "rvcc": "https://reg-prod.ec.raritanval.edu",
+};
+
+interface BannerTerm {
+  code: string;
+  description: string;
+}
+
+interface BannerSection {
+  courseReferenceNumber: string;
+  subject: string;
+  courseNumber: string;
+  courseTitle: string;
+  creditHourLow: number | null;
+  creditHourHigh: number | null;
+  creditHours: number | null;
+  campusDescription: string;
+  maximumEnrollment: number;
+  enrollment: number;
+  seatsAvailable: number;
+  faculty: { displayName: string }[];
+  meetingsFaculty: {
+    meetingTime: {
+      beginTime: string | null;
+      endTime: string | null;
+      startDate: string | null;
+      endDate: string | null;
+      monday: boolean;
+      tuesday: boolean;
+      wednesday: boolean;
+      thursday: boolean;
+      friday: boolean;
+      saturday: boolean;
+      sunday: boolean;
+      buildingDescription: string | null;
+      room: string | null;
+      campusDescription: string | null;
+    };
+  }[];
+}
+
+function bannerTermToStandard(code: string, description: string): string {
+  const descLower = description.toLowerCase();
+
+  // Extract year from description first, fall back to code prefix
+  const yearMatch = description.match(/\b(20\d{2})\b/);
+  const year = yearMatch ? yearMatch[1] : code.substring(0, 4);
+
+  if (descLower.includes("fall")) return `${year}FA`;
+  if (descLower.includes("spring") || descLower.includes("winter")) return `${year}SP`;
+  if (descLower.includes("summer")) return `${year}SU`;
+
+  // Standard suffix fallbacks
+  const suffix = code.substring(4);
+  if (suffix === "10") return `${year}FA`;
+  if (suffix === "20") return `${year}SP`;
+  if (suffix === "30") return `${year}SU`;
+  return `${year}XX`;
+}
+
+function formatTime(t: string | null): string {
+  if (!t || t.length < 4) return "";
+  const h = parseInt(t.substring(0, 2));
+  const m = t.substring(2, 4);
+  const ampm = h >= 12 ? "PM" : "AM";
+  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${h12}:${m} ${ampm}`;
+}
+
+function buildDays(
+  mt: BannerSection["meetingsFaculty"][0]["meetingTime"]
+): string {
+  const parts: string[] = [];
+  if (mt.monday) parts.push("M");
+  if (mt.tuesday) parts.push("Tu");
+  if (mt.wednesday) parts.push("W");
+  if (mt.thursday) parts.push("Th");
+  if (mt.friday) parts.push("F");
+  if (mt.saturday) parts.push("Sa");
+  if (mt.sunday) parts.push("Su");
+  return parts.join("");
+}
+
+function parseDate(d: string | null): string {
+  if (!d) return "";
+  const parts = d.split("/");
+  if (parts.length !== 3) return "";
+  return `${parts[2]}-${parts[0].padStart(2, "0")}-${parts[1].padStart(2, "0")}`;
+}
+
+function detectMode(
+  mt: BannerSection["meetingsFaculty"][0]["meetingTime"],
+  campus: string
+): string {
+  const campusLower = (campus || "").toLowerCase();
+  const buildingLower = (mt.buildingDescription || "").toLowerCase();
+  if (
+    campusLower.includes("online") ||
+    buildingLower.includes("online") ||
+    buildingLower.includes("virtual")
+  ) {
+    return "online";
+  }
+  if (campusLower.includes("zoom") || buildingLower.includes("zoom")) {
+    return "zoom";
+  }
+  if (campusLower.includes("hybrid") || buildingLower.includes("hybrid")) {
+    return "hybrid";
+  }
+  return "in-person";
+}
+
+// Prerequisite parsing
+const SUBJECT_TO_PREFIX: Record<string, string> = {};
+
+interface PrereqInfo {
+  text: string;
+  courses: string[];
+}
+
+function parsePrereqHtml(html: string): PrereqInfo | null {
+  if (html.includes("No prerequisite")) return null;
+
+  const rows: {
+    andOr: string;
+    subject: string;
+    courseNum: string;
+    grade: string;
+  }[] = [];
+  const trRegex = /<tr>\s*([\s\S]*?)<\/tr>/g;
+  let trMatch;
+  while ((trMatch = trRegex.exec(html)) !== null) {
+    const tds: string[] = [];
+    const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/g;
+    let tdMatch;
+    while ((tdMatch = tdRegex.exec(trMatch[1])) !== null) {
+      tds.push(tdMatch[1].trim());
+    }
+    if (tds.length >= 8 && (tds[4] || tds[5])) {
+      rows.push({
+        andOr: tds[0] || "",
+        subject: tds[4],
+        courseNum: tds[5],
+        grade: tds[7],
+      });
+    }
+  }
+
+  if (rows.length === 0) return null;
+
+  const courses: string[] = [];
+  const parts: string[] = [];
+  for (const row of rows) {
+    const prefix =
+      SUBJECT_TO_PREFIX[row.subject.toLowerCase()] || row.subject;
+    const courseCode = `${prefix} ${row.courseNum}`;
+    const gradeNote =
+      row.grade && row.grade !== "TR" ? ` (min ${row.grade})` : "";
+    const connector = row.andOr ? ` ${row.andOr.toLowerCase()} ` : "";
+
+    if (connector && parts.length > 0) {
+      parts.push(connector);
+    }
+    parts.push(`${courseCode}${gradeNote}`);
+
+    if (row.grade !== "TR" && !courses.includes(courseCode)) {
+      courses.push(courseCode);
+    }
+  }
+
+  return {
+    text: parts.join("").trim(),
+    courses,
+  };
+}
+
+async function buildSubjectMap(
+  baseUrl: string,
+  termCode: string,
+  cookies: string
+): Promise<void> {
+  try {
+    const res = await fetch(
+      `${baseUrl}/StudentRegistrationSsb/ssb/classSearch/get_subject?term=${termCode}&offset=1&max=500`,
+      { headers: { Cookie: cookies } }
+    );
+    const subjects: { code: string; description: string }[] = await res.json();
+    // Reset for each college
+    Object.keys(SUBJECT_TO_PREFIX).forEach(
+      (k) => delete SUBJECT_TO_PREFIX[k]
+    );
+    for (const s of subjects) {
+      SUBJECT_TO_PREFIX[s.description.toLowerCase()] = s.code;
+    }
+    console.log(
+      `  Built subject map: ${Object.keys(SUBJECT_TO_PREFIX).length} subjects`
+    );
+  } catch {
+    console.warn("  Warning: Could not fetch subject map");
+  }
+}
+
+async function fetchPrerequisites(
+  baseUrl: string,
+  termCode: string,
+  sections: BannerSection[],
+  cookies: string
+): Promise<Map<string, PrereqInfo>> {
+  const courseMap = new Map<string, string>();
+  for (const s of sections) {
+    const key = `${s.subject} ${s.courseNumber}`;
+    if (!courseMap.has(key)) {
+      courseMap.set(key, s.courseReferenceNumber);
+    }
+  }
+
+  console.log(
+    `  Fetching prerequisites for ${courseMap.size} unique courses...`
+  );
+  const prereqs = new Map<string, PrereqInfo>();
+  const entries = Array.from(courseMap.entries());
+  const BATCH_SIZE = 10;
+  let fetched = 0;
+
+  for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+    const batch = entries.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async ([courseKey, crn]) => {
+        try {
+          const res = await fetch(
+            `${baseUrl}/StudentRegistrationSsb/ssb/searchResults/getSectionPrerequisites?term=${termCode}&courseReferenceNumber=${crn}`,
+            { headers: { Cookie: cookies } }
+          );
+          const html = await res.text();
+          const info = parsePrereqHtml(html);
+          return { courseKey, info };
+        } catch {
+          return { courseKey, info: null };
+        }
+      })
+    );
+    for (const { courseKey, info } of results) {
+      if (info) prereqs.set(courseKey, info);
+    }
+    fetched += batch.length;
+    if (fetched % 100 === 0 || fetched === entries.length) {
+      console.log(
+        `    prereqs: ${fetched}/${entries.length} (${prereqs.size} with prereqs)`
+      );
+    }
+  }
+
+  return prereqs;
+}
+
+async function getTerms(baseUrl: string): Promise<BannerTerm[]> {
+  const res = await fetch(
+    `${baseUrl}/StudentRegistrationSsb/ssb/classSearch/getTerms?searchTerm=&offset=1&max=30`
+  );
+  return res.json();
+}
+
+async function searchSections(
+  baseUrl: string,
+  termCode: string,
+  cookies: string
+): Promise<BannerSection[]> {
+  const all: BannerSection[] = [];
+  let offset = 0;
+
+  while (true) {
+    const url = `${baseUrl}/StudentRegistrationSsb/ssb/searchResults/searchResults?txt_term=${termCode}&pageOffset=${offset}&pageMaxSize=${PAGE_SIZE}&sortColumn=subjectDescription&sortDirection=asc`;
+    const res = await fetch(url, {
+      headers: { Cookie: cookies },
+    });
+    const data = await res.json();
+
+    if (!data.success || !data.data || data.data.length === 0) break;
+    all.push(...data.data);
+    console.log(`  fetched ${all.length}/${data.totalCount}`);
+
+    if (all.length >= data.totalCount) break;
+    offset += PAGE_SIZE;
+  }
+
+  return all;
+}
+
+async function initSession(
+  baseUrl: string,
+  termCode: string
+): Promise<string> {
+  const res1 = await fetch(
+    `${baseUrl}/StudentRegistrationSsb/ssb/classSearch/classSearch`,
+    { redirect: "manual" }
+  );
+  const setCookies = res1.headers.getSetCookie?.() || [];
+  const cookies = setCookies.map((c) => c.split(";")[0]).join("; ");
+
+  await fetch(
+    `${baseUrl}/StudentRegistrationSsb/ssb/term/search?mode=search`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Cookie: cookies,
+      },
+      body: `term=${termCode}&studyPath=&studyPathText=&startDatepicker=&endDatepicker=`,
+    }
+  );
+
+  return cookies;
+}
+
+async function scrapeCollege(slug: string, baseUrl: string): Promise<number> {
+  console.log(`\n=== Scraping ${slug} (${baseUrl}) ===`);
+
+  let terms: BannerTerm[];
+  try {
+    console.log("  Fetching available terms...");
+    terms = await getTerms(baseUrl);
+  } catch (e) {
+    console.error(`  ERROR: Could not connect to ${baseUrl}: ${e}`);
+    console.error(`  Skipping ${slug} — the Banner URL may need verification.`);
+    return 0;
+  }
+
+  const targetTerms = pickRecentSsbTerms(terms);
+
+  if (targetTerms.length === 0) {
+    console.log(`  No recent terms found. Available: ${terms.map((t) => `${t.description} (${t.code})`).join(", ")}`);
+    return 0;
+  }
+
+  console.log(
+    `  Found ${targetTerms.length} target terms:`,
+    targetTerms.map((t) => t.description)
+  );
+
+  const outDir = path.join(process.cwd(), "data", "nj", "courses", slug);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  let totalSections = 0;
+
+  for (const term of targetTerms) {
+    const standardTerm = bannerTermToStandard(term.code, term.description);
+    console.log(
+      `\n  Scraping ${term.description} (${term.code} → ${standardTerm})...`
+    );
+
+    try {
+      const cookies = await initSession(baseUrl, term.code);
+      await buildSubjectMap(baseUrl, term.code, cookies);
+
+      const sections = await searchSections(baseUrl, term.code, cookies);
+
+      if (sections.length === 0) {
+        console.log(`  No sections found for ${term.description}`);
+        continue;
+      }
+
+      const prereqs = await fetchPrerequisites(
+        baseUrl,
+        term.code,
+        sections,
+        cookies
+      );
+      console.log(`  Found prerequisites for ${prereqs.size} courses`);
+
+      const converted = sections.map((s) => {
+        const mt = s.meetingsFaculty?.[0]?.meetingTime;
+        const credits = s.creditHours ?? s.creditHourLow ?? 3;
+        const campus =
+          mt?.campusDescription || s.campusDescription || "";
+        const mode = mt ? detectMode(mt, campus) : "online";
+        const courseKey = `${s.subject} ${s.courseNumber}`;
+        const prereq = prereqs.get(courseKey);
+
+        return {
+          college_code: slug,
+          term: standardTerm,
+          course_prefix: s.subject,
+          course_number: s.courseNumber,
+          course_title: s.courseTitle,
+          credits,
+          crn: s.courseReferenceNumber,
+          days: mt ? buildDays(mt) : "",
+          start_time: mt ? formatTime(mt.beginTime) : "",
+          end_time: mt ? formatTime(mt.endTime) : "",
+          start_date: mt ? parseDate(mt.startDate) : "",
+          location: mt?.buildingDescription || "",
+          campus: campus || "Main",
+          mode,
+          instructor: s.faculty?.[0]?.displayName || null,
+          seats_open: s.seatsAvailable,
+          seats_total: s.maximumEnrollment,
+          prerequisite_text: prereq?.text || null,
+          prerequisite_courses: prereq?.courses || [],
+        };
+      });
+
+      const outFile = path.join(outDir, `${standardTerm}.json`);
+      fs.writeFileSync(outFile, JSON.stringify(converted, null, 2));
+      const withPrereqs = converted.filter(
+        (c) => c.prerequisite_text
+      ).length;
+      console.log(
+        `  → ${converted.length} sections written to ${standardTerm}.json (${withPrereqs} with prereqs)`
+      );
+      totalSections += converted.length;
+    } catch (e) {
+      console.error(`  Error scraping ${term.description}: ${e}`);
+    }
+  }
+
+  console.log(`\n  ${slug}: ${totalSections} total sections scraped.`);
+  return totalSections;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeFlag = args.indexOf("--college");
+  const allFlag = args.includes("--all");
+
+  let targets: [string, string][];
+
+  if (allFlag) {
+    targets = Object.entries(BANNER_COLLEGES);
+  } else if (collegeFlag >= 0) {
+    const slug = args[collegeFlag + 1];
+    const baseUrl = BANNER_COLLEGES[slug];
+    if (!baseUrl) {
+      console.error(`Unknown college: ${slug}`);
+      console.error(
+        `Available: ${Object.keys(BANNER_COLLEGES).join(", ")}`
+      );
+      process.exit(1);
+    }
+    targets = [[slug, baseUrl]];
+  } else {
+    console.log("Usage:");
+    console.log(
+      "  npx tsx scripts/nj/scrape-banner-ssb.ts --college essex"
+    );
+    console.log("  npx tsx scripts/nj/scrape-banner-ssb.ts --all");
+    process.exit(0);
+  }
+
+  let grandTotal = 0;
+  const results: { slug: string; count: number }[] = [];
+
+  for (const [slug, baseUrl] of targets) {
+    const count = await scrapeCollege(slug, baseUrl);
+    results.push({ slug, count });
+    grandTotal += count;
+  }
+
+  // Summary
+  console.log("\n=== Summary ===");
+  for (const r of results) {
+    console.log(`  ${r.slug}: ${r.count} sections`);
+  }
+  console.log(`  Total: ${grandTotal} sections across ${results.length} colleges`);
+
+  // Auto-import into Supabase
+  if (!args.includes("--no-import") && grandTotal > 0) {
+    const { importCoursesToSupabase } = await import("../lib/supabase-import");
+    await importCoursesToSupabase("nj");
+  }
+
+  console.log("\nDone.");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/nj/scrape-colleague.ts
+++ b/scripts/nj/scrape-colleague.ts
@@ -1,0 +1,683 @@
+/**
+ * scrape-colleague.ts
+ *
+ * Scrapes course section data from NJ community colleges that use
+ * Ellucian Colleague Self-Service. Uses Playwright to handle the
+ * SPA rendering and CSRF token requirements, then calls the internal
+ * PostSearchCriteria API for each subject to get full section data.
+ *
+ * Usage:
+ *   npx tsx scripts/nj/scrape-colleague.ts --college bergen
+ *   npx tsx scripts/nj/scrape-colleague.ts --college bergen --term "Spring 2026"
+ *   npx tsx scripts/nj/scrape-colleague.ts --all
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { chromium, type Page, type BrowserContext } from "playwright";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const DELAY_MS = 500;
+const PAGE_SIZE = 500; // max per request to minimize pagination
+
+// NJ colleges using Ellucian Colleague Self-Service (10 confirmed publicly accessible)
+const COLLEAGUE_COLLEGES: Record<string, string> = {
+  "bergen": "https://selfservice.bergen.edu",
+  "brookdale": "https://selfservice.brookdalecc.edu",
+  "ccm": "https://titansdirect.ccm.edu",
+  "hccc": "https://libertylink.hccc.edu",
+  "passaic": "https://eselfservice.pccc.edu",
+  "rcbc": "https://selfservice2019.rcbc.edu",
+  "atlantic-cape": "https://acccdtsfss22.atlantic.edu",
+  "mercer": "https://mercer-ss.colleague.elluciancloud.com",
+  "middlesex": "https://middlesexcollege-ss.colleague.elluciancloud.com",
+  "ucnj": "https://ucc-ss.colleague.elluciancloud.com",
+};
+
+type CourseMode = "in-person" | "online" | "hybrid" | "zoom";
+
+interface CourseSection {
+  college_code: string;
+  term: string;
+  course_prefix: string;
+  course_number: string;
+  course_title: string;
+  credits: number;
+  crn: string;
+  days: string;
+  start_time: string;
+  end_time: string;
+  start_date: string;
+  location: string;
+  campus: string;
+  mode: CourseMode;
+  instructor: string | null;
+  seats_open: number | null;
+  seats_total: number | null;
+  prerequisite_text: string | null;
+  prerequisite_courses: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Convert "M/D/YYYY" or "MM/DD/YYYY" to "YYYY-MM-DD" */
+function normalizeDate(dateStr: string): string {
+  if (!dateStr) return "";
+  // Already YYYY-MM-DD
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return dateStr;
+  const match = dateStr.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+  if (!match) return dateStr;
+  return `${match[3]}-${match[1].padStart(2, "0")}-${match[2].padStart(2, "0")}`;
+}
+
+function determineMode(section: {
+  locationCode: string;
+  locationDisplay: string;
+  isOnline: boolean;
+  meetingsDisplay: string[];
+}): CourseMode {
+  const loc = section.locationDisplay.toLowerCase();
+  const allMeetings = section.meetingsDisplay.join(" ").toLowerCase();
+
+  // Check for hybrid indicators
+  if (loc.includes("hybrid") || allMeetings.includes("hybrid")) return "hybrid";
+
+  // Check for fully online
+  if (section.isOnline || loc === "online" || section.locationCode === "ONL") {
+    // Synchronous online = zoom
+    if (allMeetings.includes("synchronous") || allMeetings.includes("zoom") ||
+        allMeetings.includes("teams") || allMeetings.includes("remote")) {
+      return "zoom";
+    }
+    return "online";
+  }
+
+  // Virtual with required times = zoom
+  if (loc.includes("virtual") && loc.includes("required")) return "zoom";
+
+  return "in-person";
+}
+
+function formatDays(daysOfWeekDisplay: string): string {
+  if (!daysOfWeekDisplay) return "";
+  // Input is like "T/Th" or "M/W/F" or "M, W, F"
+  return daysOfWeekDisplay
+    .replace(/\//g, " ")
+    .replace(/,\s*/g, " ")
+    .trim();
+}
+
+interface RequisiteItem {
+  DisplayText: string;
+  DisplayTextExtension?: string;
+  IsRequired: boolean;
+}
+
+function parseRequisiteDisplayText(items: RequisiteItem[]): {
+  text: string | null;
+  courses: string[];
+} {
+  if (!items || items.length === 0) return { text: null, courses: [] };
+
+  // Extract course groups from each item
+  const itemGroups: { courses: string[]; gradeNote: string; hasOr: boolean }[] = [];
+
+  for (const item of items) {
+    if (!item.DisplayText) continue;
+    const dt = item.DisplayText;
+
+    // Extract course codes like "RUS-111", "BIOL-111C", "ENG-111"
+    const courseRegex = /([A-Z]{2,4})-(\d{3,4}[A-Z]*)/g;
+    let match;
+    const coursesInItem: string[] = [];
+    while ((match = courseRegex.exec(dt)) !== null) {
+      coursesInItem.push(`${match[1]} ${match[2]}`);
+    }
+    if (coursesInItem.length === 0) continue;
+
+    const gradeMatch = dt.match(/[Mm]inimum grade\s+([A-Z])/);
+    const gradeNote = gradeMatch ? ` (min ${gradeMatch[1]})` : "";
+    const hasOr = /\bor\b/i.test(dt);
+
+    itemGroups.push({ courses: coursesInItem, gradeNote, hasOr });
+  }
+
+  if (itemGroups.length === 0) return { text: null, courses: [] };
+
+  // Deduplicate: if same course(s) appear with and without grade, keep graded version
+  const seen = new Map<string, { courses: string[]; gradeNote: string; hasOr: boolean }>();
+  for (const group of itemGroups) {
+    const key = [...group.courses].sort().join("+");
+    const existing = seen.get(key);
+    if (!existing || group.gradeNote) {
+      seen.set(key, group);
+    }
+  }
+
+  const allCourses: string[] = [];
+  const parts: string[] = [];
+
+  for (const group of seen.values()) {
+    const connector = group.hasOr ? " or " : " and ";
+    const partText = group.courses.map((c) => {
+      if (!allCourses.includes(c)) allCourses.push(c);
+      return `${c}${group.gradeNote}`;
+    }).join(connector);
+    parts.push(partText);
+  }
+
+  if (parts.length === 0) return { text: null, courses: [] };
+
+  return {
+    text: parts.join(" and "),
+    courses: allCourses,
+  };
+}
+
+async function fetchSectionPrerequisites(
+  page: Page,
+  baseUrl: string,
+  csrfToken: string,
+  coursesWithRequisites: Map<string, string>
+): Promise<Map<string, { text: string | null; courses: string[] }>> {
+  console.log(`  Fetching prerequisites for ${coursesWithRequisites.size} courses with requisites...`);
+
+  const prereqMap = new Map<string, { text: string | null; courses: string[] }>();
+  const entries = Array.from(coursesWithRequisites.entries());
+  const BATCH_SIZE = 10;
+  let fetched = 0;
+
+  for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+    const batch = entries.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async ([courseKey, sectionId]) => {
+        try {
+          const detail = await page.evaluate(
+            async ({ url, id, token }: { url: string; id: string; token: string }) => {
+              const resp = await fetch(url, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json, charset=UTF-8",
+                  Accept: "application/json, text/javascript, */*; q=0.01",
+                  "X-Requested-With": "XMLHttpRequest",
+                  __RequestVerificationToken: token,
+                  __IsGuestUser: "true",
+                },
+                body: JSON.stringify({ sectionId: id }),
+              });
+              return await resp.json();
+            },
+            { url: `${baseUrl}/Student/Courses/SectionDetails`, id: sectionId, token: csrfToken }
+          );
+
+          return { courseKey, items: (detail?.RequisiteItems || []) as RequisiteItem[] };
+        } catch {
+          return { courseKey, items: [] as RequisiteItem[] };
+        }
+      })
+    );
+
+    for (const { courseKey, items } of results) {
+      const parsed = parseRequisiteDisplayText(items);
+      if (parsed.text) {
+        prereqMap.set(courseKey, parsed);
+      }
+    }
+
+    fetched += batch.length;
+    if (fetched % 50 === 0 || fetched === entries.length) {
+      console.log(`    prereqs: ${fetched}/${entries.length} (${prereqMap.size} with prereqs)`);
+    }
+
+    if (i + BATCH_SIZE < entries.length) await sleep(100);
+  }
+
+  return prereqMap;
+}
+
+// ---------------------------------------------------------------------------
+// Types for the Colleague API response
+// ---------------------------------------------------------------------------
+
+interface ColleagueSection {
+  Course: {
+    SubjectCode: string;
+    Number: string;
+    Title: string;
+    MinimumCredits: number;
+    Requisites: Array<{ RequirementCode?: string; IsRequired?: boolean; CompletionOrder?: string; CorequisiteCourseId?: string }>;
+  };
+  SectionNameDisplay: string;
+  FacultyDisplay: string[];
+  FormattedMeetingTimes: Array<{
+    DaysOfWeekDisplay: string;
+    StartTimeDisplay: string;
+    EndTimeDisplay: string;
+    BuildingDisplay: string;
+    RoomDisplay: string;
+    IsOnline: boolean;
+  }>;
+  StartDateDisplay: string;
+  LocationDisplay: string;
+  LocationCode: string;
+  MeetingsDisplay: string[];
+  MinimumCredits: number;
+  Available: number | null;
+  Capacity: number | null;
+  Id: string;
+}
+
+interface ColleagueSearchResponse {
+  Sections: ColleagueSection[];
+  TotalItems: number;
+  TotalPages: number;
+  PageSize: number;
+  Subjects: Array<{ Code: string; Description: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Scraping
+// ---------------------------------------------------------------------------
+
+async function scrapeCollege(
+  slug: string,
+  baseUrl: string,
+  termName: string,
+  context: BrowserContext
+): Promise<CourseSection[]> {
+  console.log(`\nScraping ${slug} (${baseUrl}) for ${termName}...`);
+
+  const page = await context.newPage();
+  const allSections: CourseSection[] = [];
+
+  try {
+    // Step 1: Load the course catalog page to get CSRF token and subjects
+    console.log(`  Loading course catalog...`);
+    await page.goto(`${baseUrl}/Student/Courses`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+    await page.waitForTimeout(3000);
+
+    // Check if we were redirected to a login page
+    const currentUrl = page.url();
+    if (currentUrl.includes("/Account/Login")) {
+      console.log(`  Redirected to login page, looking for guest access...`);
+
+      // Try clicking "Continue as Guest" / "Search as Guest" links/buttons
+      const guestLink = await page.$(
+        'a:has-text("Guest"), a:has-text("guest"), a:has-text("Search"), button:has-text("Guest")'
+      );
+      if (guestLink) {
+        await guestLink.click();
+        await page.waitForTimeout(3000);
+        console.log(`  Clicked guest access link`);
+      } else {
+        // Try navigating to guest course catalog URL
+        console.log(`  No guest link found, trying guest URL...`);
+        await page.goto(`${baseUrl}/Student/Courses?guestUser=true`, {
+          waitUntil: "domcontentloaded",
+          timeout: 30000,
+        });
+        await page.waitForTimeout(3000);
+
+        // Still on login page?
+        if (page.url().includes("/Account/Login")) {
+          console.error(`  ${slug} requires authentication — no guest access available. Skipping.`);
+          return [];
+        }
+      }
+    }
+
+    // Extract CSRF token
+    const csrfToken = await page.evaluate(() => {
+      const input = document.querySelector(
+        'input[name="__RequestVerificationToken"]'
+      ) as HTMLInputElement;
+      return input?.value || null;
+    });
+
+    if (!csrfToken) {
+      console.error(`  Could not find CSRF token for ${slug}`);
+      return [];
+    }
+    console.log(`  Got CSRF token`);
+
+    // Find the correct term code from the select dropdown
+    const termOptions = await page.evaluate(() => {
+      const select = document.getElementById("term-id") as HTMLSelectElement;
+      if (!select) return [];
+      return Array.from(select.options).map((o) => ({
+        value: o.value,
+        label: o.textContent?.trim() || "",
+      }));
+    });
+
+    // Flexible term matching: "Spring 2026" should match "Spring 2026", "Spring Semester 2026", etc.
+    const termNameLower = termName.toLowerCase();
+    const termParts = termNameLower.split(/\s+/); // e.g., ["spring", "2026"]
+
+    // Build expected term code from name (e.g., "Spring 2026" → "2026SP")
+    const seasonCodeMap: Record<string, string> = {
+      spring: "SP", summer: "SU", fall: "FA", winter: "WI",
+    };
+    const yearMatch = termName.match(/(\d{4})/);
+    const seasonMatch = termName.match(/(spring|summer|fall|winter)/i);
+    const expectedTermCode = yearMatch && seasonMatch
+      ? `${yearMatch[1]}${seasonCodeMap[seasonMatch[1].toLowerCase()] || ""}`
+      : null;
+
+    const termOption = termOptions.find(
+      (t) => {
+        const label = t.label.toLowerCase();
+        const value = t.value;
+        // Exact term code match first (highest priority)
+        if (expectedTermCode && value === expectedTermCode) return true;
+        // Exact label match
+        if (label === termNameLower) return true;
+        // All parts of the search term appear in the label, excluding reporting/CE terms
+        if (termParts.every((part) => label.includes(part)) && !label.includes("ce") && !label.includes("reporting")) return true;
+        // Match by term code in label
+        if (expectedTermCode && label === expectedTermCode.toLowerCase()) return true;
+        return false;
+      }
+    );
+    if (!termOption || !termOption.value) {
+      console.error(`  Term "${termName}" not found. Available: ${termOptions.map((t) => t.label || t.value).join(", ")}`);
+      return [];
+    }
+    const termCode = termOption.value;
+    console.log(`  Using term code: ${termCode}`);
+
+    // Get subject list from the advanced search API
+    let subjects: Array<{ Code: string; Description: string }> = [];
+
+    // Try fetching from the API endpoint
+    const advSearchResp = await page.evaluate(async (url) => {
+      try {
+        const resp = await fetch(url);
+        const data = await resp.json();
+        return data.Subjects || [];
+      } catch {
+        return [];
+      }
+    }, `${baseUrl}/Student/Courses/GetCatalogAdvancedSearch`);
+
+    if (advSearchResp.length > 0) {
+      subjects = advSearchResp;
+    } else {
+      // Fallback: extract from the select element
+      subjects = await page.evaluate(() => {
+        const select = document.getElementById("subject-0") as HTMLSelectElement;
+        if (!select) return [];
+        return Array.from(select.options)
+          .filter((o) => o.value)
+          .map((o) => ({ Code: o.value, Description: o.textContent?.trim() || "" }));
+      });
+    }
+
+    console.log(`  Found ${subjects.length} subjects to search`);
+
+    // Step 2: For each subject, search via PostSearchCriteria API
+    const cookies = await context.cookies();
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join("; ");
+
+    // Track courses with requisites for batch prerequisite fetch
+    const coursesWithRequisites = new Map<string, string>();
+
+    for (let i = 0; i < subjects.length; i++) {
+      const subject = subjects[i];
+      process.stdout.write(
+        `  [${i + 1}/${subjects.length}] ${subject.Code.padEnd(5)} `
+      );
+
+      let pageNumber = 1;
+      let totalPages = 1;
+      let subjectCount = 0;
+
+      while (pageNumber <= totalPages) {
+        const requestBody = {
+          keyword: null,
+          terms: [termCode],
+          requirement: null,
+          subrequirement: null,
+          courseIds: null,
+          sectionIds: null,
+          requirementText: null,
+          subrequirementText: "",
+          group: null,
+          startTime: null,
+          endTime: null,
+          openSections: null,
+          subjects: [subject.Code],
+          academicLevels: [],
+          courseLevels: [],
+          synonyms: [],
+          courseTypes: [],
+          topicCodes: [],
+          days: [],
+          locations: [],
+          faculty: [],
+          onlineCategories: null,
+          keywordComponents: [],
+          startDate: null,
+          endDate: null,
+          startsAtTime: null,
+          endsByTime: null,
+          pageNumber,
+          sortOn: "SectionName",
+          sortDirection: "Ascending",
+          subjectsBadge: [],
+          locationsBadge: [],
+          termFiltersBadge: [],
+          daysBadge: [],
+          facultyBadge: [],
+          academicLevelsBadge: [],
+          courseLevelsBadge: [],
+          courseTypesBadge: [],
+          topicCodesBadge: [],
+          onlineCategoriesBadge: [],
+          openSectionsBadge: "",
+          openAndWaitlistedSectionsBadge: "",
+          subRequirementText: null,
+          quantityPerPage: PAGE_SIZE,
+          openAndWaitlistedSections: null,
+          searchResultsView: "SectionListing",
+        };
+
+        try {
+          const response = await page.evaluate(
+            async ({ url, body, token }) => {
+              const resp = await fetch(url, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json, charset=UTF-8",
+                  Accept: "application/json, text/javascript, */*; q=0.01",
+                  "X-Requested-With": "XMLHttpRequest",
+                  __RequestVerificationToken: token,
+                  __IsGuestUser: "true",
+                },
+                body: JSON.stringify(body),
+              });
+              return await resp.json();
+            },
+            {
+              url: `${baseUrl}/Student/Courses/PostSearchCriteria`,
+              body: requestBody,
+              token: csrfToken,
+            }
+          );
+
+          const data = response as ColleagueSearchResponse;
+
+          if (pageNumber === 1) {
+            totalPages = data.TotalPages || 1;
+          }
+
+          if (data.Sections && data.Sections.length > 0) {
+            for (const s of data.Sections) {
+              const meeting = s.FormattedMeetingTimes?.[0];
+              const isOnline = meeting?.IsOnline || false;
+              // Track courses with requisites for batch fetch later
+              if (s.Course?.Requisites?.length > 0) {
+                const key = `${s.Course.SubjectCode} ${s.Course.Number}`;
+                if (!coursesWithRequisites.has(key)) {
+                  coursesWithRequisites.set(key, s.Id);
+                }
+              }
+
+              allSections.push({
+                college_code: slug,
+                term: termCode,
+                course_prefix: s.Course.SubjectCode,
+                course_number: s.Course.Number,
+                course_title: s.Course.Title,
+                credits: s.MinimumCredits || s.Course.MinimumCredits || 0,
+                crn: s.SectionNameDisplay || s.Id,
+                days: formatDays(meeting?.DaysOfWeekDisplay || ""),
+                start_time: meeting?.StartTimeDisplay || "",
+                end_time: meeting?.EndTimeDisplay || "",
+                start_date: normalizeDate(s.StartDateDisplay || ""),
+                location: s.LocationDisplay || "",
+                campus: s.LocationCode || "",
+                mode: determineMode({
+                  locationCode: s.LocationCode || "",
+                  locationDisplay: s.LocationDisplay || "",
+                  isOnline,
+                  meetingsDisplay: s.MeetingsDisplay || [],
+                }),
+                instructor: s.FacultyDisplay?.join(", ") || null,
+                seats_open: s.Available ?? null,
+                seats_total: s.Capacity ?? null,
+                prerequisite_text: null,
+                prerequisite_courses: [],
+              });
+              subjectCount++;
+            }
+          }
+        } catch (e) {
+          console.error(`API error: ${e}`);
+          break;
+        }
+
+        pageNumber++;
+        if (pageNumber <= totalPages) {
+          await sleep(200);
+        }
+      }
+
+      console.log(
+        `${subjectCount} sections${totalPages > 1 ? ` (${totalPages} pages)` : ""}`
+      );
+      await sleep(DELAY_MS);
+    }
+
+    // Step 3: Fetch detailed prerequisites for courses that have them
+    if (coursesWithRequisites.size > 0) {
+      const prereqMap = await fetchSectionPrerequisites(page, baseUrl, csrfToken, coursesWithRequisites);
+      for (const section of allSections) {
+        const key = `${section.course_prefix} ${section.course_number}`;
+        const prereq = prereqMap.get(key);
+        if (prereq) {
+          section.prerequisite_text = prereq.text;
+          section.prerequisite_courses = prereq.courses;
+        }
+      }
+      console.log(`  Updated ${prereqMap.size} courses with prerequisite info`);
+    }
+  } catch (e) {
+    console.error(`  Error scraping ${slug}: ${e}`);
+  } finally {
+    await page.close();
+  }
+
+  return allSections;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeFlag = args.indexOf("--college");
+  const termFlag = args.indexOf("--term");
+  const allFlag = args.includes("--all");
+
+  // Support comma-separated terms: --term "Summer 2026,Fall 2026"
+  const termNames = termFlag >= 0
+    ? args[termFlag + 1].split(",").map((t) => t.trim()).filter(Boolean)
+    : ["Spring 2026"];
+  const termName = termNames[0]; // primary term (used for single-term log below)
+
+  let targets: [string, string][];
+
+  if (allFlag) {
+    targets = Object.entries(COLLEAGUE_COLLEGES);
+  } else if (collegeFlag >= 0) {
+    const slug = args[collegeFlag + 1];
+    const baseUrl = COLLEAGUE_COLLEGES[slug];
+    if (!baseUrl) {
+      console.error(`Unknown college: ${slug}`);
+      console.error(`Available: ${Object.keys(COLLEAGUE_COLLEGES).join(", ")}`);
+      process.exit(1);
+    }
+    targets = [[slug, baseUrl]];
+  } else {
+    console.log("Usage:");
+    console.log("  npx tsx scripts/nj/scrape-colleague.ts --college bergen");
+    console.log('  npx tsx scripts/nj/scrape-colleague.ts --college bergen --term "Fall 2026"');
+    console.log("  npx tsx scripts/nj/scrape-colleague.ts --all");
+    process.exit(0);
+  }
+
+  console.log(`Scraping ${targets.length} college(s) for ${termNames.length} term(s): ${termNames.join(", ")}...\n`);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  });
+
+  for (const currentTermName of termNames) {
+    console.log(`\n--- Term: ${currentTermName} ---\n`);
+
+    for (const [slug, baseUrl] of targets) {
+      const sections = await scrapeCollege(slug, baseUrl, currentTermName, context);
+
+      if (sections.length > 0) {
+        const termCode = sections[0].term;
+        const outDir = path.join(process.cwd(), "data", "nj", "courses", slug);
+        fs.mkdirSync(outDir, { recursive: true });
+        const outPath = path.join(outDir, `${termCode}.json`);
+        fs.writeFileSync(outPath, JSON.stringify(sections, null, 2) + "\n");
+        console.log(`\n  Written ${sections.length} sections to ${outPath}`);
+      } else {
+        console.log(`\n  No sections found for ${slug} (${currentTermName})`);
+      }
+
+      await sleep(DELAY_MS);
+    }
+  }
+
+  await browser.close();
+
+  // Auto-import into Supabase (skip with --no-import)
+  if (!args.includes("--no-import")) {
+    const { importCoursesToSupabase } = await import("../lib/supabase-import");
+    await importCoursesToSupabase("nj");
+  }
+
+  console.log("\nDone.");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Closes #166.

## Summary
- Adds `scripts/nj/scrape-colleague.ts` (cloned from NC) covering 10 publicly accessible Colleague Self-Service colleges: bergen, brookdale, ccm, hccc, passaic, rcbc, atlantic-cape, mercer, middlesex, ucnj.
- Adds `scripts/nj/scrape-banner-ssb.ts` (cloned from GA, with TCSG fiscal-year suffix logic and TLS workaround removed) covering essex and rvcc.
- Adds a `colleague-nj` system to `scripts/lib/resolve-terms.ts` — Bergen serves as the term-discovery probe.
- Updates `lib/states/nj/config.ts`: removes stale `manual-only` comment, replaces `COLLEAGUE_SELF_SERVICE_URLS` with confirmed base URLs, adds `BANNER_SSB_URLS`, fixes `courseDiscoveryUrl`/`collegeCoursesUrl` to handle Banner colleges, and adds the `scrapers` field so `scheduled-scrape.yml` picks NJ up automatically (Mon/Wed/Fri 06:00 UTC).
- 6 colleges deferred (camden, ocean, rcsj-cumberland, rcsj-gloucester, sussex, warren, salem) — incompatible systems or auth-gated; their entries remain in the config for course-discovery links.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run check:scrapers` passes (18 states × 3 datatypes)
- [x] `npx tsx scripts/lib/resolve-terms.ts --system colleague-nj` → `{"terms":["Summer 2026","Fall 2026"],"termCodes":["2026SU","2026FA"]}`
- [x] `npx tsx scripts/nj/scrape-colleague.ts --college bergen --term "Summer 2026" --no-import` → 352 sections, 78 with prereqs, written to `data/nj/courses/bergen/2026S1.json`
- [x] `npx tsx scripts/nj/scrape-banner-ssb.ts --college essex --no-import` → 1,354 sections across Fall 2026 / Summer I / Summer II, 247 with prereqs
- [ ] After merge: confirm scheduled-scrape workflow opens an NJ PR on the next run; spot-check `/nj` page renders course data once imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)