### PR TITLE
search-intent: ground classifier with state's actual subject prefixes (F)

### DIFF
--- a/lib/search-intent/__tests__/classify-llm.test.ts
+++ b/lib/search-intent/__tests__/classify-llm.test.ts
@@ -1,4 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
+
+// State-context lookups for the classifier hit Supabase in production. Tests
+// run with a dummy Supabase URL, so the real calls hang. Stub them at module
+// boundary — these helpers don't change classifier output, only the prompt
+// grounding (which the fakeClient ignores).
+vi.mock("../../courses", () => ({
+  getDistinctSubjects: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("../../terms", () => ({
+  getCurrentTerm: vi.fn().mockResolvedValue("2026SP"),
+}));
+
 import { llmClassifier, toClassifiedIntent } from "../classify-llm";
 import type { ClassifierToolInput } from "../prompt";
 

--- a/lib/search-intent/classify-llm.ts
+++ b/lib/search-intent/classify-llm.ts
@@ -11,10 +11,13 @@ import {
   CLASSIFIER_MODEL,
   CLASSIFY_TOOL,
   SYSTEM_PROMPT,
+  buildSubjectPrefixBlock,
   buildUniversityBlock,
   type ClassifierToolInput,
 } from "./prompt";
 import { getStateConfig } from "../states/registry";
+import { getDistinctSubjects } from "../courses";
+import { getCurrentTerm } from "../terms";
 import type { Classifier, ClassifiedIntent, SearchIntent } from "./types";
 
 export interface LlmClassifierOptions {
@@ -45,7 +48,25 @@ export function llmClassifier(opts: LlmClassifierOptions = {}): Classifier {
       ? `\n\nUniversity aliases for ${stateName}:\n${buildUniversityBlock(aliases)}`
       : "";
 
-    const userMessage = `[State: ${stateName}]${aliasBlock}\n\n${query}`;
+    // Inject the state's actual subject prefixes so the LLM picks the right
+    // course-code prefix (VA uses PSY/MTH, ME uses ENGL/MATH, etc.) rather
+    // than defaulting to its own normalization. Both calls are cached
+    // (currentTerm + distinctSubjects) so the cost is one-time per state.
+    // If either lookup fails (no data, scraper hasn't run yet), we silently
+    // omit the prefix block — the classifier still works, just without the
+    // state-specific grounding.
+    let prefixBlock = "";
+    try {
+      const term = await getCurrentTerm(state);
+      const prefixes = await getDistinctSubjects(term, state);
+      if (prefixes.length > 0) {
+        prefixBlock = `\n\nSubject prefixes used in ${stateName}:\n${buildSubjectPrefixBlock(prefixes)}`;
+      }
+    } catch {
+      /* state data unavailable — fall through without prefix grounding */
+    }
+
+    const userMessage = `[State: ${stateName}]${aliasBlock}${prefixBlock}\n\n${query}`;
 
     const response = await client.messages.create({
       model,

--- a/lib/search-intent/prompt.ts
+++ b/lib/search-intent/prompt.ts
@@ -40,7 +40,7 @@ Intent types:
 
 Entity-extraction rules:
 
-- Course codes: extract prefix (uppercase, e.g. "ENG", "ENGL", "MATH") and number ("111", "1001"). Handle typos and missing spaces ("eng111", "psy200" → ENG 111, PSY 200). Subject aliases: "math" → "MATH", "psych"/"psychology" → "PSYC" or "PSY" (use whichever is more common).
+- Course codes: extract prefix (uppercase, e.g. "ENG", "ENGL", "MATH") and number ("111", "1001"). Handle typos and missing spaces ("eng111", "psy200" → ENG 111, PSY 200). The user message includes a "Subject prefixes used in <state>" list — when extracting a prefix, ALWAYS pick from that list. Different states use different conventions (VA uses MTH and PSY, NY uses MATH and may have both PSY and PSYC, ME uses ENGL). If the user's subject is ambiguous, prefer the prefix that appears in the state's list. If no list is provided, default to the most common form.
 - University names: use the alias table provided in the user message to resolve names and abbreviations to slugs. For universities not in the alias table, lowercase and hyphenate: "Smith College" → "smith". If the alias is ambiguous (e.g. multi-campus system with no campus specified), use the slug and lower your confidence.
 - Age: parse numeric age from "65+", "60", "I'm 65", etc.
 - Days: "weekend" → ["S", "U"]; "MWF" → ["M", "W", "F"]; "TR" or "Tu/Th" → ["T", "R"].
@@ -74,6 +74,17 @@ export function buildUniversityBlock(
   return aliases
     .map((a) => `- ${a.names.map((n) => `"${n}"`).join(" or ")} → "${a.slug}"`)
     .join("\n");
+}
+
+/**
+ * Format a state's distinct subject prefixes for injection into the user
+ * message. The classifier uses this list to pick the correct course-code
+ * prefix for the state — VA uses PSY/MTH, ME uses ENGL/MATH, NY may have
+ * both PSY and PSYC, etc. Without this, the LLM defaults to its own
+ * normalization (PSYC, MATH) which often doesn't match the data.
+ */
+export function buildSubjectPrefixBlock(prefixes: string[]): string {
+  return prefixes.join(", ");
 }
 
 // JSON-schema input for the classify_intent tool. Flat structure — fields


### PR DESCRIPTION
## Problem

Subject prefix conventions vary wildly across states:

| Subject | States and prefixes |
|---|---|
| Math | VA: `MTH` · NY/RI/ME/DC/NH: `MATH` |
| English | VA/MA/NC: `ENG` · RI/DC/ME/NH: `ENGL` · ME has both |
| CS | VA/MA: `CSC` · TN: `CISP` · ME: `CSCI` · NH: `CIS` and `CSCN` |
| Psych | VA/MA/NC: `PSY` · GA: `PSYC` · NY/MD: both |

The LLM previously defaulted to its own normalization (PSYC, MATH, ENGL), which often didn't match the data. Verified: "psych 200" on `/va/courses` returned 0 results — LLM extracted `PSYC 200` but VA's data only has `PSY 200`.

## Fix

Inject the state's actual distinct subject prefixes into the user message, alongside the existing university alias block. The LLM picks from the real list. Same pattern as the proven university-alias injection.

```
[State: Virginia]

University aliases for Virginia:
- "George Mason University" or "GMU" → "gmu"
- ...

Subject prefixes used in Virginia:
ACC, ACQ, ADJ, AGR, AIR, AMT, ARA, ART, ASL, AST, ..., PSY, ..., WEL

does psych 200 transfer to UVA?
```

## Why this is the right fix

- **State-agnostic** — generalizes to all 17 covered states + any future state. Zero per-state alias maps to maintain.
- **Data-driven** — the actual data is the source of truth. As scrapers update, the prefix list updates.
- **Cheap** — both lookups (`getCurrentTerm`, `getDistinctSubjects`) are already cached. Cost is one Supabase trip per state per cache lifetime.
- **Resilient** — wrapped in try/catch; if state data is unavailable (new state, scraper hasn't run), the classifier silently falls through without prefix grounding.
- **Token cost** — ~125 tokens per call. Negligible at Haiku 4.5 rates.

## Test plan

- [x] 301 tests pass (mocked `getDistinctSubjects` and `getCurrentTerm` in classifier tests)
- [ ] After merge: `/va/courses` "psych 200" → returns PSY 200 sections
- [ ] After merge: `/ga/courses` "psych 200" → returns PSYC 200 sections (GA uses PSYC)
- [ ] After merge: `/me/courses` "english 101" → LLM picks ENG vs ENGL based on what exists for that course number

🤖 Generated with [Claude Code](https://claude.com/claude-code)