### PR TITLE
seo: fix Soft 404s by replacing notFound() with noindex empty state

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -139,7 +139,18 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const currentTerm = await getCurrentTerm(state);
   const sections = await loadCourseByCode(parsed.prefix, parsed.number, currentTerm, state);
 
-  if (sections.length === 0) return { title: "Not Found" };
+  if (sections.length === 0) {
+    // Course code is well-formed but has no sections this term. We render a
+    // real page (with helpful links) instead of calling notFound() — see the
+    // page body for why. Tell Google not to index it via robots metadata.
+    return {
+      title: `${parsed.prefix} ${parsed.number} — Not offered ${termLabel(currentTerm)} | ${config.branding.siteName}`,
+      robots: { index: false, follow: true },
+      alternates: {
+        canonical: `${process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"}/${state}/course/${code}`,
+      },
+    };
+  }
 
   const title = sections[0].course_title;
   const credits = sections[0].credits;
@@ -205,7 +216,65 @@ export default async function CoursePage(props: PageProps) {
   const subjectSections = await loadCoursesBySubject(prefix, currentTerm, state);
   const sections = subjectSections.filter((c) => c.course_number === number);
 
-  if (sections.length === 0) notFound();
+  if (sections.length === 0) {
+    // The course code is well-formed and the state is valid — but no sections
+    // exist for this term. We deliberately do NOT call notFound() here:
+    // Next.js ISR caches notFound() responses as successful prerenders and
+    // Vercel's CDN re-serves them as HTTP 200, which Google treats as a soft
+    // 404. Instead we render a real page with helpful next-steps links and
+    // rely on the noindex meta in generateMetadata() to keep these out of
+    // Google's index.
+    const relatedSubjectCourses = Array.from(
+      new Map(subjectSections.map((s) => [s.course_number, s])).values(),
+    )
+      .sort((a, b) => a.course_number.localeCompare(b.course_number))
+      .slice(0, 12);
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2">
+          {prefix} {number}
+        </h1>
+        <p className="text-gray-600 dark:text-slate-400 mb-8">
+          No sections of {prefix} {number} are scheduled at {config.systemName}{" "}
+          colleges for {termLabel(currentTerm)}. The course may run a different
+          term, or the catalog code may have changed.
+        </p>
+        {relatedSubjectCourses.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">
+              Other {subjectName(prefix)} courses this term
+            </h2>
+            <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {relatedSubjectCourses.map((c) => (
+                <li key={c.course_number}>
+                  <Link
+                    href={`/${state}/course/${prefix.toLowerCase()}-${c.course_number.toLowerCase()}`}
+                    className="text-teal-700 dark:text-teal-400 hover:underline"
+                  >
+                    {prefix} {c.course_number} — {c.course_title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        <div className="flex flex-wrap gap-3 mt-8">
+          <Link
+            href={`/${state}/subject/${prefix.toLowerCase()}`}
+            className="rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 transition"
+          >
+            Browse all {subjectName(prefix)} courses
+          </Link>
+          <Link
+            href={`/${state}`}
+            className="rounded-lg border border-gray-300 dark:border-slate-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition"
+          >
+            {config.name} home
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   const courseTitle = sections[0].course_title;
   const credits = sections[0].credits;

--- a/app/[state]/starting-soon/page.tsx
+++ b/app/[state]/starting-soon/page.tsx
@@ -19,6 +19,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: `Courses Starting Soon — Late-Start Classes | ${config.branding.siteName}`,
     description: `Find late-start courses, mini-sessions, and upcoming classes across all ${config.collegeCount} ${config.name} community colleges. Don't miss registration deadlines.`,
     alternates: { canonical: `/${state}/starting-soon` },
+    // Tool page: the section list loads client-side, so the server HTML is
+    // just a heading + empty container. Google was flagging these as Soft
+    // 404 because the rendered HTML it crawls contains no real content.
+    robots: { index: false, follow: true },
   };
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,10 +12,11 @@ const STATE_LIST_SENTENCE =
   STATE_NAMES.length <= 1
     ? STATE_NAMES.join("")
     : `${STATE_NAMES.slice(0, -1).join(", ")}, and ${STATE_NAMES[STATE_NAMES.length - 1]}`;
+const META_DESCRIPTION = `Search community college courses, transfer credits, and schedules across ${STATE_NAMES.length} states. Free, no signup.`;
 
 export const metadata: Metadata = {
   title: "Community College Path — Find any community college course in one search",
-  description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
+  description: META_DESCRIPTION,
   keywords: [
     "community college courses",
     "CC course finder",
@@ -26,14 +27,14 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: "Community College Path — Course Finder & Transfer Guide",
-    description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
+    description: META_DESCRIPTION,
     type: "website",
     url: "/",
   },
   twitter: {
     card: "summary_large_image",
     title: "Community College Path — Course Finder & Transfer Guide",
-    description: `Search courses, look up transfer credits, and build a schedule across community colleges in ${STATE_LIST_SENTENCE}.`,
+    description: META_DESCRIPTION,
   },
   alternates: {
     canonical: "/",


### PR DESCRIPTION
## Summary
Fixes the 1,229 Soft 404 pages flagged in Google Search Console.

**Root cause:** When `/[state]/course/[code]/page.tsx` (revalidate=7d ISR) calls `notFound()`, Next.js caches the not-found render as a successful prerender (`x-nextjs-prerender: 1`) and Vercel's CDN serves it as HTTP 200 forever. Google sees a 200 with empty content → soft 404.

Verified locally: `/ga/course/cist-2570` previously returned HTTP 200 with `<title>Not Found</title>`. With this PR it returns HTTP 200 with a real page (\"CIST 2570 — Not offered Summer 2026\") and `<meta name=\"robots\" content=\"noindex, follow\">`.

## Changes
- **[app/[state]/course/[code]/page.tsx](app/[state]/course/[code]/page.tsx)** — when sections is empty (course code well-formed but not offered this term), render a helpful empty-state page with related-course links and `robots: { index: false }` in metadata. `notFound()` is now reserved for genuinely invalid input (parseCode failure, invalid state slug).
- **[app/[state]/starting-soon/page.tsx](app/[state]/starting-soon/page.tsx)** — client-rendered tool page; server HTML is just a heading. Added `robots: { index: false }` since Googlebot can't see the actual content.

## Why this fixes it
- Google fetches the page → sees `<meta name=\"robots\" content=\"noindex\">` → drops the URL from the indexing queue (clean signal, not the soft-404 ambiguity)
- Users who land on the page now get useful next-steps links instead of a dead-end
- Cached soft-404 responses will roll over as the 7-day revalidate window expires; they'll re-render with the new noindex meta automatically

## Test plan
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Local curl: `/ga/course/cist-2570` returns 200 with `noindex` and \"Not offered Summer 2026\" title
- [x] Local curl: `/de/starting-soon` returns 200 with `noindex`
- [x] Empty-state UI renders \"Other CIST courses this term\" + \"Browse all CIST courses\" links
- [ ] Post-merge: confirm in GSC that Soft 404 count starts trending down over the next 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)