### PR TITLE
search-intent: use all LLM-extracted entities for course search

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -88,6 +88,27 @@ function formatSchedule(s: SectionResult): string {
   return "Asynchronous / Online";
 }
 
+// The LLM emits compact single-letter day codes per the classifier prompt
+// ("T" for Tuesday, "R" for Thursday, "S"/"U" for weekend). The UI/API use
+// 2-char codes ("Tu", "Th", "Sa", "Su"). Map between them when applying
+// LLM-extracted day filters; otherwise a query like "tuesday classes"
+// silently filters to nothing because "T" doesn't match any section's "Tu".
+const LLM_TO_UI_DAY: Record<string, string> = {
+  M: "M",
+  T: "Tu",
+  W: "W",
+  R: "Th",
+  F: "F",
+  S: "Sa",
+  U: "Su",
+};
+
+function mapLLMDays(llmDays: string[]): string[] {
+  return llmDays
+    .map((d) => LLM_TO_UI_DAY[d] ?? d)
+    .filter((d, i, arr) => arr.indexOf(d) === i);
+}
+
 function buildCourseUrl(slug: string, s: SectionResult, courseUrlMap?: Record<string, string>): string {
   if (!courseUrlMap?.[slug]) return "";
   return courseUrlMap[slug]
@@ -236,15 +257,18 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     setClassification(null);
 
     const trimmed = searchQuery.trim();
-    // The user query may be natural language ("is ENG 111 offered this
-    // semester?"). The keyword course-search can't parse that — it would
+    // The user query may be natural language ("Computer Science classes on
+    // wednesday"). The keyword course-search can't parse that — it would
     // try to match the whole sentence against course titles and return 0
-    // results. So we await the LLM classifier first; if it extracted a
-    // course code, we use that to drive the course search instead of the
-    // raw query. Falls back to the raw query if /ask fails or returns
-    // nothing extractable. The /ask endpoint is rate-limited and cached,
-    // so the latency hit is small for repeat queries.
+    // results. We await the LLM classifier first and use its extracted
+    // entities (course code, keyword, days, mode, timeOfDay) to drive the
+    // search. Falls back to the raw query when /ask fails or extracts
+    // nothing useful. /ask is rate-limited and cached, so the latency hit
+    // is small for repeat queries.
     let searchQ = trimmed;
+    let llmDays: string[] | null = null;
+    let llmMode: string | null = null;
+    let llmTimeOfDay: string | null = null;
     try {
       const askRes = await fetch(
         `/api/${state}/ask?q=${encodeURIComponent(trimmed)}`,
@@ -255,29 +279,56 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
           classification?: ClassificationSummary & {
             intent?: {
               type: string;
-              filters?: { course?: { prefix: string; number: string } | null };
+              keyword?: string | null;
+              filters?: {
+                course?: { prefix: string; number: string } | null;
+                days?: string[] | null;
+                mode?: string | null;
+                timeOfDay?: string | null;
+              };
             };
           };
         } | null = await askRes.json();
         if (askData?.answer) setAnswer(askData.answer);
         if (askData?.classification) setClassification(askData.classification);
 
-        // If the LLM extracted a course code, prefer that over the raw query.
         const intent = askData?.classification?.intent;
-        if (intent?.type === "course" && intent.filters?.course) {
-          searchQ = `${intent.filters.course.prefix} ${intent.filters.course.number}`;
+        if (intent?.type === "course") {
+          // Refine q: course code beats keyword beats raw query.
+          if (intent.filters?.course) {
+            searchQ = `${intent.filters.course.prefix} ${intent.filters.course.number}`;
+          } else if (intent.keyword) {
+            searchQ = intent.keyword;
+          }
+          // Capture filter extractions; we apply them below only if the user
+          // hasn't already set the corresponding filter manually (UI wins).
+          if (intent.filters?.days?.length) {
+            llmDays = mapLLMDays(intent.filters.days);
+          }
+          if (intent.filters?.mode) llmMode = intent.filters.mode;
+          if (intent.filters?.timeOfDay) llmTimeOfDay = intent.filters.timeOfDay;
         }
       }
     } catch {
       /* silent — no answer card, fall through to raw-query search below */
     }
 
+    // Sync LLM-extracted filters into UI state when the user hasn't set
+    // them, so the active filters are visible in the toggle/dropdowns and
+    // the user can clear or adjust them. User-set filters take precedence.
+    const effectiveDays = days.length > 0 ? days : (llmDays ?? []);
+    const effectiveMode = mode || llmMode || "";
+    const effectiveTimeOfDay = timeOfDay || llmTimeOfDay || "";
+    if (llmDays && days.length === 0) setDays(effectiveDays);
+    if (llmMode && !mode) setMode(effectiveMode);
+    if (llmTimeOfDay && !timeOfDay) setTimeOfDay(effectiveTimeOfDay);
+
     try {
       const params = new URLSearchParams({ q: searchQ, limit: "50" });
       if (zip) params.set("zip", zip);
-      if (mode) params.set("mode", mode);
-      if (days.length > 0) params.set("days", days.join(","));
-      if (timeOfDay) params.set("timeOfDay", timeOfDay);
+      if (effectiveMode) params.set("mode", effectiveMode);
+      if (effectiveDays.length > 0) params.set("days", effectiveDays.join(","));
+      if (effectiveTimeOfDay) params.set("timeOfDay", effectiveTimeOfDay);
 
       const res = await fetch(`/api/${state}/courses/search?${params}`);
       if (!res.ok) {

--- a/components/AnswerCard.tsx
+++ b/components/AnswerCard.tsx
@@ -38,7 +38,13 @@ export default function AnswerCard({ answer, state, classification, onFollowupCl
   if (answer.type === "none") {
     if (answer.reason === "intent-not-supported") {
       if (classification?.studentSummary) {
-        return <CourseSummaryCard summary={classification.studentSummary} />;
+        return (
+          <CourseSummaryCard
+            summary={classification.studentSummary}
+            followups={classification.suggestedFollowups ?? []}
+            onFollowupClick={onFollowupClick}
+          />
+        );
       }
       return null;
     }
@@ -96,10 +102,18 @@ export default function AnswerCard({ answer, state, classification, onFollowupCl
 // queries like "is ENG 111 offered this semester?" — without it, the
 // studentSummary work would be invisible for the most common intent.
 
-function CourseSummaryCard({ summary }: { summary: string }) {
+function CourseSummaryCard({
+  summary,
+  followups,
+  onFollowupClick,
+}: {
+  summary: string;
+  followups: string[];
+  onFollowupClick?: (q: string) => void;
+}) {
   return (
     <div
-      className="mb-4 px-4 py-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40"
+      className="mb-4 px-4 py-2 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 space-y-2"
       data-testid="answer-card"
       role="region"
       aria-live="polite"
@@ -108,6 +122,9 @@ function CourseSummaryCard({ summary }: { summary: string }) {
       <p className="text-sm italic text-slate-600 dark:text-slate-300">
         {summary}
       </p>
+      {followups.length > 0 && (
+        <FollowupPills followups={followups} onFollowupClick={onFollowupClick} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

"are there any Computer Science courses taking place on wednesday?" returned 0 results. The classifier extracted `keyword="computer science"` and `filters.days=["W"]` correctly, but PR #200 only handled `filters.course` — keyword and days were silently dropped.

Verified manually: `/api/va/courses/search?q=Computer+Science&days=W` returns 1 course / 3 sections. The data is there; we just weren't using the extracted entities.

## Fixes (1–4 of the failure-mode list)

**1. Use all extracted entities.** Search query priority is now: course code → keyword → raw query. Days, mode, and timeOfDay from the LLM apply when the user hasn't manually set the corresponding filter.

**2. Sync filter UI state from LLM extraction.** Day toggle, Mode dropdown, and Time selector now reflect what's actually filtering results, so users can see and adjust LLM-applied filters. User-set filters take precedence.

**3. Map LLM day codes to UI/API codes.** The classifier prompt emits `T, R, S, U` (per `types.ts`) but DayToggle and the search API use `Tu, Th, Sa, Su`. Without the mapping, "tuesday classes" silently filtered to nothing.

**4. Raw-query fallback** when course intent has no course code and no keyword.

## Also fixes

The `CourseSummaryCard` was missing follow-up pills — the second commit of PR #200 was dropped during squash-merge. Restored.

## Test plan

- [x] 301 tests pass, typecheck clean
- [ ] After merge, `/va/courses` "are there any Computer Science courses taking place on wednesday?" → CSC 110 sections returned, Day toggle shows Wed lit
- [ ] "evening English classes" → Time dropdown shows Evening, ENG sections returned
- [ ] Plain "ENG 111" still works (no LLM-extracted filters; UI state untouched)
- [ ] User-set filters not overridden by LLM extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)