### PR TITLE
NJ Colleague: sanitize slashes in term code when used as filename

### DIFF
--- a/scripts/nj/scrape-colleague.ts
+++ b/scripts/nj/scrape-colleague.ts
@@ -654,9 +654,15 @@ async function main() {
 
       if (sections.length > 0) {
         const termCode = sections[0].term;
+        // Some NJ Colleague installations (e.g. Passaic) return term codes
+        // containing slashes like "26/SU1". Use a sanitized form for the
+        // filename so we keep the flat data/{state}/courses/{slug}/{term}.json
+        // layout; the in-memory `term` field is left alone for downstream
+        // import logic.
+        const fileTermCode = termCode.replace(/[\\/]/g, "-");
         const outDir = path.join(process.cwd(), "data", "nj", "courses", slug);
         fs.mkdirSync(outDir, { recursive: true });
-        const outPath = path.join(outDir, `${termCode}.json`);
+        const outPath = path.join(outDir, `${fileTermCode}.json`);
         fs.writeFileSync(outPath, JSON.stringify(sections, null, 2) + "\n");
         console.log(`\n  Written ${sections.length} sections to ${outPath}`);
       } else {


### PR DESCRIPTION
## Problem
Passaic (and likely other NJ Colleague installations) returns term codes shaped like `26/SU1` with an embedded slash. `path.join` treated that as a subdirectory, but `mkdirSync` only created `data/nj/courses/passaic/` — so the write crashed with:

\`\`\`
Error: ENOENT: no such file or directory, open 'data/nj/courses/passaic/26/SU1.json'
\`\`\`

That took down the entire all-colleges scrape mid-run after Passaic. Visible in [run 25294595320, job 74151308650](https://github.com/rohan-c0de/cc-coursemap/actions/runs/25294595320). NJ Banner SSB succeeded on the same run (3,667 sections across Essex + RVCC), so this is the only thing standing between the scheduled workflow and a clean NJ data PR.

## Fix
Replace `[/\\]` → `-` only at the filename layer (`fileTermCode`). The in-memory `term` field on each section is left alone so the import path still sees the raw Colleague code.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] After merge: re-trigger workflow and confirm NJ Colleague run completes across all 10 colleges, including Passaic, and produces \`26-SU1.json\` instead of crashing on \`26/SU1.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)