### PR TITLE
search-intent: add entity validators and answer-lookup layer

### DIFF
--- a/app/api/[state]/prereqs/chain/route.ts
+++ b/app/api/[state]/prereqs/chain/route.ts
@@ -1,131 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidState } from "@/lib/states/registry";
-import fs from "fs";
-import path from "path";
+import { buildChain, loadPrereqs } from "@/lib/prereqs";
+
+// Re-export for any external callers that imported these from the route
+// before lib/prereqs existed.
+export { buildChain, parsePrereqGroups } from "@/lib/prereqs";
+export type { ChainNode } from "@/lib/prereqs";
 
 type RouteContext = { params: Promise<{ state: string }> };
-
-/**
- * Prerequisite chain tree node. Each node represents a course and its
- * direct prerequisites, recursively nested. Children are grouped into
- * AND-of-OR groups: outer array = AND (all required), inner array = OR
- * (pick one). A flat `children` array is also provided for backward compat.
- */
-export interface ChainNode {
-  course: string;
-  text: string;        // Human-readable prereq description for THIS course
-  children: ChainNode[];
-  groups?: ChainNode[][]; // AND-of-OR groups (if applicable)
-}
-
-/**
- * Load the prereqs.json for a state and return it as a Map.
- */
-function loadPrereqs(
-  state: string,
-): Map<string, { text: string; courses: string[] }> {
-  const jsonPath = path.join(process.cwd(), "data", state, "prereqs.json");
-  try {
-    const raw = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Record<
-      string,
-      { text: string; courses: string[] }
-    >;
-    return new Map(Object.entries(raw));
-  } catch {
-    return new Map();
-  }
-}
-
-/**
- * Parse prereq text into AND-of-OR groups.
- * "ACC 101 and (BUS 107 or CIS 107)" → [["ACC 101"], ["BUS 107","CIS 107"]]
- */
-export function parsePrereqGroups(text: string, courses: string[]): string[][] {
-  if (courses.length === 0) return [];
-  if (courses.length === 1) return [courses];
-
-  const chunks: string[] = [];
-  let depth = 0;
-  let current = "";
-  const tokens = text.split(/(\s+)/);
-  for (const token of tokens) {
-    for (const ch of token) {
-      if (ch === "(") depth++;
-      if (ch === ")") depth--;
-    }
-    if (token.toLowerCase() === "and" && depth === 0 && current.trim()) {
-      chunks.push(current.trim());
-      current = "";
-    } else {
-      current += token;
-    }
-  }
-  if (current.trim()) chunks.push(current.trim());
-
-  const groups: string[][] = [];
-  const assigned = new Set<string>();
-  for (const chunk of chunks) {
-    const group: string[] = [];
-    for (const course of courses) {
-      if (assigned.has(course)) continue;
-      if (chunk.toUpperCase().includes(course)) {
-        group.push(course);
-        assigned.add(course);
-      }
-    }
-    if (group.length > 0) groups.push(group);
-  }
-  for (const course of courses) {
-    if (!assigned.has(course)) groups.push([course]);
-  }
-  return groups;
-}
-
-/**
- * Recursively build the prerequisite chain tree. Caps depth at 6 to avoid
- * runaway recursion from circular prereq definitions (which exist in some
- * catalogs, e.g. "MATH A requires MATH B" + "MATH B requires MATH A").
- *
- * Returns both a flat `children` array (backward compat) and a `groups`
- * array that preserves AND-of-OR structure from the prereq text.
- */
-export function buildChain(
-  course: string,
-  prereqs: Map<string, { text: string; courses: string[] }>,
-  visited: Set<string>,
-  depth: number,
-): ChainNode {
-  const entry = prereqs.get(course);
-  const node: ChainNode = {
-    course,
-    text: entry?.text || "",
-    children: [],
-  };
-
-  if (depth >= 6 || !entry || visited.has(course)) return node;
-  visited.add(course);
-
-  // Build children with AND/OR grouping
-  const orGroups = parsePrereqGroups(entry.text, entry.courses);
-  const groupNodes: ChainNode[][] = [];
-
-  for (const group of orGroups) {
-    const groupChildren: ChainNode[] = [];
-    for (const dep of group) {
-      const child = buildChain(dep, prereqs, new Set(visited), depth + 1);
-      node.children.push(child);
-      groupChildren.push(child);
-    }
-    groupNodes.push(groupChildren);
-  }
-
-  // Only include groups if there are actual OR alternatives
-  if (groupNodes.some((g) => g.length > 1)) {
-    node.groups = groupNodes;
-  }
-
-  return node;
-}
 
 /**
  * GET /api/[state]/prereqs/chain?course=CHEM+1110

--- a/lib/prereqs.ts
+++ b/lib/prereqs.ts
@@ -1,0 +1,134 @@
+// Prerequisite data: loader + chain builder.
+//
+// Originally lived inside app/api/[state]/prereqs/chain/route.ts. Extracted
+// here so both the existing route and the search-intent answer-lookup
+// (lib/search-intent/answer/prereqs.ts) can share one implementation.
+//
+// Reads from data/{state}/prereqs.json via fs.readFileSync — NOT edge-safe.
+// Callers running on the Node runtime are fine (the prereq route already
+// runs on Node).
+
+import fs from "fs";
+import path from "path";
+
+/**
+ * Prerequisite chain tree node. Each node represents a course and its
+ * direct prerequisites, recursively nested. Children are grouped into
+ * AND-of-OR groups: outer array = AND (all required), inner array = OR
+ * (pick one). A flat `children` array is also provided for backward compat.
+ */
+export interface ChainNode {
+  course: string;
+  text: string; // Human-readable prereq description for THIS course
+  children: ChainNode[];
+  groups?: ChainNode[][]; // AND-of-OR groups (if applicable)
+}
+
+export type PrereqsMap = Map<string, { text: string; courses: string[] }>;
+
+/**
+ * Load the prereqs.json for a state and return it as a Map. Returns an
+ * empty Map (not an error) if the state has no prereq data yet.
+ */
+export function loadPrereqs(state: string): PrereqsMap {
+  const jsonPath = path.join(process.cwd(), "data", state, "prereqs.json");
+  try {
+    const raw = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Record<
+      string,
+      { text: string; courses: string[] }
+    >;
+    return new Map(Object.entries(raw));
+  } catch {
+    return new Map();
+  }
+}
+
+/**
+ * Parse prereq text into AND-of-OR groups.
+ * "ACC 101 and (BUS 107 or CIS 107)" → [["ACC 101"], ["BUS 107","CIS 107"]]
+ */
+export function parsePrereqGroups(text: string, courses: string[]): string[][] {
+  if (courses.length === 0) return [];
+  if (courses.length === 1) return [courses];
+
+  const chunks: string[] = [];
+  let depth = 0;
+  let current = "";
+  const tokens = text.split(/(\s+)/);
+  for (const token of tokens) {
+    for (const ch of token) {
+      if (ch === "(") depth++;
+      if (ch === ")") depth--;
+    }
+    if (token.toLowerCase() === "and" && depth === 0 && current.trim()) {
+      chunks.push(current.trim());
+      current = "";
+    } else {
+      current += token;
+    }
+  }
+  if (current.trim()) chunks.push(current.trim());
+
+  const groups: string[][] = [];
+  const assigned = new Set<string>();
+  for (const chunk of chunks) {
+    const group: string[] = [];
+    for (const course of courses) {
+      if (assigned.has(course)) continue;
+      if (chunk.toUpperCase().includes(course)) {
+        group.push(course);
+        assigned.add(course);
+      }
+    }
+    if (group.length > 0) groups.push(group);
+  }
+  for (const course of courses) {
+    if (!assigned.has(course)) groups.push([course]);
+  }
+  return groups;
+}
+
+/**
+ * Recursively build the prerequisite chain tree. Caps depth at 6 to avoid
+ * runaway recursion from circular prereq definitions (which exist in some
+ * catalogs, e.g. "MATH A requires MATH B" + "MATH B requires MATH A").
+ *
+ * Returns both a flat `children` array (backward compat) and a `groups`
+ * array that preserves AND-of-OR structure from the prereq text.
+ */
+export function buildChain(
+  course: string,
+  prereqs: PrereqsMap,
+  visited: Set<string>,
+  depth: number,
+): ChainNode {
+  const entry = prereqs.get(course);
+  const node: ChainNode = {
+    course,
+    text: entry?.text || "",
+    children: [],
+  };
+
+  if (depth >= 6 || !entry || visited.has(course)) return node;
+  visited.add(course);
+
+  const orGroups = parsePrereqGroups(entry.text, entry.courses);
+  const groupNodes: ChainNode[][] = [];
+
+  for (const group of orGroups) {
+    const groupChildren: ChainNode[] = [];
+    for (const dep of group) {
+      const child = buildChain(dep, prereqs, new Set(visited), depth + 1);
+      node.children.push(child);
+      groupChildren.push(child);
+    }
+    groupNodes.push(groupChildren);
+  }
+
+  // Only include groups if there are actual OR alternatives
+  if (groupNodes.some((g) => g.length > 1)) {
+    node.groups = groupNodes;
+  }
+
+  return node;
+}

