### PR TITLE
search-intent: add /api/[state]/ask endpoint

### DIFF
--- a/app/api/[state]/ask/route.ts
+++ b/app/api/[state]/ask/route.ts
@@ -1,0 +1,102 @@
+// GET /api/[state]/ask?q=<query>
+//
+// The natural-language question endpoint. Pipeline:
+//
+//   1. Validate state slug + rate limit + query length.
+//   2. classifyQuery(q)    — LLM classifier with Supabase cache (PR 2).
+//   3. lookupAnswer(...)   — entity validation + structured answer (PR 3).
+//   4. Respond with { classification, answer }.
+//
+// Failure modes:
+//   - 400: missing or too-short ?q=
+//   - 404: invalid state slug
+//   - 429: rate-limited
+//   - 503: classifier threw (Anthropic outage, missing key, etc.)
+//          The UI in PR 5 treats 5xx as "no answer card" and falls back
+//          to the existing course search results — graceful degradation.
+//
+// Caching: this endpoint is deterministic given (state, q). Same query
+// always produces the same answer (until underlying data updates), so
+// the CDN can hold it for an hour.
+
+import { NextRequest, NextResponse } from "next/server";
+import { isValidState } from "@/lib/states/registry";
+import { rateLimit, getClientKey } from "@/lib/rate-limit";
+import { classifyQuery } from "@/lib/search-intent/classify";
+import { lookupAnswer } from "@/lib/search-intent/answer";
+
+type RouteContext = { params: Promise<{ state: string }> };
+
+// LLM calls cost real money, so keep the per-IP cap tighter than the
+// course-search endpoint's 30/min default.
+const ASK_RATE_LIMIT = 15;
+
+const MIN_QUERY_LENGTH = 2;
+const MAX_QUERY_LENGTH = 500;
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const { state } = await context.params;
+
+  if (!isValidState(state)) {
+    return NextResponse.json({ error: "Unknown state" }, { status: 404 });
+  }
+
+  const { allowed, remaining } = rateLimit(getClientKey(request), ASK_RATE_LIMIT);
+  if (!allowed) {
+    return NextResponse.json(
+      { error: "Too many requests. Please try again in a minute." },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": "60",
+          "X-RateLimit-Remaining": "0",
+        },
+      },
+    );
+  }
+
+  const q = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+  if (q.length < MIN_QUERY_LENGTH) {
+    return NextResponse.json(
+      { error: `Query must be at least ${MIN_QUERY_LENGTH} characters.` },
+      { status: 400 },
+    );
+  }
+  if (q.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json(
+      { error: `Query must be at most ${MAX_QUERY_LENGTH} characters.` },
+      { status: 400 },
+    );
+  }
+
+  let classification;
+  try {
+    classification = await classifyQuery(q);
+  } catch (err) {
+    // Anthropic outage, missing key, billing issue, network error, etc.
+    // Log server-side, return 503 so the UI knows to skip the answer card.
+    console.error("[ask] classifier failed:", err);
+    return NextResponse.json(
+      {
+        error: "Classifier service unavailable.",
+        // Surface the high-level cause without leaking stack details.
+        cause: err instanceof Error ? err.message : "unknown",
+      },
+      { status: 503 },
+    );
+  }
+
+  const answer = await lookupAnswer(classification.intent, state);
+
+  return NextResponse.json(
+    { classification, answer },
+    {
+      headers: {
+        // Same query → same answer until data updates. Browser holds 5
+        // minutes; CDN holds 1 hour.
+        "Cache-Control": "public, max-age=300, s-maxage=3600",
+        "X-RateLimit-Remaining": String(remaining),
+      },
+    },
+  );
+}

