### PR TITLE
seo: rewrite homepage meta description for click-through

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,10 +12,11 @@ const STATE_LIST_SENTENCE =
   STATE_NAMES.length <= 1
     ? STATE_NAMES.join("")
     : `${STATE_NAMES.slice(0, -1).join(", ")}, and ${STATE_NAMES[STATE_NAMES.length - 1]}`;
+const META_DESCRIPTION = `Search community college courses, transfer credits, and schedules across ${STATE_NAMES.length} states. Free, no signup.`;
 
 export const metadata: Metadata = {
   title: "Community College Path — Find any community college course in one search",
-  description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
+  description: META_DESCRIPTION,
   keywords: [
     "community college courses",
     "CC course finder",
@@ -26,14 +27,14 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: "Community College Path — Course Finder & Transfer Guide",
-    description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
+    description: META_DESCRIPTION,
     type: "website",
     url: "/",
   },
   twitter: {
     card: "summary_large_image",
     title: "Community College Path — Course Finder & Transfer Guide",
-    description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
+    description: META_DESCRIPTION,
   },
   alternates: {
     canonical: "/",


### PR DESCRIPTION
## Summary
- Homepage `<meta name=\"description\">` was a comma-list of all 18 state names — read as spam, exceeded Google's ~155-char snippet limit, and got truncated mid-list in SERPs.
- Replaced with a benefit-focused sentence: *\"Search community college courses, transfer credits, and schedules across 18 states. Free, no signup.\"*
- Count is derived from `getAllStates().length`, so it auto-updates as new states ship.
- Same string is now reused across `description`, `openGraph.description`, and `twitter.description` via a single `META_DESCRIPTION` constant.

## Why
Part of the SEO punch list after fixing sitemap timeouts (PR #184). Sitemaps now resolve, but the homepage snippet that appears in search results was a wall of state names — the kind of thing a user scans past. Tighter copy ending in a clear value prop should improve click-through rate without sacrificing keyword coverage (the JSON-LD `description` block at line 74 still names every state).

## Test plan
- [ ] After Vercel redeploys, curl `https://communitycollegepath.com/` and confirm `<meta name=\"description\" content=\"Search community college courses, transfer credits, and schedules across 18 states. Free, no signup.\">`
- [ ] Same string appears in og:description and twitter:description
- [ ] Character count <155 (currently 109 — well under the cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)