--- a/lib/search-intent/answer/__tests__/eligibility.test.ts
+++ b/lib/search-intent/answer/__tests__/eligibility.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { lookupEligibility } from "../eligibility";
+import type { EligibilityIntent } from "../../types";
+
+// Eligibility runs against statically-bundled institutions data, so no
+// mocking is needed — these are integration tests against real fixtures
+// in data/{state}/institutions.json.
+
+describe("lookupEligibility", () => {
+  it("returns NoAnswer for veteran (no schema support)", async () => {
+    const intent: EligibilityIntent = {
+      type: "eligibility",
+      topic: "veteran",
+      age: null,
+    };
+    const result = await lookupEligibility(intent, "va");
+    expect(result.type).toBe("none");
+    if (result.type !== "none") return;
+    expect(result.message).toMatch(/veteran/i);
+  });
+
+  it("returns NoAnswer for an invalid state slug", async () => {
+    const intent: EligibilityIntent = {
+      type: "eligibility",
+      topic: "senior",
+      age: 65,
+    };
+    const result = await lookupEligibility(intent, "xx");
+    expect(result.type).toBe("none");
+    if (result.type !== "none") return;
+    expect(result.reason).toBe("no-state-data");
+  });
+
+  it("returns senior eligibility for VA with state-level summary", async () => {
+    const intent: EligibilityIntent = {
+      type: "eligibility",
+      topic: "senior",
+      age: 65,
+    };
+    const result = await lookupEligibility(intent, "va");
+    if (result.type !== "eligibility") throw new Error("wrong type");
+    expect(result.topic).toBe("senior");
+    expect(result.state).toBe("va");
+    expect(result.summary.length).toBeGreaterThan(0);
+    expect(result.colleges.length).toBeGreaterThan(0);
+    // Summary should reference age-65 user meeting the 60+ threshold.
+    expect(result.summary.toLowerCase()).toMatch(/\b6[05]\b/);
+  });
+
+  it("notes when user's age is below the threshold", async () => {
+    const intent: EligibilityIntent = {
+      type: "eligibility",
+      topic: "senior",
+      age: 50,
+    };
+    const result = await lookupEligibility(intent, "va");
+    if (result.type !== "eligibility") throw new Error("wrong type");
+    expect(result.summary.toLowerCase()).toMatch(/below/);
+  });
+
+  it("returns audit-policy breakdown for topic 'audit'", async () => {
+    const intent: EligibilityIntent = {
+      type: "eligibility",
+      topic: "audit",
+      age: null,
+    };
+    const result = await lookupEligibility(intent, "va");
+    if (result.type !== "eligibility") throw new Error("wrong type");
+    expect(result.topic).toBe("audit");
+    // Each college entry should have a cost + name.
+    expect(result.colleges[0]).toHaveProperty("name");
+    expect(result.colleges[0]).toHaveProperty("cost");
+  });
+
+  it("includes a SourceCitation pointing to institutions.json", async () => {
+    const intent: EligibilityIntent = {
+      type: "eligibility",
+      topic: "senior",
+      age: null,
+    };
+    const result = await lookupEligibility(intent, "va");
+    if (result.type !== "eligibility") throw new Error("wrong type");
+    expect(result.source.source).toBe("institutions");
+    expect(result.source.reference).toBe("data/va/institutions.json");
+  });
+});

--- a/lib/search-intent/answer/__tests__/index.test.ts
+++ b/lib/search-intent/answer/__tests__/index.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../transfer", () => ({
+  lookupTransfer: vi.fn().mockResolvedValue({ type: "transfer", status: "yes" }),
+}));
+vi.mock("../prereqs", () => ({
+  lookupPrereqs: vi.fn().mockResolvedValue({ type: "prereqs", status: "found" }),
+}));
+vi.mock("../eligibility", () => ({
+  lookupEligibility: vi.fn().mockResolvedValue({ type: "eligibility", topic: "senior" }),
+}));
+
+import { lookupAnswer } from "..";
+import { lookupTransfer } from "../transfer";
+import { lookupPrereqs } from "../prereqs";
+import { lookupEligibility } from "../eligibility";
+
+describe("lookupAnswer dispatch", () => {
+  it("dispatches transfer intents to lookupTransfer", async () => {
+    await lookupAnswer(
+      { type: "transfer", course: { prefix: "ENG", number: "111" }, university: "gmu" },
+      "va",
+    );
+    expect(lookupTransfer).toHaveBeenCalled();
+  });
+
+  it("dispatches prereqs intents to lookupPrereqs", async () => {
+    await lookupAnswer(
+      { type: "prereqs", course: { prefix: "BIO", number: "256" } },
+      "va",
+    );
+    expect(lookupPrereqs).toHaveBeenCalled();
+  });
+
+  it("dispatches eligibility intents to lookupEligibility", async () => {
+    await lookupAnswer(
+      { type: "eligibility", topic: "senior", age: null },
+      "va",
+    );
+    expect(lookupEligibility).toHaveBeenCalled();
+  });
+
+  it("returns NoAnswer with intent-not-supported for course intents", async () => {
+    const result = await lookupAnswer(
+      { type: "course", keyword: "biology", filters: {} },
+      "va",
+    );
+    expect(result.type).toBe("none");
+    if (result.type !== "none") return;
+    expect(result.reason).toBe("intent-not-supported");
+  });
+
+  it("returns NoAnswer with out-of-scope for unknown intents", async () => {
+    const result = await lookupAnswer(
+      { type: "unknown", raw: "good professors" },
+      "va",
+    );
+    expect(result.type).toBe("none");
+    if (result.type !== "none") return;
+    expect(result.reason).toBe("out-of-scope");
+  });
+});

