### PR TITLE
Remove state="va" defaults from lib functions and components

### DIFF
--- a/app/colleges/page.tsx
+++ b/app/colleges/page.tsx
@@ -9,9 +9,9 @@ export const revalidate = 86400;
 
 export const metadata: Metadata = {
   title:
-    "All Community Colleges — Browse 160+ Colleges Across 13 States | CC CourseMap",
+    "All Community Colleges — Browse Every College Across All States | Community College Path",
   description:
-    "Browse every community college on CC CourseMap. Find courses, check transfer equivalencies, and compare colleges across Virginia, North Carolina, Georgia, New York, and more.",
+    "Browse every community college on Community College Path. Find courses, check transfer equivalencies, and compare colleges across states — all in one place.",
   keywords: [
     "community colleges",
     "community college directory",

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -16,7 +16,7 @@ const NAV_ITEMS = [
   { path: "/about", label: "About" },
 ];
 
-export default function Header({ state = "va", stateName, transferSupported = true, prereqsAvailable = false }: { state?: string; stateName?: string; transferSupported?: boolean; prereqsAvailable?: boolean }) {
+export default function Header({ state, stateName, transferSupported = true, prereqsAvailable = false }: { state: string; stateName?: string; transferSupported?: boolean; prereqsAvailable?: boolean }) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const links = NAV_ITEMS

--- a/components/SearchForm.tsx
+++ b/components/SearchForm.tsx
@@ -6,12 +6,12 @@ import { useRouter } from "next/navigation";
 const RADIUS_OPTIONS = [10, 25, 50] as const;
 
 interface SearchFormProps {
-  state?: string;
+  state: string;
   /** Optional placeholder for the zip/city input. Pass from a server component using StateConfig. */
   placeholder?: string;
 }
 
-export default function SearchForm({ state = "va", placeholder }: SearchFormProps) {
+export default function SearchForm({ state, placeholder }: SearchFormProps) {
   const router = useRouter();
   const [zip, setZip] = useState("");
   const [radius, setRadius] = useState<number>(25);

--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -44,7 +44,7 @@ async function cached<T>(key: string, fn: () => Promise<T>): Promise<T> {
 export async function loadCoursesForCollege(
   collegeSlug: string,
   term: string,
-  state = "va"
+  state: string
 ): Promise<CourseSection[]> {
   return cached(`courses:${state}:${collegeSlug}:${term}`, async () => {
     // Supabase caps rows at 1000 by default. Paginate in parallel to get
@@ -95,7 +95,7 @@ export async function loadCoursesForCollege(
  * Get all term codes that have at least one course in Supabase for a state.
  * Uses RPC function to avoid downloading all rows.
  */
-export async function getAvailableTerms(state = "va"): Promise<string[]> {
+export async function getAvailableTerms(state: string): Promise<string[]> {
   return cached(`terms:${state}`, async () => {
     // Use RPC if available, fallback to manual distinct
     const { data, error } = await supabase.rpc("get_distinct_terms", {
@@ -134,7 +134,7 @@ export async function getAvailableTerms(state = "va"): Promise<string[]> {
 export async function getTermsWithDataForCollegeSubject(
   collegeSlug: string,
   prefix: string,
-  state = "va"
+  state: string
 ): Promise<string[]> {
   return cached(
     `termsForCollegeSubject:${state}:${collegeSlug}:${prefix}`,
@@ -176,7 +176,7 @@ export async function getTermsWithDataForCollegeSubject(
 export async function getCourseCount(
   collegeSlug: string,
   term: string,
-  state = "va"
+  state: string
 ): Promise<number> {
   return cached(`count:${state}:${collegeSlug}:${term}`, async () => {
     const { count, error } = await supabase
@@ -223,7 +223,7 @@ export function filterCourses(
 export async function isDataStale(
   collegeSlug: string,
   term: string,
-  state = "va"
+  state: string
 ): Promise<boolean> {
   const { data, error } = await supabase
     .from("courses")
@@ -296,7 +296,7 @@ export function getUniqueSubjects(courses: CourseSection[]): string[] {
  */
 export async function loadAllCourses(
   term: string,
-  state = "va"
+  state: string
 ): Promise<CourseSection[]> {
   return cached(`allCourses:${state}:${term}`, async () => {
     // First, get total count to know how many pages we need
@@ -347,7 +347,7 @@ export async function loadCourseByCode(
   prefix: string,
   number: string,
   term: string,
-  state = "va"
+  state: string
 ): Promise<CourseSection[]> {
   return cached(`course:${state}:${term}:${prefix}:${number}`, async () => {
     const { data, error } = await supabase
@@ -377,7 +377,7 @@ export async function loadCourseByCode(
 export async function loadCoursesBySubject(
   prefix: string,
   term: string,
-  state = "va"
+  state: string
 ): Promise<CourseSection[]> {
   return cached(`subject:${state}:${term}:${prefix}`, async () => {
     const { count, error: countErr } = await supabase
@@ -429,7 +429,7 @@ export async function loadCoursesBySubject(
  */
 export async function getSitemapCourseIndex(
   term: string,
-  state = "va"
+  state: string
 ): Promise<{
   codes: { prefix: string; number: string }[];
   subjectSectionCounts: Map<string, number>;
@@ -477,7 +477,7 @@ export async function getSitemapCourseIndex(
  */
 export async function getDistinctSubjects(
   term: string,
-  state = "va"
+  state: string
 ): Promise<string[]> {
   return cached(`distinctSubjects:${state}:${term}`, async () => {
     // Fallback scan that pulls only the prefix column — even without an RPC
@@ -510,7 +510,7 @@ export async function getDistinctSubjects(
  */
 export async function getDistinctCourseCodes(
   term: string,
-  state = "va"
+  state: string
 ): Promise<{ prefix: string; number: string }[]> {
   return cached(`distinctCourses:${state}:${term}`, async () => {
     // Try RPC first (most efficient: server-side DISTINCT)

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -47,7 +47,7 @@ const ZIP_REGISTRY: Record<string, Record<string, ZipEntry>> = {
   wv: wvZipcodes as Record<string, ZipEntry>,
 };
 
-function loadZipData(state = "va"): Record<string, ZipEntry> {
+function loadZipData(state: string): Record<string, ZipEntry> {
   return ZIP_REGISTRY[state] ?? {};
 }
 
@@ -57,7 +57,7 @@ function loadZipData(state = "va"): Record<string, ZipEntry> {
  */
 export function getZipCoordinates(
   zip: string,
-  state = "va"
+  state: string
 ): { lat: number; lng: number; city: string } | null {
   const data = loadZipData(state);
   const entry = data[zip];
@@ -70,7 +70,7 @@ export function getZipCoordinates(
  */
 export function findZipByCity(
   cityQuery: string,
-  state = "va"
+  state: string
 ): { zip: string; lat: number; lng: number; city: string } | null {
   const data = loadZipData(state);
   const query = cityQuery.trim().toLowerCase();
@@ -99,7 +99,7 @@ export function findZipByCity(
  */
 export function resolveLocation(
   query: string,
-  state = "va"
+  state: string
 ): { zip: string; lat: number; lng: number; city: string } | null {
   const trimmed = query.trim();
 

--- a/lib/institutions.ts
+++ b/lib/institutions.ts
@@ -52,6 +52,6 @@ const REGISTRY: Record<string, Institution[]> = {
  * Load institutions for a given state. Data is statically bundled so this
  * works on both Node and edge runtimes.
  */
-export function loadInstitutions(state = "va"): Institution[] {
+export function loadInstitutions(state: string): Institution[] {
   return REGISTRY[state] ?? [];
 }

--- a/lib/terms.ts
+++ b/lib/terms.ts
@@ -47,7 +47,7 @@ async function cached<T>(key: string, fn: () => Promise<T>): Promise<T> {
 /**
  * Get all available terms with labels, sorted newest first.
  */
-export async function getAvailableTermsForDisplay(state = "va"): Promise<{
+export async function getAvailableTermsForDisplay(state: string): Promise<{
   code: string;
   label: string;
 }[]> {
@@ -63,7 +63,7 @@ export async function getAvailableTermsForDisplay(state = "va"): Promise<{
  * Returns the term with the most college data, breaking ties by recency.
  * Falls back to "2026SP" if no data is found.
  */
-export async function getCurrentTerm(state = "va"): Promise<string> {
+export async function getCurrentTerm(state: string): Promise<string> {
   return cached(`currentTerm:${state}`, async () => {
     // Try RPC first (single query instead of N+1)
     const { data: rpcData, error: rpcErr } = await supabase.rpc(
@@ -126,7 +126,7 @@ export async function getCurrentTerm(state = "va"): Promise<string> {
  * Get the next term after the latest one we have data for.
  * SP → SU → FA → next year SP
  */
-export async function getNextTerm(state = "va"): Promise<{ code: string; label: string }> {
+export async function getNextTerm(state: string): Promise<{ code: string; label: string }> {
   const current = await getCurrentTerm(state);
   const match = current.match(/^(\d{4})(SP|SU|FA)$/);
   if (!match) return { code: "2026FA", label: "Fall 2026" };

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -82,7 +82,7 @@ export function capMappingsByRoundRobin(
   return out;
 }
 
-function dataPath(state = "va"): string {
+function dataPath(state: string): string {
   return path.join(process.cwd(), "data", state, "transfer-equiv.json");
 }
 
@@ -99,7 +99,7 @@ const PAGE_SIZE = 1000;
  * Cached after first load.
  */
 export async function loadTransferMappings(
-  state = "va"
+  state: string
 ): Promise<TransferMapping[]> {
   if (transferCache[state]) return transferCache[state];
 
@@ -149,7 +149,7 @@ export async function loadTransferMappings(
 export async function getTransferInfo(
   prefix: string,
   number: string,
-  state = "va"
+  state: string
 ): Promise<TransferMapping[]> {
   const mappings = await loadTransferMappings(state);
   return mappings.filter(
@@ -167,7 +167,7 @@ export async function getTransferInfo(
 export async function transferSummaryLine(
   prefix: string,
   number: string,
-  state = "va"
+  state: string
 ): Promise<{ text: string; type: "direct" | "elective" | "no-credit" } | null> {
   const info = await getTransferInfo(prefix, number, state);
   if (info.length === 0) return null;
@@ -194,7 +194,7 @@ export async function transferSummaryLine(
 export async function getAcceptingUniversities(
   prefix: string,
   number: string,
-  state = "va"
+  state: string
 ): Promise<string[]> {
   const info = await getTransferInfo(prefix, number, state);
   return info.filter((m) => !m.no_credit).map((m) => m.university_name);
@@ -203,7 +203,7 @@ export async function getAcceptingUniversities(
 /** Get all mappings for a specific university. */
 export async function getCoursesForUniversity(
   university: string,
-  state = "va"
+  state: string
 ): Promise<TransferMapping[]> {
   const mappings = await loadTransferMappings(state);
   return mappings.filter((m) => m.university === university);
@@ -211,7 +211,7 @@ export async function getCoursesForUniversity(
 
 /** Get the list of all universities in the dataset. */
 export async function getUniversities(
-  state = "va"
+  state: string
 ): Promise<{ slug: string; name: string }[]> {
   const mappings = await loadTransferMappings(state);
   const seen = new Map<string, string>();
@@ -231,7 +231,7 @@ export async function getUniversities(
  * Used by the /[state]/transfer "Browse by university" list and by the
  * transfer-hub page's thin-content guard in generateStaticParams.
  */
-export async function getUniversitiesWithCounts(state = "va"): Promise<
+export async function getUniversitiesWithCounts(state: string): Promise<
   {
     slug: string;
     name: string;
@@ -282,7 +282,7 @@ import type { TransferLookup } from "./transfer-scoped";
  * Build a lookup map for client-side filtering:
  * { "ENG-111": [{ university: "vt", type: "direct" }], ... }
  */
-export async function buildTransferLookup(state = "va"): Promise<TransferLookup> {
+export async function buildTransferLookup(state: string): Promise<TransferLookup> {
   const mappings = await loadTransferMappings(state);
   const lookup: TransferLookup = {};
 


### PR DESCRIPTION
## Summary
- **~25 lib functions** across `lib/courses.ts`, `lib/transfer.ts`, `lib/geo.ts`, `lib/terms.ts`, `lib/institutions.ts`: removed `state = "va"` default parameters — state is now a required argument. TypeScript will catch any future caller that omits it.
- **`components/Header.tsx`** and **`components/SearchForm.tsx`**: `state` changed from optional with VA default to required prop. Both are only ever rendered from `[state]/` routes where state is always present.
- **`app/colleges/page.tsx`**: SEO title and description no longer hardcode a state list (Virginia first). Updated to state-agnostic copy and corrected brand name from "CC CourseMap" to "Community College Path".

## Why
These were friction-level findings from the state-bias audit. No live bugs since production always passes state explicitly, but the `state = "va"` pattern violated the architectural rule that defaults must come from `StateConfig`, not hardcodes — and it created a footgun for future developers.

## Test plan
- [ ] `npx tsc --noEmit` passes (already verified locally)
- [ ] Load any state page — confirm Header and SearchForm render correctly
- [ ] Check `/colleges` page title/description in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)