### PR TITLE
Remove VA hardcodes from homepage and privacy page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,7 +65,6 @@ export default async function LandingPage() {
 
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
-  const searchState = geoState ?? "va";
   const orgLd = {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -79,14 +78,16 @@ export default async function LandingPage() {
     "@type": "WebSite",
     name: "Community College Path",
     url: siteUrl,
-    potentialAction: {
-      "@type": "SearchAction",
-      target: {
-        "@type": "EntryPoint",
-        urlTemplate: `${siteUrl}/${searchState}/courses?q={search_term_string}`,
+    ...(geoState && {
+      potentialAction: {
+        "@type": "SearchAction",
+        target: {
+          "@type": "EntryPoint",
+          urlTemplate: `${siteUrl}/${geoState}/courses?q={search_term_string}`,
+        },
+        "query-input": "required name=search_term_string",
       },
-      "query-input": "required name=search_term_string",
-    },
+    }),
   };
 
   return (
@@ -178,7 +179,7 @@ export default async function LandingPage() {
                 num: "02",
                 title: "Check what transfers",
                 body: "Pick your CC and your target university. See which courses count, which don't, and what they map to.",
-                href: "/va/transfer",
+                href: geoState ? `/${geoState}/transfer` : "/colleges",
                 cta: "Look up transfers",
                 icon: (
                   <path
@@ -192,7 +193,7 @@ export default async function LandingPage() {
                 num: "03",
                 title: "Build a schedule",
                 body: "Drag classes onto a weekly grid, see conflicts immediately, and export when you're ready to register.",
-                href: "/va/schedule",
+                href: geoState ? `/${geoState}/schedule` : "/colleges",
                 cta: "Open the planner",
                 icon: (
                   <path

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -129,7 +129,7 @@ export default function PrivacyPage() {
             If you have questions about this privacy policy, please open an issue on
             our{" "}
             <a
-              href="https://github.com/rohan-c0de/auditmap-virginia"
+              href="https://github.com/rohan-c0de/cc-coursemap"
               target="_blank"
               rel="noopener noreferrer"
               className="text-teal-600 underline hover:text-teal-800 dark:hover:text-teal-300"


### PR DESCRIPTION
## Summary
- `app/page.tsx`: schema.org `SearchAction` now only emits when geolocation resolves a real state — no longer defaults to `/va/courses` for all non-geo visitors
- `app/page.tsx`: Transfer and schedule task cards now link to `/{geoState}/transfer` and `/{geoState}/schedule` when geolocation is available, falling back to `/colleges` instead of `/va/`
- `app/privacy/page.tsx`: GitHub contact link updated from `auditmap-virginia` to `cc-coursemap`

## Why
These three were blockers from the state-bias audit — the `/va/` hardcodes were actively sending non-VA users to the wrong state, and the old repo name was user-visible in the privacy policy.

Note: these fixes were in PR #179 but got dropped when the branch was squash-merged (only the first commit landed).

## Test plan
- [ ] Visit homepage without geolocation — confirm no `/va/` links appear in the task cards
- [ ] Visit homepage from a supported state — confirm cards link to the correct state
- [ ] Check page source — confirm schema.org `potentialAction` is absent when no geo state
- [ ] Visit `/privacy` — confirm GitHub link goes to `cc-coursemap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)