--- a/lib/search-intent/answer/__tests__/prereqs.test.ts
+++ b/lib/search-intent/answer/__tests__/prereqs.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../prereqs", () => ({
+  loadPrereqs: vi.fn(),
+  buildChain: vi.fn(),
+}));
+
+vi.mock("../validate", () => ({
+  courseExists: vi.fn(),
+  resolveUniversity: vi.fn(),
+}));
+
+import { lookupPrereqs } from "../prereqs";
+import type { PrereqsIntent } from "../../types";
+import { buildChain, loadPrereqs } from "../../../prereqs";
+import { courseExists } from "../validate";
+
+const mockLoadPrereqs = loadPrereqs as ReturnType<typeof vi.fn>;
+const mockBuildChain = buildChain as ReturnType<typeof vi.fn>;
+const mockCourseExists = courseExists as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockLoadPrereqs.mockReset();
+  mockBuildChain.mockReset();
+  mockCourseExists.mockReset();
+});
+
+const BIO_256: PrereqsIntent = {
+  type: "prereqs",
+  course: { prefix: "BIO", number: "256" },
+};
+
+describe("lookupPrereqs", () => {
+  it("returns 'no-course-named' when course is missing", async () => {
+    const result = await lookupPrereqs({ type: "prereqs", course: null }, "va");
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.status).toBe("no-course-named");
+    expect(result.course).toBeNull();
+  });
+
+  it("returns 'no-data' when state has empty prereqs map", async () => {
+    mockLoadPrereqs.mockReturnValue(new Map());
+    const result = await lookupPrereqs(BIO_256, "va");
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.status).toBe("no-data");
+  });
+
+  it("returns 'unknown-course' when course not in prereqs map and not in catalog", async () => {
+    mockLoadPrereqs.mockReturnValue(
+      new Map([["ENG 111", { text: "", courses: [] }]]),
+    );
+    mockCourseExists.mockResolvedValue({ exists: false });
+    const result = await lookupPrereqs(BIO_256, "va");
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.status).toBe("unknown-course");
+  });
+
+  it("returns 'no-prereqs' when course exists in catalog but isn't in prereqs map", async () => {
+    mockLoadPrereqs.mockReturnValue(
+      new Map([["ENG 111", { text: "", courses: [] }]]),
+    );
+    mockCourseExists.mockResolvedValue({ exists: true });
+    const result = await lookupPrereqs(BIO_256, "va");
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.status).toBe("no-prereqs");
+  });
+
+  it("returns 'no-prereqs' when course is in prereqs map with empty text+courses", async () => {
+    mockLoadPrereqs.mockReturnValue(
+      new Map([["BIO 256", { text: "", courses: [] }]]),
+    );
+    const result = await lookupPrereqs(BIO_256, "va");
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.status).toBe("no-prereqs");
+  });
+
+  it("returns 'found' with chain when prereqs are recorded", async () => {
+    mockLoadPrereqs.mockReturnValue(
+      new Map([["BIO 256", { text: "BIO 101 and BIO 102", courses: ["BIO 101", "BIO 102"] }]]),
+    );
+    mockBuildChain.mockReturnValue({
+      course: "BIO 256",
+      text: "BIO 101 and BIO 102",
+      children: [],
+    });
+    const result = await lookupPrereqs(BIO_256, "va");
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.status).toBe("found");
+    expect(result.chain?.course).toBe("BIO 256");
+  });
+
+  it("uppercases the prefix when looking up the prereqs map", async () => {
+    mockLoadPrereqs.mockReturnValue(
+      new Map([["BIO 256", { text: "BIO 101", courses: ["BIO 101"] }]]),
+    );
+    mockBuildChain.mockReturnValue({ course: "BIO 256", text: "BIO 101", children: [] });
+    const result = await lookupPrereqs(
+      { type: "prereqs", course: { prefix: "bio", number: "256" } },
+      "va",
+    );
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.status).toBe("found");
+  });
+
+  it("includes a SourceCitation on every prereqs answer", async () => {
+    mockLoadPrereqs.mockReturnValue(new Map());
+    const result = await lookupPrereqs(BIO_256, "va");
+    if (result.type !== "prereqs") throw new Error("wrong type");
+    expect(result.source.source).toBe("prereqs");
+    expect(result.source.reference).toBe("data/va/prereqs.json");
+  });
+});