--- a/app/api/__tests__/ask.route.test.ts
+++ b/app/api/__tests__/ask.route.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import type { Answer } from "@/lib/search-intent/answer";
+
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: vi.fn(() => ({ allowed: true, remaining: 99 })),
+  getClientKey: vi.fn(() => "ip:1.2.3.4"),
+}));
+vi.mock("@/lib/search-intent/classify", () => ({
+  classifyQuery: vi.fn(),
+}));
+vi.mock("@/lib/search-intent/answer", () => ({
+  lookupAnswer: vi.fn(),
+}));
+
+import { GET } from "../[state]/ask/route";
+import { rateLimit } from "@/lib/rate-limit";
+import { classifyQuery } from "@/lib/search-intent/classify";
+import { lookupAnswer } from "@/lib/search-intent/answer";
+
+const rateLimitMock = vi.mocked(rateLimit);
+const classifyMock = vi.mocked(classifyQuery);
+const lookupAnswerMock = vi.mocked(lookupAnswer);
+
+function makeRequest(state: string, query: Record<string, string>): {
+  req: NextRequest;
+  ctx: { params: Promise<{ state: string }> };
+} {
+  const url = new URL(`http://localhost/api/${state}/ask`);
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return {
+    req: new NextRequest(url),
+    ctx: { params: Promise.resolve({ state }) },
+  };
+}
+
+beforeEach(() => {
+  rateLimitMock.mockReset();
+  rateLimitMock.mockReturnValue({ allowed: true, remaining: 99 });
+  classifyMock.mockReset();
+  lookupAnswerMock.mockReset();
+});
+
+describe("GET /api/[state]/ask", () => {
+  it("returns 404 for an unknown state", async () => {
+    const { req, ctx } = makeRequest("xx", { q: "Does ENG 111 transfer to GMU?" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+    expect(classifyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when rate-limited and never calls the classifier", async () => {
+    rateLimitMock.mockReturnValueOnce({ allowed: false, remaining: 0 });
+    const { req, ctx } = makeRequest("va", { q: "Does ENG 111 transfer to GMU?" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(classifyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when q is missing", async () => {
+    const { req, ctx } = makeRequest("va", {});
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+    expect(classifyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when q is shorter than 2 chars", async () => {
+    const { req, ctx } = makeRequest("va", { q: "a" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+    expect(classifyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when q exceeds 500 chars", async () => {
+    const { req, ctx } = makeRequest("va", { q: "x".repeat(501) });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+    expect(classifyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with classification and answer on the happy path", async () => {
+    const classification = {
+      intent: {
+        type: "transfer" as const,
+        course: { prefix: "ENG", number: "111" },
+        university: "gmu",
+      },
+      confidence: 0.95,
+      reasoning: "test",
+    };
+    const answer: Answer = {
+      type: "transfer",
+      status: "yes",
+      course: { prefix: "ENG", number: "111" },
+      university: { slug: "gmu", name: "George Mason University" },
+      equivalency: {
+        univ_course: "ENGH 101",
+        univ_title: "Composition",
+        univ_credits: "3",
+        is_elective: false,
+        no_credit: false,
+        notes: "",
+      },
+      source: {
+        source: "transfer-equiv",
+        state: "va",
+        reference: "data/va/transfer-equiv.json",
+      },
+    };
+    classifyMock.mockResolvedValue(classification);
+    lookupAnswerMock.mockResolvedValue(answer);
+
+    const { req, ctx } = makeRequest("va", { q: "Does ENG 111 transfer to GMU?" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ classification, answer });
+  });
+
+  it("passes the user's state into lookupAnswer (not a hardcoded one)", async () => {
+    classifyMock.mockResolvedValue({
+      intent: { type: "unknown", raw: "x" },
+      confidence: 0.1,
+    });
+    lookupAnswerMock.mockResolvedValue({
+      type: "none",
+      reason: "out-of-scope",
+      message: "x",
+    });
+    const { req, ctx } = makeRequest("nc", { q: "asdf" });
+    await GET(req, ctx);
+    expect(lookupAnswerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "unknown" }),
+      "nc",
+    );
+  });
+
+  it("returns 503 when the classifier throws", async () => {
+    classifyMock.mockRejectedValue(new Error("Anthropic API down"));
+    const { req, ctx } = makeRequest("va", { q: "Does ENG 111 transfer to GMU?" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/Classifier service unavailable/);
+    expect(body.cause).toBe("Anthropic API down");
+    expect(lookupAnswerMock).not.toHaveBeenCalled();
+  });
+
+  it("sets Cache-Control + X-RateLimit-Remaining headers on 200 responses", async () => {
+    classifyMock.mockResolvedValue({
+      intent: { type: "unknown", raw: "x" },
+      confidence: 0.1,
+    });
+    lookupAnswerMock.mockResolvedValue({
+      type: "none",
+      reason: "out-of-scope",
+      message: "x",
+    });
+    rateLimitMock.mockReturnValueOnce({ allowed: true, remaining: 12 });
+    const { req, ctx } = makeRequest("va", { q: "anything" });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toMatch(/max-age=300/);
+    expect(res.headers.get("Cache-Control")).toMatch(/s-maxage=3600/);
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("12");
+  });
+
+  it("trims whitespace from q before length validation", async () => {
+    classifyMock.mockResolvedValue({
+      intent: { type: "unknown", raw: "x" },
+      confidence: 0,
+    });
+    lookupAnswerMock.mockResolvedValue({
+      type: "none",
+      reason: "out-of-scope",
+      message: "x",
+    });
+    // 10 spaces + "ENG 111" + 5 spaces — trims to 7 chars, valid
+    const { req, ctx } = makeRequest("va", { q: "          ENG 111     " });
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    expect(classifyMock).toHaveBeenCalledWith("ENG 111");
+  });
+});


### PR DESCRIPTION
## Summary
Wires the classifier (#189) and answer-lookup (#190) behind a single HTTP endpoint. This is what the search bar UI in PR 5 will call.

```
GET /api/[state]/ask?q=Does+ENG+111+transfer+to+GMU%3F

200 OK
{
  "classification": { "intent": {...}, "confidence": 0.95, "reasoning": "..." },
  "answer":         { "type": "transfer", "status": "yes", "equivalency": {...}, "source": {...} }
}
```

## Pipeline
1. **Validate** state slug + rate limit (15/min per IP — tighter than the 30/min on `/courses/search` since LLM calls cost real money).
2. **`classifyQuery(q)`** — Claude Haiku 4.5 + Supabase cache. The cache is a graceful no-op if migration `010` hasn't been applied yet.
3. **`lookupAnswer(intent, state)`** — entity-validated structured answer.
4. **Respond 200** with `{ classification, answer }`.

## Status codes
| Code | Meaning |
|---|---|
| 200 | success |
| 400 | missing `q`, `q < 2` chars, or `q > 500` chars |
| 404 | invalid state slug |
| 429 | rate-limited (`Retry-After: 60`) |
| 503 | classifier threw (Anthropic outage, missing key, billing) |

The UI in PR 5 will treat 5xx as "no answer card" and fall back to existing course search results — graceful degradation, never a broken page.

## HTTP caching
Same `(state, q)` → same answer until data updates, so:
```
Cache-Control: public, max-age=300, s-maxage=3600
```
5 min browser, 1 h CDN. Combined with the Supabase classification cache, repeat queries in production should rarely hit Anthropic.

## What this PR does NOT do
- UI wiring (PR 5)
- Any change to the existing `/api/[state]/courses/search` flow
- Apply migration `010_search_intent_cache.sql` — endpoint works without it (just no cache)

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 282/282 passing (10 new + 272 existing)
- [x] `npm run lint` — 0 errors, no new warnings
- [ ] Reviewer: apply migration `010_search_intent_cache.sql` against Supabase (Dashboard SQL Editor or `scripts/lib/run-migration.ts`) **before relying on the cache in prod**. Endpoint serves correct answers without it; just incurs an LLM call per request until applied.
- [ ] Reviewer: with `ANTHROPIC_API_KEY` set in Vercel and the migration applied, hit `https://communitycollegepath.com/api/va/ask?q=does+ENG+111+transfer+to+GMU` and verify a 200 with `answer.status: "yes"`.

## What's next
- PR 5: `AnswerCard` component + wire-up on the search results page

🤖 Generated with [Claude Code](https://claude.com/claude-code)