### PR TITLE
sitemaps: parallelize queries and add 24h cache

### DIFF
--- a/app/sitemap/college-subjects.xml/route.ts
+++ b/app/sitemap/college-subjects.xml/route.ts
@@ -9,37 +9,49 @@ import {
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
 
+export const revalidate = 86400;
+
 export async function GET() {
   const url = siteOrigin();
-  const entries: SitemapEntry[] = [];
 
-  for (const state of getAllStates()) {
-    const institutions = loadInstitutions(state.slug);
-    const currentTerm = await getCurrentTerm(state.slug);
-    for (const inst of institutions) {
-      try {
-        const courses = await loadCoursesForCollege(
-          inst.college_slug,
-          currentTerm,
-          state.slug
-        );
-        for (const prefix of getUniqueSubjects(courses)) {
-          const count = courses.filter(
-            (c) => c.course_prefix === prefix
-          ).length;
-          if (count >= 3) {
-            entries.push({
-              url: `${url}/${state.slug}/college/${inst.id}/courses/${prefix.toLowerCase()}`,
-              changeFrequency: "weekly",
-              priority: 0.6,
-            });
+  const results = await Promise.allSettled(
+    getAllStates().map(async (state) => {
+      const institutions = loadInstitutions(state.slug);
+      const currentTerm = await getCurrentTerm(state.slug);
+
+      const collegeResults = await Promise.allSettled(
+        institutions.map(async (inst) => {
+          const courses = await loadCoursesForCollege(
+            inst.college_slug,
+            currentTerm,
+            state.slug
+          );
+          const entries: SitemapEntry[] = [];
+          for (const prefix of getUniqueSubjects(courses)) {
+            const count = courses.filter(
+              (c) => c.course_prefix === prefix
+            ).length;
+            if (count >= 3) {
+              entries.push({
+                url: `${url}/${state.slug}/college/${inst.id}/courses/${prefix.toLowerCase()}`,
+                changeFrequency: "weekly",
+                priority: 0.6,
+              });
+            }
           }
-        }
-      } catch {
-        // skip if course loading fails
-      }
-    }
-  }
+          return entries;
+        })
+      );
+
+      return collegeResults.flatMap((r) =>
+        r.status === "fulfilled" ? r.value : []
+      );
+    })
+  );
+
+  const entries: SitemapEntry[] = results.flatMap((r) =>
+    r.status === "fulfilled" ? r.value : []
+  );
 
   return xmlResponse(toSitemapXml(entries));
 }

--- a/app/sitemap/core.xml/route.ts
+++ b/app/sitemap/core.xml/route.ts
@@ -7,6 +7,8 @@ import {
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
 
+export const revalidate = 86400;
+
 export async function GET() {
   const url = siteOrigin();
   const entries: SitemapEntry[] = [
@@ -14,7 +16,9 @@ export async function GET() {
     { url: `${url}/colleges`, changeFrequency: "weekly", priority: 0.9 },
   ];
 
-  for (const state of getAllStates()) {
+  const states = getAllStates();
+
+  for (const state of states) {
     const s = state.slug;
     entries.push(
       { url: `${url}/${s}`, changeFrequency: "weekly", priority: 1 },
@@ -38,17 +42,25 @@ export async function GET() {
         priority: 0.85,
       });
     }
-    try {
-      const od = await loadOnlineData(s);
-      if (onlineQualifies(od)) {
-        entries.push({
-          url: `${url}/${s}/online`,
-          changeFrequency: "weekly",
+  }
+
+  const onlineResults = await Promise.allSettled(
+    states.map(async (state) => {
+      const od = await loadOnlineData(state.slug);
+      if (od && onlineQualifies(od)) {
+        return {
+          url: `${url}/${state.slug}/online`,
+          changeFrequency: "weekly" as const,
           priority: 0.85,
-        });
+        };
       }
-    } catch {
-      // skip if online data load fails
+      return null;
+    })
+  );
+
+  for (const r of onlineResults) {
+    if (r.status === "fulfilled" && r.value) {
+      entries.push(r.value);
     }
   }
 

--- a/app/sitemap/courses.xml/route.ts
+++ b/app/sitemap/courses.xml/route.ts
@@ -8,26 +8,26 @@ import {
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
 
+export const revalidate = 86400;
+
 export async function GET() {
   const url = siteOrigin();
-  const entries: SitemapEntry[] = [];
 
-  for (const state of getAllStates()) {
-    try {
+  const results = await Promise.allSettled(
+    getAllStates().map(async (state) => {
       const currentTerm = await getCurrentTerm(state.slug);
       const { codes } = await getSitemapCourseIndex(currentTerm, state.slug);
-      for (const c of codes) {
-        const key = `${c.prefix}-${c.number}`.toLowerCase();
-        entries.push({
-          url: `${url}/${state.slug}/course/${key}`,
-          changeFrequency: "weekly",
-          priority: 0.7,
-        });
-      }
-    } catch {
-      // skip state if data loading fails
-    }
-  }
+      return codes.map((c) => ({
+        url: `${url}/${state.slug}/course/${`${c.prefix}-${c.number}`.toLowerCase()}`,
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      }));
+    })
+  );
+
+  const entries: SitemapEntry[] = results.flatMap((r) =>
+    r.status === "fulfilled" ? r.value : []
+  );
 
   return xmlResponse(toSitemapXml(entries));
 }

--- a/app/sitemap/instructors.xml/route.ts
+++ b/app/sitemap/instructors.xml/route.ts
@@ -8,28 +8,29 @@ import {
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
 
+export const revalidate = 86400;
+
 export async function GET() {
   const url = siteOrigin();
-  const entries: SitemapEntry[] = [];
 
-  for (const state of getAllStates()) {
-    try {
+  const results = await Promise.allSettled(
+    getAllStates().map(async (state) => {
       const currentTerm = await getCurrentTerm(state.slug);
       const instructors = await getInstructorSitemapEntries(
         currentTerm,
         state.slug
       );
-      for (const e of instructors) {
-        entries.push({
-          url: `${url}/${state.slug}/college/${e.collegeId}/instructor/${e.slug}`,
-          changeFrequency: "weekly",
-          priority: 0.6,
-        });
-      }
-    } catch {
-      // skip state if instructor loading fails
-    }
-  }
+      return instructors.map((e) => ({
+        url: `${url}/${state.slug}/college/${e.collegeId}/instructor/${e.slug}`,
+        changeFrequency: "weekly" as const,
+        priority: 0.6,
+      }));
+    })
+  );
+
+  const entries: SitemapEntry[] = results.flatMap((r) =>
+    r.status === "fulfilled" ? r.value : []
+  );
 
   return xmlResponse(toSitemapXml(entries));
 }

--- a/app/sitemap/programs.xml/route.ts
+++ b/app/sitemap/programs.xml/route.ts
@@ -7,24 +7,25 @@ import {
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
 
+export const revalidate = 86400;
+
 export async function GET() {
   const url = siteOrigin();
-  const entries: SitemapEntry[] = [];
 
-  for (const state of getAllStates()) {
-    try {
+  const results = await Promise.allSettled(
+    getAllStates().map(async (state) => {
       const slugs = await getQualifyingProgramSlugs(state.slug);
-      for (const slug of slugs) {
-        entries.push({
-          url: `${url}/${state.slug}/program/${slug}`,
-          changeFrequency: "weekly",
-          priority: 0.75,
-        });
-      }
-    } catch {
-      // skip state if program data loading fails
-    }
-  }
+      return slugs.map((slug) => ({
+        url: `${url}/${state.slug}/program/${slug}`,
+        changeFrequency: "weekly" as const,
+        priority: 0.75,
+      }));
+    })
+  );
+
+  const entries: SitemapEntry[] = results.flatMap((r) =>
+    r.status === "fulfilled" ? r.value : []
+  );
 
   return xmlResponse(toSitemapXml(entries));
 }

--- a/app/sitemap/state-subjects.xml/route.ts
+++ b/app/sitemap/state-subjects.xml/route.ts
@@ -8,17 +8,19 @@ import {
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
 
+export const revalidate = 86400;
+
 export async function GET() {
   const url = siteOrigin();
-  const entries: SitemapEntry[] = [];
 
-  for (const state of getAllStates()) {
-    try {
+  const results = await Promise.allSettled(
+    getAllStates().map(async (state) => {
       const currentTerm = await getCurrentTerm(state.slug);
       const { subjectSectionCounts } = await getSitemapCourseIndex(
         currentTerm,
         state.slug
       );
+      const entries: SitemapEntry[] = [];
       for (const [prefix, count] of subjectSectionCounts) {
         if (count >= 5) {
           entries.push({
@@ -28,10 +30,13 @@ export async function GET() {
           });
         }
       }
-    } catch {
-      // skip state if data loading fails
-    }
-  }
+      return entries;
+    })
+  );
+
+  const entries: SitemapEntry[] = results.flatMap((r) =>
+    r.status === "fulfilled" ? r.value : []
+  );
 
   return xmlResponse(toSitemapXml(entries));
 }

--- a/app/sitemap/transfer.xml/route.ts
+++ b/app/sitemap/transfer.xml/route.ts
@@ -1,5 +1,5 @@
 import { getAllStates } from "@/lib/states/registry";
-import { getUniversitiesWithCounts } from "@/lib/transfer";
+import { getUniversitySlugsForSitemap } from "@/lib/transfer";
 import {
   toSitemapXml,
   siteOrigin,
@@ -7,28 +7,31 @@ import {
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
 
+export const revalidate = 86400;
+
 const MIN_TRANSFER_HUB_COUNT = 10;
 
 export async function GET() {
   const url = siteOrigin();
-  const entries: SitemapEntry[] = [];
 
-  for (const state of getAllStates()) {
-    if (!state.transferSupported) continue;
-    try {
-      const universities = await getUniversitiesWithCounts(state.slug);
-      for (const u of universities) {
-        if (u.totalCount < MIN_TRANSFER_HUB_COUNT) continue;
-        entries.push({
-          url: `${url}/${state.slug}/transfer/to/${u.slug}`,
-          changeFrequency: "weekly",
-          priority: 0.8,
-        });
-      }
-    } catch {
-      // skip if transfer data loading fails
-    }
-  }
+  const results = await Promise.allSettled(
+    getAllStates()
+      .filter((s) => s.transferSupported)
+      .map(async (state) => {
+        const universities = await getUniversitySlugsForSitemap(state.slug);
+        return universities
+          .filter((u) => u.totalCount >= MIN_TRANSFER_HUB_COUNT)
+          .map((u) => ({
+            url: `${url}/${state.slug}/transfer/to/${u.slug}`,
+            changeFrequency: "weekly" as const,
+            priority: 0.8,
+          }));
+      })
+  );
+
+  const entries: SitemapEntry[] = results.flatMap((r) =>
+    r.status === "fulfilled" ? r.value : []
+  );
 
   return xmlResponse(toSitemapXml(entries));
 }

--- a/lib/transfer.ts
+++ b/lib/transfer.ts
@@ -272,6 +272,60 @@ export async function getUniversitiesWithCounts(state: string): Promise<
     .sort((a, b) => b.totalCount - a.totalCount);
 }
 
+/**
+ * Lightweight version for the sitemap: returns only { slug, totalCount } per
+ * university without loading every row. Fetches only the `university` column
+ * with pagination, then aggregates in memory.
+ */
+export async function getUniversitySlugsForSitemap(
+  state: string
+): Promise<{ slug: string; totalCount: number }[]> {
+  try {
+    const counts = new Map<string, number>();
+    let offset = 0;
+    while (true) {
+      const { data, error } = await supabase
+        .from("transfers")
+        .select("university")
+        .eq("state", state)
+        .eq("no_credit", false)
+        .not("univ_course", "like", "%*%")
+        .range(offset, offset + PAGE_SIZE - 1);
+
+      if (error || !data || data.length === 0) break;
+      for (const row of data) {
+        counts.set(row.university, (counts.get(row.university) || 0) + 1);
+      }
+      if (data.length < PAGE_SIZE) break;
+      offset += PAGE_SIZE;
+    }
+
+    if (counts.size > 0) {
+      return Array.from(counts.entries())
+        .map(([slug, totalCount]) => ({ slug, totalCount }))
+        .sort((a, b) => b.totalCount - a.totalCount);
+    }
+  } catch {
+    // fall through to local file
+  }
+
+  try {
+    const raw = fs.readFileSync(dataPath(state), "utf-8");
+    const mappings = JSON.parse(raw) as TransferMapping[];
+    const counts = new Map<string, number>();
+    for (const m of mappings) {
+      if (m.univ_course && m.univ_course.includes("*")) continue;
+      if (m.no_credit) continue;
+      counts.set(m.university, (counts.get(m.university) || 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([slug, totalCount]) => ({ slug, totalCount }))
+      .sort((a, b) => b.totalCount - a.totalCount);
+  } catch {
+    return [];
+  }
+}
+
 // Re-export the lookup shape from the edge-safe module so callers that need
 // the type can import it from either module. The scoped helpers themselves
 // live in `lib/transfer-scoped.ts` to keep `fs`/`path` out of edge bundles.


### PR DESCRIPTION
## Summary

- 7 of 9 sitemap route handlers were timing out in production — Google couldn't discover ~90% of the site's pages (courses, transfers, instructors, subjects)
- Replaced sequential `for` loops with `Promise.allSettled` so all 17 states query Supabase in parallel
- Added `export const revalidate = 86400` (24h HTTP cache) to every async sitemap so subsequent requests serve instantly
- New lightweight `getUniversitySlugsForSitemap()` fetches only the `university` column instead of loading all 400K+ transfer rows

## What was broken

| Sitemap | Before | After |
|---|---|---|
| `courses.xml` | Timeout (sequential queries × 17 states) | Parallel + cached |
| `transfer.xml` | Timeout (loaded ALL transfer rows per state) | Lightweight column-only query + parallel |
| `state-subjects.xml` | Timeout | Parallel + cached |
| `instructors.xml` | Timeout | Parallel + cached |
| `college-subjects.xml` | Timeout (222 individual college queries) | Double-parallel (states + colleges) + cached |
| `programs.xml` | Timeout | Parallel + cached |
| `core.xml` | Timeout (online data queries sequential) | Parallel online checks + cached |

## Test plan

- [ ] Verify Vercel build succeeds
- [ ] After deploy, curl each sitemap and confirm it returns XML within 10s:
  - `curl -o /dev/null -w "%{time_total}s" https://communitycollegepath.com/sitemap/courses.xml`
  - `curl -o /dev/null -w "%{time_total}s" https://communitycollegepath.com/sitemap/transfer.xml`
  - `curl -o /dev/null -w "%{time_total}s" https://communitycollegepath.com/sitemap/state-subjects.xml`
- [ ] Spot-check that sitemap XML contains expected URLs (e.g. `/va/subject/eng`, `/va/transfer/to/vt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)