--- a/lib/search-intent/answer/__tests__/transfer.test.ts
+++ b/lib/search-intent/answer/__tests__/transfer.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../transfer", () => ({
+  getTransferInfo: vi.fn(),
+  getUniversities: vi.fn(),
+}));
+
+vi.mock("../validate", () => ({
+  courseExists: vi.fn(),
+  resolveUniversity: vi.fn(),
+}));
+
+import { lookupTransfer } from "../transfer";
+import type { TransferIntent } from "../../types";
+import { getTransferInfo } from "../../../transfer";
+import { courseExists, resolveUniversity } from "../validate";
+import type { TransferMapping } from "../../../types";
+
+const mockGetTransferInfo = getTransferInfo as ReturnType<typeof vi.fn>;
+const mockCourseExists = courseExists as ReturnType<typeof vi.fn>;
+const mockResolveUniversity = resolveUniversity as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockGetTransferInfo.mockReset();
+  mockCourseExists.mockReset();
+  mockResolveUniversity.mockReset();
+});
+
+function mapping(partial: Partial<TransferMapping>): TransferMapping {
+  return {
+    cc_prefix: "ENG",
+    cc_number: "111",
+    cc_course: "ENG 111",
+    cc_title: "Composition I",
+    cc_credits: "3",
+    university: "gmu",
+    university_name: "George Mason University",
+    univ_course: "ENGH 101",
+    univ_title: "Composition",
+    univ_credits: "3",
+    notes: "",
+    no_credit: false,
+    is_elective: false,
+    ...partial,
+  };
+}
+
+const ENG_111_INTENT: TransferIntent = {
+  type: "transfer",
+  course: { prefix: "ENG", number: "111" },
+  university: "gmu",
+};
+
+describe("lookupTransfer", () => {
+  it("returns NoAnswer when course is missing", async () => {
+    const result = await lookupTransfer(
+      { type: "transfer", course: null, university: "gmu" },
+      "va",
+    );
+    expect(result.type).toBe("none");
+    if (result.type !== "none") return;
+    expect(result.reason).toBe("missing-entity");
+  });
+
+  it("returns unknown-course when course not in catalog", async () => {
+    mockCourseExists.mockResolvedValue({ exists: false });
+    const result = await lookupTransfer(ENG_111_INTENT, "va");
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("unknown-course");
+  });
+
+  it("returns 'no' when course exists but has zero mappings", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([]);
+    const result = await lookupTransfer(ENG_111_INTENT, "va");
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("no");
+  });
+
+  it("returns 'no-destination' with alternatives when no university specified", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([
+      mapping({ university: "gmu", university_name: "George Mason University" }),
+      mapping({ university: "vcu", university_name: "VCU", univ_course: "ENGL 101" }),
+      mapping({ university: "vt", university_name: "Virginia Tech", univ_course: "ENGL 1105" }),
+    ]);
+    const result = await lookupTransfer(
+      { type: "transfer", course: { prefix: "ENG", number: "111" }, university: null },
+      "va",
+    );
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("no-destination");
+    expect(result.alternatives?.length).toBe(3);
+    expect(result.alternatives?.[0].slug).toBe("gmu");
+  });
+
+  it("returns 'unknown-university' with suggestions when slug doesn't resolve", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([mapping({})]);
+    mockResolveUniversity.mockResolvedValue({
+      resolved: null,
+      suggestions: [{ slug: "gmu", name: "George Mason University" }],
+    });
+    const result = await lookupTransfer(
+      { type: "transfer", course: { prefix: "ENG", number: "111" }, university: "nonsense" },
+      "va",
+    );
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("unknown-university");
+    expect(result.suggestions?.[0].slug).toBe("gmu");
+  });
+
+  it("returns 'yes' with equivalency when mapping is full credit", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([
+      mapping({ univ_course: "ENGH 101", is_elective: false, no_credit: false }),
+    ]);
+    mockResolveUniversity.mockResolvedValue({
+      resolved: { slug: "gmu", name: "George Mason University" },
+      suggestions: [],
+    });
+    const result = await lookupTransfer(ENG_111_INTENT, "va");
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("yes");
+    expect(result.equivalency?.univ_course).toBe("ENGH 101");
+    expect(result.university?.slug).toBe("gmu");
+  });
+
+  it("returns 'partial' when mapping is is_elective", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([
+      mapping({ is_elective: true, univ_course: "ENGH 1XX" }),
+    ]);
+    mockResolveUniversity.mockResolvedValue({
+      resolved: { slug: "gmu", name: "George Mason University" },
+      suggestions: [],
+    });
+    const result = await lookupTransfer(ENG_111_INTENT, "va");
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("partial");
+  });
+
+  it("returns 'partial' when mapping is no_credit", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([mapping({ no_credit: true, univ_course: "" })]);
+    mockResolveUniversity.mockResolvedValue({
+      resolved: { slug: "gmu", name: "George Mason University" },
+      suggestions: [],
+    });
+    const result = await lookupTransfer(ENG_111_INTENT, "va");
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("partial");
+  });
+
+  it("returns 'no' with alternatives when destination university has no mapping for this course", async () => {
+    mockCourseExists.mockResolvedValue({ exists: true });
+    mockGetTransferInfo.mockResolvedValue([
+      mapping({ university: "vcu", university_name: "VCU", univ_course: "ENGL 101" }),
+    ]);
+    mockResolveUniversity.mockResolvedValue({
+      resolved: { slug: "gmu", name: "George Mason University" },
+      suggestions: [],
+    });
+    const result = await lookupTransfer(ENG_111_INTENT, "va");
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.status).toBe("no");
+    expect(result.university?.slug).toBe("gmu");
+    expect(result.alternatives?.[0].slug).toBe("vcu");
+  });
+
+  it("includes a SourceCitation on every transfer answer", async () => {
+    mockCourseExists.mockResolvedValue({ exists: false });
+    const result = await lookupTransfer(ENG_111_INTENT, "va");
+    if (result.type !== "transfer") throw new Error("wrong type");
+    expect(result.source.source).toBe("transfer-equiv");
+    expect(result.source.state).toBe("va");
+    expect(result.source.reference).toBe("data/va/transfer-equiv.json");
+  });
+});

