### PR TITLE
Fix missing Supabase RPCs causing build-time statement timeouts

### DIFF
--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -139,30 +139,37 @@ export async function getTermsWithDataForCollegeSubject(
   return cached(
     `termsForCollegeSubject:${state}:${collegeSlug}:${prefix}`,
     async () => {
-      // Paginate the term-only scan to handle subjects at large colleges
-      // that exceed the 1000-row default cap (rare but possible).
+      // Use RPC for a single-query DISTINCT scan backed by idx_courses_college_prefix_state.
+      const { data, error } = await supabase.rpc(
+        "get_terms_for_college_subject",
+        { p_college_code: collegeSlug, p_prefix: prefix, p_state: state }
+      );
+
+      if (!error && data) {
+        return (data as { term: string }[]).map((r) => r.term).sort();
+      }
+
+      // Fallback: paginated scan (slow — only reached if RPC is unavailable).
+      console.warn(
+        "getTermsWithDataForCollegeSubject error:",
+        error?.message,
+        "— using paginated fallback"
+      );
       const seen = new Set<string>();
       const PAGE_SIZE = 1000;
       let page = 0;
       while (true) {
         const start = page * PAGE_SIZE;
-        const { data, error } = await supabase
+        const { data: rows, error: fbErr } = await supabase
           .from("courses")
           .select("term")
           .eq("college_code", collegeSlug)
           .eq("course_prefix", prefix)
           .eq("state", state)
           .range(start, start + PAGE_SIZE - 1);
-        if (error) {
-          console.error(
-            "getTermsWithDataForCollegeSubject error:",
-            error.message
-          );
-          break;
-        }
-        if (!data || data.length === 0) break;
-        for (const row of data) seen.add(row.term);
-        if (data.length < PAGE_SIZE) break;
+        if (fbErr || !rows || rows.length === 0) break;
+        for (const row of rows) seen.add(row.term);
+        if (rows.length < PAGE_SIZE) break;
         page++;
       }
       return Array.from(seen).sort();

--- a/supabase/migrations/009_rpc_functions.sql
+++ b/supabase/migrations/009_rpc_functions.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- 009: RPC functions for build-time performance
+-- ============================================================================
+-- Creates three RPC functions that replace slow fallback query paths used
+-- during Next.js static generation:
+--
+--   get_distinct_terms(p_state)
+--     Called by getAvailableTerms(). Without this, the fallback downloads up
+--     to 50k rows just to extract distinct term codes.
+--
+--   get_term_college_counts(p_state)
+--     Called by getCurrentTerm(). Without this, the fallback runs one COUNT
+--     query per term per state — N+1 queries at build time.
+--
+--   get_terms_for_college_subject(p_college_code, p_prefix, p_state)
+--     Called by getTermsWithDataForCollegeSubject(). Without this, the
+--     fallback paginates through all matching rows; the query was hitting
+--     Supabase statement_timeout during parallel static generation.
+--
+-- Also adds a supporting index for the college+subject term lookup.
+--
+-- All statements are idempotent (CREATE OR REPLACE / IF NOT EXISTS).
+-- Safe to run in the Supabase Dashboard SQL Editor or via
+-- scripts/lib/run-migration.ts.
+--
+-- Note: CREATE INDEX CONCURRENTLY cannot run inside a transaction — run
+-- that statement separately if using a transaction-wrapped executor.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- get_distinct_terms
+-- Returns all distinct term codes that have at least one course for a state.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_distinct_terms(p_state text)
+RETURNS TABLE(term text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT DISTINCT c.term
+  FROM courses c
+  WHERE c.state = p_state
+  ORDER BY c.term;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- get_term_college_counts
+-- Returns each term with the count of distinct colleges that have courses,
+-- used to determine the "current" term (most colleges = most active).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_term_college_counts(p_state text)
+RETURNS TABLE(term text, college_count bigint)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT c.term, COUNT(DISTINCT c.college_code) AS college_count
+  FROM courses c
+  WHERE c.state = p_state
+  GROUP BY c.term
+  ORDER BY c.term;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- get_terms_for_college_subject
+-- Returns distinct terms that have at least one section of a given subject
+-- prefix at a specific college. Replaces the paginated scan in
+-- getTermsWithDataForCollegeSubject() which was hitting statement_timeout.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION get_terms_for_college_subject(
+  p_college_code text,
+  p_prefix text,
+  p_state text
+)
+RETURNS TABLE(term text)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT DISTINCT c.term
+  FROM courses c
+  WHERE c.college_code = p_college_code
+    AND c.course_prefix = p_prefix
+    AND c.state = p_state
+  ORDER BY c.term;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Supporting index for get_terms_for_college_subject
+-- The existing idx_courses_state_term_prefix_number index leads with state+term
+-- and can't efficiently serve WHERE college_code=? AND course_prefix=? AND state=?.
+-- This index lets Postgres resolve that query with a single index scan.
+-- ---------------------------------------------------------------------------
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_courses_college_prefix_state
+  ON courses(college_code, course_prefix, state);


### PR DESCRIPTION
## Summary
Three Supabase RPC functions were missing, forcing the app to use slow fallback query paths during static generation. With 846 pages building in parallel, these fallbacks were hitting Supabase `statement_timeout`.

### Migration 009 adds:

**`get_distinct_terms(p_state)`**
- Replaces a fallback that downloads up to 50k rows just to extract distinct term codes
- Called by `getAvailableTerms()` on every state page build

**`get_term_college_counts(p_state)`**
- Replaces N+1 COUNT queries (one per term per state) to find the current term
- Called by `getCurrentTerm()` which is called on every college and state page

**`get_terms_for_college_subject(p_college_code, p_prefix, p_state)`**
- Replaces a paginated row scan that was directly hitting `statement_timeout`
- Backed by new `idx_courses_college_prefix_state` index for a single index scan

### Code change
`getTermsWithDataForCollegeSubject()` in `lib/courses.ts` now tries the RPC first, with the paginated scan kept as a fallback.

## Deployment order
**Run the migration before merging this PR** — the code will call the new RPCs immediately on the next build. Without the migration, it falls back to the old slow paths (no regression, just no improvement).

1. Open Supabase Dashboard → SQL Editor
2. Run `supabase/migrations/009_rpc_functions.sql`
3. Run the `CREATE INDEX CONCURRENTLY` statement separately (can't be in a transaction)
4. Then merge this PR

## Test plan
- [ ] All three RPC functions exist in Supabase after migration
- [ ] `get_distinct_terms` and `get_term_college_counts` warnings no longer appear in build logs
- [ ] Vercel build completes without `statement_timeout` errors
- [ ] `/[state]/college/[id]/courses/[prefix]` pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)