### PR TITLE
search-intent: honor LLM-extracted term in course search (E, Path A)

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import type { CourseMode } from "@/lib/types";
 import type { Answer } from "@/lib/search-intent/answer";
 import { expandDays } from "@/lib/time-utils";
+import { termCodeFromLabel } from "@/lib/term-label";
 import DayToggle from "@/components/DayToggle";
 import PrereqChain from "@/components/PrereqChain";
 import AnswerCard, { type ClassificationSummary } from "@/components/AnswerCard";
@@ -270,6 +271,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     let llmMode: string | null = null;
     let llmTimeOfDay: string | null = null;
     let llmTransferTo: string | null = null;
+    let llmTermCode: string | null = null;
     try {
       const askRes = await fetch(
         `/api/${state}/ask?q=${encodeURIComponent(trimmed)}`,
@@ -288,6 +290,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
                 days?: string[] | null;
                 mode?: string | null;
                 timeOfDay?: string | null;
+                term?: string | null;
               };
             };
           };
@@ -310,6 +313,12 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
           }
           if (intent.filters?.mode) llmMode = intent.filters.mode;
           if (intent.filters?.timeOfDay) llmTimeOfDay = intent.filters.timeOfDay;
+          // LLM emits term as a label ("Fall 2026"); search API expects the
+          // code ("2026FA"). Skip mapping if the label is malformed — backend
+          // also validates against actual available terms before applying.
+          if (intent.filters?.term) {
+            llmTermCode = termCodeFromLabel(intent.filters.term);
+          }
         } else if (intent?.type === "transfer") {
           // Transfer intent fires the AnswerCard above, but the course
           // search below still runs. Use the extracted course code and
@@ -344,6 +353,10 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       if (effectiveMode) params.set("mode", effectiveMode);
       if (effectiveDays.length > 0) params.set("days", effectiveDays.join(","));
       if (effectiveTimeOfDay) params.set("timeOfDay", effectiveTimeOfDay);
+      // No UI for term yet (Path A): LLM-extracted only. Backend validates
+      // the code against the state's actual terms and falls back to current
+      // when invalid, so no user-set "term" state to merge with.
+      if (llmTermCode) params.set("term", llmTermCode);
 
       const res = await fetch(`/api/${state}/courses/search?${params}`);
       if (!res.ok) {

--- a/app/api/[state]/courses/search/route.ts
+++ b/app/api/[state]/courses/search/route.ts
@@ -4,6 +4,7 @@ import { rateLimit, getClientKey } from "@/lib/rate-limit";
 import { loadInstitutions } from "@/lib/institutions";
 import { isValidState } from "@/lib/states/registry";
 import { getCurrentTerm } from "@/lib/terms";
+import { getAvailableTerms } from "@/lib/courses";
 
 type RouteContext = { params: Promise<{ state: string }> };
 
@@ -51,8 +52,21 @@ export async function GET(request: NextRequest, context: RouteContext) {
     );
   }
 
+  // Optional ?term=2026FA — validate against the state's actual term list
+  // (cached) and ignore unknown values so a stale or hand-typed code doesn't
+  // produce empty results without explanation. Default to current term when
+  // omitted, preserving existing behavior.
+  const termParam = searchParams.get("term")?.trim();
+  let term: string;
+  if (termParam) {
+    const available = await getAvailableTerms(state);
+    term = available.includes(termParam) ? termParam : await getCurrentTerm(state);
+  } else {
+    term = await getCurrentTerm(state);
+  }
+
   const results = await searchCoursesAcrossColleges(
-    await getCurrentTerm(state),
+    term,
     q,
     institutions,
     { mode, days, timeOfDay, zip },

--- a/lib/__tests__/term-label.test.ts
+++ b/lib/__tests__/term-label.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { termCodeFromLabel, termLabel } from "../term-label";
+
+describe("termCodeFromLabel", () => {
+  it("converts each season label to the right code", () => {
+    expect(termCodeFromLabel("Spring 2026")).toBe("2026SP");
+    expect(termCodeFromLabel("Summer 2026")).toBe("2026SU");
+    expect(termCodeFromLabel("Fall 2026")).toBe("2026FA");
+  });
+
+  it("is case-insensitive and tolerant of whitespace", () => {
+    expect(termCodeFromLabel("fall 2026")).toBe("2026FA");
+    expect(termCodeFromLabel("  FALL 2026  ")).toBe("2026FA");
+  });
+
+  it("returns null for malformed input rather than guessing", () => {
+    expect(termCodeFromLabel("Fall")).toBeNull();
+    expect(termCodeFromLabel("Winter 2026")).toBeNull();
+    expect(termCodeFromLabel("2026")).toBeNull();
+    expect(termCodeFromLabel("")).toBeNull();
+  });
+
+  it("round-trips with termLabel", () => {
+    for (const code of ["2026SP", "2026SU", "2026FA", "2027SP"]) {
+      expect(termCodeFromLabel(termLabel(code))).toBe(code);
+    }
+  });
+});

--- a/lib/term-label.ts
+++ b/lib/term-label.ts
@@ -17,6 +17,24 @@ export function termLabel(code: string): string {
 }
 
 /**
+ * Inverse of termLabel: convert a human label like "Fall 2026" or
+ * "Summer 2026" into the term code ("2026FA", "2026SU"). Returns null
+ * if the input doesn't match the expected shape — callers should fall
+ * back to the default (current) term in that case rather than guess.
+ *
+ * Used to translate LLM-extracted term strings (which come out as
+ * labels per the classifier prompt) into backend-compatible codes.
+ */
+export function termCodeFromLabel(label: string): string | null {
+  const m = label.trim().match(/^(spring|summer|fall)\s+(\d{4})$/i);
+  if (!m) return null;
+  const season = m[1].toLowerCase();
+  const year = m[2];
+  const code = season === "spring" ? "SP" : season === "summer" ? "SU" : "FA";
+  return `${year}${code}`;
+}
+
+/**
  * Sort key for term codes — later terms sort higher.
  * "2026SP" → 20261, "2026SU" → 20262, "2026FA" → 20263
  */


### PR DESCRIPTION
## What this is

**Path A — minimal, no UI surface.** Stops the LLM-extracted term from being silently dropped. Path B (term dropdown, multi-term, etc.) deferred until there's real demand — see #203 thread for the analysis.

## Changes

- **`lib/term-label.ts`** — new `termCodeFromLabel("Fall 2026") → "2026FA"` inverse mapper. Returns null for malformed labels (backend falls back to current term).
- **`/api/[state]/courses/search`** — accepts `?term=2026FA`. Validates against `getAvailableTerms(state)` (cached). Unknown values fall back to current term, so a stale or hand-typed code doesn't produce an unexplained empty result. Default behavior unchanged.
- **`CourseSearchClient`** — when classifier returns `CourseIntent.filters.term`, maps label→code and passes through. No new UI surface.
- **Tests** — 4 new cases for the round-trip (`Fall 2026` ↔ `2026FA`, case-insensitive, malformed → null).

## What's intentionally NOT in this PR

- No Term dropdown in the UI
- No `/api/[state]/terms` endpoint
- No multi-term selection
- No "no Fall 2026 data yet" empty state

These are Path B and need product decisions before code.

## Test plan

- [x] 305 tests pass (was 301 + 4 new for `termCodeFromLabel`)
- [ ] After merge: "ENG 111 Fall 2026" on `/va/courses` → searches the 2026FA term
- [ ] "ENG 111 fall 2099" → invalid term, falls back to current term silently
- [ ] Plain "ENG 111" → behavior unchanged (current term)

🤖 Generated with [Claude Code](https://claude.com/claude-code)