--- a/lib/search-intent/answer/__tests__/validate.test.ts
+++ b/lib/search-intent/answer/__tests__/validate.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the high-level data accessors. Each test sets the mock return value
+// before calling the validator.
+vi.mock("../../../transfer", () => ({
+  getUniversities: vi.fn(),
+}));
+
+vi.mock("../../../supabase", () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+import { courseExists, resolveUniversity } from "../validate";
+import { getUniversities } from "../../../transfer";
+import { supabase } from "../../../supabase";
+
+const mockGetUniversities = getUniversities as ReturnType<typeof vi.fn>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSupabaseFrom = (supabase as any).from as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockGetUniversities.mockReset();
+  mockSupabaseFrom.mockReset();
+});
+
+// ─── courseExists ────────────────────────────────────────────────────────
+
+function setCourseExistsResponse(rows: Array<{ course_title?: string }>) {
+  // Mimic the Supabase query builder chain that courseExists uses.
+  const queryBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data: rows, error: null }),
+  };
+  mockSupabaseFrom.mockReturnValue(queryBuilder);
+}
+
+describe("courseExists", () => {
+  it("returns true with title when course is in catalog", async () => {
+    setCourseExistsResponse([{ course_title: "Composition I" }]);
+    const result = await courseExists("va", "ENG", "111");
+    expect(result).toEqual({ exists: true, title: "Composition I" });
+    expect(mockSupabaseFrom).toHaveBeenCalledWith("courses");
+  });
+
+  it("returns false when no rows", async () => {
+    setCourseExistsResponse([]);
+    const result = await courseExists("va", "ZZZ", "999");
+    expect(result).toEqual({ exists: false });
+  });
+
+  it("uppercases the prefix before querying", async () => {
+    const queryBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [{}], error: null }),
+    };
+    mockSupabaseFrom.mockReturnValue(queryBuilder);
+    await courseExists("va", "eng", "111");
+    expect(queryBuilder.eq).toHaveBeenCalledWith("course_prefix", "ENG");
+  });
+
+  it("returns false on Supabase error", async () => {
+    const queryBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: null, error: new Error("nope") }),
+    };
+    mockSupabaseFrom.mockReturnValue(queryBuilder);
+    const result = await courseExists("va", "ENG", "111");
+    expect(result).toEqual({ exists: false });
+  });
+});
+
+// ─── resolveUniversity ───────────────────────────────────────────────────
+
+const VA_UNIS = [
+  { slug: "gmu", name: "George Mason University" },
+  { slug: "vcu", name: "Virginia Commonwealth University" },
+  { slug: "vt", name: "Virginia Tech" },
+  { slug: "uva", name: "University of Virginia" },
+  { slug: "umass-amherst", name: "University of Massachusetts at Amherst" },
+];
+
+describe("resolveUniversity", () => {
+  it("matches an exact slug case-insensitively", async () => {
+    mockGetUniversities.mockResolvedValue(VA_UNIS);
+    const r = await resolveUniversity("va", "GMU");
+    expect(r.resolved).toEqual({ slug: "gmu", name: "George Mason University" });
+    expect(r.suggestions).toEqual([]);
+  });
+
+  it("matches a normalized slug (punctuation differences)", async () => {
+    mockGetUniversities.mockResolvedValue(VA_UNIS);
+    const r = await resolveUniversity("va", "umass_amherst");
+    expect(r.resolved?.slug).toBe("umass-amherst");
+  });
+
+  it("matches a substring of the display name", async () => {
+    mockGetUniversities.mockResolvedValue(VA_UNIS);
+    const r = await resolveUniversity("va", "George Mason");
+    expect(r.resolved?.slug).toBe("gmu");
+  });
+
+  it("returns suggestions when no match found", async () => {
+    mockGetUniversities.mockResolvedValue(VA_UNIS);
+    const r = await resolveUniversity("va", "harvard");
+    expect(r.resolved).toBeNull();
+    expect(r.suggestions.length).toBeGreaterThan(0);
+    expect(r.suggestions.length).toBeLessThanOrEqual(3);
+  });
+
+  it("returns empty resolution + suggestions when state has no transfer data", async () => {
+    mockGetUniversities.mockResolvedValue([]);
+    const r = await resolveUniversity("xx", "gmu");
+    expect(r.resolved).toBeNull();
+    expect(r.suggestions).toEqual([]);
+  });
+
+  it("returns first 3 universities as suggestions when input is empty", async () => {
+    mockGetUniversities.mockResolvedValue(VA_UNIS);
+    const r = await resolveUniversity("va", "");
+    expect(r.resolved).toBeNull();
+    expect(r.suggestions.length).toBe(3);
+  });
+});

--- a/lib/search-intent/answer/eligibility.ts
+++ b/lib/search-intent/answer/eligibility.ts
@@ -1,0 +1,119 @@
+// Eligibility answer lookup.
+//
+// Topics handled:
+//   - "senior" → senior_discount fields per college + state-level waiver banner
+//   - "audit"  → general audit-allowed + cost per college
+//   - "cost"   → same surface as audit (cost_note + cost_model)
+//   - "veteran"→ NOT in our data schema; returns NoAnswer
+//
+// State context is critical here: senior-tuition rules vary state-by-state
+// (Virginia 60+ waiver, Tennessee >=65, etc.). The state-level summary is
+// drawn from StateConfig.seniorWaiver when present.
+
+import { loadInstitutions } from "../../institutions";
+import { getStateConfig, isValidState } from "../../states/registry";
+import type { EligibilityIntent } from "../types";
+import type {
+  Answer,
+  CollegeEligibility,
+  EligibilityAnswer,
+} from "./types";
+
+export async function lookupEligibility(
+  intent: EligibilityIntent,
+  state: string,
+): Promise<Answer> {
+  if (!isValidState(state)) {
+    return {
+      type: "none",
+      reason: "no-state-data",
+      message: `We don't have data for state "${state}".`,
+    };
+  }
+
+  if (intent.topic === "veteran") {
+    return {
+      type: "none",
+      reason: "no-state-data",
+      message:
+        "We don't track veteran-specific tuition data. Contact your state's Department of Veterans Services or your college's veteran-services office.",
+    };
+  }
+
+  const institutions = loadInstitutions(state);
+  if (institutions.length === 0) {
+    return {
+      type: "none",
+      reason: "no-state-data",
+      message: `We don't have audit-policy data for ${state.toUpperCase()} yet.`,
+    };
+  }
+
+  const cfg = getStateConfig(state);
+
+  let summary: string;
+  let colleges: CollegeEligibility[];
+
+  if (intent.topic === "senior") {
+    summary = buildSeniorSummary(cfg.name, cfg.seniorWaiver, intent.age);
+    colleges = institutions.map((inst): CollegeEligibility => {
+      const sd = inst.audit_policy.eligibility.senior_discount;
+      return {
+        slug: inst.college_slug,
+        name: inst.name,
+        eligible: sd.available,
+        ageThreshold: sd.age_threshold || undefined,
+        cost: sd.cost || "see college",
+        notes: sd.notes || undefined,
+      };
+    });
+  } else {
+    // "audit" or "cost" — surface general audit policy
+    summary = buildAuditSummary(cfg.name, institutions.length);
+    colleges = institutions.map((inst): CollegeEligibility => {
+      const ap = inst.audit_policy;
+      return {
+        slug: inst.college_slug,
+        name: inst.name,
+        eligible: ap.allowed === true,
+        ageThreshold: ap.eligibility.minimum_age || undefined,
+        cost: ap.cost_note || ap.cost_model || "see college",
+        notes: ap.restrictions.length > 0 ? ap.restrictions.join("; ") : undefined,
+      };
+    });
+  }
+
+  const answer: EligibilityAnswer = {
+    type: "eligibility",
+    topic: intent.topic,
+    state,
+    summary,
+    colleges,
+    source: {
+      source: "institutions",
+      state,
+      reference: `data/${state}/institutions.json`,
+    },
+  };
+  return answer;
+}
+
+function buildSeniorSummary(
+  stateName: string,
+  waiver: ReturnType<typeof getStateConfig>["seniorWaiver"],
+  askedAge: number | null,
+): string {
+  if (!waiver) {
+    return `${stateName} has no statewide senior tuition waiver. Audit policies vary by college — see the breakdown below.`;
+  }
+  const ageNote = askedAge !== null
+    ? askedAge >= waiver.ageThreshold
+      ? `At ${askedAge}, you meet the threshold.`
+      : `At ${askedAge}, you're below the ${waiver.ageThreshold}+ threshold.`
+    : "";
+  return [waiver.bannerSummary, ageNote].filter(Boolean).join(" ");
+}
+
+function buildAuditSummary(stateName: string, collegeCount: number): string {
+  return `Audit policies in ${stateName} vary by college. Of the ${collegeCount} colleges we have data for, see eligibility and cost details below.`;
+}

