### PR TITLE
search-intent: add AnswerCard UI on the search results page

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -4,9 +4,11 @@ import { useState, useEffect, useMemo, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import type { CourseMode } from "@/lib/types";
+import type { Answer } from "@/lib/search-intent/answer";
 import { expandDays } from "@/lib/time-utils";
 import DayToggle from "@/components/DayToggle";
 import PrereqChain from "@/components/PrereqChain";
+import AnswerCard from "@/components/AnswerCard";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { createClient } from "@/lib/supabase/client";
 import { track } from "@/lib/analytics";
@@ -195,6 +197,10 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [hasSearched, setHasSearched] = useState(false);
+  // Natural-language answer card. Populated from /api/[state]/ask in
+  // parallel with the course search; null until a query has resolved or
+  // when the classifier returned a non-actionable intent.
+  const [answer, setAnswer] = useState<Answer | null>(null);
 
   // Fetch transfer lookup data on mount (small, cached 24h)
   useEffect(() => {
@@ -223,6 +229,22 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     setError("");
     setHasSearched(true);
     setDisplayLimit(10);
+    // Reset previous answer card before either fetch resolves so a stale
+    // card never lingers under a new query.
+    setAnswer(null);
+
+    // Kick off the natural-language /ask fetch in parallel with the
+    // course search. Fire-and-forget — failure or 5xx silently leaves the
+    // answer card unrendered (graceful degradation; course results still
+    // load below).
+    fetch(`/api/${state}/ask?q=${encodeURIComponent(searchQuery.trim())}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { answer: Answer } | null) => {
+        if (data?.answer) setAnswer(data.answer);
+      })
+      .catch(() => {
+        /* silent — no answer card, course results still render */
+      });
 
     try {
       const params = new URLSearchParams({ q: searchQuery.trim(), limit: "50" });
@@ -455,6 +477,11 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
           <p className="text-sm text-red-800 dark:text-red-300">{error}</p>
         </div>
       )}
+
+      {/* Natural-language answer card. Renders above course results
+          whenever /api/[state]/ask returns a typed answer. NoAnswer
+          variants render nothing — the user just sees course results. */}
+      {answer && <AnswerCard answer={answer} state={state} />}
 
       {/* Loading */}
       {loading && (

--- a/components/AnswerCard.tsx
+++ b/components/AnswerCard.tsx
@@ -1,0 +1,437 @@
+// AnswerCard renders a structured Answer from /api/[state]/ask above the
+// course search results. One card per query.
+//
+// Variant routing:
+//   transfer     → TransferBody (status-driven: yes / partial / no / etc.)
+//   prereqs      → PrereqsBody  (status-driven: found / no-prereqs / etc.)
+//   eligibility  → EligibilityBody (per-college breakdown + state summary)
+//   none         → null (no card; UI just renders course search results)
+//
+// Every typed answer carries a SourceCitation; footer renders that as a
+// trust signal so first-gen students can verify the underlying data.
+
+"use client";
+
+import type { Answer, SourceCitation } from "@/lib/search-intent/answer";
+
+interface AnswerCardProps {
+  answer: Answer;
+  state: string;
+}
+
+export default function AnswerCard({ answer, state }: AnswerCardProps) {
+  if (answer.type === "none") return null;
+
+  return (
+    <div
+      className="mb-6 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-sm overflow-hidden"
+      data-testid="answer-card"
+      role="region"
+      aria-live="polite"
+      aria-label="Answer to your question"
+    >
+      <div className="p-5 space-y-3">
+        {answer.type === "transfer" && <TransferBody answer={answer} />}
+        {answer.type === "prereqs" && <PrereqsBody answer={answer} state={state} />}
+        {answer.type === "eligibility" && <EligibilityBody answer={answer} />}
+      </div>
+      <SourceFooter source={answer.source} />
+    </div>
+  );
+}
+
+// ─── Transfer ───────────────────────────────────────────────────────────
+
+function TransferBody({
+  answer,
+}: {
+  answer: Extract<Answer, { type: "transfer" }>;
+}) {
+  const courseLabel = `${answer.course.prefix} ${answer.course.number}`;
+
+  switch (answer.status) {
+    case "yes": {
+      const eq = answer.equivalency!;
+      return (
+        <>
+          <Headline tone="success" icon="✓">
+            Yes — {courseLabel} transfers to {answer.university!.name} as{" "}
+            <strong>{eq.univ_course}</strong>
+            {eq.univ_credits ? ` (${eq.univ_credits} credits)` : ""}
+          </Headline>
+          {eq.univ_title && (
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              {eq.univ_title}
+            </p>
+          )}
+          {eq.notes && <Note>{eq.notes}</Note>}
+        </>
+      );
+    }
+    case "partial": {
+      const eq = answer.equivalency!;
+      const reason = eq.no_credit
+        ? "but receives no credit at the university"
+        : "as elective credit only";
+      return (
+        <>
+          <Headline tone="warning" icon="⚠">
+            {courseLabel} transfers to {answer.university!.name} as{" "}
+            <strong>{eq.univ_course || "(elective)"}</strong>, {reason}.
+          </Headline>
+          {eq.notes && <Note>{eq.notes}</Note>}
+        </>
+      );
+    }
+    case "no": {
+      return (
+        <>
+          <Headline tone="neutral" icon="✗">
+            We don&apos;t have a transfer agreement on file for {courseLabel} →{" "}
+            {answer.university!.name}.
+          </Headline>
+          {answer.alternatives && answer.alternatives.length > 0 && (
+            <AlternativesList
+              label={`${courseLabel} does transfer to:`}
+              items={answer.alternatives}
+            />
+          )}
+        </>
+      );
+    }
+    case "no-destination": {
+      return (
+        <>
+          <Headline tone="info" icon="↪">
+            {courseLabel} transfers to several universities:
+          </Headline>
+          {answer.alternatives && (
+            <AlternativesList items={answer.alternatives} />
+          )}
+        </>
+      );
+    }
+    case "unknown-course":
+      return (
+        <Headline tone="neutral" icon="?">
+          We couldn&apos;t find {courseLabel} in this state&apos;s catalog. Try
+          a course code from the search below.
+        </Headline>
+      );
+    case "unknown-university":
+      return (
+        <>
+          <Headline tone="neutral" icon="?">
+            We don&apos;t have transfer data for that university.
+          </Headline>
+          {answer.suggestions && answer.suggestions.length > 0 && (
+            <SuggestionList
+              label="Did you mean:"
+              items={answer.suggestions.map((s) => s.name)}
+            />
+          )}
+        </>
+      );
+    case "no-data":
+      return (
+        <Headline tone="neutral" icon="—">
+          Transfer data isn&apos;t available for this state yet.
+        </Headline>
+      );
+  }
+}
+
+// ─── Prereqs ────────────────────────────────────────────────────────────
+
+function PrereqsBody({
+  answer,
+  state,
+}: {
+  answer: Extract<Answer, { type: "prereqs" }>;
+  state: string;
+}) {
+  if (answer.status === "no-course-named") {
+    return (
+      <Headline tone="neutral" icon="?">
+        Which course&apos;s prerequisites are you asking about? Try &ldquo;prereqs for BIO 256&rdquo;.
+      </Headline>
+    );
+  }
+
+  const courseLabel = answer.course
+    ? `${answer.course.prefix} ${answer.course.number}`
+    : "this course";
+
+  switch (answer.status) {
+    case "found": {
+      // Top-level prereq courses from the chain (one level deep).
+      // Multi-level rendering is intentionally deferred; the deepest
+      // info isn't usually what the user wants on the answer card.
+      const chain = answer.chain;
+      const topLevel = chain?.children ?? [];
+      const groups = chain?.groups;
+      return (
+        <>
+          <Headline tone="info" icon="📋">
+            To take <strong>{courseLabel}</strong>, you need:
+          </Headline>
+          {chain?.text && (
+            <p className="text-sm text-slate-700 dark:text-slate-200">
+              {chain.text}
+            </p>
+          )}
+          {groups && groups.length > 0 ? (
+            <div className="space-y-1.5">
+              {groups.map((group, i) => (
+                <div key={i} className="flex flex-wrap items-center gap-1.5">
+                  {i > 0 && (
+                    <span className="text-xs font-medium uppercase text-slate-400">
+                      and
+                    </span>
+                  )}
+                  {group.map((c, j) => (
+                    <span key={c.course} className="flex items-center gap-1.5">
+                      {j > 0 && (
+                        <span className="text-xs uppercase text-slate-400">
+                          or
+                        </span>
+                      )}
+                      <CoursePill course={c.course} state={state} />
+                    </span>
+                  ))}
+                </div>
+              ))}
+            </div>
+          ) : (
+            topLevel.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {topLevel.map((c) => (
+                  <CoursePill key={c.course} course={c.course} state={state} />
+                ))}
+              </div>
+            )
+          )}
+        </>
+      );
+    }
+    case "no-prereqs":
+      return (
+        <Headline tone="success" icon="✓">
+          {courseLabel} has no prerequisites — you can take it directly.
+        </Headline>
+      );
+    case "unknown-course":
+      return (
+        <Headline tone="neutral" icon="?">
+          We couldn&apos;t find {courseLabel} in this state&apos;s catalog.
+        </Headline>
+      );
+    case "no-data":
+      return (
+        <Headline tone="neutral" icon="—">
+          Prerequisite data isn&apos;t available for this state yet.
+        </Headline>
+      );
+  }
+}
+
+// ─── Eligibility ────────────────────────────────────────────────────────
+
+function EligibilityBody({
+  answer,
+}: {
+  answer: Extract<Answer, { type: "eligibility" }>;
+}) {
+  // Cap to first 5 colleges to keep the card from dominating the page.
+  const visible = answer.colleges.slice(0, 5);
+  const remaining = answer.colleges.length - visible.length;
+
+  return (
+    <>
+      <Headline tone="info" icon="🎓">
+        {answer.summary}
+      </Headline>
+      {visible.length > 0 && (
+        <div className="border border-slate-200 dark:border-slate-700 rounded-md overflow-hidden">
+          <ul className="divide-y divide-slate-200 dark:divide-slate-700">
+            {visible.map((c) => (
+              <li
+                key={c.slug}
+                className="flex items-start justify-between gap-3 px-3 py-2 text-sm"
+              >
+                <div className="min-w-0">
+                  <div className="font-medium text-slate-900 dark:text-slate-100 truncate">
+                    {c.name}
+                  </div>
+                  {c.notes && (
+                    <div className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                      {c.notes}
+                    </div>
+                  )}
+                </div>
+                <div className="text-right whitespace-nowrap">
+                  <span
+                    className={`text-xs font-medium ${
+                      c.eligible
+                        ? "text-emerald-700 dark:text-emerald-400"
+                        : "text-slate-500 dark:text-slate-400"
+                    }`}
+                  >
+                    {c.eligible ? "Eligible" : "Not available"}
+                  </span>
+                  <div className="text-xs text-slate-600 dark:text-slate-300">
+                    {c.cost}
+                    {c.ageThreshold ? ` · ${c.ageThreshold}+` : ""}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {remaining > 0 && (
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          + {remaining} more college{remaining === 1 ? "" : "s"} not shown.
+        </p>
+      )}
+    </>
+  );
+}
+
+// ─── Shared bits ────────────────────────────────────────────────────────
+
+function Headline({
+  tone,
+  icon,
+  children,
+}: {
+  tone: "success" | "warning" | "neutral" | "info";
+  icon: string;
+  children: React.ReactNode;
+}) {
+  const toneClass = {
+    success: "text-emerald-700 dark:text-emerald-400",
+    warning: "text-amber-700 dark:text-amber-400",
+    neutral: "text-slate-700 dark:text-slate-300",
+    info: "text-teal-700 dark:text-teal-400",
+  }[tone];
+  return (
+    <div className="flex items-start gap-2">
+      <span className={`mt-0.5 ${toneClass}`} aria-hidden="true">
+        {icon}
+      </span>
+      <p className={`text-base font-medium ${toneClass}`}>{children}</p>
+    </div>
+  );
+}
+
+function Note({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs text-slate-500 dark:text-slate-400 italic">
+      {children}
+    </p>
+  );
+}
+
+function AlternativesList({
+  label,
+  items,
+}: {
+  label?: string;
+  items: Array<{
+    slug: string;
+    name: string;
+    univ_course: string;
+    is_elective: boolean;
+    no_credit: boolean;
+  }>;
+}) {
+  return (
+    <div className="space-y-1.5">
+      {label && (
+        <p className="text-sm text-slate-600 dark:text-slate-300">{label}</p>
+      )}
+      <ul className="space-y-1 text-sm">
+        {items.map((m) => (
+          <li
+            key={m.slug}
+            className="flex items-baseline justify-between gap-3 border-b border-slate-100 dark:border-slate-800 last:border-0 pb-1 last:pb-0"
+          >
+            <span className="font-medium text-slate-900 dark:text-slate-100">
+              {m.name}
+            </span>
+            <span className="text-slate-600 dark:text-slate-300 text-xs">
+              {m.univ_course || "—"}
+              {m.is_elective ? " (elective)" : ""}
+              {m.no_credit ? " (no credit)" : ""}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SuggestionList({
+  label,
+  items,
+}: {
+  label: string;
+  items: string[];
+}) {
+  return (
+    <div>
+      <p className="text-sm text-slate-600 dark:text-slate-300 mb-1">{label}</p>
+      <ul className="text-sm text-slate-700 dark:text-slate-200">
+        {items.map((s) => (
+          <li key={s}>• {s}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function CoursePill({ course, state }: { course: string; state: string }) {
+  // Course code format: "PREFIX NUMBER". Encode for URL safety.
+  const q = encodeURIComponent(course);
+  return (
+    <a
+      href={`/${state}/courses?q=${q}`}
+      className="inline-flex items-center rounded-md border border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800 px-2 py-0.5 text-xs font-mono text-slate-800 dark:text-slate-200 hover:border-teal-500 hover:text-teal-700 transition-colors"
+    >
+      {course}
+    </a>
+  );
+}
+
+function SourceFooter({ source }: { source: SourceCitation }) {
+  const SOURCE_LABEL: Record<SourceCitation["source"], string> = {
+    "transfer-equiv": "transfer agreements",
+    prereqs: "prerequisite catalog",
+    institutions: "audit policies",
+    "supabase-courses": "course catalog",
+  };
+  const label = SOURCE_LABEL[source.source];
+  return (
+    <div className="px-5 py-2 border-t border-slate-100 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/40">
+      <p className="text-[11px] text-slate-500 dark:text-slate-400">
+        Based on {label} for{" "}
+        <span className="font-mono uppercase">{source.state}</span>
+        {source.lastUpdated ? ` · last verified ${source.lastUpdated}` : ""}
+        {source.upstreamUrl ? (
+          <>
+            {" "}·{" "}
+            <a
+              href={source.upstreamUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="underline hover:text-teal-700"
+            >
+              source
+            </a>
+          </>
+        ) : null}
+      </p>
+    </div>
+  );
+}

--- a/lib/search-intent/answer/index.ts
+++ b/lib/search-intent/answer/index.ts
@@ -11,7 +11,7 @@ import { lookupEligibility } from "./eligibility";
 import { lookupPrereqs } from "./prereqs";
 import { lookupTransfer } from "./transfer";
 
-export type { Answer } from "./types";
+export type { Answer, SourceCitation } from "./types";
 
 export async function lookupAnswer(
   intent: SearchIntent,


### PR DESCRIPTION
## Summary
The user-facing payoff. Wires the `/api/[state]/ask` endpoint (#191) into the course-search results UI. When a user types a question like *"Does ENG 111 transfer to GMU?"* on the homepage, the page now renders an answer card above the course list with a direct, citation-backed answer.

## What's new
- **`components/AnswerCard.tsx`** — one component, discriminated-union variants:
  - **Transfer**: status-driven (yes / partial / no / no-destination / unknown-course / unknown-university / no-data) with alternatives + equivalency details
  - **Prereqs**: AND-of-OR pill groups, each pill linking back to course search
  - **Eligibility**: per-college breakdown (top 5 + "+ N more") plus state-level summary from `StateConfig.seniorWaiver`
  - **NoAnswer / 5xx**: renders nothing — graceful fallback to existing course results
  - **SourceCitation footer** on every typed answer ("Based on transfer agreements for VA")

- **`CourseSearchClient.tsx`**: parallel fire-and-forget fetch to `/api/[state]/ask` alongside existing course-search. Course results render at normal speed (200-500ms); answer card layers in when /ask returns (~1.5s p50 cold, <100ms with cache).

## Backend verification
End-to-end pipeline verified against the live LLM:
```
$ curl 'http://localhost:3000/api/va/ask?q=Does+ENG+111+transfer+to+GMU'
{
  "classification": {
    "intent": { "type":"transfer","course":{"prefix":"ENG","number":"111"},"university":"gmu" },
    "confidence": 0.95,
    "reasoning": "Clear transfer intent with specific course code (ENG 111) and destination university (GMU)."
  },
  "answer": {
    "type": "transfer",
    "status": "partial",
    "course": {"prefix":"ENG","number":"111"},
    "university": {"slug":"gmu","name":"George Mason University"},
    "equivalency": {"univ_course":"ENGH ----","univ_title":"English Elective","univ_credits":"3","is_elective":true,"no_credit":false,"notes":""},
    "source": {"source":"transfer-equiv","state":"va","reference":"data/va/transfer-equiv.json"}
  }
}
```

## Verification caveat — please exercise locally before merging
I couldn't get end-to-end browser-rendered verification through the preview tool I'm using — page navigations were being silently swallowed and the route never rendered the answer card visually. Backend was verified via curl as above, and TypeScript guarantees the types match end-to-end, but I haven't *seen* the rendered card.

**To verify locally before merging:**
1. `git checkout claude/search-intent-pr5-answer-card`
2. Make sure `ANTHROPIC_API_KEY` is in `.env.local` (already there from PR #189 testing)
3. `npm run dev` — wait for "Ready"
4. Visit `http://localhost:3000/` → click **Virginia** on the map
5. From the VA hero, click each of the 4 popular search chips and verify:
   - **"Does ENG 111 transfer to GMU?"** → answer card with "ENG 111 transfers to George Mason University as ENGH ----, as elective credit only" (status: partial)
   - **"prereqs for BIO 256"** → answer card with prereq pill chain
   - **"online math, summer 2026"** → no answer card (course intent), course results below
   - **"free college if I'm 65+"** → answer card with VA senior waiver summary + per-college breakdown

Note: **first** request to each route is slow in dev (Turbopack cold-compile, up to 4 minutes for /api/ask the first time). Subsequent requests are fast. Production on Vercel doesn't have this problem.

## Migration reminder
PR #191 added `supabase/migrations/010_search_intent_cache.sql`. Apply it before this PR sees real production traffic — without it, every query hits the LLM fresh (works correctly, just no caching). Server logs will show `[search-intent] cache write failed: Could not find the table 'public.search_intent_cache'` until applied; harmless but noisy.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 282/282 passing (no new tests; project has no React Testing Library and no `.tsx` tests by convention — type system + backend tests + browser verification cover the surface)
- [x] `npm run lint` — 0 errors, no new warnings
- [x] backend pipeline verified end-to-end with curl
- [ ] reviewer: local browser walkthrough of all 4 popular-search chips per the steps above
- [ ] reviewer: apply migration `010_search_intent_cache.sql` before relying on the cache

## What's complete with this PR
The end-to-end story:
- Homepage search bar → /[state]/courses?q=…
- LLM classifier (Haiku 4.5) → structured intent
- Entity validator → courseExists + resolveUniversity (hallucination boundary)
- Answer-lookup → real data from transfer-equiv / prereqs / institutions
- AnswerCard renders the answer with source citation above existing course results

🤖 Generated with [Claude Code](https://claude.com/claude-code)