### PR TITLE
search-intent: support multi-intent classification end-to-end (H)

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -223,6 +223,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
   // parallel with the course search; null until a query has resolved or
   // when the classifier returned a non-actionable intent.
   const [answer, setAnswer] = useState<Answer | null>(null);
+  const [secondaryAnswer, setSecondaryAnswer] = useState<Answer | null>(null);
   const [classification, setClassification] = useState<ClassificationSummary | null>(null);
 
   // Fetch transfer lookup data on mount (small, cached 24h)
@@ -255,6 +256,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
     // Reset previous answer card before either fetch resolves so a stale
     // card never lingers under a new query.
     setAnswer(null);
+    setSecondaryAnswer(null);
     setClassification(null);
 
     const trimmed = searchQuery.trim();
@@ -279,6 +281,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
       if (askRes.ok) {
         const askData: {
           answer?: Answer;
+          secondaryAnswer?: Answer;
           classification?: ClassificationSummary & {
             intent?: {
               type: string;
@@ -296,6 +299,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
           };
         } | null = await askRes.json();
         if (askData?.answer) setAnswer(askData.answer);
+        if (askData?.secondaryAnswer) setSecondaryAnswer(askData.secondaryAnswer);
         if (askData?.classification) setClassification(askData.classification);
 
         const intent = askData?.classification?.intent;
@@ -583,14 +587,29 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
         </div>
       )}
 
