### PR TITLE
Colleague: skip terms that started 3+ weeks ago (closes #173)

### DIFF
--- a/scripts/lib/colleague-terms.ts
+++ b/scripts/lib/colleague-terms.ts
@@ -17,6 +17,7 @@
  */
 
 import { currentCalendarTerm, nextTerm, type TermInfo } from "./resolve-terms";
+import { isFrozen } from "./term-freeze";
 
 interface ColleagueActivePlanTerm {
   Code: string;         // "2026SP", custom like "V26SP", or quirky like "26/SU1"
@@ -162,10 +163,18 @@ export interface CollegeTerm {
  * live sections at this specific college, and return the site's native
  * codes for each. ~1 HTTP roundtrip + 1 verification POST per matched term.
  *
+ * When `opts.freezeContext` is provided, terms whose on-disk data started
+ * 3+ weeks ago (issue #173) are dropped from the result — drop-add is
+ * closed and the data on disk is the final record. Pass `state` and `slug`
+ * so the freeze check can locate `data/{state}/courses/{slug}/{term}.json`.
+ *
  * Returns an empty array if the college is offline, gates Self-Service
  * behind auth, or has no sections posted for any of the candidate terms.
  */
-export async function resolveCollegeTerms(baseUrl: string): Promise<CollegeTerm[]> {
+export async function resolveCollegeTerms(
+  baseUrl: string,
+  opts: { freezeContext?: { state: string; slug: string } } = {}
+): Promise<CollegeTerm[]> {
   const session = await openColleagueSession(baseUrl);
   if (!session) return [];
 
@@ -186,6 +195,13 @@ export async function resolveCollegeTerms(baseUrl: string): Promise<CollegeTerm[
   // catalog has been built but no sections exist yet.
   const found: CollegeTerm[] = [];
   for (const m of matches) {
+    if (
+      opts.freezeContext &&
+      isFrozen(opts.freezeContext.state, opts.freezeContext.slug, m.active.Code)
+    ) {
+      console.log(`  [frozen] skipping ${opts.freezeContext.slug}/${m.active.Code} (${m.active.Description}) — started 3+ weeks ago`);
+      continue;
+    }
     const verify = await colleaguePostSearch(baseUrl, session, [m.active.Code]);
     if ((verify?.TotalItems ?? 0) > 0) {
       found.push({

--- a/scripts/lib/term-freeze.ts
+++ b/scripts/lib/term-freeze.ts
@@ -1,0 +1,63 @@
+/**
+ * term-freeze.ts — issue #173.
+ *
+ * Once a term has been running for 3+ weeks, drop-add has closed at every
+ * system in scope and the on-disk section data is the final record.
+ * Re-scraping it produces nothing new, burns runner minutes, and adds
+ * load to college SIS servers. This helper detects that state by reading
+ * the on-disk JSON for `(state, slug, termCode)` and checking the earliest
+ * `start_date` across its sections.
+ *
+ * Returns false (don't freeze) on any of:
+ *   - file doesn't exist (first-time scrape — we have nothing yet)
+ *   - file is empty / unparseable
+ *   - no section has a non-empty `start_date` (bad data shouldn't pin a
+ *     term forever; default to scrape)
+ *
+ * Returns true only when we have data and `min(start_date) + 21 days`
+ * is strictly before today (UTC).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const FREEZE_DAYS = 21;
+
+interface SectionLike {
+  start_date?: string;
+}
+
+/**
+ * Look up the on-disk file for this (state, slug, termCode) and decide
+ * whether the term is "frozen" (started 3+ weeks ago). Sanitizes path
+ * separators in `termCode` the same way scrapers do at write time, so
+ * a Passaic-style "26/FA" code maps to "data/nj/courses/passaic/26-FA.json".
+ */
+export function isFrozen(state: string, slug: string, termCode: string): boolean {
+  const fileTermCode = termCode.replace(/[\\/]/g, "-");
+  const filePath = path.join(
+    process.cwd(), "data", state, "courses", slug, `${fileTermCode}.json`
+  );
+  if (!fs.existsSync(filePath)) return false;
+
+  let sections: SectionLike[];
+  try {
+    sections = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(sections) || sections.length === 0) return false;
+
+  const startDates = sections
+    .map((s) => s.start_date)
+    .filter((d): d is string => typeof d === "string" && d.length > 0)
+    .sort();
+  if (startDates.length === 0) return false;
+
+  const earliest = new Date(startDates[0]);
+  if (Number.isNaN(earliest.getTime())) return false;
+
+  const freezeAfter = new Date(earliest);
+  freezeAfter.setUTCDate(freezeAfter.getUTCDate() + FREEZE_DAYS);
+  return freezeAfter.getTime() < Date.now();
+}

--- a/scripts/md/scrape-colleague.ts
+++ b/scripts/md/scrape-colleague.ts
@@ -692,7 +692,7 @@ async function main() {
     if (overrideTermNames) {
       termNames = overrideTermNames;
     } else {
-      const discovered = await resolveCollegeTerms(baseUrl);
+      const discovered = await resolveCollegeTerms(baseUrl, { freezeContext: { state: "md", slug } });
       if (discovered.length === 0) {
         console.log(`\n--- ${slug}: no terms discovered (offline, gated, or no live sections); skipping ---`);
         await sleep(DELAY_MS);

--- a/scripts/nc/scrape-colleague.ts
+++ b/scripts/nc/scrape-colleague.ts
@@ -696,7 +696,7 @@ async function main() {
     if (overrideTermNames) {
       termNames = overrideTermNames;
     } else {
-      const discovered = await resolveCollegeTerms(baseUrl);
+      const discovered = await resolveCollegeTerms(baseUrl, { freezeContext: { state: "nc", slug } });
       if (discovered.length === 0) {
         console.log(`\n--- ${slug}: no terms discovered (offline, gated, or no live sections); skipping ---`);
         await sleep(DELAY_MS);

--- a/scripts/nj/scrape-colleague.ts
+++ b/scripts/nj/scrape-colleague.ts
@@ -659,7 +659,7 @@ async function main() {
     if (overrideTermNames) {
       termNames = overrideTermNames;
     } else {
-      const discovered = await resolveCollegeTerms(baseUrl);
+      const discovered = await resolveCollegeTerms(baseUrl, { freezeContext: { state: "nj", slug } });
       if (discovered.length === 0) {
         console.log(`\n--- ${slug}: no terms discovered (offline, gated, or no live sections); skipping ---`);
         await sleep(DELAY_MS);

--- a/scripts/sc/scrape-colleague.ts
+++ b/scripts/sc/scrape-colleague.ts
@@ -655,7 +655,7 @@ async function main() {
     if (overrideTermNames) {
       termNames = overrideTermNames;
     } else {
-      const discovered = await resolveCollegeTerms(baseUrl);
+      const discovered = await resolveCollegeTerms(baseUrl, { freezeContext: { state: "sc", slug } });
       if (discovered.length === 0) {
         console.log(`\n--- ${slug}: no terms discovered (offline, gated, or no live sections); skipping ---`);
         await sleep(DELAY_MS);

--- a/scripts/vt/scrape-colleague.ts
+++ b/scripts/vt/scrape-colleague.ts
@@ -567,7 +567,7 @@ async function main() {
   if (overrideTermNames) {
     termNames = overrideTermNames;
   } else {
-    const discovered = await resolveCollegeTerms(BASE_URL);
+    const discovered = await resolveCollegeTerms(BASE_URL, { freezeContext: { state: STATE, slug: SLUG } });
     if (discovered.length === 0) {
       console.log(`No terms discovered at ${BASE_URL} (offline, gated, or no live sections); nothing to do.`);
       return;


### PR DESCRIPTION
Closes #173.

## Why
Once a term has been running 21+ days, drop-add is closed at every system in scope and the on-disk section data is the final record. Re-scraping Spring 2026 in May 2026 (the current waste) produces nothing new — burns runner minutes, adds load to college SIS servers, and risks the 50%-row-drop regression check firing if a college quietly drops a closed term from their SIS.

Builds on [#172](https://github.com/rohan-c0de/cc-coursemap/pull/174) — per-college term discovery is the natural insertion point for the freeze filter.

## Change
- New \`scripts/lib/term-freeze.ts\` exporting \`isFrozen(state, slug, termCode)\`. Reads \`data/{state}/courses/{slug}/{term}.json\`, finds \`min(section.start_date)\`, returns true if \`+ 21 days < today\`. Slashes in \`termCode\` are sanitized to dashes so Passaic-style \`26/FA\` correctly looks up \`26-FA.json\`.
- \`resolveCollegeTerms\` grows an optional \`opts.freezeContext = { state, slug }\`. When provided, frozen terms are dropped from the discovered set with a \`[frozen]\` log line. Verification POSTs are also skipped for frozen terms (no need to ask the SIS "do you have sections" if we're not going to scrape).
- All five Colleague scrapers (\`nc\`, \`sc\`, \`md\`, \`vt\`, \`nj\`) pass their state + college slug.

## Safe defaults
\`isFrozen\` returns \`false\` (don't freeze) on every ambiguous case:
- File doesn't exist → first-time scrape, run normally
- File is empty / unparseable → don't pin a term forever on bad data
- No section has a \`start_date\` → same

The freeze rule pins a term only when we have *actual data* showing it started 3+ weeks ago.

## Out of scope
- Banner SSB scrapers — different code path (they call \`pickRecentSsbTerms\` per-college after \`getTerms\`). Worth a follow-up; lower priority since most Banner SSB instances correctly drop closed terms from their \`getTerms\` API anyway.
- VCCS / VCCS-PS — single shared resolver; freezing requires per-college signal that the workflow doesn't currently plumb through.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Unit-style smoke against synthetic data:
  - 30-day-old start_date → \`isFrozen\` true
  - 5-day-old start_date → \`isFrozen\` false
  - Empty / missing file → \`isFrozen\` false
  - Slash code "26/FA" → resolves "26-FA.json" correctly
- [ ] After merge: next NJ scheduled tick shows \`[frozen] skipping bergen/2026SP\` (or similar) for any committed term whose data has aged past 21 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)