### PR TITLE
blog: NH transfer spoke + TN senior waivers spoke

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -9,6 +9,16 @@
       "slug": "new-jersey-senior-citizens-county-college-tuition-waiver",
       "draftedAt": "2026-05-02T19:30:00Z",
       "trigger": "cluster-gap"
+    },
+    {
+      "slug": "new-hampshire-ccsnh-transfer-credit-guide",
+      "draftedAt": "2026-05-04T15:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "tennessee-senior-citizens-tbr-community-colleges",
+      "draftedAt": "2026-05-04T15:00:00Z",
+      "trigger": "cluster-gap"
     }
   ]
 }

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -471,6 +471,22 @@ export const articles: ArticleMeta[] = [
     clusterRole: "spoke",
   },
 
+  // --- Cluster A spoke: NH CCSNH transfer ---
+  {
+    slug: "new-hampshire-ccsnh-transfer-credit-guide",
+    title:
+      "How New Hampshire Community College Transfer Credit Actually Works: A CCSNH Student's Guide",
+    description:
+      "NH has 7 CCSNH colleges and transfer equivalencies published for only one university so far — Keene State, with a 31.1% direct match rate. Here's what that means if you're planning to transfer.",
+    date: "2026-05-04",
+    category: "state-system-explainers",
+    state: "nh",
+    author: "Community College Path",
+    tags: ["transfer", "new-hampshire", "ccsnh", "keene-state", "unh"],
+    cluster: "transfer-credit-guide",
+    clusterRole: "spoke",
+  },
+
   // --- Cluster A spoke: TN TBR transfer ---
   {
     slug: "tennessee-tbr-community-college-transfer-guide",
@@ -561,6 +577,22 @@ export const articles: ArticleMeta[] = [
     state: null,
     author: "Community College Path",
     tags: ["seniors", "tuition-waiver", "auditing", "comparison", "all-states"],
+    cluster: "senior-waivers-guide",
+    clusterRole: "spoke",
+  },
+
+  // --- Cluster B spoke: TN seniors ---
+  {
+    slug: "tennessee-senior-citizens-tbr-community-colleges",
+    title:
+      "Tennessee Senior Citizens at TBR Community Colleges: How the 65+ Tuition Waiver Actually Works",
+    description:
+      "Tennessee residents aged 65+ can take credit courses at TBR community colleges with tuition and most fees waived under Tenn. Code Ann. § 49-7-113. A small service fee (~$70/term) still applies. Here's how it works.",
+    date: "2026-05-04",
+    category: "senior-waivers",
+    state: "tn",
+    author: "Community College Path",
+    tags: ["seniors", "tennessee", "tbr", "tuition-waiver", "65-plus"],
     cluster: "senior-waivers-guide",
     clusterRole: "spoke",
   },

--- a/content/blog/new-hampshire-ccsnh-transfer-credit-guide.mdx
+++ b/content/blog/new-hampshire-ccsnh-transfer-credit-guide.mdx
@@ -1,0 +1,93 @@
+# How New Hampshire Community College Transfer Credit Actually Works: A CCSNH Student's Guide
+
+New Hampshire has seven community colleges under the Community College System of New Hampshire (CCSNH) — Great Bay, Lakes Region, Manchester, Nashua, NHTI in Concord, River Valley, and White Mountains. If you're at any of them and planning to transfer to a four-year university, the transfer picture looks different here than it does in most states: published transfer equivalencies currently exist for only one receiving university, Keene State College.
+
+That's not a gap in this article. It's the current state of transfer data in New Hampshire, and understanding it before you register is the difference between a well-planned two years and a semester of credits that don't land where you expected.
+
+## What the published data actually covers
+
+As of early 2026, Community College Path has indexed 2,680 CCSNH-to-Keene State transfer equivalencies — pulled from Keene State's published transfer guide and covering all seven CCSNH colleges. Every college in the system is represented: Great Bay, Lakes Region, Manchester, Nashua, NHTI, River Valley, and White Mountains.
+
+The destination is Keene State College exclusively. Equivalencies for UNH Durham, Plymouth State University, and UNH College of Professional Studies are not yet published in a scrapable format. Until that data lands, those students need to go directly to each university's transfer office.
+
+This is an important distinction. If Keene State is your target, you have real data to plan with. If UNH Durham or Plymouth State is your target, the guidance in this article on how to check and what to ask still applies — you just need to use each university's transfer equivalency tool directly rather than Community College Path's lookup.
+
+## The 31.1% direct match rate — and what it means
+
+Of those 2,680 Keene State equivalencies, 834 (31.1%) are direct matches — meaning the CCSNH course maps to a specific named Keene State course. The other 1,846 (68.9%) transfer as elective credit.
+
+31.1% is a low direct match rate compared to most states in our dataset. Massachusetts averages 38–79% depending on the destination university. Maryland runs higher. New Jersey's Rowan University is at 96%. A direct match rate under a third means that for most CCSNH courses you look up, you'll find elective credit waiting on the other end — not a named Keene State equivalent.
+
+[The difference between a direct match and elective credit](/blog/what-direct-match-vs-elective-credit-means) is not a technicality. A direct match means your community college course substitutes for a specific Keene State course and satisfies the same requirement. Elective credit means Keene State acknowledges the work and gives you hours — but those hours sit in a free-elective bucket and don't count toward any specific general education or major requirement. If your degree plan has no room for free electives, elective credit doesn't move you forward.
+
+## Which course prefixes have the most published equivalencies
+
+With 168 unique course prefixes in the dataset, here's where the density sits (by number of Keene State equivalencies published):
+
+- **ENGL** — 148 mappings
+- **CIS** — 113
+- **BIOL** — 100
+- **BUS** — 99
+- **MATH** — 99
+
+English composition and writing courses have the most coverage — which makes sense, since ENGL 101 is a near-universal general education requirement at every four-year school and faculty committees spend the most time vetting these equivalencies. CIS (computer information systems) and biology have dense coverage because Keene State has active programs in both areas. Business and math follow closely.
+
+If you're at a CCSNH college and planning to transfer to Keene State, these are the prefixes where checking the actual equivalency table before you register pays off most: the data is dense enough to find the course you're considering, and the outcome varies enough from course to course that you can't assume.
+
+For prefixes outside this top tier — some occupational, technical, or career-track courses — the equivalency may simply not be listed. That means a Keene State registrar will evaluate the course on submission of transcripts and a syllabus. Don't assume "not listed" means "won't transfer"; it means you'll need to make the case manually.
+
+## The no-credit finding
+
+One number that stands out: 0 no-credit outcomes in the published dataset. Every CCSNH course that Keene State has published an equivalency for lands as either a direct match or elective credit — nothing is flatly rejected.
+
+That's different from New Jersey, where the NJTransfer system is effectively binary (direct match or zero credit). At Keene State, the floor is at least elective credit for anything Keene has mapped. The practical question isn't "will this transfer?" — for listed courses, the answer is yes. The question is "will this count toward something I need?"
+
+<ProductCallout
+  text="Community College Path's NH transfer lookup shows how CCSNH courses map to Keene State — direct match vs elective credit, course by course — before you register."
+  href="/nh/transfer"
+  label="Check NH Transfer Equivalencies"
+/>
+
+## Planning around what's not published yet
+
+Three of the universities that CCSNH students commonly target — UNH Durham, Plymouth State, and UNH College of Professional Studies — don't have published equivalencies in our system yet. If any of those is your destination, here's what to do while the data gap exists:
+
+**UNH Durham:** UNH publishes a transfer equivalency guide through its Office of Admissions. Search for your specific CCSNH course code in their online database. CCSNH courses from NHTI, Nashua, and Manchester appear most frequently in UNH's guide because those colleges draw the most applicants.
+
+**Plymouth State University:** Plymouth State participates in NH's regional transfer framework. Their Registrar's Office will provide a preliminary credit evaluation before you apply. Bring your transcript and the course descriptions from CCSNH's catalog — Plymouth State reviewers often ask for syllabi for courses outside their standard equivalency list.
+
+**UNH College of Professional Studies:** CPS is UNH's online and continuing education division. It accepts transfer credit but evaluates it somewhat differently than UNH Durham does — some courses that don't map at Durham map cleanly at CPS. Contact CPS's enrollment office directly.
+
+For any of these, the process is the same: check the university's published equivalency tool first, then request a preliminary evaluation from the registrar with your specific course list. Do this before you register for your courses at CCSNH — not after.
+
+## Courses that transfer most reliably in NH
+
+Based on the published Keene State data and general transfer patterns across New England:
+
+- **ENGL 101** (English Composition) — this course transfers as a direct match at virtually every four-year university in New England. At Keene State and any other destination, it's the highest-confidence course in any CCSNH transfer plan.
+- **MATH 120** (College Algebra or equivalent) — direct match at Keene State; broadly accepted elsewhere.
+- **BIOL 105** (General Biology I) — direct match at Keene State for non-science-major biology requirements; confirm at your specific destination if you're pre-health or science-track.
+- **PSYC 101** (General Psychology) — strong coverage in the dataset; commonly maps directly.
+- **HIST 101** (US History I or Western Civ equivalent) — high coverage, commonly direct match.
+- **SOCI 101** (Intro to Sociology) — high coverage, commonly direct match.
+
+If you're undecided on your destination or in early planning, these six courses are close to universal currency in the NH transfer system. Taking them early gives you flexibility regardless of where you end up.
+
+## How to check before you register
+
+1. **Identify your destination university.** The same CCSNH course can have different outcomes at different schools — "Keene State accepts it as a direct match" tells you nothing about UNH.
+2. **Look up the specific course, not just the prefix.** ENGL 101 might transfer directly while ENGL 102 lands as elective credit at the same university. Check each course you're registering for.
+3. **If the equivalency isn't listed, ask.** Contact the receiving university's transfer office with your CCSNH course code and request a preliminary determination. Most NH universities can turn this around in a week.
+4. **Request a preliminary credit evaluation before applying.** All four NH public universities — Keene State, UNH Durham, Plymouth State, UNH CPS — will do a preliminary evaluation before you formally apply. Use this. Show up with your transcript and a target degree program, and ask specifically which courses apply to that program's requirements.
+
+[Understanding how to read a transfer equivalency table](/blog/how-to-read-transfer-equivalency-table) helps before you start — the notation used in these databases (direct match vs elective, grade minimums, credit caps) is not explained anywhere obvious.
+
+## The bottom line
+
+New Hampshire's community college transfer system is in a transitional state: one receiving university (Keene State) has comprehensive published equivalencies, and three others are still being mapped. That's honest, and it shapes how CCSNH students should plan.
+
+If Keene State is your destination, you have real data — 2,680 mappings, a 31.1% direct match rate, no-credit floor of zero. Use Community College Path's lookup to check each course before you register, identify which courses come back as direct matches, and build your elective selections around what actually counts.
+
+If UNH, Plymouth State, or UNH CPS is your destination, the process is manual for now: check each university's published tool, request a preliminary evaluation, and plan from confirmed equivalencies rather than assumptions. The [broader picture of how transfer credit works across states](/blog/comparing-transfer-credit-across-states) is worth reading as context — New Hampshire's 31.1% direct match rate at Keene State is toward the lower end nationally, which means course selection discipline pays off more here than in states with 70%+ rates.
+
+Search and plan your CCSNH courses at [Community College Path New Hampshire](/nh). The transfer lookup shows you Keene State equivalencies course by course before you register.

--- a/content/blog/tennessee-senior-citizens-tbr-community-colleges.mdx
+++ b/content/blog/tennessee-senior-citizens-tbr-community-colleges.mdx
@@ -1,0 +1,109 @@
+# Tennessee Senior Citizens at TBR Community Colleges: How the 65+ Tuition Waiver Actually Works
+
+If you're 65 or older and a Tennessee resident, state law gives you the right to attend credit courses at any of the 12 Tennessee Board of Regents community colleges with tuition and most mandatory fees waived. The legal authority is Tenn. Code Ann. § 49-7-113, and it's been on the books for years.
+
+There's a catch, but it's a small one: a service fee — typically around $70 per term — still applies. The catch is not an income test. Not a retirement requirement. Not an audit-only restriction. You can take courses for a grade, earn credits, and work toward a degree or certificate if you choose. That puts Tennessee's program in a meaningfully different category from states like [North Carolina](/blog/north-carolina-senior-citizens-community-colleges), where the waiver covers auditing only.
+
+Here's what the waiver covers, what it doesn't, and how to use it.
+
+## The basic rule
+
+Tennessee residents aged 65 and older may enroll in credit courses at TBR community colleges on a space-available basis. Tuition and most mandatory fees are waived by statute. The law does not impose an income cap, a residency-duration requirement, or a retirement condition. If you're 65 and a Tennessee resident, you qualify.
+
+At a glance:
+
+- **Age:** 65 or older
+- **Residency:** Tennessee resident
+- **Enrollment type:** Credit courses (not limited to auditing)
+- **What's waived:** Tuition and most mandatory fees
+- **What still applies:** A small service fee, typically capped around $70 per term
+- **Availability:** Space permitting — tuition-paying students register first
+- **Legal basis:** Tenn. Code Ann. § 49-7-113
+
+## The fee structure: what "most fees waived" actually means
+
+Tennessee's waiver is notably broader than comparable programs in neighboring states. [South Carolina](/blog/south-carolina-senior-citizens-technical-colleges) waives tuition only — all fees apply at the standard rate, which can add $100–200 per term. New Jersey is similar. Tennessee goes further: most mandatory fees are waived, not just tuition.
+
+The one exception is a service fee, typically capped at around $70 per term. This covers basic administrative costs. The college will tell you the exact amount when you contact the registrar.
+
+What this means in practice: a semester at a TBR community college as a senior waiver student will cost you roughly $70 plus the cost of textbooks and course materials. That's substantially less than the hundreds of dollars in fees that senior students in some other states still owe after tuition is waived.
+
+Before you register, call the college's business office and ask for the full out-of-pocket cost under the senior tuition waiver. The answer should be around $70, plus books. If it's significantly higher, ask for a line-item breakdown.
+
+## Credit courses, not just auditing
+
+This is the detail that matters most if you're taking the waiver seriously.
+
+In [North Carolina](/blog/north-carolina-senior-citizens-community-colleges), the 65+ waiver covers auditing only. You can sit in on a course, but you don't earn a grade or credits — nothing appears on a transcript, and the course can't transfer or count toward a credential. If you're taking a photography class for personal enrichment, that's fine. If you want something on paper, it's not.
+
+Tennessee's waiver covers credit enrollment. You take the course as a regular student: you get a grade, earn credit hours, and those credits count. If you're working toward an associate degree, a certificate, or eventually transferring to a four-year university, the waiver works for that.
+
+For a clear explanation of what auditing actually means versus credit enrollment, see our [guide to auditing a class](/blog/what-does-audit-a-class-mean).
+
+## "Space permitting" — what it means at TBR colleges
+
+The waiver comes with the same condition you'll find in most states: senior waiver students register after students paying full tuition. The tradeoff is built into the statute — tuition is nearly free, but you're not displacing a paying student.
+
+In practice, this matters more for some courses than others:
+
+- **High-demand gen-ed sections close fastest.** ENGL 1010, MATH 1530, BIOL 1110, PSYC 1030 — anything that counts toward a transfer pathway or a popular degree program. By the time senior registration opens, popular time slots for these are often gone.
+- **Online sections fill across all demographics.** If flexibility is your main goal, have backups.
+- **Evening, weekend, and less-common sections** tend to have more room. These are also often the more interesting courses if you're enrolling for personal reasons rather than chasing a credential.
+- **Summer and late-start sessions** sometimes have seats when main-semester sections are full.
+
+Each TBR community college sets its own registration calendar, including when senior waiver students can enroll. Call the registrar at the college you're interested in and ask for the senior registration date — it typically falls a week or two after general registration opens.
+
+<ProductCallout
+  text="Community College Path shows current course offerings across Tennessee's 12 TBR community colleges — search by subject, campus, day, or time to find what's available this term."
+  href="/tn"
+  label="Search TN Courses"
+/>
+
+## The 12 TBR community colleges
+
+Tennessee's Board of Regents community colleges serve every part of the state. The waiver applies at all 12:
+
+- Chattanooga State Community College
+- Cleveland State Community College
+- Columbia State Community College
+- Dyersburg State Community College
+- Jackson State Community College
+- Motlow State Community College
+- Nashville State Community College
+- Northeast State Community College
+- Pellissippi State Community College
+- Southwest Tennessee Community College
+- Volunteer State Community College
+- Walters State Community College
+
+You're not restricted to the college nearest your home. If your local college doesn't have the course you want, or if a section is already full, another TBR institution might have availability — including through online delivery.
+
+## How Tennessee compares to other states
+
+| | Tennessee | South Carolina | North Carolina | Maryland |
+|---|---|---|---|---|
+| **Age threshold** | 65 | 60 | 65 | 60 |
+| **Waiver covers** | Credit courses | Credit courses | Audit only | Credit + audit |
+| **Fees waived?** | Most mandatory fees | No | Partially | No |
+| **Service/admin fee** | ~$70/term | Standard fees apply | Standard fees apply | Standard fees apply |
+| **Colleges** | 12 TBR | 16 SCTCS | 58 NCCCS | 16 |
+
+The age threshold (65) is higher than Maryland's and South Carolina's (both 60). But once you clear it, Tennessee's fee waiver is more complete than South Carolina's. And unlike North Carolina's audit-only waiver, Tennessee lets you take courses for credit.
+
+For a full comparison across all 15 states we track, see the [senior citizen community college tuition comparison](/blog/senior-citizen-community-college-tuition-all-15-states).
+
+## How to enroll
+
+1. **Identify a college.** Pick one or two of the 12 TBR colleges near you or with online offerings you're interested in.
+2. **Browse the course schedule.** Look for the term you want to start. Identify two or three courses or sections — having backups is important under space-available registration.
+3. **Call the registrar.** Ask specifically about enrolling under the senior tuition waiver (Tenn. Code Ann. § 49-7-113). They'll confirm your eligibility (65+, TN resident), tell you the exact service fee for the term, and give you the senior registration date.
+4. **Register when your window opens.** Don't wait until the week classes start. Popular sections go fast after senior registration opens.
+5. **Budget for the service fee and books.** Expect roughly $70 in fees and whatever textbooks cost for your course. Some instructors use free or low-cost materials; others require a textbook that runs $100+. Ask before you finalize.
+
+## The bottom line
+
+Tennessee's senior tuition waiver is a real and notably generous benefit: tuition and most mandatory fees waived, credit courses available (not just auditing), at all 12 TBR community colleges statewide. The main constraint is the age threshold — 65, not 60 — and the space-available registration window that means popular sections may close before you can enroll.
+
+The ~$70 service fee is not a loophole or a surprise — it's explicit in how the program works. Plan for it, pick a backup section, and call the registrar early. If you've been considering going back to school, or taking a class you've always wanted to take, the waiver makes the cost close to negligible.
+
+For a broader look at how senior tuition waivers work across the country — including states you might not expect — start with the [free community college classes for seniors guide](/blog/free-community-college-classes-for-seniors).


### PR DESCRIPTION
## Summary

Two cluster-gap triggered blog articles, both passing all quality gates (G1–G3, G5, G6):

- **[NH CCSNH Transfer Credit Guide](content/blog/new-hampshire-ccsnh-transfer-credit-guide.mdx)** (1,576 words) — Cluster A spoke (`transfer-credit-guide`). Covers NH's unique situation: only Keene State has published equivalencies (2,680 mappings, 31.1% direct match rate). Honest about UNH/Plymouth State data gaps. Links to hub + 2 sibling spokes + ProductCallout.

- **[TN Senior Citizens at TBR Colleges](content/blog/tennessee-senior-citizens-tbr-community-colleges.mdx)** (1,370 words) — Cluster B spoke (`senior-waivers-guide`). Covers the 65+ tuition waiver under Tenn. Code Ann. § 49-7-113, which uniquely waives most mandatory fees and covers credit courses (not just auditing). ~$70/term service fee clearly disclosed. Links to hub + 3 sibling spokes + ProductCallout.

## Quality gates

| Gate | NH | TN |
|---|---|---|
| G1 (word count) | 1,576 (1000–1800) | 1,370 (1000–1800) |
| G2 (internal links) | Pass | Pass |
| G3 (banned phrases) | Pass | Pass |
| G5 (build) | Pass | Pass |
| G6 (output block) | Pass | Pass |

## Reviewer checklist
- [ ] Read for fluff. Any "Top N tips" energy? Any generic education-blog filler?
- [ ] Verify factual claims (NH: 2,680 mappings, 31.1% direct match — check `data/nh/transfer-equiv.json`; TN: Tenn. Code Ann. § 49-7-113, ~$70 fee — check `lib/states/tn/config.ts`)
- [ ] Click every internal link — do they resolve to existing posts/tools?
- [ ] State-specific posts: confirm StateToolsCTA renders top + bottom
- [ ] Cluster spokes: confirm the hub link is present and a sibling spoke is referenced
- [ ] If review-cadence flag is true, add a calendar reminder for annual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)