--- a/lib/search-intent/answer/index.ts
+++ b/lib/search-intent/answer/index.ts
@@ -1,0 +1,43 @@
+// Public entry point for the answer-lookup layer.
+//
+// `lookupAnswer(intent, state)` is the bridge between the LLM classifier
+// (PR 2) and the UI answer card (PR 5). It dispatches by intent type to
+// the per-domain lookups and returns an `Answer` discriminated union the
+// UI can render directly.
+
+import type { SearchIntent } from "../types";
+import type { Answer } from "./types";
+import { lookupEligibility } from "./eligibility";
+import { lookupPrereqs } from "./prereqs";
+import { lookupTransfer } from "./transfer";
+
+export type { Answer } from "./types";
+
+export async function lookupAnswer(
+  intent: SearchIntent,
+  state: string,
+): Promise<Answer> {
+  switch (intent.type) {
+    case "transfer":
+      return lookupTransfer(intent, state);
+    case "prereqs":
+      return lookupPrereqs(intent, state);
+    case "eligibility":
+      return lookupEligibility(intent, state);
+    case "course":
+      // Course intents flow into the existing course-search results.
+      // No answer card; PR 5 will render the standard course list.
+      return {
+        type: "none",
+        reason: "intent-not-supported",
+        message: "Use the course search results below.",
+      };
+    case "unknown":
+      return {
+        type: "none",
+        reason: "out-of-scope",
+        message:
+          "I'm not sure what you're asking. Try a course code (like ENG 111), 'prereqs for BIO 256', or 'does ENG 111 transfer to GMU'.",
+      };
+  }
+}

--- a/lib/search-intent/answer/prereqs.ts
+++ b/lib/search-intent/answer/prereqs.ts
@@ -1,0 +1,105 @@
+// Prereqs answer lookup.
+//
+// Decision tree:
+//
+//   intent.course == null
+//     → status: "no-course-named" → "Which course?"
+//
+//   prereqs map for state is empty
+//     → status: "no-data" — state has no prereq data yet
+//
+//   course not in prereqs map (and doesn't exist in courses table)
+//     → status: "unknown-course"
+//
+//   course in prereqs map but no recorded prereqs
+//     → status: "no-prereqs"
+//
+//   else
+//     → status: "found", chain returned
+
+import { buildChain, loadPrereqs } from "../../prereqs";
+import type { PrereqsIntent } from "../types";
+import type { Answer, PrereqsAnswer } from "./types";
+import { courseExists } from "./validate";
+
+export async function lookupPrereqs(
+  intent: PrereqsIntent,
+  state: string,
+): Promise<Answer> {
+  const { course } = intent;
+
+  if (!course) {
+    return makeAnswer({
+      status: "no-course-named",
+      course: null,
+      state,
+    });
+  }
+
+  const prereqs = loadPrereqs(state);
+  if (prereqs.size === 0) {
+    return makeAnswer({
+      status: "no-data",
+      course,
+      state,
+    });
+  }
+
+  // The map keys use the form "PREFIX NUMBER" (e.g. "BIO 256"). Try that
+  // first; if not present, fall back to the courses-table existence check
+  // before declaring "unknown-course" — the prereq scrape may not have
+  // covered every catalog course.
+  const key = `${course.prefix.toUpperCase()} ${course.number}`;
+  const entry = prereqs.get(key);
+
+  if (!entry) {
+    const check = await courseExists(state, course.prefix, course.number);
+    if (!check.exists) {
+      return makeAnswer({
+        status: "unknown-course",
+        course,
+        state,
+      });
+    }
+    // Course exists in catalog but isn't in prereqs.json — most likely it
+    // has none.
+    return makeAnswer({
+      status: "no-prereqs",
+      course,
+      state,
+    });
+  }
+
+  // Course is in the map. If text and courses are both empty, treat as
+  // no prereqs.
+  if ((!entry.text || entry.text.trim() === "") && entry.courses.length === 0) {
+    return makeAnswer({
+      status: "no-prereqs",
+      course,
+      state,
+    });
+  }
+
+  const chain = buildChain(key, prereqs, new Set(), 0);
+  return makeAnswer({
+    status: "found",
+    course,
+    chain,
+    state,
+  });
+}
+
+function makeAnswer(
+  parts: Omit<PrereqsAnswer, "type" | "source"> & { state: string },
+): PrereqsAnswer {
+  const { state, ...rest } = parts;
+  return {
+    type: "prereqs",
+    ...rest,
+    source: {
+      source: "prereqs",
+      state,
+      reference: `data/${state}/prereqs.json`,
+    },
+  };
+}

--- a/lib/search-intent/answer/transfer.ts
+++ b/lib/search-intent/answer/transfer.ts
@@ -1,0 +1,152 @@
+// Transfer answer lookup.
+//
+// Maps a TransferIntent + state slug to a TransferAnswer. The decision tree:
+//
+//   intent.course == null
+//     ↓
+//     status: "missing-entity" → NoAnswer (can't lookup without a course)
+//
+//   intent.course present, intent.university == null
+//     ↓
+//     "no-destination": list top-N alternatives where this course transfers
+//
+//   intent.university present
+//     ↓
+//     resolveUniversity → unknown-university? → suggestions
+//                       → resolved? → look up mapping → yes / partial / no
+
+import { getTransferInfo } from "../../transfer";
+import type { TransferIntent } from "../types";
+import type {
+  Answer,
+  TransferAnswer,
+  TransferEquivalency,
+} from "./types";
+import { courseExists, resolveUniversity } from "./validate";
+
+const MAX_ALTERNATIVES = 5;
+
+export async function lookupTransfer(
+  intent: TransferIntent,
+  state: string,
+): Promise<Answer> {
+  const { course } = intent;
+
+  if (!course) {
+    return {
+      type: "none",
+      reason: "missing-entity",
+      message:
+        "Which course are you asking about? Try 'Does ENG 111 transfer to GMU?'",
+    };
+  }
+
+  // Validate course exists in this state.
+  const courseCheck = await courseExists(state, course.prefix, course.number);
+  if (!courseCheck.exists) {
+    return makeAnswer({
+      status: "unknown-course",
+      course,
+      university: null,
+      state,
+    });
+  }
+
+  // Pull all transfer mappings for this course in this state.
+  const mappings = await getTransferInfo(course.prefix, course.number, state);
+  if (mappings.length === 0) {
+    // No mappings at all — could be either no transfer data for this state
+    // or this specific course has none.
+    return makeAnswer({
+      status: "no",
+      course,
+      university: null,
+      state,
+    });
+  }
+
+  // No destination specified → return alternatives list, no specific equivalency.
+  if (!intent.university) {
+    return makeAnswer({
+      status: "no-destination",
+      course,
+      university: null,
+      alternatives: mappings.slice(0, MAX_ALTERNATIVES).map((m) => ({
+        slug: m.university,
+        name: m.university_name,
+        univ_course: m.univ_course,
+        is_elective: m.is_elective,
+        no_credit: m.no_credit,
+      })),
+      state,
+    });
+  }
+
+  // Destination specified → resolve and look up.
+  const resolution = await resolveUniversity(state, intent.university);
+  if (!resolution.resolved) {
+    return makeAnswer({
+      status: "unknown-university",
+      course,
+      university: null,
+      suggestions: resolution.suggestions,
+      state,
+    });
+  }
+
+  const match = mappings.find(
+    (m) => m.university === resolution.resolved!.slug,
+  );
+  if (!match) {
+    // University exists in the state's transfer space, but this course
+    // doesn't map to it. Surface alternatives.
+    return makeAnswer({
+      status: "no",
+      course,
+      university: resolution.resolved,
+      alternatives: mappings.slice(0, MAX_ALTERNATIVES).map((m) => ({
+        slug: m.university,
+        name: m.university_name,
+        univ_course: m.univ_course,
+        is_elective: m.is_elective,
+        no_credit: m.no_credit,
+      })),
+      state,
+    });
+  }
+
+  const equivalency: TransferEquivalency = {
+    univ_course: match.univ_course,
+    univ_title: match.univ_title,
+    univ_credits: match.univ_credits,
+    is_elective: match.is_elective,
+    no_credit: match.no_credit,
+    notes: match.notes,
+  };
+  const status =
+    match.no_credit || match.is_elective ? "partial" : "yes";
+
+  return makeAnswer({
+    status,
+    course,
+    university: resolution.resolved,
+    equivalency,
+    state,
+  });
+}
+
+// Tiny builder so we don't repeat `source: { ... }` six times.
+function makeAnswer(
+  parts: Omit<TransferAnswer, "type" | "source"> & { state: string },
+): TransferAnswer {
+  const { state, ...rest } = parts;
+  return {
+    type: "transfer",
+    ...rest,
+    source: {
+      source: "transfer-equiv",
+      state,
+      reference: `data/${state}/transfer-equiv.json`,
+    },
+  };
+}

