### PR TITLE
sitemaps: add lastmod to all entries, drop noindex starting-soon URLs

### DIFF
--- a/app/sitemap/college-subjects.xml/route.ts
+++ b/app/sitemap/college-subjects.xml/route.ts
@@ -36,6 +36,7 @@ export async function GET() {
                 url: `${url}/${state.slug}/college/${inst.id}/courses/${prefix.toLowerCase()}`,
                 changeFrequency: "weekly",
                 priority: 0.6,
+                lastModified: new Date(),
               });
             }
           }

--- a/app/sitemap/colleges.xml/route.ts
+++ b/app/sitemap/colleges.xml/route.ts
@@ -10,6 +10,7 @@ import {
 export function GET() {
   const url = siteOrigin();
   const entries: SitemapEntry[] = [];
+  const lastModified = new Date();
 
   for (const state of getAllStates()) {
     for (const inst of loadInstitutions(state.slug)) {
@@ -17,6 +18,7 @@ export function GET() {
         url: `${url}/${state.slug}/college/${inst.id}`,
         changeFrequency: "weekly",
         priority: 0.7,
+        lastModified,
       });
     }
   }

--- a/app/sitemap/core.xml/route.ts
+++ b/app/sitemap/core.xml/route.ts
@@ -11,9 +11,10 @@ export const revalidate = 86400;
 
 export async function GET() {
   const url = siteOrigin();
+  const now = new Date();
   const entries: SitemapEntry[] = [
-    { url, changeFrequency: "weekly", priority: 1 },
-    { url: `${url}/colleges`, changeFrequency: "weekly", priority: 0.9 },
+    { url, changeFrequency: "weekly", priority: 1, lastModified: now },
+    { url: `${url}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
   ];
 
   const states = getAllStates();
@@ -21,25 +22,18 @@ export async function GET() {
   for (const state of states) {
     const s = state.slug;
     entries.push(
-      { url: `${url}/${s}`, changeFrequency: "weekly", priority: 1 },
-      { url: `${url}/${s}/courses`, changeFrequency: "weekly", priority: 0.9 },
-      {
-        url: `${url}/${s}/colleges`,
-        changeFrequency: "weekly",
-        priority: 0.9,
-      },
-      {
-        url: `${url}/${s}/starting-soon`,
-        changeFrequency: "daily",
-        priority: 0.85,
-      },
-      { url: `${url}/${s}/about`, changeFrequency: "monthly", priority: 0.6 }
+      { url: `${url}/${s}`, changeFrequency: "weekly", priority: 1, lastModified: now },
+      { url: `${url}/${s}/courses`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
+      { url: `${url}/${s}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
+      // /starting-soon is noindex (client-rendered tool page) — omit from sitemap
+      { url: `${url}/${s}/about`, changeFrequency: "monthly", priority: 0.6, lastModified: now }
     );
     if (state.transferSupported) {
       entries.push({
         url: `${url}/${s}/transfer`,
         changeFrequency: "weekly",
         priority: 0.85,
+        lastModified: now,
       });
     }
   }

--- a/app/sitemap/courses.xml/route.ts
+++ b/app/sitemap/courses.xml/route.ts
@@ -17,10 +17,12 @@ export async function GET() {
     getAllStates().map(async (state) => {
       const currentTerm = await getCurrentTerm(state.slug);
       const { codes } = await getSitemapCourseIndex(currentTerm, state.slug);
+      const lastModified = new Date();
       return codes.map((c) => ({
         url: `${url}/${state.slug}/course/${`${c.prefix}-${c.number}`.toLowerCase()}`,
         changeFrequency: "weekly" as const,
         priority: 0.7,
+        lastModified,
       }));
     })
   );

--- a/app/sitemap/instructors.xml/route.ts
+++ b/app/sitemap/instructors.xml/route.ts
@@ -20,10 +20,12 @@ export async function GET() {
         currentTerm,
         state.slug
       );
+      const lastModified = new Date();
       return instructors.map((e) => ({
         url: `${url}/${state.slug}/college/${e.collegeId}/instructor/${e.slug}`,
         changeFrequency: "weekly" as const,
         priority: 0.6,
+        lastModified,
       }));
     })
   );

--- a/app/sitemap/programs.xml/route.ts
+++ b/app/sitemap/programs.xml/route.ts
@@ -15,10 +15,12 @@ export async function GET() {
   const results = await Promise.allSettled(
     getAllStates().map(async (state) => {
       const slugs = await getQualifyingProgramSlugs(state.slug);
+      const lastModified = new Date();
       return slugs.map((slug) => ({
         url: `${url}/${state.slug}/program/${slug}`,
         changeFrequency: "weekly" as const,
         priority: 0.75,
+        lastModified,
       }));
     })
   );

--- a/app/sitemap/state-subjects.xml/route.ts
+++ b/app/sitemap/state-subjects.xml/route.ts
@@ -27,6 +27,7 @@ export async function GET() {
             url: `${url}/${state.slug}/subject/${prefix.toLowerCase()}`,
             changeFrequency: "weekly",
             priority: 0.65,
+            lastModified: new Date(),
           });
         }
       }

--- a/app/sitemap/transfer.xml/route.ts
+++ b/app/sitemap/transfer.xml/route.ts
@@ -25,6 +25,7 @@ export async function GET() {
             url: `${url}/${state.slug}/transfer/to/${u.slug}`,
             changeFrequency: "weekly" as const,
             priority: 0.8,
+            lastModified: new Date(),
           }));
       })
   );


### PR DESCRIPTION
## Summary
- Adds `lastModified: new Date()` to every entry in all 8 data-driven sitemaps: `courses.xml`, `transfer.xml`, `state-subjects.xml`, `college-subjects.xml`, `instructors.xml`, `programs.xml`, `colleges.xml`, `core.xml`. The `blog.xml` sitemap already had `lastModified` from article publish dates.
- Removes `/[state]/starting-soon` entries from `core.xml` — those pages are now `noindex` (PR #186) since Googlebot can't see the client-rendered section list. Submitting noindex URLs wastes crawl budget.

## Why lastmod matters
`lastmod` is the strongest crawl-frequency signal Google still honours. Without it, Googlebot decides entirely on its own when to re-crawl — which for a new site with low authority means infrequent visits. With accurate `lastmod` stamps, Google sees "this changed recently" and prioritises re-crawling.

All data-driven sitemaps use `revalidate = 86400` (24h ISR), so `new Date()` at generation time is an accurate stamp — it reflects the current state of the data. Entries are regenerated at most once per day.

## Test plan
- [x] Typecheck clean
- [ ] After merge: `curl https://communitycollegepath.com/sitemap/courses.xml | grep lastmod | head -3` — confirm ISO timestamps appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)