### PR TITLE
scheduled-scrape: one PR per state (closes #169)

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -1,14 +1,25 @@
 name: Scheduled scrape (unified)
 
-# Unified scheduled-scrape workflow (issue #59, PR 2). Replaces the
-# VA-only weekly-scrape-va.yml exemplar (#58). Reads StateConfig.scrapers
-# to build its matrix, so adding a state to cron is a config edit, not
-# a YAML edit.
+# Unified scheduled-scrape workflow (issue #59, PR 2; per-state PRs in
+# issue #169). Replaces the VA-only weekly-scrape-va.yml exemplar (#58).
+# Reads StateConfig.scrapers to build its matrix, so adding a state to
+# cron is a config edit, not a YAML edit.
+#
+# Pipeline:
+#   plan      — emit scrape matrix + aggregate states list
+#   scrape    — matrix over ScrapeJobs (parallel; one runner each)
+#   aggregate — matrix over states (parallel; one PR each)
+#   health    — single runner; rolling issue per datatype
+#
+# Per-state aggregate (issue #169): each state opens its own PR keyed by
+# `scheduled-scrape/{state}-{datatype}`, so a fast state's data isn't
+# blocked by a slow state's scrape finishing. Cross-state coupling lives
+# only in `health`, which intentionally needs the whole picture.
 #
 # Runs `--no-import` only. The scraped JSON never touches Supabase from
-# this workflow — a human merges the PR, then scripts/import-courses.ts
-# picks up the files on main and runs schema validation (#49) + change
-# detection (#51) before any row lands in the database.
+# this workflow — a human merges the per-state PR, then
+# scripts/import-courses.ts picks up the files on main and runs schema
+# validation (#49) + change detection (#51) before any row lands.
 #
 # Three crons, one per data type. `github.event.schedule` tells us which
 # fired. Manual dispatch accepts a `datatype` input.
@@ -39,6 +50,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
+      states: ${{ steps.plan.outputs.states }}
       datatype: ${{ steps.plan.outputs.datatype }}
       empty: ${{ steps.plan.outputs.empty }}
     steps:
@@ -70,15 +82,21 @@ jobs:
         run: |
           dt="${{ steps.datatype.outputs.value }}"
           matrix=$(npx tsx scripts/lib/scraper-matrix.ts --datatype "$dt")
+          # Per-state aggregate matrix (issue #169) — includes states with
+          # explicit ScrapeJobs *and* prereqs-via-aggregate-from-courses
+          # states whose prereqs.json refreshes off committed course data.
+          states=$(npx tsx scripts/lib/scraper-matrix.ts --datatype "$dt" --mode states)
           count=$(echo "$matrix" | jq '.include | length')
+          state_count=$(echo "$states" | jq '.states | length')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "states=$states" >> "$GITHUB_OUTPUT"
           echo "datatype=$dt" >> "$GITHUB_OUTPUT"
-          if [ "$count" = "0" ]; then
+          if [ "$count" = "0" ] && [ "$state_count" = "0" ]; then
             echo "empty=true" >> "$GITHUB_OUTPUT"
-            echo "No states declare scheduled $dt scraping. Nothing to do." >&2
+            echo "No states declare scheduled $dt scraping or aggregation. Nothing to do." >&2
           else
             echo "empty=false" >> "$GITHUB_OUTPUT"
-            echo "Matrix: $count entries across the registry." >&2
+            echo "Scrape matrix: $count entries; aggregate matrix: $state_count states." >&2
           fi
 
   scrape:
@@ -157,11 +175,21 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # ----------------------------------------------------------------------
+  # Per-state aggregate (issue #169). Each state opens its own PR so a
+  # 30-min NJ scrape doesn't wait on a 2-hr VA PeopleSoft run before its
+  # data can land. Each runner only handles its own state's artifacts and
+  # diffs `data/{state}/` against main — no cross-state coupling.
+  # ----------------------------------------------------------------------
   aggregate:
     needs: [plan, scrape]
     if: always() && needs.plan.outputs.empty == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        state: ${{ fromJSON(needs.plan.outputs.states) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -170,42 +198,37 @@ jobs:
           cache: "npm"
       - run: npm ci
 
-      - name: Download all scrape artifacts
+      - name: Download this state's scrape artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: scrape-*
+          # Matches scrape-{state}-{datatype}-{idx} (e.g. scrape-nj-courses-0).
+          # Aggregate-from-courses prereqs states have no artifacts; the
+          # download step is a no-op for them and we proceed to re-aggregate
+          # off committed course data below.
+          pattern: scrape-${{ matrix.state }}-*
           path: /tmp/scrape-artifacts
 
       - name: Overlay artifacts into working tree
         run: |
-          # Each artifact was uploaded from data/{state}/; restore that
-          # directory structure under data/ in this checkout.
           shopt -s nullglob
-          for dir in /tmp/scrape-artifacts/scrape-*; do
-            # Artifact name is scrape-{state}-{datatype}-{idx}
-            base=$(basename "$dir")
-            state=$(echo "$base" | sed -E 's/^scrape-([a-z]+)-.*/\1/')
-            mkdir -p "data/$state"
-            cp -R "$dir"/. "data/$state/"
+          for dir in /tmp/scrape-artifacts/scrape-${{ matrix.state }}-*; do
+            mkdir -p "data/${{ matrix.state }}"
+            cp -R "$dir"/. "data/${{ matrix.state }}/"
           done
           git status --short | head -40
 
-      - name: Aggregate prereqs from course data
-        # Issue #144: aggregate-from-courses states (declared in their
-        # StateConfig) have no scrape job in the matrix, so without this
-        # step their prereqs.json never refreshes. The script reads
-        # data/{state}/courses/** (committed on main, plus any artifacts
-        # overlaid above) and rewrites data/{state}/prereqs.json. The
-        # subsequent diff step picks up changes and folds them into the
-        # auto-PR.
+      - name: Aggregate prereqs from course data (this state)
+        # Issue #144: aggregate-from-courses states declare prereqs in
+        # StateConfig but have no scrape job. Refresh prereqs.json off
+        # data/{state}/courses/** (committed on main + overlay above).
         if: needs.plan.outputs.datatype == 'prereqs'
-        run: npx tsx scripts/lib/aggregate-prereqs.ts --all
+        run: npx tsx scripts/lib/aggregate-prereqs.ts ${{ matrix.state }}
 
-      - name: Diff against main
+      - name: Diff against main (this state only)
         id: diff
         run: |
-          json=$(npx tsx scripts/lib/scrape-diff.ts --path data/ --format json)
-          md=$(npx tsx scripts/lib/scrape-diff.ts --path data/ --format markdown)
+          json=$(npx tsx scripts/lib/scrape-diff.ts --path data/${{ matrix.state }} --format json)
+          md=$(npx tsx scripts/lib/scrape-diff.ts --path data/${{ matrix.state }} --format markdown)
           {
             echo "report_json<<EOF"
             echo "$json"
@@ -225,46 +248,84 @@ jobs:
           REPORT_MD: ${{ steps.diff.outputs.report_md }}
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           DT: ${{ needs.plan.outputs.datatype }}
+          ST: ${{ matrix.state }}
         run: |
           today=$(date -u +"%Y-%m-%d")
           {
-            echo "Scheduled **${DT}** scrape on ${today} produced one or more files that dropped below 50% of their prior row count. Scraper is likely broken (expired cookie, source-site change, parser regression)."
+            echo "Scheduled **${DT}** scrape for **${ST}** on ${today} produced one or more files that dropped below 50% of their prior row count. Scraper is likely broken (expired cookie, source-site change, parser regression)."
             echo
             printf '%s\n' "$REPORT_MD"
             echo
-            echo "**No PR was opened.** Investigate the scraper(s) before re-running."
+            echo "**No PR was opened.** Investigate the ${ST} scraper(s) before re-running."
             echo
             echo "Workflow run: ${RUN_URL}"
           } > issue-body.md
           gh issue create \
-            --title "Scheduled ${DT} scrape: suspected regression (${today})" \
+            --title "Scheduled ${DT} scrape: ${ST} regression (${today})" \
             --body-file issue-body.md
 
       - name: Open PR with fresh data
         if: steps.diff.outputs.broken == 'false' && steps.diff.outputs.changed != '0'
         uses: peter-evans/create-pull-request@v7
         with:
-          branch: scheduled-scrape/${{ needs.plan.outputs.datatype }}
-          commit-message: "Scheduled ${{ needs.plan.outputs.datatype }} scrape — ${{ steps.diff.outputs.changed }} file(s)"
-          title: "Scheduled ${{ needs.plan.outputs.datatype }} scrape — ${{ steps.diff.outputs.changed }} file(s) updated"
+          branch: scheduled-scrape/${{ matrix.state }}-${{ needs.plan.outputs.datatype }}
+          commit-message: "Scheduled ${{ needs.plan.outputs.datatype }} scrape: ${{ matrix.state }} — ${{ steps.diff.outputs.changed }} file(s)"
+          title: "Scheduled ${{ needs.plan.outputs.datatype }} scrape: ${{ matrix.state }} — ${{ steps.diff.outputs.changed }} file(s) updated"
           body: |
-            Automated output of the unified scheduled-scrape workflow (issue #59).
+            Automated output of the unified scheduled-scrape workflow (issues #59, #169).
+
+            State: **${{ matrix.state }}** · datatype: **${{ needs.plan.outputs.datatype }}**
 
             ${{ steps.diff.outputs.report_md }}
 
-            **Do not auto-merge.** Skim the diff — spot-check one or two states in the preview URL before landing. Schema validation (#49) and change detection (#51) both run again at import time once this lands on main.
+            **Do not auto-merge.** Skim the diff before landing. Schema validation (#49) and change detection (#51) both run again at import time once this lands on main.
           labels: scraper-output,automated
           delete-branch: true
 
       - name: No-op summary
         if: steps.diff.outputs.broken == 'false' && steps.diff.outputs.changed == '0'
-        run: echo "No changes vs. main — nothing to PR."
+        run: echo "No changes for ${{ matrix.state }} — nothing to PR."
 
-      # ----------------------------------------------------------------------
-      # Health monitor (issue #120) — runs every tick, never gated on diff.
-      # Classifies every (state × declared scraper) pair as healthy/empty/failed
-      # and keeps a rolling issue per datatype so silence is never the answer.
-      # ----------------------------------------------------------------------
+  # ----------------------------------------------------------------------
+  # Health monitor (issue #120) — runs once after all per-state aggregates.
+  # Classifies every (state × declared scraper) pair as healthy/empty/failed
+  # and keeps a rolling issue per datatype so silence is never the answer.
+  # Needs all artifacts (and a full prereqs aggregation) to classify
+  # accurately — this is the one place a single-runner view is correct.
+  # ----------------------------------------------------------------------
+  health:
+    needs: [plan, scrape, aggregate]
+    if: always() && needs.plan.outputs.empty == 'false'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+
+      - name: Download all scrape artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: scrape-*
+          path: /tmp/scrape-artifacts
+
+      - name: Overlay artifacts into working tree
+        run: |
+          shopt -s nullglob
+          for dir in /tmp/scrape-artifacts/scrape-*; do
+            base=$(basename "$dir")
+            state=$(echo "$base" | sed -E 's/^scrape-([a-z]+)-.*/\1/')
+            mkdir -p "data/$state"
+            cp -R "$dir"/. "data/$state/"
+          done
+
+      - name: Aggregate prereqs from course data (all states)
+        if: needs.plan.outputs.datatype == 'prereqs'
+        run: npx tsx scripts/lib/aggregate-prereqs.ts --all
+
       - name: Run health check
         id: health
         env:
@@ -305,8 +366,6 @@ jobs:
           printf '%s\n' "$BODY" > /tmp/issue-body.md
 
           if [ -z "$existing" ]; then
-            # First run for this datatype — only file an issue if there's
-            # something to report. All-healthy on first tick stays silent.
             if [ "$ALL_HEALTHY" = "true" ]; then
               echo "First run for '${title}', all healthy — not opening an issue."
               exit 0
@@ -318,10 +377,8 @@ jobs:
             exit 0
           fi
 
-          # Existing issue: always update the body so it reflects the latest tick.
           gh issue edit "$existing" --body-file /tmp/issue-body.md
 
-          # Close on green, reopen on red. gh handles the no-op cases gracefully.
           state=$(gh issue view "$existing" --json state --jq .state)
           if [ "$ALL_HEALTHY" = "true" ] && [ "$state" = "OPEN" ]; then
             gh issue close "$existing" --comment "All declared ${DT} scrapers healthy on the latest tick. Closing — will reopen automatically if a future tick regresses."

--- a/scripts/lib/scraper-matrix.ts
+++ b/scripts/lib/scraper-matrix.ts
@@ -7,10 +7,16 @@
  *
  * Usage:
  *   npx tsx scripts/lib/scraper-matrix.ts --datatype courses
+ *   npx tsx scripts/lib/scraper-matrix.ts --datatype prereqs --mode states
  *
- * Output (single-line JSON to stdout; consumed via `fromJSON()` in a
- * workflow's `strategy.matrix`):
- *   {"include":[{"state":"va","scripts":"scripts/va/scrape-vccs.ts","runner":"http","id":"va-courses-0"}, ...]}
+ * Modes:
+ *   --mode scrape (default) — emits `{"include":[...]}` for `strategy.matrix`
+ *     of the scrape job. One entry per registered ScrapeJob.
+ *   --mode states — emits `{"states":["va","nj",...]}` of every state with
+ *     anything to aggregate for this datatype. Drives the per-state aggregate
+ *     matrix (issue #169). Includes both states with explicit ScrapeJobs and
+ *     prereqs-via-`aggregate-from-courses` states whose prereqs.json is
+ *     refreshed from already-committed course data each tick.
  *
  * `scripts` is a newline-separated string so the workflow can pipe it
  * through `xargs` — GitHub Actions matrix entries don't support arrays.
@@ -25,9 +31,11 @@ const args = process.argv.slice(2);
 const dtIdx = args.indexOf("--datatype");
 const datatype = (dtIdx >= 0 ? args[dtIdx + 1] : null) as DataType | null;
 if (!datatype || !["courses", "transfers", "prereqs"].includes(datatype)) {
-  console.error("Usage: scraper-matrix.ts --datatype courses|transfers|prereqs");
+  console.error("Usage: scraper-matrix.ts --datatype courses|transfers|prereqs [--mode scrape|states]");
   process.exit(1);
 }
+const modeIdx = args.indexOf("--mode");
+const mode = (modeIdx >= 0 ? args[modeIdx + 1] : "scrape") as "scrape" | "states";
 
 function jobsFor(scrapers: ScraperCoverage, dt: DataType): ScrapeJob[] {
   if (dt === "courses") return scrapers.courses ?? [];
@@ -38,6 +46,17 @@ function jobsFor(scrapers: ScraperCoverage, dt: DataType): ScrapeJob[] {
   // separate aggregation step runs at import time. Nothing to schedule here.
   if (!p || !Array.isArray(p)) return [];
   return p;
+}
+
+function aggregatesFor(scrapers: ScraperCoverage, dt: DataType): boolean {
+  if (jobsFor(scrapers, dt).length > 0) return true;
+  // Prereqs-via-aggregate-from-courses still produces a per-tick prereqs.json
+  // diff and so needs a per-state aggregate runner even though no scrape ran.
+  if (dt === "prereqs") {
+    const p = scrapers.prereqs;
+    if (p && !Array.isArray(p) && p.source === "aggregate-from-courses") return true;
+  }
+  return false;
 }
 
 interface MatrixEntry {
@@ -51,23 +70,30 @@ interface MatrixEntry {
   termSystem: string;
 }
 
-const include: MatrixEntry[] = [];
-
-for (const cfg of getAllStates()) {
-  if (!cfg.scrapers) continue;
-  const jobs = jobsFor(cfg.scrapers, datatype);
-  jobs.forEach((job, i) => {
-    include.push({
-      id: `${cfg.slug}-${datatype}-${i}`,
-      state: cfg.slug,
-      datatype,
-      runner: job.runner,
-      scripts: job.scripts.join("\n"),
-      termSystem: job.termSystem ?? "",
+if (mode === "states") {
+  const states: string[] = [];
+  for (const cfg of getAllStates()) {
+    if (!cfg.scrapers) continue;
+    if (aggregatesFor(cfg.scrapers, datatype)) states.push(cfg.slug);
+  }
+  console.log(JSON.stringify({ states }));
+} else {
+  const include: MatrixEntry[] = [];
+  for (const cfg of getAllStates()) {
+    if (!cfg.scrapers) continue;
+    const jobs = jobsFor(cfg.scrapers, datatype);
+    jobs.forEach((job, i) => {
+      include.push({
+        id: `${cfg.slug}-${datatype}-${i}`,
+        state: cfg.slug,
+        datatype,
+        runner: job.runner,
+        scripts: job.scripts.join("\n"),
+        termSystem: job.termSystem ?? "",
+      });
     });
-  });
+  }
+  // Matrix must be emitted as a single JSON line — GitHub Actions' `fromJSON`
+  // doesn't accept pretty-printed input reliably inside ${{ }}.
+  console.log(JSON.stringify({ include }));
 }
-
-// Matrix must be emitted as a single JSON line — GitHub Actions' `fromJSON`
-// doesn't accept pretty-printed input reliably inside ${{ }}.
-console.log(JSON.stringify({ include }));


### PR DESCRIPTION
Closes #169.

## Problem
The single `aggregate` job waited for every matrix entry (`needs: [plan, scrape]`) and bundled all states into one PR. NJ's 30-min scrape couldn't land until VA's 2-hour PeopleSoft scrape drained — visible on run [25294595320](https://github.com/rohan-c0de/cc-coursemap/actions/runs/25294595320) — and reviewers had to eyeball ~17 states' diffs at once.

## Change
Pipeline is now:
- **plan** — emits scrape matrix + deduped aggregate-states list
- **scrape** — matrix job (unchanged)
- **aggregate** — *new*: matrix over `state`, `fail-fast: false`. Each runner downloads only `scrape-{state}-*`, diffs `data/{state}/`, and opens its own `scheduled-scrape/{state}-{datatype}` PR.
- **health** — *new* separate single-runner job at the end. Coverage/health classification keeps its whole-system view because that's the one place cross-state visibility is correct.

`scraper-matrix.ts` grows `--mode states` to emit the aggregate-states list, including `aggregate-from-courses` prereq states whose `prereqs.json` refreshes off committed course data each tick.

## Tradeoffs
- Up to ~17 PRs per courses tick (Mon/Wed/Fri) instead of 1, but most state-tick combos no-op. Worst case still feels manageable; `do not auto-merge` label unchanged.
- Health monitor still gets the full picture — runs once after all aggregates, with all artifacts overlaid.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run check:scrapers` passes (18 states × 3 datatypes)
- [x] `npx tsx scripts/lib/scraper-matrix.ts --datatype courses --mode states` → 16 states; `--datatype prereqs --mode states` → 17 (includes `pa` via aggregate-from-courses); `--datatype transfers --mode states` → 15
- [x] Workflow YAML parses (`js-yaml`)
- [ ] After merge: re-trigger workflow with `gh workflow run "Scheduled scrape (unified)" -f datatype=courses` and confirm one PR per state instead of one bundled PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)