### PR TITLE
NJ scrapers: default to all colleges when no --college flag

### DIFF
--- a/scripts/nj/scrape-banner-ssb.ts
+++ b/scripts/nj/scrape-banner-ssb.ts
@@ -448,9 +448,7 @@ async function main() {
 
   let targets: [string, string][];
 
-  if (allFlag) {
-    targets = Object.entries(BANNER_COLLEGES);
-  } else if (collegeFlag >= 0) {
+  if (collegeFlag >= 0) {
     const slug = args[collegeFlag + 1];
     const baseUrl = BANNER_COLLEGES[slug];
     if (!baseUrl) {
@@ -462,12 +460,11 @@ async function main() {
     }
     targets = [[slug, baseUrl]];
   } else {
-    console.log("Usage:");
-    console.log(
-      "  npx tsx scripts/nj/scrape-banner-ssb.ts --college essex"
-    );
-    console.log("  npx tsx scripts/nj/scrape-banner-ssb.ts --all");
-    process.exit(0);
+    // No --college flag → scrape all. The unified scheduled-scrape workflow
+    // invokes scrapers without a college selector, so the unattended path
+    // must default to all colleges. --all is still accepted explicitly.
+    void allFlag;
+    targets = Object.entries(BANNER_COLLEGES);
   }
 
   let grandTotal = 0;

--- a/scripts/nj/scrape-colleague.ts
+++ b/scripts/nj/scrape-colleague.ts
@@ -617,13 +617,10 @@ async function main() {
   const termNames = termFlag >= 0
     ? args[termFlag + 1].split(",").map((t) => t.trim()).filter(Boolean)
     : ["Spring 2026"];
-  const termName = termNames[0]; // primary term (used for single-term log below)
 
   let targets: [string, string][];
 
-  if (allFlag) {
-    targets = Object.entries(COLLEAGUE_COLLEGES);
-  } else if (collegeFlag >= 0) {
+  if (collegeFlag >= 0) {
     const slug = args[collegeFlag + 1];
     const baseUrl = COLLEAGUE_COLLEGES[slug];
     if (!baseUrl) {
@@ -633,11 +630,12 @@ async function main() {
     }
     targets = [[slug, baseUrl]];
   } else {
-    console.log("Usage:");
-    console.log("  npx tsx scripts/nj/scrape-colleague.ts --college bergen");
-    console.log('  npx tsx scripts/nj/scrape-colleague.ts --college bergen --term "Fall 2026"');
-    console.log("  npx tsx scripts/nj/scrape-colleague.ts --all");
-    process.exit(0);
+    // No --college flag → scrape all. The unified scheduled-scrape workflow
+    // invokes scrapers as `npx tsx <script> --no-import --term "..."` with no
+    // college selector, so the unattended path must default to all colleges.
+    // --all is still accepted for explicit invocations.
+    void allFlag;
+    targets = Object.entries(COLLEAGUE_COLLEGES);
   }
 
   console.log(`Scraping ${targets.length} college(s) for ${termNames.length} term(s): ${termNames.join(", ")}...\n`);


### PR DESCRIPTION
Follow-up to #167. The scheduled-scrape workflow invokes scrapers as `npx tsx <script> --no-import --term "..."` with no college selector. The NJ scrapers from #167 printed Usage and exited 0 in that case, so the manual workflow run [25294268987](https://github.com/rohan-c0de/cc-coursemap/actions/runs/25294268987) had both NJ jobs report success while producing **zero course files**.

## Summary
- `scripts/nj/scrape-colleague.ts` and `scripts/nj/scrape-banner-ssb.ts`: drop the Usage-exit branch; treat "no `--college` flag" as scrape-all. `--all` is still accepted explicitly.
- Removed unused `termName` local in the Colleague scraper that the Usage branch used to gate compile against.

## Out of scope (flagged for separate PR)
NC, SC, VT, and MA Colleague-playwright scrapers have the same latent bug — they've been silently no-op'ing in scheduled runs. Their data on `main` came from manual `--all` invocations. Their Banner-SSB siblings already default to all-colleges via `getTerms()`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx tsx scripts/nj/scrape-banner-ssb.ts --no-import` (no college flag) → scraped Essex (1,354 sections across 2026FA / 2026SU) and started RVCC, confirming the workflow-style invocation now dispatches
- [ ] After merge: re-trigger the courses workflow (`gh workflow run "Scheduled scrape (unified)" -f datatype=courses`) and confirm an NJ data PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)