--- a/lib/search-intent/answer/types.ts
+++ b/lib/search-intent/answer/types.ts
@@ -1,0 +1,126 @@
+// Answer shapes returned by lookupAnswer(intent, state).
+//
+// Each answer carries a SourceCitation so the UI can render trust signals
+// ("based on transfer-equiv data, last verified YYYY-MM-DD"). Required, not
+// optional — first-gen students need provenance to verify enrollment-bearing
+// answers against official sources.
+//
+// The status field on each typed answer is a discriminated union of
+// outcomes: "yes / no / partial / missing-entity / no-data". The UI uses
+// these to pick a card variant and copy.
+
+import type { ChainNode } from "../../prereqs";
+
+export interface SourceCitation {
+  source: "transfer-equiv" | "prereqs" | "institutions" | "supabase-courses";
+  state: string;
+  // Where the data came from. For JSON files: path. For DB: table name.
+  reference: string;
+  // Best-effort freshness signal. May be undefined for files without metadata.
+  lastUpdated?: string;
+  // Optional URL pointing to the authoritative external source.
+  upstreamUrl?: string;
+}
+
+export type Answer =
+  | TransferAnswer
+  | PrereqsAnswer
+  | EligibilityAnswer
+  | NoAnswer;
+
+// ─── Transfer ────────────────────────────────────────────────────────────
+
+export type TransferStatus =
+  | "yes" //              equivalency exists, full credit
+  | "partial" //          equivalency exists but is_elective or no_credit
+  | "no" //               course exists, university exists, no mapping
+  | "no-destination" //   user didn't specify a destination — show options
+  | "unknown-course" //   course doesn't exist in this state
+  | "unknown-university"// university not in this state's transfer data
+  | "no-data"; //         state has no transfer data at all
+
+export interface TransferEquivalency {
+  univ_course: string;
+  univ_title: string;
+  univ_credits: string;
+  is_elective: boolean;
+  no_credit: boolean;
+  notes: string;
+}
+
+export interface TransferAnswer {
+  type: "transfer";
+  status: TransferStatus;
+  course: { prefix: string; number: string };
+  // null when status is "no-destination" or "unknown-university".
+  university: { slug: string; name: string } | null;
+  // Present when status is "yes" or "partial".
+  equivalency?: TransferEquivalency;
+  // For "no" / "no-destination": other universities where this course transfers.
+  alternatives?: Array<{
+    slug: string;
+    name: string;
+    univ_course: string;
+    is_elective: boolean;
+    no_credit: boolean;
+  }>;
+  // For "unknown-university": closest slug matches.
+  suggestions?: Array<{ slug: string; name: string }>;
+  source: SourceCitation;
+}
+
+// ─── Prereqs ─────────────────────────────────────────────────────────────
+
+export type PrereqsStatus =
+  | "found" //              course has prereqs, chain returned
+  | "no-prereqs" //         course exists, no prereqs documented
+  | "unknown-course" //     course doesn't exist in this state
+  | "no-course-named" //    intent.course was null
+  | "no-data"; //           state has no prereq data at all
+
+export interface PrereqsAnswer {
+  type: "prereqs";
+  status: PrereqsStatus;
+  // null when status is "no-course-named".
+  course: { prefix: string; number: string } | null;
+  // Present when status is "found". Reuses the existing ChainNode from
+  // lib/prereqs.ts so the UI can share rendering with /api/[state]/prereqs/chain.
+  chain?: ChainNode;
+  source: SourceCitation;
+}
+
+// ─── Eligibility ─────────────────────────────────────────────────────────
+
+export interface CollegeEligibility {
+  slug: string;
+  name: string;
+  eligible: boolean;
+  ageThreshold?: number;
+  cost: string; // e.g. "free", "reduced", "same as credit"
+  notes?: string;
+}
+
+export interface EligibilityAnswer {
+  type: "eligibility";
+  topic: "senior" | "audit" | "cost" | "veteran";
+  state: string;
+  // One-sentence state-wide summary, e.g. "Virginia residents 60+ may audit
+  // any VCCS course for free under VA Code § 23.1-638."
+  summary: string;
+  colleges: CollegeEligibility[];
+  source: SourceCitation;
+}
+
+// ─── No-answer ───────────────────────────────────────────────────────────
+
+export interface NoAnswer {
+  type: "none";
+  reason:
+    | "intent-not-supported" // course intent — UI just shows search results
+    | "missing-entity" //      not enough info to look up
+    | "out-of-scope" //        unknown intent or vague query
+    | "no-state-data"; //      state hasn't been populated yet
+  message: string;
+  // Optional: things the user could try instead.
+  suggestions?: string[];
+}

