### PR TITLE
search-intent: enrich classifier output with 4 new fields (PR B)

### DIFF
--- a/app/api/__tests__/ask.route.test.ts
+++ b/app/api/__tests__/ask.route.test.ts
@@ -88,6 +88,10 @@ describe("GET /api/[state]/ask", () => {
       },
       confidence: 0.95,
       reasoning: "test",
+      studentSummary: "You're asking whether ENG 111 transfers to George Mason.",
+      clarifyingQuestion: null,
+      sourceCollege: null,
+      suggestedFollowups: ["What are the prereqs for ENG 111?"],
     };
     const answer: Answer = {
       type: "transfer",
@@ -122,6 +126,10 @@ describe("GET /api/[state]/ask", () => {
     classifyMock.mockResolvedValue({
       intent: { type: "unknown", raw: "x" },
       confidence: 0.1,
+      studentSummary: "test",
+      clarifyingQuestion: null,
+      sourceCollege: null,
+      suggestedFollowups: [],
     });
     lookupAnswerMock.mockResolvedValue({
       type: "none",
@@ -151,6 +159,10 @@ describe("GET /api/[state]/ask", () => {
     classifyMock.mockResolvedValue({
       intent: { type: "unknown", raw: "x" },
       confidence: 0.1,
+      studentSummary: "test",
+      clarifyingQuestion: null,
+      sourceCollege: null,
+      suggestedFollowups: [],
     });
     lookupAnswerMock.mockResolvedValue({
       type: "none",
@@ -170,6 +182,10 @@ describe("GET /api/[state]/ask", () => {
     classifyMock.mockResolvedValue({
       intent: { type: "unknown", raw: "x" },
       confidence: 0,
+      studentSummary: "test",
+      clarifyingQuestion: null,
+      sourceCollege: null,
+      suggestedFollowups: [],
     });
     lookupAnswerMock.mockResolvedValue({
       type: "none",

--- a/lib/search-intent/__tests__/classify-llm.test.ts
+++ b/lib/search-intent/__tests__/classify-llm.test.ts
@@ -12,6 +12,10 @@ function fakeClient(toolInput: Partial<ClassifierToolInput>) {
         input: {
           confidence: 0.95,
           reasoning: "test reasoning",
+          student_summary: "You're asking a question about your coursework.",
+          clarifying_question: null,
+          source_college: null,
+          suggested_followups: ["What are the prereqs?", "Are there online sections?"],
           ...toolInput,
         },
       },
@@ -154,6 +158,8 @@ describe("toClassifiedIntent", () => {
       course_number: "111",
       confidence: 0.1,
       reasoning: "x",
+      student_summary: "You're asking an unknown question.",
+      suggested_followups: [],
     });
     expect(result.intent).toEqual({ type: "unknown", raw: "test" });
   });
@@ -165,8 +171,41 @@ describe("toClassifiedIntent", () => {
       course_number: null,
       confidence: 0.5,
       reasoning: "x",
+      student_summary: "You're asking about transfer.",
+      suggested_followups: [],
     });
     if (result.intent.type !== "transfer") throw new Error("wrong type");
     expect(result.intent.course).toBeNull();
+  });
+
+  it("maps new enrichment fields onto ClassifiedIntent", () => {
+    const result = toClassifiedIntent("Does ENG 111 transfer to GMU? I'm at NOVA.", {
+      type: "transfer",
+      course_prefix: "ENG",
+      course_number: "111",
+      university: "gmu",
+      confidence: 0.6,
+      reasoning: "low confidence",
+      student_summary: "You're asking whether ENG 111 transfers to George Mason.",
+      clarifying_question: "Which campus of NOVA are you attending?",
+      source_college: "nova",
+      suggested_followups: ["What are the prereqs for ENG 111?", "Does ENG 111 transfer to VCU?"],
+    });
+    expect(result.studentSummary).toBe("You're asking whether ENG 111 transfers to George Mason.");
+    expect(result.clarifyingQuestion).toBe("Which campus of NOVA are you attending?");
+    expect(result.sourceCollege).toBe("nova");
+    expect(result.suggestedFollowups).toEqual(["What are the prereqs for ENG 111?", "Does ENG 111 transfer to VCU?"]);
+  });
+
+  it("defaults clarifyingQuestion to null and suggestedFollowups to [] when LLM omits them", () => {
+    const result = toClassifiedIntent("test", {
+      type: "unknown",
+      confidence: 0.9,
+      reasoning: "x",
+      student_summary: "You're asking something unclear.",
+    });
+    expect(result.clarifyingQuestion).toBeNull();
+    expect(result.sourceCollege).toBeNull();
+    expect(result.suggestedFollowups).toEqual([]);
   });
 });

--- a/lib/search-intent/__tests__/classify.test.ts
+++ b/lib/search-intent/__tests__/classify.test.ts
@@ -3,6 +3,13 @@ import { classifierWith } from "../classify";
 import { hashQuery, memoryCache, normalizeQuery, nullCache } from "../cache";
 import type { Classifier } from "../types";
 
+const BASE_ENRICHMENT = {
+  studentSummary: "test summary",
+  clarifyingQuestion: null,
+  sourceCollege: null,
+  suggestedFollowups: [] as string[],
+};
+
 describe("normalizeQuery", () => {
   it("lowercases and collapses whitespace", () => {
     expect(normalizeQuery("  Does   ENG 111   Transfer  ")).toBe(
@@ -31,6 +38,7 @@ describe("memoryCache", () => {
     const intent = {
       intent: { type: "unknown" as const, raw: "x" },
       confidence: 0.3,
+      ...BASE_ENRICHMENT,
     };
     await cache.put("hello", "va", "model-x", intent);
     expect(await cache.get("hello", "va", "model-x")).toEqual(intent);
@@ -41,6 +49,7 @@ describe("memoryCache", () => {
     const intent = {
       intent: { type: "unknown" as const, raw: "x" },
       confidence: 0.3,
+      ...BASE_ENRICHMENT,
     };
     await cache.put("hello", "va", "model-x", intent);
     expect(await cache.get("hello", "va", "model-y")).toBeNull();
@@ -51,6 +60,7 @@ describe("memoryCache", () => {
     const intent = {
       intent: { type: "unknown" as const, raw: "x" },
       confidence: 0.3,
+      ...BASE_ENRICHMENT,
     };
     await cache.put("hello", "va", "model-x", intent);
     expect(await cache.get("hello", "ma", "model-x")).toBeNull();
@@ -61,6 +71,7 @@ describe("memoryCache", () => {
     const make = (raw: string) => ({
       intent: { type: "unknown" as const, raw },
       confidence: 0,
+      ...BASE_ENRICHMENT,
     });
     await cache.put("q1", "va", "m", make("q1"));
     await cache.put("q2", "va", "m", make("q2"));
@@ -77,6 +88,7 @@ describe("classifierWith", () => {
     const cached = {
       intent: { type: "unknown" as const, raw: "cached" },
       confidence: 0.99,
+      ...BASE_ENRICHMENT,
     };
     await cache.put("hello", "va", "model-x", cached);
 
@@ -93,6 +105,7 @@ describe("classifierWith", () => {
     const fresh = {
       intent: { type: "unknown" as const, raw: "fresh" },
       confidence: 0.42,
+      ...BASE_ENRICHMENT,
     };
     const llm: Classifier = vi.fn().mockResolvedValue(fresh);
     const classifier = classifierWith({ cache, llm, modelVersion: "model-x" });
@@ -111,6 +124,7 @@ describe("classifierWith", () => {
     const fresh = {
       intent: { type: "unknown" as const, raw: "fresh" },
       confidence: 0.42,
+      ...BASE_ENRICHMENT,
     };
     const llm: Classifier = vi.fn().mockResolvedValue(fresh);
     const classifier = classifierWith({ cache: nullCache, llm });

--- a/lib/search-intent/__tests__/eval-runner.test.ts
+++ b/lib/search-intent/__tests__/eval-runner.test.ts
@@ -35,6 +35,13 @@ const TINY_CASES: EvalCase[] = [
   },
 ];
 
+const BASE_ENRICHMENT = {
+  studentSummary: "test summary",
+  clarifyingQuestion: null,
+  sourceCollege: null,
+  suggestedFollowups: [] as string[],
+};
+
 const PERFECT_CLASSIFIER: Classifier = (q, _state) => {
   let intent: SearchIntent;
   if (q.includes("transfer")) {
@@ -51,12 +58,13 @@ const PERFECT_CLASSIFIER: Classifier = (q, _state) => {
   } else {
     intent = { type: "unknown", raw: q };
   }
-  return { intent, confidence: 1 };
+  return { intent, confidence: 1, ...BASE_ENRICHMENT };
 };
 
 const ALWAYS_UNKNOWN: Classifier = (q, _state) => ({
   intent: { type: "unknown", raw: q },
   confidence: 0,
+  ...BASE_ENRICHMENT,
 });
 
 describe("runEval", () => {
@@ -103,6 +111,7 @@ describe("runEval", () => {
     const asyncClassifier: Classifier = async (q, _state) => ({
       intent: { type: "unknown", raw: q },
       confidence: 0,
+      ...BASE_ENRICHMENT,
     });
     const report = await runEval(asyncClassifier, TINY_CASES);
     expect(report.total).toBe(3);

--- a/lib/search-intent/classify-llm.ts
+++ b/lib/search-intent/classify-llm.ts
@@ -82,6 +82,10 @@ export function toClassifiedIntent(
     intent: toSearchIntent(rawQuery, input),
     confidence: clamp01(input.confidence),
     reasoning: input.reasoning,
+    studentSummary: input.student_summary,
+    clarifyingQuestion: input.clarifying_question ?? null,
+    sourceCollege: input.source_college ?? null,
+    suggestedFollowups: input.suggested_followups ?? [],
   };
 }
 

--- a/lib/search-intent/prompt.ts
+++ b/lib/search-intent/prompt.ts
@@ -54,6 +54,13 @@ Confidence rules:
 
 If the query contains TWO clear intents (e.g. "Does ENG 111 transfer to GMU and what are the prereqs?"), pick the one that appears first or feels primary, and include the other in your reasoning. Don't try to return both.
 
+Additional output fields:
+
+- student_summary: Always provide a 1-2 sentence plain-English restatement of what the student is asking. Write as if addressing the student directly. Example: "You're asking whether ENG 111 transfers to George Mason."
+- clarifying_question: When confidence < 0.85, suggest one specific follow-up question. Be specific ("Which university are you hoping to transfer to?"), not vague ("Can you clarify?"). Null when confidence >= 0.85.
+- source_college: If the student names their community college ("I'm at NOVA", "from Bunker Hill CC"), extract it as a lowercase hyphenated slug. Otherwise null.
+- suggested_followups: Always provide 2-3 follow-up questions a student in this situation would naturally want to know next.
+
 Always call the tool. Never produce conversational text.`;
 
 /** Format a state's university aliases for injection into the user message. */
@@ -135,8 +142,25 @@ export const CLASSIFY_TOOL = {
         type: "string",
         description: "One-sentence explanation. Useful for debugging and eval reports.",
       },
+      student_summary: {
+        type: "string",
+        description: "Always provide a 1-2 sentence plain-English restatement of what the student is asking. Write as if addressing the student directly. Example: \"You're asking whether ENG 111 transfers to George Mason.\"",
+      },
+      clarifying_question: {
+        type: ["string", "null"],
+        description: "When confidence < 0.85, suggest one specific follow-up question. Be specific ('Which university are you hoping to transfer to?'), not vague ('Can you clarify?'). Null when confidence >= 0.85.",
+      },
+      source_college: {
+        type: ["string", "null"],
+        description: "If the student names their community college ('I'm at NOVA', 'from Bunker Hill CC'), extract it as a lowercase hyphenated slug. Otherwise null.",
+      },
+      suggested_followups: {
+        type: "array",
+        items: { type: "string" },
+        description: "Always provide 2-3 follow-up questions a student in this situation would naturally want to know next.",
+      },
     },
-    required: ["type", "confidence", "reasoning"],
+    required: ["type", "confidence", "reasoning", "student_summary", "suggested_followups"],
   },
 };
 
@@ -156,4 +180,8 @@ export interface ClassifierToolInput {
   term?: string | null;
   confidence: number;
   reasoning: string;
+  student_summary: string;
+  clarifying_question?: string | null;
+  source_college?: string | null;
+  suggested_followups?: string[];
 }

--- a/lib/search-intent/types.ts
+++ b/lib/search-intent/types.ts
@@ -67,6 +67,14 @@ export interface ClassifiedIntent {
   confidence: number;
   // Optional human-readable reasoning, useful for debugging and eval output.
   reasoning?: string;
+  // Plain-English restatement of what the student asked, addressed to them.
+  studentSummary: string;
+  // Specific follow-up question when confidence < 0.85. Null otherwise.
+  clarifyingQuestion: string | null;
+  // Community college the student named in their query, as a slug. Null if not mentioned.
+  sourceCollege: string | null;
+  // 2-3 follow-up questions the student would naturally ask next.
+  suggestedFollowups: string[];
 }
 
 export type Classifier = (


### PR DESCRIPTION
## Summary

- Adds `student_summary`, `clarifying_question`, `source_college`, and `suggested_followups` to the `CLASSIFY_TOOL` JSON schema and `ClassifierToolInput`
- Extends `ClassifiedIntent` with the camelCase equivalents: `studentSummary`, `clarifyingQuestion`, `sourceCollege`, `suggestedFollowups`
- Updates `toClassifiedIntent()` in `classify-llm.ts` to map the new tool fields onto the intent
- Updates the system prompt with instructions for each new field
- Updates all test files (4) to include the new required fields in mock objects

## Why

We were paying for an LLM call and discarding its ability to summarise, clarify, and suggest. These 4 fields cost nothing extra and unblock PR E (UI rendering).

## Test plan

- [ ] `npx vitest run lib/search-intent/__tests__/ app/api/__tests__/` — 99 tests pass
- [ ] `npx tsc --noEmit` — clean

## Dependencies

- Depends on: PR #194 (merged) — state context injection
- Unblocks: PR E (UI for new fields) — which also needs PR D (deterministic followups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)