### PR TITLE
search-intent: add eval harness for natural-language query classifier

### DIFF
--- a/lib/search-intent/__tests__/eval-cases.test.ts
+++ b/lib/search-intent/__tests__/eval-cases.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { EVAL_CASES, type EvalCase } from "../eval/cases";
+
+describe("EVAL_CASES fixture", () => {
+  it("has at least 60 cases", () => {
+    expect(EVAL_CASES.length).toBeGreaterThanOrEqual(60);
+  });
+
+  it("has substantial non-VA coverage (project is national)", () => {
+    const nonVa = EVAL_CASES.filter((c) => c.tags?.includes("non-va")).length;
+    // Floor of 10 keeps us honest about not regressing into VCCS-only fixtures.
+    expect(nonVa, `only ${nonVa} non-VA cases`).toBeGreaterThanOrEqual(10);
+  });
+
+  it("has at least one alias-resolution case", () => {
+    const hasAlias = EVAL_CASES.some((c) => c.tags?.includes("alias"));
+    expect(hasAlias).toBe(true);
+  });
+
+  it("has unique ids", () => {
+    const ids = EVAL_CASES.map((c) => c.id);
+    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+    expect(dupes).toEqual([]);
+  });
+
+  it("has non-empty queries", () => {
+    for (const c of EVAL_CASES) {
+      expect(c.query.length, `case ${c.id}: query is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers each category with at least 3 cases", () => {
+    const REQUIRED_CATEGORIES: EvalCase["category"][] = [
+      "course-code",
+      "course-keyword",
+      "prereqs",
+      "transfer",
+      "eligibility",
+      "course-with-filters",
+      "vague",
+      "multi-intent",
+      "gibberish",
+    ];
+    for (const cat of REQUIRED_CATEGORIES) {
+      const count = EVAL_CASES.filter((c) => c.category === cat).length;
+      expect(count, `category "${cat}" has only ${count} cases`).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it("has at least one typo case (otherwise we're not testing realistic input)", () => {
+    const hasTypo = EVAL_CASES.some((c) => c.tags?.includes("typo"));
+    expect(hasTypo).toBe(true);
+  });
+
+  it("has at least one multi-intent case", () => {
+    const hasMulti = EVAL_CASES.some((c) => c.tags?.includes("multi-intent"));
+    expect(hasMulti).toBe(true);
+  });
+
+  it("only uses valid expected intent types", () => {
+    const VALID = new Set([
+      "transfer",
+      "prereqs",
+      "eligibility",
+      "course",
+      "unknown",
+      "any-of",
+    ]);
+    for (const c of EVAL_CASES) {
+      expect(VALID.has(c.expected.type), `case ${c.id} has bad type ${c.expected.type}`).toBe(true);
+    }
+  });
+});

--- a/lib/search-intent/__tests__/eval-runner.test.ts
+++ b/lib/search-intent/__tests__/eval-runner.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { Classifier, SearchIntent } from "../types";
+import { formatReport, runEval } from "../eval/runner";
+import type { EvalCase } from "../eval/cases";
+
+// Minimal fixture used to exercise the runner without depending on the full
+// EVAL_CASES list. Each case here has a known, unambiguous expected intent
+// so we can write a hand-crafted "perfect" classifier and a dumb one and
+// verify the runner reports them correctly.
+const TINY_CASES: EvalCase[] = [
+  {
+    id: "tiny-transfer",
+    query: "Does ENG 111 transfer to GMU?",
+    category: "transfer",
+    expected: {
+      type: "transfer",
+      course: { prefix: "ENG", number: "111" },
+      university: "gmu",
+    },
+  },
+  {
+    id: "tiny-prereqs",
+    query: "prereqs for BIO 256",
+    category: "prereqs",
+    expected: {
+      type: "prereqs",
+      course: { prefix: "BIO", number: "256" },
+    },
+  },
+  {
+    id: "tiny-unknown",
+    query: "what should I take",
+    category: "vague",
+    expected: { type: "unknown" },
+  },
+];
+
+const PERFECT_CLASSIFIER: Classifier = (q) => {
+  let intent: SearchIntent;
+  if (q.includes("transfer")) {
+    intent = {
+      type: "transfer",
+      course: { prefix: "ENG", number: "111" },
+      university: "gmu",
+    };
+  } else if (q.includes("prereqs")) {
+    intent = {
+      type: "prereqs",
+      course: { prefix: "BIO", number: "256" },
+    };
+  } else {
+    intent = { type: "unknown", raw: q };
+  }
+  return { intent, confidence: 1 };
+};
+
+const ALWAYS_UNKNOWN: Classifier = (q) => ({
+  intent: { type: "unknown", raw: q },
+  confidence: 0,
+});
+
+describe("runEval", () => {
+  it("reports 100% pass for a classifier that gets everything right", async () => {
+    const report = await runEval(PERFECT_CLASSIFIER, TINY_CASES);
+    expect(report.total).toBe(3);
+    expect(report.passed).toBe(3);
+    expect(report.passRate).toBe(1);
+  });
+
+  it("reports partial pass for a stub classifier", async () => {
+    const report = await runEval(ALWAYS_UNKNOWN, TINY_CASES);
+    // Only the "tiny-unknown" case passes; transfer and prereqs fail.
+    expect(report.passed).toBe(1);
+    expect(report.total).toBe(3);
+  });
+
+  it("breaks down by category", async () => {
+    const report = await runEval(PERFECT_CLASSIFIER, TINY_CASES);
+    const transferStats = report.byCategory.find((c) => c.category === "transfer");
+    expect(transferStats).toEqual({
+      category: "transfer",
+      total: 1,
+      passed: 1,
+      passRate: 1,
+    });
+  });
+
+  it("captures latency percentiles", async () => {
+    const report = await runEval(PERFECT_CLASSIFIER, TINY_CASES);
+    expect(report.latencyMsP50).toBeGreaterThanOrEqual(0);
+    expect(report.latencyMsP95).toBeGreaterThanOrEqual(report.latencyMsP50);
+  });
+
+  it("formatReport renders without throwing", async () => {
+    const report = await runEval(ALWAYS_UNKNOWN, TINY_CASES);
+    const text = formatReport(report);
+    expect(text).toContain("Overall:");
+    expect(text).toContain("By category:");
+    expect(text).toContain("Failures:");
+  });
+
+  it("supports async classifiers", async () => {
+    const asyncClassifier: Classifier = async (q) => ({
+      intent: { type: "unknown", raw: q },
+      confidence: 0,
+    });
+    const report = await runEval(asyncClassifier, TINY_CASES);
+    expect(report.total).toBe(3);
+  });
+});

--- a/lib/search-intent/eval/cases.ts
+++ b/lib/search-intent/eval/cases.ts
@@ -1,0 +1,606 @@
+import type { CourseIntent, CourseRef, EligibilityIntent, SearchIntent } from "../types";
+
+// `ExpectedIntent` is a partial shape the matcher checks against the
+// classifier's actual output. Only fields that are explicitly set are
+// asserted — undefined fields mean "we don't care."
+//
+// `any-of` is for queries where multiple classifications are reasonable
+// (e.g. multi-intent, ambiguous shorthand). Matching counts as a pass if
+// the actual intent type is in `oneOf`.
+export type ExpectedIntent =
+  | { type: "transfer"; course?: CourseRef; university?: string | null }
+  | { type: "prereqs"; course?: CourseRef }
+  | {
+      type: "eligibility";
+      topic?: EligibilityIntent["topic"];
+      age?: number | null;
+    }
+  | { type: "course"; mustExtract?: Partial<CourseIntent["filters"]> }
+  | { type: "unknown" }
+  | { type: "any-of"; oneOf: Array<SearchIntent["type"]> };
+
+export interface EvalCase {
+  id: string;
+  query: string;
+  category:
+    | "course-code"
+    | "course-keyword"
+    | "prereqs"
+    | "transfer"
+    | "eligibility"
+    | "course-with-filters"
+    | "vague"
+    | "multi-intent"
+    | "gibberish";
+  // Crosscutting markers (typos, slang, multi-intent). Useful for slicing
+  // the eval report along non-category axes.
+  tags?: Array<
+    | "typo"
+    | "slang"
+    | "lowercase"
+    | "multi-intent"
+    | "missing-entity"
+    // "alias": tests university name resolution (e.g. "GMU" → "gmu",
+    // "George Mason" → "gmu", "UMass Amherst" → "umass-amherst").
+    | "alias"
+    // "non-va": tests course prefixes / universities outside Virginia.
+    // Project is national; the fixture must not implicitly assume VCCS.
+    | "non-va"
+  >;
+  expected: ExpectedIntent;
+  notes?: string;
+}
+
+const ENG_111: CourseRef = { prefix: "ENG", number: "111" };
+const BIO_256: CourseRef = { prefix: "BIO", number: "256" };
+const MTH_263: CourseRef = { prefix: "MTH", number: "263" };
+const PSY_200: CourseRef = { prefix: "PSY", number: "200" };
+
+export const EVAL_CASES: EvalCase[] = [
+  // ─── course-code ─────────────────────────────────────────────────────
+  {
+    id: "cc-01-eng-111-spaced",
+    query: "ENG 111",
+    category: "course-code",
+    expected: { type: "course", mustExtract: { course: ENG_111 } },
+  },
+  {
+    id: "cc-02-eng-111-lowercase",
+    query: "eng 111",
+    category: "course-code",
+    tags: ["lowercase"],
+    expected: { type: "course", mustExtract: { course: ENG_111 } },
+  },
+  {
+    id: "cc-03-eng-111-no-space",
+    query: "ENG111",
+    category: "course-code",
+    expected: { type: "course", mustExtract: { course: ENG_111 } },
+  },
+  {
+    id: "cc-04-bio-256",
+    query: "BIO 256",
+    category: "course-code",
+    expected: { type: "course", mustExtract: { course: BIO_256 } },
+  },
+  {
+    id: "cc-05-math-lowercase",
+    query: "math 154",
+    category: "course-code",
+    tags: ["lowercase"],
+    expected: {
+      type: "course",
+      mustExtract: { course: { prefix: "MATH", number: "154" } },
+    },
+  },
+  {
+    id: "cc-06-psy200-jammed",
+    query: "psy200",
+    category: "course-code",
+    tags: ["lowercase"],
+    expected: { type: "course", mustExtract: { course: PSY_200 } },
+  },
+  {
+    id: "cc-07-cs-101",
+    query: "CS 101",
+    category: "course-code",
+    expected: {
+      type: "course",
+      mustExtract: { course: { prefix: "CS", number: "101" } },
+    },
+  },
+  {
+    id: "cc-08-engl-101-cuny",
+    query: "ENGL 101",
+    category: "course-code",
+    tags: ["non-va"],
+    expected: {
+      type: "course",
+      mustExtract: { course: { prefix: "ENGL", number: "101" } },
+    },
+    notes: "CUNY/SUNY/GA-style 4-letter prefix. Regex must accept 2-4 letters.",
+  },
+  {
+    id: "cc-09-biol-110",
+    query: "BIOL 110",
+    category: "course-code",
+    tags: ["non-va"],
+    expected: {
+      type: "course",
+      mustExtract: { course: { prefix: "BIOL", number: "110" } },
+    },
+  },
+  {
+    id: "cc-10-psyc-101",
+    query: "PSYC 101",
+    category: "course-code",
+    tags: ["non-va"],
+    expected: {
+      type: "course",
+      mustExtract: { course: { prefix: "PSYC", number: "101" } },
+    },
+  },
+  {
+    id: "cc-11-acct-201",
+    query: "ACCT 201",
+    category: "course-code",
+    tags: ["non-va"],
+    expected: {
+      type: "course",
+      mustExtract: { course: { prefix: "ACCT", number: "201" } },
+    },
+    notes: "Common in NY/NC; tests 4-letter prefix without 'common knowledge' bias.",
+  },
+
+  // ─── course-keyword ──────────────────────────────────────────────────
+  {
+    id: "ck-01-intro-biology",
+    query: "intro biology",
+    category: "course-keyword",
+    expected: { type: "course" },
+    notes: "Should fall through to keyword search; no course code extractable.",
+  },
+  {
+    id: "ck-02-introduction-to-psychology",
+    query: "Introduction to Psychology",
+    category: "course-keyword",
+    expected: { type: "course" },
+  },
+  {
+    id: "ck-03-prefix-only",
+    query: "ENG",
+    category: "course-keyword",
+    expected: { type: "course" },
+    notes:
+      "Subject-prefix-only query. Existing courses-search.parseQuery returns prefix. Either course or any-of acceptable.",
+  },
+  {
+    id: "ck-04-macroeconomics",
+    query: "macroeconomics",
+    category: "course-keyword",
+    tags: ["lowercase"],
+    expected: { type: "course" },
+    notes: "Single-word topical keyword; should fall through to title search.",
+  },
+  {
+    id: "ck-05-organic-chem",
+    query: "organic chemistry",
+    category: "course-keyword",
+    tags: ["lowercase"],
+    expected: { type: "course" },
+  },
+
+  // ─── prereqs ─────────────────────────────────────────────────────────
+  {
+    id: "pr-01-prereqs-for-bio",
+    query: "prereqs for BIO 256",
+    category: "prereqs",
+    expected: { type: "prereqs", course: BIO_256 },
+  },
+  {
+    id: "pr-02-what-are-prereqs",
+    query: "what are the prereqs for BIO 256",
+    category: "prereqs",
+    expected: { type: "prereqs", course: BIO_256 },
+  },
+  {
+    id: "pr-03-prerequisites-spelled",
+    query: "prerequisites for math 263",
+    category: "prereqs",
+    tags: ["lowercase"],
+    expected: { type: "prereqs", course: MTH_263 },
+    notes:
+      "math → MTH normalization is the classifier's job; the answer layer maps subject aliases.",
+  },
+  {
+    id: "pr-04-trailing-prereqs",
+    query: "BIO 256 prereqs",
+    category: "prereqs",
+    expected: { type: "prereqs", course: BIO_256 },
+  },
+  {
+    id: "pr-05-natural-language",
+    query: "what do I need to take before MTH 263",
+    category: "prereqs",
+    expected: { type: "prereqs", course: MTH_263 },
+  },
+  {
+    id: "pr-06-informal",
+    query: "do i need to take anything before psy 200",
+    category: "prereqs",
+    tags: ["lowercase"],
+    expected: { type: "prereqs", course: PSY_200 },
+  },
+  {
+    id: "pr-07-shorthand",
+    query: "prereq BIO 101",
+    category: "prereqs",
+    expected: {
+      type: "prereqs",
+      course: { prefix: "BIO", number: "101" },
+    },
+  },
+  {
+    id: "pr-08-comes-before",
+    query: "what comes before ENG 111",
+    category: "prereqs",
+    expected: { type: "prereqs", course: ENG_111 },
+    notes: "Stretch case — informal phrasing without 'prereq' keyword.",
+  },
+  {
+    id: "pr-09-prereqs-math-cuny",
+    query: "prereqs for MATH 121",
+    category: "prereqs",
+    tags: ["non-va"],
+    expected: {
+      type: "prereqs",
+      course: { prefix: "MATH", number: "121" },
+    },
+  },
+  {
+    id: "pr-10-prereqs-psyc",
+    query: "what do I need before PSYC 101",
+    category: "prereqs",
+    tags: ["non-va"],
+    expected: {
+      type: "prereqs",
+      course: { prefix: "PSYC", number: "101" },
+    },
+  },
+
+  // ─── transfer ────────────────────────────────────────────────────────
+  {
+    id: "tr-01-classic",
+    query: "Does ENG 111 transfer to GMU?",
+    category: "transfer",
+    expected: { type: "transfer", course: ENG_111, university: "gmu" },
+  },
+  {
+    id: "tr-02-lowercase",
+    query: "does eng 111 transfer to gmu",
+    category: "transfer",
+    tags: ["lowercase"],
+    expected: { type: "transfer", course: ENG_111, university: "gmu" },
+  },
+  {
+    id: "tr-03-full-university-name",
+    query: "will ENG 111 transfer to George Mason",
+    category: "transfer",
+    expected: { type: "transfer", course: ENG_111, university: "gmu" },
+    notes: "University alias resolution: 'George Mason' → 'gmu'.",
+  },
+  {
+    id: "tr-04-arrow-shorthand",
+    query: "ENG 111 → GMU",
+    category: "transfer",
+    tags: ["slang"],
+    expected: { type: "transfer", course: ENG_111, university: "gmu" },
+  },
+  {
+    id: "tr-05-typos",
+    query: "does eng111 trasnfer 2 gmu",
+    category: "transfer",
+    tags: ["typo", "slang", "lowercase"],
+    expected: { type: "transfer", course: ENG_111, university: "gmu" },
+    notes: "Hard case for regex; LLM should handle.",
+  },
+  {
+    id: "tr-06-vcu",
+    query: "Does math 263 transfer to vcu",
+    category: "transfer",
+    tags: ["lowercase"],
+    expected: { type: "transfer", course: MTH_263, university: "vcu" },
+  },
+  {
+    id: "tr-07-imperative",
+    query: "transfer ENG 111 to UMass",
+    category: "transfer",
+    expected: { type: "transfer", course: ENG_111 },
+    notes: "UMass spans a system; alias resolution may yield multiple. Don't assert university slug.",
+  },
+  {
+    id: "tr-08-bare-juxtaposition",
+    query: "ENG 111 GMU",
+    category: "transfer",
+    tags: ["slang"],
+    expected: { type: "any-of", oneOf: ["transfer", "course"] },
+    notes: "Could be transfer-shorthand or just course+filter; either is reasonable.",
+  },
+  {
+    id: "tr-09-no-destination",
+    query: "Does ENG 111 transfer?",
+    category: "transfer",
+    tags: ["missing-entity"],
+    expected: { type: "transfer", course: ENG_111, university: null },
+    notes: "Missing destination → answer layer should prompt for one.",
+  },
+  {
+    id: "tr-10-no-course",
+    query: "will my biology credits transfer to gmu",
+    category: "transfer",
+    tags: ["missing-entity", "lowercase"],
+    expected: { type: "transfer", university: "gmu" },
+    notes:
+      "No course code; answer layer should prompt or do keyword-based course matching.",
+  },
+  {
+    id: "tr-11-umass-amherst",
+    query: "Does ENGL 101 transfer to UMass Amherst",
+    category: "transfer",
+    tags: ["non-va", "alias"],
+    expected: {
+      type: "transfer",
+      course: { prefix: "ENGL", number: "101" },
+    },
+    notes:
+      "MA. UMass is a multi-campus system; 'UMass Amherst' should resolve to a specific slug. Slug not asserted (normalization is the answer-layer's job).",
+  },
+  {
+    id: "tr-12-nc-state",
+    query: "Will MATH 100 transfer to NC State",
+    category: "transfer",
+    tags: ["non-va", "alias"],
+    expected: {
+      type: "transfer",
+      course: { prefix: "MATH", number: "100" },
+    },
+    notes: "NC. 'NC State' (a.k.a. NCSU) — common informal name.",
+  },
+  {
+    id: "tr-13-georgia-tech-arrow",
+    query: "ENGL 102 → Georgia Tech",
+    category: "transfer",
+    tags: ["non-va", "slang", "alias"],
+    expected: {
+      type: "transfer",
+      course: { prefix: "ENGL", number: "102" },
+    },
+    notes: "GA. 'Georgia Tech' should map to slug 'gatech'.",
+  },
+  {
+    id: "tr-14-unc-ambiguous",
+    query: "Does BIOL 101 transfer to UNC",
+    category: "transfer",
+    tags: ["non-va", "alias", "missing-entity"],
+    expected: {
+      type: "transfer",
+      course: { prefix: "BIOL", number: "101" },
+    },
+    notes:
+      "NC. 'UNC' alone is ambiguous (Chapel Hill, Charlotte, Greensboro, Wilmington…). Answer layer should either default to Chapel Hill or prompt.",
+  },
+  {
+    id: "tr-15-bu-vs-bc",
+    query: "will my english credits transfer to BU",
+    category: "transfer",
+    tags: ["non-va", "alias", "missing-entity", "lowercase"],
+    expected: { type: "transfer" },
+    notes:
+      "MA. BU = Boston University, NOT Boston College (BC). Important disambiguation case.",
+  },
+  {
+    id: "tr-16-pitt",
+    query: "Does HIST 101 transfer to Pitt",
+    category: "transfer",
+    tags: ["non-va", "alias"],
+    expected: {
+      type: "transfer",
+      course: { prefix: "HIST", number: "101" },
+    },
+    notes: "PA. 'Pitt' = University of Pittsburgh (NOT Pittsburgh State or Penn State).",
+  },
+  {
+    id: "tr-17-uconn",
+    query: "Does ENGL 102 transfer to UConn",
+    category: "transfer",
+    tags: ["non-va", "alias"],
+    expected: {
+      type: "transfer",
+      course: { prefix: "ENGL", number: "102" },
+    },
+    notes: "CT. 'UConn' = University of Connecticut.",
+  },
+  {
+    id: "tr-18-rutgers",
+    query: "Does PSYC 101 transfer to Rutgers",
+    category: "transfer",
+    tags: ["non-va", "alias", "missing-entity"],
+    expected: {
+      type: "transfer",
+      course: { prefix: "PSYC", number: "101" },
+    },
+    notes:
+      "NJ. Rutgers spans New Brunswick, Newark, Camden — multi-campus disambiguation.",
+  },
+
+  // ─── eligibility ─────────────────────────────────────────────────────
+  {
+    id: "el-01-65-plus",
+    query: "free college if I'm 65+",
+    category: "eligibility",
+    expected: { type: "eligibility", topic: "senior", age: 65 },
+  },
+  {
+    id: "el-02-natural-language",
+    query: "I'm 65 can I take classes for free",
+    category: "eligibility",
+    expected: { type: "eligibility", topic: "senior", age: 65 },
+  },
+  {
+    id: "el-03-senior-audit",
+    query: "senior citizen audit",
+    category: "eligibility",
+    expected: { type: "any-of", oneOf: ["eligibility"] },
+    notes: "Topic could be 'senior' or 'audit'; both acceptable.",
+  },
+  {
+    id: "el-04-free-for-seniors",
+    query: "free classes for seniors",
+    category: "eligibility",
+    expected: { type: "eligibility", topic: "senior" },
+  },
+  {
+    id: "el-05-veteran",
+    query: "tuition waiver veterans",
+    category: "eligibility",
+    expected: { type: "eligibility", topic: "veteran" },
+  },
+  {
+    id: "el-06-over-60",
+    query: "am I eligible for free classes if I'm over 60",
+    category: "eligibility",
+    expected: { type: "eligibility", topic: "senior", age: 60 },
+  },
+
+  // ─── course-with-filters ─────────────────────────────────────────────
+  {
+    id: "cf-01-online-math-summer",
+    query: "online math, summer 2026",
+    category: "course-with-filters",
+    expected: {
+      type: "course",
+      mustExtract: { mode: "online", term: "Summer 2026" },
+    },
+  },
+  {
+    id: "cf-02-evening-biology",
+    query: "evening biology",
+    category: "course-with-filters",
+    expected: { type: "course", mustExtract: { timeOfDay: "evening" } },
+  },
+  {
+    id: "cf-03-weekend-accounting",
+    query: "weekend accounting",
+    category: "course-with-filters",
+    expected: { type: "course", mustExtract: { days: ["S", "U"] } },
+  },
+  {
+    id: "cf-04-online-eng-111",
+    query: "online ENG 111",
+    category: "course-with-filters",
+    expected: {
+      type: "course",
+      mustExtract: { mode: "online", course: ENG_111 },
+    },
+  },
+  {
+    id: "cf-05-morning-classes",
+    query: "morning classes",
+    category: "course-with-filters",
+    expected: { type: "course", mustExtract: { timeOfDay: "morning" } },
+  },
+  {
+    id: "cf-06-summer-biology-online",
+    query: "summer biology online",
+    category: "course-with-filters",
+    expected: { type: "course", mustExtract: { mode: "online" } },
+    notes: "Term phrase 'summer' alone is ambiguous (no year). Don't assert term.",
+  },
+  {
+    id: "cf-07-intro-psych-online",
+    query: "intro to psych online",
+    category: "course-with-filters",
+    expected: { type: "course", mustExtract: { mode: "online" } },
+  },
+  {
+    id: "cf-08-in-person-math",
+    query: "in person math",
+    category: "course-with-filters",
+    expected: { type: "course", mustExtract: { mode: "in-person" } },
+  },
+
+  // ─── vague ───────────────────────────────────────────────────────────
+  {
+    id: "vg-01-cheap-classes",
+    query: "cheap classes",
+    category: "vague",
+    expected: { type: "any-of", oneOf: ["unknown", "eligibility"] },
+    notes: "'Cheap' could route to senior/audit waiver answer or be unknown.",
+  },
+  {
+    id: "vg-02-what-should-i-take",
+    query: "what should I take",
+    category: "vague",
+    expected: { type: "unknown" },
+  },
+  {
+    id: "vg-03-good-professors",
+    query: "good professors",
+    category: "vague",
+    expected: { type: "unknown" },
+    notes: "We don't have ratings data; this is genuinely unanswerable.",
+  },
+  {
+    id: "vg-04-easy-classes",
+    query: "easy classes",
+    category: "vague",
+    expected: { type: "unknown" },
+  },
+
+  // ─── multi-intent ────────────────────────────────────────────────────
+  {
+    id: "mi-01-transfer-and-prereqs",
+    query: "Does ENG 111 transfer to GMU and what are the prereqs?",
+    category: "multi-intent",
+    tags: ["multi-intent"],
+    expected: { type: "any-of", oneOf: ["transfer", "prereqs"] },
+    notes: "Either single intent is acceptable in v1; multi-card UI deferred.",
+  },
+  {
+    id: "mi-02-online-and-transfers",
+    query: "online ENG 111 that transfers to GMU",
+    category: "multi-intent",
+    tags: ["multi-intent"],
+    expected: { type: "any-of", oneOf: ["transfer", "course"] },
+  },
+  {
+    id: "mi-03-prereqs-and-transfer",
+    query: "prereqs for BIO 256 and does it transfer to VCU",
+    category: "multi-intent",
+    tags: ["multi-intent"],
+    expected: { type: "any-of", oneOf: ["transfer", "prereqs"] },
+  },
+
+  // ─── gibberish ───────────────────────────────────────────────────────
+  {
+    id: "gb-01-double-course",
+    query: "ENG 111 ENG 112",
+    category: "gibberish",
+    expected: { type: "any-of", oneOf: ["course", "unknown"] },
+    notes: "Two course codes. Either pick the first or punt to unknown.",
+  },
+  {
+    id: "gb-02-keyboard-mash",
+    query: "asdfghjk",
+    category: "gibberish",
+    expected: { type: "any-of", oneOf: ["course", "unknown"] },
+    notes:
+      "Currently keyword-search would treat this as a title query and return nothing. 'course' with no match is acceptable; 'unknown' is also fine.",
+  },
+  {
+    id: "gb-03-emoji-only",
+    query: "🎓",
+    category: "gibberish",
+    expected: { type: "unknown" },
+  },
+];

--- a/lib/search-intent/eval/matcher.ts
+++ b/lib/search-intent/eval/matcher.ts
@@ -1,0 +1,151 @@
+import type { CourseRef, SearchIntent } from "../types";
+import type { ExpectedIntent } from "./cases";
+
+export interface MatchResult {
+  matched: boolean;
+  // Why the match failed, when it did. Useful for the eval report.
+  reason?: string;
+}
+
+function eqCourse(a: CourseRef, b: CourseRef): boolean {
+  return a.prefix.toUpperCase() === b.prefix.toUpperCase() && a.number === b.number;
+}
+
+function arrEq<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+/** Returns true if `actual` satisfies the partial constraints in `expected`. */
+export function matchesExpected(
+  actual: SearchIntent,
+  expected: ExpectedIntent,
+): MatchResult {
+  if (expected.type === "any-of") {
+    if (!expected.oneOf.includes(actual.type)) {
+      return {
+        matched: false,
+        reason: `expected one of [${expected.oneOf.join(", ")}], got "${actual.type}"`,
+      };
+    }
+    return { matched: true };
+  }
+
+  if (actual.type !== expected.type) {
+    return {
+      matched: false,
+      reason: `expected type "${expected.type}", got "${actual.type}"`,
+    };
+  }
+
+  switch (expected.type) {
+    case "transfer": {
+      if (actual.type !== "transfer") return { matched: false }; // narrow
+      if (expected.course) {
+        if (!actual.course) {
+          return { matched: false, reason: "expected course, got null" };
+        }
+        if (!eqCourse(actual.course, expected.course)) {
+          return {
+            matched: false,
+            reason: `expected course ${expected.course.prefix} ${expected.course.number}, got ${actual.course.prefix} ${actual.course.number}`,
+          };
+        }
+      }
+      if (expected.university !== undefined) {
+        if (actual.university !== expected.university) {
+          return {
+            matched: false,
+            reason: `expected university "${expected.university}", got "${actual.university}"`,
+          };
+        }
+      }
+      return { matched: true };
+    }
+
+    case "prereqs": {
+      if (actual.type !== "prereqs") return { matched: false };
+      if (expected.course) {
+        if (!actual.course) {
+          return { matched: false, reason: "expected course, got null" };
+        }
+        if (!eqCourse(actual.course, expected.course)) {
+          return {
+            matched: false,
+            reason: `expected course ${expected.course.prefix} ${expected.course.number}, got ${actual.course.prefix} ${actual.course.number}`,
+          };
+        }
+      }
+      return { matched: true };
+    }
+
+    case "eligibility": {
+      if (actual.type !== "eligibility") return { matched: false };
+      if (expected.topic !== undefined && actual.topic !== expected.topic) {
+        return {
+          matched: false,
+          reason: `expected topic "${expected.topic}", got "${actual.topic}"`,
+        };
+      }
+      if (expected.age !== undefined && actual.age !== expected.age) {
+        return {
+          matched: false,
+          reason: `expected age ${expected.age}, got ${actual.age}`,
+        };
+      }
+      return { matched: true };
+    }
+
+    case "course": {
+      if (actual.type !== "course") return { matched: false };
+      const must = expected.mustExtract;
+      if (!must) return { matched: true };
+      if (must.course) {
+        if (!actual.filters.course) {
+          return {
+            matched: false,
+            reason: `expected filters.course ${must.course.prefix} ${must.course.number}, got none`,
+          };
+        }
+        if (!eqCourse(actual.filters.course, must.course)) {
+          return {
+            matched: false,
+            reason: `expected filters.course ${must.course.prefix} ${must.course.number}, got ${actual.filters.course.prefix} ${actual.filters.course.number}`,
+          };
+        }
+      }
+      if (must.mode !== undefined && actual.filters.mode !== must.mode) {
+        return {
+          matched: false,
+          reason: `expected mode "${must.mode}", got "${actual.filters.mode}"`,
+        };
+      }
+      if (must.timeOfDay !== undefined && actual.filters.timeOfDay !== must.timeOfDay) {
+        return {
+          matched: false,
+          reason: `expected timeOfDay "${must.timeOfDay}", got "${actual.filters.timeOfDay}"`,
+        };
+      }
+      if (must.term !== undefined && actual.filters.term !== must.term) {
+        return {
+          matched: false,
+          reason: `expected term "${must.term}", got "${actual.filters.term}"`,
+        };
+      }
+      if (must.days !== undefined) {
+        if (!actual.filters.days || !arrEq(actual.filters.days, must.days)) {
+          return {
+            matched: false,
+            reason: `expected days [${must.days.join(",")}], got [${actual.filters.days?.join(",") ?? ""}]`,
+          };
+        }
+      }
+      return { matched: true };
+    }
+
+    case "unknown":
+      return { matched: true };
+  }
+}

--- a/lib/search-intent/eval/runner.ts
+++ b/lib/search-intent/eval/runner.ts
@@ -1,0 +1,119 @@
+import type { Classifier } from "../types";
+import { EVAL_CASES, type EvalCase } from "./cases";
+import { matchesExpected } from "./matcher";
+
+export interface CaseResult {
+  case: EvalCase;
+  passed: boolean;
+  reason?: string;
+  // Wall-clock latency of the classifier call, in ms.
+  latencyMs: number;
+  // Confidence as reported by the classifier.
+  confidence: number;
+  // Actual intent type the classifier produced. Useful for confusion-matrix
+  // style reporting in later PRs.
+  actualType: string;
+}
+
+export interface CategoryStats {
+  category: EvalCase["category"];
+  total: number;
+  passed: number;
+  passRate: number;
+}
+
+export interface EvalReport {
+  total: number;
+  passed: number;
+  passRate: number;
+  // Per-category breakdown so we can spot regressions in a single bucket
+  // even when the overall rate looks fine.
+  byCategory: CategoryStats[];
+  // p50 / p95 classifier latency. Matters once LLM tier ships.
+  latencyMsP50: number;
+  latencyMsP95: number;
+  results: CaseResult[];
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+export async function runEval(
+  classifier: Classifier,
+  cases: EvalCase[] = EVAL_CASES,
+): Promise<EvalReport> {
+  const results: CaseResult[] = [];
+
+  for (const c of cases) {
+    const start = performance.now();
+    const classified = await classifier(c.query);
+    const latencyMs = performance.now() - start;
+    const match = matchesExpected(classified.intent, c.expected);
+    results.push({
+      case: c,
+      passed: match.matched,
+      reason: match.reason,
+      latencyMs,
+      confidence: classified.confidence,
+      actualType: classified.intent.type,
+    });
+  }
+
+  const byCategoryMap = new Map<EvalCase["category"], { total: number; passed: number }>();
+  for (const r of results) {
+    const slot = byCategoryMap.get(r.case.category) ?? { total: 0, passed: 0 };
+    slot.total += 1;
+    if (r.passed) slot.passed += 1;
+    byCategoryMap.set(r.case.category, slot);
+  }
+  const byCategory: CategoryStats[] = [...byCategoryMap.entries()].map(
+    ([category, { total, passed }]) => ({
+      category,
+      total,
+      passed,
+      passRate: total === 0 ? 0 : passed / total,
+    }),
+  );
+
+  const passed = results.filter((r) => r.passed).length;
+  const total = results.length;
+  const sortedLatencies = results.map((r) => r.latencyMs).sort((a, b) => a - b);
+
+  return {
+    total,
+    passed,
+    passRate: total === 0 ? 0 : passed / total,
+    byCategory,
+    latencyMsP50: percentile(sortedLatencies, 50),
+    latencyMsP95: percentile(sortedLatencies, 95),
+    results,
+  };
+}
+
+/** Render an EvalReport as a console-friendly multi-line string. */
+export function formatReport(report: EvalReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `Overall: ${report.passed}/${report.total} (${(report.passRate * 100).toFixed(1)}%)  p50=${report.latencyMsP50.toFixed(1)}ms p95=${report.latencyMsP95.toFixed(1)}ms`,
+  );
+  lines.push("");
+  lines.push("By category:");
+  for (const c of report.byCategory) {
+    lines.push(
+      `  ${c.category.padEnd(22)} ${c.passed}/${c.total}  (${(c.passRate * 100).toFixed(1)}%)`,
+    );
+  }
+  const failures = report.results.filter((r) => !r.passed);
+  if (failures.length > 0) {
+    lines.push("");
+    lines.push("Failures:");
+    for (const f of failures) {
+      lines.push(`  [${f.case.id}] "${f.case.query}"`);
+      lines.push(`    → ${f.reason ?? "(no reason given)"}`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/lib/search-intent/types.ts
+++ b/lib/search-intent/types.ts
@@ -1,0 +1,74 @@
+// Structured representation of what a user is asking for in the search bar.
+//
+// Every classifier (regex, LLM, hybrid) produces a `ClassifiedIntent`. The
+// rest of the system — entity validation, answer lookup, UI rendering — only
+// reads this shape. Keep it stable across PRs; classifier internals can change.
+
+export interface CourseRef {
+  prefix: string; // e.g. "ENG"
+  number: string; // e.g. "111"
+}
+
+export interface TransferIntent {
+  type: "transfer";
+  // null = user asked about transfer but didn't name a course
+  // (e.g. "will my biology credits transfer"). Answer layer responds
+  // with a clarification prompt rather than a lookup.
+  course: CourseRef | null;
+  // university slug as it appears in transfer-equiv data (e.g. "gmu", "vcu").
+  // null = "transfer to anywhere" (show all destinations).
+  university: string | null;
+}
+
+export interface PrereqsIntent {
+  type: "prereqs";
+  // null = "prereqs for what?" — clarification prompt.
+  course: CourseRef | null;
+}
+
+export interface EligibilityIntent {
+  type: "eligibility";
+  topic: "senior" | "audit" | "cost" | "veteran";
+  age: number | null;
+}
+
+export interface CourseIntent {
+  type: "course";
+  // Free-text remainder after structured filters are extracted.
+  // null when the entire query was a course code or filter set.
+  keyword: string | null;
+  filters: {
+    course?: CourseRef;
+    mode?: "in-person" | "online" | "hybrid" | "zoom";
+    days?: ("M" | "T" | "W" | "R" | "F" | "S" | "U")[];
+    timeOfDay?: "morning" | "afternoon" | "evening";
+    // Term as written by the user, e.g. "Summer 2026". Validation against
+    // available terms happens in the answer-lookup layer.
+    term?: string;
+  };
+}
+
+export interface UnknownIntent {
+  type: "unknown";
+  raw: string;
+}
+
+export type SearchIntent =
+  | TransferIntent
+  | PrereqsIntent
+  | EligibilityIntent
+  | CourseIntent
+  | UnknownIntent;
+
+export interface ClassifiedIntent {
+  intent: SearchIntent;
+  // Self-reported confidence in [0, 1]. Tier-1 regex returns >= 0.95 for
+  // strong matches; LLM returns its own estimate. Used to decide fallback.
+  confidence: number;
+  // Optional human-readable reasoning, useful for debugging and eval output.
+  reasoning?: string;
+}
+
+export type Classifier = (
+  query: string,
+) => ClassifiedIntent | Promise<ClassifiedIntent>;


### PR DESCRIPTION
## Summary
First PR in a series adding natural-language question support to the homepage search bar. This one ships **only the measurement infrastructure** — no runtime code changes, no UI, no classifier yet. It establishes the contract every later classifier (regex in PR 2, LLM in PR 6) will satisfy and gives us a baseline number from day one.

- `SearchIntent` type — the contract: `transfer | prereqs | eligibility | course | unknown`
- 62 fixture queries across 9 categories, with crosscutting tags for typos, slang, missing entities, alias resolution, and non-VA coverage (NY/MA/GA/NC/NJ/PA/CT)
- `runEval(classifier)` returns overall + per-category pass rate and p50/p95 latency
- Structural test floors: ≥60 cases, ≥10 non-VA cases, ≥1 alias case — so the fixture can't silently regress to VCCS-only

## Why now
The popular-search chips on the homepage ("Does ENG 111 transfer to GMU?", "free college if I'm 65+") promise natural language but the current `parseQuery` only handles course codes and keyword substring matches. Before building the classifier we want a ruler — otherwise we'll iterate blind.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 210/210 passing (15 new + 195 existing)
- [x] `npm run lint` — 0 new warnings
- [ ] Reviewer sanity-check the 62 fixtures reflect realistic first-gen-student inputs

## What's next (separate PRs)
- PR 2: tier-1 regex classifier wired into `runEval`
- PR 3: entity validator + answer lookup against existing transfer / prereq / institution data
- PR 4: `/api/[state]/ask` endpoint
- PR 5: `AnswerCard` component on the results page
- PR 6: LLM (Claude Haiku) classifier as the long-tail tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)