--- a/lib/search-intent/answer/validate.ts
+++ b/lib/search-intent/answer/validate.ts
@@ -1,0 +1,113 @@
+// Entity validators — the hallucination boundary.
+//
+// The LLM classifier may produce a course code or university slug that
+// doesn't exist. These validators catch invented entities BEFORE the
+// answer-lookup layer queries on them, so the failure mode is
+// "did you mean...?" rather than "we couldn't find your course."
+
+import { supabase } from "../../supabase";
+import { getUniversities } from "../../transfer";
+
+export interface CourseValidation {
+  exists: boolean;
+  // Best-known display title (when we found the course). Useful for the
+  // UI to show "ENG 111: Composition I" instead of just "ENG 111".
+  title?: string;
+}
+
+/**
+ * Cheap existence check: does any row in the courses table for this state
+ * have this prefix + number? Uses HEAD count to avoid pulling row data.
+ *
+ * Note: a course can exist in some terms and not others. This returns true
+ * if it exists in ANY term — that's what the user means when they ask
+ * about a course.
+ */
+export async function courseExists(
+  state: string,
+  prefix: string,
+  number: string,
+): Promise<CourseValidation> {
+  const { data, error } = await supabase
+    .from("courses")
+    .select("course_title")
+    .eq("state", state)
+    .eq("course_prefix", prefix.toUpperCase())
+    .eq("course_number", number)
+    .limit(1);
+  if (error || !data || data.length === 0) return { exists: false };
+  return { exists: true, title: (data[0] as { course_title?: string }).course_title };
+}
+
+export interface UniversityResolution {
+  resolved: { slug: string; name: string } | null;
+  // Closest 3 alternatives by string similarity, sorted best-first.
+  // Surfaced in the answer when resolution fails.
+  suggestions: Array<{ slug: string; name: string }>;
+}
+
+/**
+ * Resolve a user-provided university slug or name against the state's
+ * transfer-equiv data. Strategy, in order:
+ *   1. Exact slug match (case-insensitive)
+ *   2. Normalized match (lowercase, alphanumeric only)
+ *   3. Substring of display name (also normalized)
+ *   4. None — return suggestions ranked by Jaccard similarity on tokens
+ */
+export async function resolveUniversity(
+  state: string,
+  slugOrName: string,
+): Promise<UniversityResolution> {
+  const universities = await getUniversities(state);
+  if (universities.length === 0) {
+    return { resolved: null, suggestions: [] };
+  }
+  const target = normalize(slugOrName);
+  if (!target) {
+    return { resolved: null, suggestions: universities.slice(0, 3) };
+  }
+
+  // Tier 1: exact slug match
+  const exact = universities.find((u) => u.slug.toLowerCase() === slugOrName.toLowerCase());
+  if (exact) return { resolved: exact, suggestions: [] };
+
+  // Tier 2: normalized slug match
+  const normalizedSlug = universities.find((u) => normalize(u.slug) === target);
+  if (normalizedSlug) return { resolved: normalizedSlug, suggestions: [] };
+
+  // Tier 3: substring of display name
+  const byName = universities.find((u) => normalize(u.name).includes(target));
+  if (byName) return { resolved: byName, suggestions: [] };
+
+  // Tier 4: none — rank suggestions by token-Jaccard similarity.
+  const ranked = [...universities]
+    .map((u) => ({ u, score: jaccard(target, normalize(u.name)) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map((r) => r.u);
+
+  return { resolved: null, suggestions: ranked };
+}
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function jaccard(a: string, b: string): number {
+  if (!a || !b) return 0;
+  const setA = new Set(tokens(a));
+  const setB = new Set(tokens(b));
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let intersect = 0;
+  for (const t of setA) if (setB.has(t)) intersect++;
+  return intersect / (setA.size + setB.size - intersect);
+}
+
+function tokens(s: string): string[] {
+  // Treat each 3+ char run as a token. "umassamherst" → ["umassamherst"]
+  // "umass amherst" → ["umass", "amherst"]
+  return s
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3);
+}


### PR DESCRIPTION
## Summary
Bridges the LLM classifier (#189) to existing transfer / prereqs / institutions data. `lookupAnswer(intent, state)` is now the single function PR 4's API route will call to turn a classified intent into a structured `Answer` ready for the UI.

- **`lib/prereqs.ts`** (new): extracts `loadPrereqs` / `parsePrereqGroups` / `buildChain` from the existing prereqs API route so both the route and the answer-lookup can share one implementation. Route now imports from the new lib and re-exports the symbols (no breaking change for any external importers).

- **`answer/types.ts`**: `Answer` discriminated union with a **required** `SourceCitation` on every typed answer. Status enums (`yes` / `partial` / `no` / `unknown-course` / `unknown-university` / `no-destination` / `no-data` / `missing-entity` / `out-of-scope` / `intent-not-supported`) encode every outcome the UI needs to distinguish.

- **`answer/validate.ts`**: the hallucination boundary.
  - `courseExists()` — HEAD-style Supabase query.
  - `resolveUniversity()` — four-tier matching: exact slug → normalized slug → name substring → Jaccard-similarity suggestions. An LLM-invented university surfaces as "did you mean…?" rather than a wrong answer.

- **`answer/transfer.ts`**: full decision tree — `missing-entity` → `unknown-course` → `unknown-university` → `no-destination` (with alternatives) → `no` (with alternatives) → `yes`/`partial`.

- **`answer/prereqs.ts`**: `no-course-named` → `no-data` → `unknown-course` → `no-prereqs` → `found` (chain). Handles courses that exist in the catalog but have no prereqs entry by returning `no-prereqs` rather than `unknown-course`.

- **`answer/eligibility.ts`**: `senior` / `audit` / `cost` topics map to per-college breakdowns + state-level summary from `StateConfig.seniorWaiver`. `veteran` returns `NoAnswer` (no schema field).

- **`answer/index.ts`**: `lookupAnswer` dispatcher. `course` intents return `intent-not-supported` so the UI just renders existing search results without an answer card.

## Hallucination boundary
This is where it lands. The LLM may produce a course or university that doesn't exist; the validators catch it BEFORE we look up an answer. Failed validation → "did you mean…?" with suggestions.

## What this PR does NOT do
- API route (PR 4 — `/api/[state]/ask`)
- UI (PR 5 — `AnswerCard`)
- Wire to any existing user-facing flow

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 272/272 passing (39 new + 233 existing, including the existing prereqs route test which still works via re-exports)
- [x] `npm run lint` — 0 errors, no new warnings

## Files
- 13 files changed, +1365 / −124
- 6 new lookup/validator/types modules + 5 new test files
- 1 modified file (existing API route slimmed by 124 lines)

## What's next
- PR 4: `/api/[state]/ask` endpoint that wires classifier → answer-lookup → JSON response, with the search_intent_cache from migration 010
- PR 5: `AnswerCard` UI component on the results page

🤖 Generated with [Claude Code](https://claude.com/claude-code)