### PR TITLE
search-intent: drive course search with LLM-extracted entities

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -235,22 +235,45 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     setAnswer(null);
     setClassification(null);
 
-    // Kick off the natural-language /ask fetch in parallel with the
-    // course search. Fire-and-forget — failure or 5xx silently leaves the
-    // answer card unrendered (graceful degradation; course results still
-    // load below).
-    fetch(`/api/${state}/ask?q=${encodeURIComponent(searchQuery.trim())}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data: { answer: Answer; classification?: ClassificationSummary } | null) => {
-        if (data?.answer) setAnswer(data.answer);
-        if (data?.classification) setClassification(data.classification);
-      })
-      .catch(() => {
-        /* silent — no answer card, course results still render */
-      });
+    const trimmed = searchQuery.trim();
+    // The user query may be natural language ("is ENG 111 offered this
+    // semester?"). The keyword course-search can't parse that — it would
+    // try to match the whole sentence against course titles and return 0
+    // results. So we await the LLM classifier first; if it extracted a
+    // course code, we use that to drive the course search instead of the
+    // raw query. Falls back to the raw query if /ask fails or returns
+    // nothing extractable. The /ask endpoint is rate-limited and cached,
+    // so the latency hit is small for repeat queries.
+    let searchQ = trimmed;
+    try {
+      const askRes = await fetch(
+        `/api/${state}/ask?q=${encodeURIComponent(trimmed)}`,
+      );
+      if (askRes.ok) {
+        const askData: {
+          answer?: Answer;
+          classification?: ClassificationSummary & {
+            intent?: {
+              type: string;
+              filters?: { course?: { prefix: string; number: string } | null };
+            };
+          };
+        } | null = await askRes.json();
+        if (askData?.answer) setAnswer(askData.answer);
+        if (askData?.classification) setClassification(askData.classification);
+
+        // If the LLM extracted a course code, prefer that over the raw query.
+        const intent = askData?.classification?.intent;
+        if (intent?.type === "course" && intent.filters?.course) {
+          searchQ = `${intent.filters.course.prefix} ${intent.filters.course.number}`;
+        }
+      }
+    } catch {
+      /* silent — no answer card, fall through to raw-query search below */
+    }
 
     try {
-      const params = new URLSearchParams({ q: searchQuery.trim(), limit: "50" });
+      const params = new URLSearchParams({ q: searchQ, limit: "50" });
       if (zip) params.set("zip", zip);
       if (mode) params.set("mode", mode);
       if (days.length > 0) params.set("days", days.join(","));

--- a/components/AnswerCard.tsx
+++ b/components/AnswerCard.tsx
@@ -28,15 +28,20 @@ interface AnswerCardProps {
 }
 
 export default function AnswerCard({ answer, state, classification, onFollowupClick }: AnswerCardProps) {
-  // `intent-not-supported` is the one NoAnswer reason we deliberately
-  // suppress — it fires for course intents, where the existing course
-  // search results below are the answer. Every other NoAnswer carries a
-  // helpful message the user should see ("Which course are you asking
-  // about?", "I'm not sure what you're asking", etc.). Render those as
-  // a quieter info card so the user gets feedback that we understood
-  // the question shape but couldn't answer it as-asked.
+  // `intent-not-supported` fires for course intents, where the course
+  // search results below are the actual answer. We don't render the full
+  // typed-answer card, but we DO surface the LLM's studentSummary so the
+  // user sees what we understood ("You're asking about ENG 111") — without
+  // it, a natural-language query like "is ENG 111 offered?" looks like it
+  // was ignored. Every other NoAnswer carries a helpful message the user
+  // should see — render those as a quieter info card.
   if (answer.type === "none") {
-    if (answer.reason === "intent-not-supported") return null;
+    if (answer.reason === "intent-not-supported") {
+      if (classification?.studentSummary) {
+        return <CourseSummaryCard summary={classification.studentSummary} />;
+      }
+      return null;
+    }
     return (
       <NoAnswerCard
         answer={answer}
@@ -79,6 +84,30 @@ export default function AnswerCard({ answer, state, classification, onFollowupCl
         )}
       </div>
       <SourceFooter source={answer.source} />
+    </div>
+  );
+}
+
+// ─── Course confirmation (slim card for course intents) ────────────────
+//
+// When the LLM classifies a query as a course search, we don't render a
+// typed answer (the course results below are the answer). But we do echo
+// back what we understood so the user gets feedback on natural-language
+// queries like "is ENG 111 offered this semester?" — without it, the
+// studentSummary work would be invisible for the most common intent.
+
+function CourseSummaryCard({ summary }: { summary: string }) {
+  return (
+    <div
+      className="mb-4 px-4 py-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40"
+      data-testid="answer-card"
+      role="region"
+      aria-live="polite"
+      aria-label="What we understood"
+    >
+      <p className="text-sm italic text-slate-600 dark:text-slate-300">
+        {summary}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Searching "is ENG 111 offered this semester?" on `/ny/courses` returned **0 results** — even though `/api/ny/courses/search?q=ENG+111` returns 2 sections at 2 colleges.

Root cause: `/ask` and `/courses/search` ran in parallel with the same raw query. The LLM extracted `{ prefix: "ENG", number: "111" }` correctly, but that extraction was thrown away. The keyword search then tried to match "is ENG 111 offered this semester?" against course titles → nothing matched.

Plus the user got zero feedback. Since `course` intent returns `intent-not-supported` (suppressed in the UI), the LLM's `studentSummary` ("You're asking whether ENG 111 is being offered") was never rendered. The query looked ignored.

## Fix

**1. Use the LLM's extraction.** `CourseSearchClient.doSearch` now awaits `/ask` first. If the classifier returns a course intent with an extracted course code, that code drives the search query. Falls back to the raw query if /ask fails or returns nothing extractable.

**2. Show what we understood.** New `CourseSummaryCard` renders the studentSummary as a slim italic card for course intents — so the user sees confirmation that we parsed their natural-language query.

## Test plan

- [ ] 301 tests pass, typecheck clean
- [ ] After merge, `/ny/courses` search "is ENG 111 offered this semester?" returns ENG 111 results + a "You're asking..." card
- [ ] Plain "ENG 111" still works (raw query == extracted query, no re-fetch)
- [ ] Natural-language transfer/prereqs queries still hit their answer cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)