-      {/* Natural-language answer card. Renders above course results
-          whenever /api/[state]/ask returns a typed answer. NoAnswer
-          variants render nothing — the user just sees course results. */}
+      {/* Natural-language answer cards. The primary card carries the LLM's
+          studentSummary + clarifying question + suggested follow-ups (which
+          describe the WHOLE query). The secondary card, when present for
+          multi-intent queries like "prereqs for ENG 111 and does it
+          transfer to GMU?", renders just its typed answer body — passing
+          classification={null} naturally suppresses the duplicate summary
+          UI on the second card. */}
       {answer && (
         <AnswerCard
           answer={answer}
           state={state}
           classification={classification}
+          onFollowupClick={(q) => {
+            setQuery(q);
+            doSearch(q);
+          }}
+        />
+      )}
+      {secondaryAnswer && (
+        <AnswerCard
+          answer={secondaryAnswer}
+          state={state}
+          classification={null}
           onFollowupClick={(q) => {
             setQuery(q);
             doSearch(q);

--- a/app/api/[state]/ask/route.ts
+++ b/app/api/[state]/ask/route.ts
@@ -23,7 +23,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { isValidState } from "@/lib/states/registry";
 import { rateLimit, getClientKey } from "@/lib/rate-limit";
 import { classifyQuery } from "@/lib/search-intent/classify";
-import { lookupAnswer } from "@/lib/search-intent/answer";
+import { lookupAnswers } from "@/lib/search-intent/answer";
 
 type RouteContext = { params: Promise<{ state: string }> };
 
@@ -86,10 +86,13 @@ export async function GET(request: NextRequest, context: RouteContext) {
     );
   }
 
-  const answer = await lookupAnswer(classification.intent, state);
+  const { primary: answer, secondary: secondaryAnswer } = await lookupAnswers(
+    classification,
+    state,
+  );
 
   return NextResponse.json(
-    { classification, answer },
+    { classification, answer, secondaryAnswer },
     {
       headers: {
         // Same query → same answer until data updates. Browser holds 5

--- a/app/api/__tests__/ask.route.test.ts
+++ b/app/api/__tests__/ask.route.test.ts
@@ -11,16 +11,18 @@ vi.mock("@/lib/search-intent/classify", () => ({
 }));
 vi.mock("@/lib/search-intent/answer", () => ({
   lookupAnswer: vi.fn(),
+  lookupAnswers: vi.fn(),
 }));
 
 import { GET } from "../[state]/ask/route";
 import { rateLimit } from "@/lib/rate-limit";
 import { classifyQuery } from "@/lib/search-intent/classify";
-import { lookupAnswer } from "@/lib/search-intent/answer";
+import { lookupAnswer, lookupAnswers } from "@/lib/search-intent/answer";
 
 const rateLimitMock = vi.mocked(rateLimit);
 const classifyMock = vi.mocked(classifyQuery);
 const lookupAnswerMock = vi.mocked(lookupAnswer);
+const lookupAnswersMock = vi.mocked(lookupAnswers);
 
 function makeRequest(state: string, query: Record<string, string>): {
   req: NextRequest;
@@ -39,6 +41,7 @@ beforeEach(() => {
   rateLimitMock.mockReturnValue({ allowed: true, remaining: 99 });
   classifyMock.mockReset();
   lookupAnswerMock.mockReset();
+  lookupAnswersMock.mockReset();
 });
 
 describe("GET /api/[state]/ask", () => {
@@ -86,6 +89,7 @@ describe("GET /api/[state]/ask", () => {
         course: { prefix: "ENG", number: "111" },
         university: "gmu",
       },
+      secondaryIntent: null,
       confidence: 0.95,
       reasoning: "test",
       studentSummary: "You're asking whether ENG 111 transfers to George Mason.",
@@ -113,7 +117,7 @@ describe("GET /api/[state]/ask", () => {
       },
     };
     classifyMock.mockResolvedValue(classification);
-    lookupAnswerMock.mockResolvedValue(answer);
+    lookupAnswersMock.mockResolvedValue({ primary: answer });
 
     const { req, ctx } = makeRequest("va", { q: "Does ENG 111 transfer to GMU?" });
     const res = await GET(req, ctx);
@@ -122,26 +126,23 @@ describe("GET /api/[state]/ask", () => {
     expect(body).toEqual({ classification, answer });
   });
 
-  it("passes the user's state into lookupAnswer (not a hardcoded one)", async () => {
-    classifyMock.mockResolvedValue({
-      intent: { type: "unknown", raw: "x" },
+  it("passes the user's state into lookupAnswers (not a hardcoded one)", async () => {
+    const classification = {
+      intent: { type: "unknown" as const, raw: "x" },
+      secondaryIntent: null,
       confidence: 0.1,
       studentSummary: "test",
       clarifyingQuestion: null,
       sourceCollege: null,
       suggestedFollowups: [],
-    });
-    lookupAnswerMock.mockResolvedValue({
-      type: "none",
-      reason: "out-of-scope",
-      message: "x",
+    };
+    classifyMock.mockResolvedValue(classification);
+    lookupAnswersMock.mockResolvedValue({
+      primary: { type: "none", reason: "out-of-scope", message: "x" },
     });
     const { req, ctx } = makeRequest("nc", { q: "asdf" });
     await GET(req, ctx);
-    expect(lookupAnswerMock).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "unknown" }),
-      "nc",
-    );
+    expect(lookupAnswersMock).toHaveBeenCalledWith(classification, "nc");
   });
 
   it("returns 503 when the classifier throws", async () => {
@@ -152,22 +153,21 @@ describe("GET /api/[state]/ask", () => {
     const body = await res.json();
     expect(body.error).toMatch(/Classifier service unavailable/);
     expect(body.cause).toBe("Anthropic API down");
-    expect(lookupAnswerMock).not.toHaveBeenCalled();
+    expect(lookupAnswersMock).not.toHaveBeenCalled();
   });
 
   it("sets Cache-Control + X-RateLimit-Remaining headers on 200 responses", async () => {
     classifyMock.mockResolvedValue({
       intent: { type: "unknown", raw: "x" },
+      secondaryIntent: null,
       confidence: 0.1,
       studentSummary: "test",
       clarifyingQuestion: null,
       sourceCollege: null,
       suggestedFollowups: [],
     });
-    lookupAnswerMock.mockResolvedValue({
-      type: "none",
-      reason: "out-of-scope",
-      message: "x",
+    lookupAnswersMock.mockResolvedValue({
+      primary: { type: "none", reason: "out-of-scope", message: "x" },
     });
     rateLimitMock.mockReturnValueOnce({ allowed: true, remaining: 12 });
     const { req, ctx } = makeRequest("va", { q: "anything" });
@@ -181,16 +181,15 @@ describe("GET /api/[state]/ask", () => {
   it("trims whitespace from q before length validation", async () => {
     classifyMock.mockResolvedValue({
       intent: { type: "unknown", raw: "x" },
+      secondaryIntent: null,
       confidence: 0,
       studentSummary: "test",
       clarifyingQuestion: null,
       sourceCollege: null,
       suggestedFollowups: [],
     });
-    lookupAnswerMock.mockResolvedValue({
-      type: "none",
-      reason: "out-of-scope",
-      message: "x",
+    lookupAnswersMock.mockResolvedValue({
+      primary: { type: "none", reason: "out-of-scope", message: "x" },
     });
     // 10 spaces + "ENG 111" + 5 spaces — trims to 7 chars, valid
     const { req, ctx } = makeRequest("va", { q: "          ENG 111     " });

--- a/lib/search-intent/__tests__/classify-llm.test.ts
+++ b/lib/search-intent/__tests__/classify-llm.test.ts
@@ -251,4 +251,65 @@ describe("toClassifiedIntent", () => {
     expect(result.sourceCollege).toBeNull();
     expect(result.suggestedFollowups).toEqual([]);
   });
+
+  it("leaves secondaryIntent null when the LLM omits secondary", () => {
+    const result = toClassifiedIntent("Does ENG 111 transfer to GMU?", {
+      type: "transfer",
+      course_prefix: "ENG",
+      course_number: "111",
+      university: "gmu",
+      confidence: 0.95,
+      reasoning: "x",
+      student_summary: "x",
+    });
+    expect(result.secondaryIntent).toBeNull();
+  });
+
+  it("populates secondaryIntent when LLM emits a secondary block", () => {
+    const result = toClassifiedIntent(
+      "What are the prereqs for ENG 111 and does it transfer to GMU?",
+      {
+        type: "prereqs",
+        course_prefix: "ENG",
+        course_number: "111",
+        confidence: 0.95,
+        reasoning: "two intents",
+        student_summary: "You're asking about prereqs and transfer for ENG 111.",
+        secondary: {
+          type: "transfer",
+          course_prefix: "ENG",
+          course_number: "111",
+          university: "gmu",
+        },
+      },
+    );
+    expect(result.intent).toEqual({
+      type: "prereqs",
+      course: { prefix: "ENG", number: "111" },
+    });
+    expect(result.secondaryIntent).toEqual({
+      type: "transfer",
+      course: { prefix: "ENG", number: "111" },
+      university: "gmu",
+    });
+  });
+
+  it("uppercases secondary course prefix", () => {
+    const result = toClassifiedIntent("test", {
+      type: "transfer",
+      course_prefix: "ENG",
+      course_number: "111",
+      university: "gmu",
+      confidence: 0.95,
+      reasoning: "x",
+      student_summary: "x",
+      secondary: {
+        type: "prereqs",
+        course_prefix: "bio",
+        course_number: "256",
+      },
+    });
+    if (result.secondaryIntent?.type !== "prereqs") throw new Error("wrong type");
+    expect(result.secondaryIntent.course?.prefix).toBe("BIO");
+  });
 });

--- a/lib/search-intent/__tests__/classify.test.ts
+++ b/lib/search-intent/__tests__/classify.test.ts
@@ -4,6 +4,7 @@ import { hashQuery, memoryCache, normalizeQuery, nullCache } from "../cache";
 import type { Classifier } from "../types";
 
 const BASE_ENRICHMENT = {
+  secondaryIntent: null,
   studentSummary: "test summary",
   clarifyingQuestion: null,
   sourceCollege: null,

--- a/lib/search-intent/__tests__/eval-runner.test.ts
+++ b/lib/search-intent/__tests__/eval-runner.test.ts
@@ -36,6 +36,7 @@ const TINY_CASES: EvalCase[] = [
 ];
 
 const BASE_ENRICHMENT = {
+  secondaryIntent: null,
   studentSummary: "test summary",
   clarifyingQuestion: null,
   sourceCollege: null,

--- a/lib/search-intent/answer/__tests__/index.test.ts
+++ b/lib/search-intent/answer/__tests__/index.test.ts
@@ -13,11 +13,20 @@ vi.mock("../pathway", () => ({
   lookupPathway: vi.fn().mockResolvedValue({ type: "pathway", status: "no-data" }),
 }));
 
-import { lookupAnswer } from "..";
+import { lookupAnswer, lookupAnswers } from "..";
 import { lookupTransfer } from "../transfer";
 import { lookupPrereqs } from "../prereqs";
 import { lookupEligibility } from "../eligibility";
 import { lookupPathway } from "../pathway";
+import type { ClassifiedIntent } from "../../types";
+
+const BASE_CLASSIFICATION = {
+  confidence: 0.95,
+  studentSummary: "test",
+  clarifyingQuestion: null,
+  sourceCollege: null,
+  suggestedFollowups: [],
+};
 
 describe("lookupAnswer dispatch", () => {
   it("dispatches transfer intents to lookupTransfer", async () => {
@@ -70,5 +79,57 @@ describe("lookupAnswer dispatch", () => {
     expect(result.type).toBe("none");
     if (result.type !== "none") return;
     expect(result.reason).toBe("out-of-scope");
+  });
+});
+
+describe("lookupAnswers (multi-intent)", () => {
+  it("returns only primary when secondaryIntent is null", async () => {
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: { type: "prereqs", course: { prefix: "BIO", number: "256" } },
+      secondaryIntent: null,
+    };
+    const result = await lookupAnswers(classification, "va");
+    expect(result.primary).toBeDefined();
+    expect(result.secondary).toBeUndefined();
+  });
+
+  it("returns both when secondaryIntent is set", async () => {
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" } },
+      secondaryIntent: {
+        type: "transfer",
+        course: { prefix: "ENG", number: "111" },
+        university: "gmu",
+      },
+    };
+    const result = await lookupAnswers(classification, "va");
+    expect(result.primary).toBeDefined();
+    expect(result.secondary).toBeDefined();
+  });
+
+  it("filters out secondary when it's an intent-not-supported NoAnswer", async () => {
+    // Course intent as secondary always returns intent-not-supported. The
+    // wrapper should hide it — we don't want a confusing empty card.
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" } },
+      secondaryIntent: { type: "course", keyword: "biology", filters: {} },
+    };
+    const result = await lookupAnswers(classification, "va");
+    expect(result.primary).toBeDefined();
+    expect(result.secondary).toBeUndefined();
+  });
+
+  it("filters out secondary when it's an out-of-scope NoAnswer", async () => {
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: { type: "prereqs", course: { prefix: "ENG", number: "111" } },
+      secondaryIntent: { type: "unknown", raw: "good professors" },
+    };
+    const result = await lookupAnswers(classification, "va");
+    expect(result.primary).toBeDefined();
+    expect(result.secondary).toBeUndefined();
   });
 });

--- a/lib/search-intent/answer/index.ts
+++ b/lib/search-intent/answer/index.ts
@@ -5,7 +5,7 @@
 // the per-domain lookups and returns an `Answer` discriminated union the
 // UI can render directly.
 
-import type { SearchIntent } from "../types";
+import type { ClassifiedIntent, SearchIntent } from "../types";
 import type { Answer } from "./types";
 import { lookupEligibility } from "./eligibility";
 import { lookupPathway } from "./pathway";
@@ -13,6 +13,36 @@ import { lookupPrereqs } from "./prereqs";
 import { lookupTransfer } from "./transfer";
 
 export type { Answer, SourceCitation } from "./types";
+
+/**
+ * Look up answers for a classified query. Returns the primary answer
+ * always, and a secondary answer when the classifier identified a second
+ * intent. The two lookups run in parallel.
+ *
+ * Secondary answers that are NoAnswer with `intent-not-supported` (course
+ * intent) or `out-of-scope` (unknown) are filtered out — they would render
+ * as a confusing empty card with no studentSummary to anchor them. The
+ * primary's studentSummary already covers the whole query.
+ */
+export async function lookupAnswers(
+  classification: ClassifiedIntent,
+  state: string,
+): Promise<{ primary: Answer; secondary?: Answer }> {
+  const primaryPromise = lookupAnswer(classification.intent, state);
+  const secondaryPromise = classification.secondaryIntent
+    ? lookupAnswer(classification.secondaryIntent, state)
+    : Promise.resolve(null);
+
+  const [primary, secondary] = await Promise.all([primaryPromise, secondaryPromise]);
+
+  if (!secondary) return { primary };
+  if (secondary.type === "none") {
+    if (secondary.reason === "intent-not-supported" || secondary.reason === "out-of-scope") {
+      return { primary };
+    }
+  }
+  return { primary, secondary };
+}
 
 export async function lookupAnswer(
   intent: SearchIntent,

--- a/lib/search-intent/classify-llm.ts
+++ b/lib/search-intent/classify-llm.ts
@@ -14,6 +14,7 @@ import {
   buildSubjectPrefixBlock,
   buildUniversityBlock,
   type ClassifierToolInput,
+  type ClassifierToolSecondary,
 } from "./prompt";
 import { getStateConfig } from "../states/registry";
 import { getDistinctSubjects } from "../courses";
@@ -101,6 +102,9 @@ export function toClassifiedIntent(
 ): ClassifiedIntent {
   return {
     intent: toSearchIntent(rawQuery, input),
+    secondaryIntent: input.secondary
+      ? toSecondarySearchIntent(rawQuery, input.secondary)
+      : null,
     confidence: clamp01(input.confidence),
     reasoning: input.reasoning,
     studentSummary: input.student_summary,
@@ -108,6 +112,55 @@ export function toClassifiedIntent(
     sourceCollege: input.source_college ?? null,
     suggestedFollowups: input.suggested_followups ?? [],
   };
+}
+
+// Build a SearchIntent from the narrower secondary sub-object. Doesn't
+// reuse toSearchIntent because secondaries don't carry filters/major/age —
+// CourseIntent always gets empty filters, EligibilityIntent always gets
+// null age, PathwayIntent always gets null major. That's by design: the
+// secondary slot is for "and the other thing", not a full second query.
+function toSecondarySearchIntent(
+  rawQuery: string,
+  secondary: ClassifierToolSecondary,
+): SearchIntent {
+  const courseRef =
+    secondary.course_prefix && secondary.course_number
+      ? {
+          prefix: secondary.course_prefix.toUpperCase(),
+          number: secondary.course_number,
+        }
+      : null;
+
+  switch (secondary.type) {
+    case "transfer":
+      return {
+        type: "transfer",
+        course: courseRef,
+        university: secondary.university ?? null,
+      };
+    case "pathway":
+      return {
+        type: "pathway",
+        university: secondary.university ?? null,
+        major: null,
+      };
+    case "prereqs":
+      return { type: "prereqs", course: courseRef };
+    case "eligibility":
+      return {
+        type: "eligibility",
+        topic: secondary.topic ?? "senior",
+        age: null,
+      };
+    case "course":
+      return {
+        type: "course",
+        keyword: null,
+        filters: { course: courseRef ?? undefined },
+      };
+    case "unknown":
+      return { type: "unknown", raw: rawQuery };
+  }
 }
 
 function toSearchIntent(rawQuery: string, input: ClassifierToolInput): SearchIntent {

--- a/lib/search-intent/prompt.ts
+++ b/lib/search-intent/prompt.ts
@@ -56,7 +56,20 @@ Confidence rules:
 - 0.50–0.79 : Best-effort guess, multiple plausible interpretations.
 - < 0.50 : Use "unknown" instead.
 
-If the query contains TWO clear intents (e.g. "Does ENG 111 transfer to GMU and what are the prereqs?"), pick the one that appears first or feels primary, and include the other in your reasoning. Don't try to return both.
+Multi-intent queries:
+
+When the query contains TWO genuinely distinct intents, set the primary fields for the first/more-important one AND populate the "secondary" sub-object for the second. Pick the more answerable one as primary (typed answers like transfer/prereqs/eligibility beat course-search). Cap at 2 — if the query has 3+ asks, include only the top two.
+
+EMIT secondary for:
+- "What are the prereqs for ENG 111 and does it transfer to GMU?" → primary: prereqs (ENG 111), secondary: transfer (ENG 111 → gmu)
+- "Transfer to GMU for CS, also what's the senior tuition policy?" → primary: pathway (gmu, CS), secondary: eligibility (senior)
+- "Does ENG 111 transfer to UVA, and what are the prereqs?" → primary: transfer, secondary: prereqs
+
+DO NOT emit secondary for:
+- "Online evening ENG classes" → ONE course intent with filters, not two
+- "Does ENG 111 transfer to GMU?" → ONE transfer intent
+- "I'm at NOVA, does ENG 111 transfer?" → ONE transfer intent (sourceCollege captures NOVA separately)
+- Anything where the second clause is a qualifier, not a separate question
 
 Additional output fields:
 
@@ -179,6 +192,29 @@ export const CLASSIFY_TOOL = {
         items: { type: "string" },
         description: "Always provide 2-3 follow-up questions a student in this situation would naturally want to know next.",
       },
+      // Optional secondary intent for queries with two genuinely distinct asks
+      // (e.g., "prereqs for ENG 111 and does it transfer to GMU?"). Nested
+      // sub-object — fewer fields than primary because secondaries are
+      // typically simpler ("and the other thing"). Omit entirely or pass null
+      // for single-intent queries (the common case).
+      secondary: {
+        type: ["object", "null"],
+        properties: {
+          type: {
+            type: "string",
+            enum: ["transfer", "pathway", "prereqs", "eligibility", "course", "unknown"],
+          },
+          course_prefix: { type: ["string", "null"] },
+          course_number: { type: ["string", "null"] },
+          university: { type: ["string", "null"] },
+          topic: {
+            type: ["string", "null"],
+            enum: ["senior", "audit", "cost", "veteran", null],
+          },
+        },
+        required: ["type"],
+        description: "Secondary intent. Set ONLY when the query has TWO distinct intents (e.g., transfer + prereqs). Do NOT set for follow-up qualifiers ('online evening ENG' is one intent, not two). Null/omit for single-intent queries.",
+      },
     },
     required: ["type", "confidence", "reasoning", "student_summary", "suggested_followups"],
   },
@@ -205,4 +241,17 @@ export interface ClassifierToolInput {
   clarifying_question?: string | null;
   source_college?: string | null;
   suggested_followups?: string[];
+  secondary?: ClassifierToolSecondary | null;
+}
+
+// Subset of fields used for secondary intents. Intentionally narrower than
+// the primary — secondaries express "and the other thing", not full second-
+// query power. Filters (mode/days/timeOfDay/term), age, and major are
+// excluded because they're rarely useful in secondaries.
+export interface ClassifierToolSecondary {
+  type: "transfer" | "pathway" | "prereqs" | "eligibility" | "course" | "unknown";
+  course_prefix?: string | null;
+  course_number?: string | null;
+  university?: string | null;
+  topic?: "senior" | "audit" | "cost" | "veteran" | null;
 }

--- a/lib/search-intent/types.ts
+++ b/lib/search-intent/types.ts
@@ -69,6 +69,13 @@ export type SearchIntent =
 
 export interface ClassifiedIntent {
   intent: SearchIntent;
+  // Optional second intent when the query genuinely contains two distinct
+  // asks (e.g., "prereqs for ENG 111 and does it transfer to GMU?"). Null
+  // for the common case of a single-intent query. Capped at one secondary
+  // — three+ intents collapse to the top two. Studentsummary, clarifying
+  // question, and follow-ups always describe the WHOLE query, not the
+  // secondary alone.
+  secondaryIntent: SearchIntent | null;
   // Self-reported confidence in [0, 1]. Tier-1 regex returns >= 0.95 for
   // strong matches; LLM returns its own estimate. Used to decide fallback.
   confidence: number;


### PR DESCRIPTION
## What

Queries like *"what are the prereqs for ENG 111 and does it transfer to GMU?"* used to silently drop one intent. The classifier prompt explicitly told the LLM "pick one, mention the other in reasoning." This PR threads a second intent through the entire stack — classifier → answer lookup → API → UI.

## How

**Data model** — `ClassifiedIntent` gets optional `secondaryIntent: SearchIntent | null`. Additive; null in the common single-intent case. Cap at 2; 3+ asks collapse to top two.

**Classifier prompt + tool schema** — new nested `secondary` sub-object in `classify_intent` (5 fields: type, course_prefix, course_number, university, topic). Intentionally narrower than primary — secondaries express "and the other thing", not full second-query power. SYSTEM_PROMPT flips from "pick one, mention the other" to "emit secondary when there are TWO genuinely distinct intents," with explicit examples of when **not** to emit (qualifiers, source-college mentions, filter combos).

**Answer lookup** — new `lookupAnswers(classification, state)` wrapper runs both lookups in parallel via `Promise.all`. Filters out secondary answers that are `intent-not-supported` or `out-of-scope` — those would render as confusing empty cards with no studentSummary anchor.

**API + UI** — `/api/[state]/ask` returns `{ classification, answer, secondaryAnswer? }`. `CourseSearchClient` renders TWO `AnswerCard`s when secondary exists. **Zero AnswerCard component changes** — passing `classification={null}` to the second card naturally suppresses the duplicate studentSummary/clarifying/followups (which describe the whole query, not the secondary alone).

**Course-search refinement** — primary intent still drives the search. Secondary doesn't affect search params — clean boundary.

## What this is NOT

- Not three+ intents
- Not multi-intent eval cases (added unit tests instead — multi-intent rare enough that 100s of eval cases aren't worth it)
- Not secondary-driven search refinement (deferred — adds complexity for marginal value)

## Cache compat

Old `ClassifiedIntent` cache entries without `secondaryIntent` deserialize the field as `undefined`. `lookupAnswers` checks truthiness, so undefined behaves as null. No migration needed.

## Test plan

- [x] 312 tests pass (was 305; +7 new for secondary parsing and `lookupAnswers` wrapper)
- [x] Typecheck clean
- [ ] After merge: "prereqs for ENG 111 and does it transfer to GMU?" → both prereqs and transfer answer cards stack
- [ ] "online evening ENG classes" → ONE course intent (no secondary spuriously emitted)
- [ ] Single-intent queries unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)