### PR TITLE
search-intent: surface classifier fields and follow-up pills in UI (PR E)

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -8,7 +8,7 @@ import type { Answer } from "@/lib/search-intent/answer";
 import { expandDays } from "@/lib/time-utils";
 import DayToggle from "@/components/DayToggle";
 import PrereqChain from "@/components/PrereqChain";
-import AnswerCard from "@/components/AnswerCard";
+import AnswerCard, { type ClassificationSummary } from "@/components/AnswerCard";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { createClient } from "@/lib/supabase/client";
 import { track } from "@/lib/analytics";
@@ -201,6 +201,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   // parallel with the course search; null until a query has resolved or
   // when the classifier returned a non-actionable intent.
   const [answer, setAnswer] = useState<Answer | null>(null);
+  const [classification, setClassification] = useState<ClassificationSummary | null>(null);
 
   // Fetch transfer lookup data on mount (small, cached 24h)
   useEffect(() => {
@@ -232,6 +233,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     // Reset previous answer card before either fetch resolves so a stale
     // card never lingers under a new query.
     setAnswer(null);
+    setClassification(null);
 
     // Kick off the natural-language /ask fetch in parallel with the
     // course search. Fire-and-forget — failure or 5xx silently leaves the
@@ -239,8 +241,9 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     // load below).
     fetch(`/api/${state}/ask?q=${encodeURIComponent(searchQuery.trim())}`)
       .then((r) => (r.ok ? r.json() : null))
-      .then((data: { answer: Answer } | null) => {
+      .then((data: { answer: Answer; classification?: ClassificationSummary } | null) => {
         if (data?.answer) setAnswer(data.answer);
+        if (data?.classification) setClassification(data.classification);
       })
       .catch(() => {
         /* silent — no answer card, course results still render */
@@ -481,7 +484,17 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       {/* Natural-language answer card. Renders above course results
           whenever /api/[state]/ask returns a typed answer. NoAnswer
           variants render nothing — the user just sees course results. */}
-      {answer && <AnswerCard answer={answer} state={state} />}
+      {answer && (
+        <AnswerCard
+          answer={answer}
+          state={state}
+          classification={classification}
+          onFollowupClick={(q) => {
+            setQuery(q);
+            doSearch(q);
+          }}
+        />
+      )}
 
       {/* Loading */}
       {loading && (

--- a/components/AnswerCard.tsx
+++ b/components/AnswerCard.tsx
@@ -14,12 +14,20 @@
 
 import type { Answer, SourceCitation } from "@/lib/search-intent/answer";
 
+export interface ClassificationSummary {
+  studentSummary: string;
+  clarifyingQuestion: string | null;
+  suggestedFollowups: string[];
+}
+
 interface AnswerCardProps {
   answer: Answer;
   state: string;
+  classification?: ClassificationSummary | null;
+  onFollowupClick?: (q: string) => void;
 }
 
-export default function AnswerCard({ answer, state }: AnswerCardProps) {
+export default function AnswerCard({ answer, state, classification, onFollowupClick }: AnswerCardProps) {
   // `intent-not-supported` is the one NoAnswer reason we deliberately
   // suppress — it fires for course intents, where the existing course
   // search results below are the answer. Every other NoAnswer carries a
@@ -29,8 +37,19 @@ export default function AnswerCard({ answer, state }: AnswerCardProps) {
   // the question shape but couldn't answer it as-asked.
   if (answer.type === "none") {
     if (answer.reason === "intent-not-supported") return null;
-    return <NoAnswerCard answer={answer} />;
+    return (
+      <NoAnswerCard
+        answer={answer}
+        classification={classification}
+        onFollowupClick={onFollowupClick}
+      />
+    );
   }
+
+  const followups = dedupeFollowups(
+    answer.followups ?? [],
+    classification?.suggestedFollowups ?? [],
+  );
 
   return (
     <div
@@ -41,9 +60,23 @@ export default function AnswerCard({ answer, state }: AnswerCardProps) {
       aria-label="Answer to your question"
     >
       <div className="p-5 space-y-3">
+        {classification?.studentSummary && (
+          <p className="text-xs italic text-slate-500 dark:text-slate-400">
+            {classification.studentSummary}
+          </p>
+        )}
         {answer.type === "transfer" && <TransferBody answer={answer} />}
         {answer.type === "prereqs" && <PrereqsBody answer={answer} state={state} />}
         {answer.type === "eligibility" && <EligibilityBody answer={answer} />}
+        {classification?.clarifyingQuestion && (
+          <ClarifyingPrompt
+            question={classification.clarifyingQuestion}
+            onSearch={onFollowupClick}
+          />
+        )}
+        {followups.length > 0 && (
+          <FollowupPills followups={followups} onFollowupClick={onFollowupClick} />
+        )}
       </div>
       <SourceFooter source={answer.source} />
     </div>
@@ -54,9 +87,18 @@ export default function AnswerCard({ answer, state }: AnswerCardProps) {
 
 function NoAnswerCard({
   answer,
+  classification,
+  onFollowupClick,
 }: {
   answer: Extract<Answer, { type: "none" }>;
+  classification?: ClassificationSummary | null;
+  onFollowupClick?: (q: string) => void;
 }) {
+  const followups = dedupeFollowups(
+    answer.followups ?? [],
+    classification?.suggestedFollowups ?? [],
+  );
+
   // No source citation (NoAnswer has no SourceCitation). Visually softer
   // than typed answers — slate background, no colored accent — to signal
   // "this is a hint, not an authoritative answer."
@@ -85,6 +127,11 @@ function NoAnswerCard({
                 <li key={s}>• {s}</li>
               ))}
             </ul>
+          )}
+          {followups.length > 0 && (
+            <div className="mt-3">
+              <FollowupPills followups={followups} onFollowupClick={onFollowupClick} />
+            </div>
           )}
         </div>
       </div>
@@ -453,6 +500,77 @@ function CoursePill({ course, state }: { course: string; state: string }) {
     >
       {course}
     </a>
+  );
+}
+
+function dedupeFollowups(deterministic: string[], llmSuggested: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const q of [...deterministic, ...llmSuggested]) {
+    const key = q.toLowerCase().trim();
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(q);
+    }
+  }
+  return result;
+}
+
+function ClarifyingPrompt({
+  question,
+  onSearch,
+}: {
+  question: string;
+  onSearch?: (q: string) => void;
+}) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-3 py-2">
+      <span className="mt-0.5 text-amber-600 dark:text-amber-400 text-sm" aria-hidden="true">
+        ?
+      </span>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-amber-800 dark:text-amber-200">{question}</p>
+        {onSearch && (
+          <button
+            onClick={() => onSearch(question)}
+            className="mt-1 text-xs text-amber-700 dark:text-amber-300 underline hover:no-underline"
+          >
+            Search this
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FollowupPills({
+  followups,
+  onFollowupClick,
+}: {
+  followups: string[];
+  onFollowupClick?: (q: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {followups.map((q) =>
+        onFollowupClick ? (
+          <button
+            key={q}
+            onClick={() => onFollowupClick(q)}
+            className="rounded-full border border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800 px-2.5 py-1 text-xs text-slate-700 dark:text-slate-200 hover:border-teal-500 hover:text-teal-700 dark:hover:text-teal-400 transition-colors"
+          >
+            {q}
+          </button>
+        ) : (
+          <span
+            key={q}
+            className="rounded-full border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 px-2.5 py-1 text-xs text-slate-600 dark:text-slate-300"
+          >
+            {q}
+          </span>
+        ),
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Exports `ClassificationSummary` from `AnswerCard` as the narrow UI contract (3 fields: `studentSummary`, `clarifyingQuestion`, `suggestedFollowups`)
- Renders `studentSummary` as a small italic subtitle above the main answer body, giving first-gen students plain-English confirmation of what we understood
- Shows `ClarifyingPrompt` (amber box with "Search this" shortcut) when the LLM returns a clarifying question
- Adds `FollowupPills` at the bottom of typed answers and NoAnswer cards — deterministic follow-ups (PR D) listed first, then LLM-suggested (PR B), deduped by normalized lowercase key
- Clicking a pill in `CourseSearchClient` replaces the search query and fires a new search instantly

## Depends on
- PR B (#195) — classifier enrichment fields (`studentSummary`, `clarifyingQuestion`, `suggestedFollowups`)
- PR D (#196) — deterministic `followups` field on answer types

## Test plan
- [ ] All 294 tests pass (`npx vitest run --exclude="**/classify-gemini*"`)
- [ ] TypeScript clean (only pre-existing gemini stash errors)
- [ ] Search for a transfer question (e.g. "does ENG 111 transfer to GMU") — confirm student summary + follow-up pills render
- [ ] Click a follow-up pill — confirm query updates and new search fires
- [ ] Search an unknown query — confirm NoAnswer card shows follow-up pills
- [ ] Search a course code — confirm AnswerCard stays hidden (intent-not-supported suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)