### PR TITLE
search-intent: don't bail to unknown when half the query is supported

### DIFF
--- a/lib/search-intent/prompt.ts
+++ b/lib/search-intent/prompt.ts
@@ -71,6 +71,17 @@ DO NOT emit secondary for:
 - "I'm at NOVA, does ENG 111 transfer?" → ONE transfer intent (sourceCollege captures NOVA separately)
 - Anything where the second clause is a qualifier, not a separate question
 
+Mixed supported + unsupported intents:
+
+If the query mixes a SUPPORTED intent (transfer/pathway/prereqs/eligibility/course) with an UNSUPPORTED ask (instructor lookup, professor reviews, course ratings/difficulty, "easy A" judgments, schedule conflicts with another course, advisor questions), use the supported intent as PRIMARY and IGNORE the unsupported part. Do NOT bail to "unknown" just because part of the query is out of scope. Examples:
+
+- "who teaches ENG 111 and where does it transfer" → primary: transfer (ENG 111). Ignore the instructor part. (NOT unknown.)
+- "easy A math classes online" → primary: course (keyword: math, mode: online). Ignore the "easy A" judgment.
+- "best professor for BIO 256 prereqs" → primary: prereqs (BIO 256). Ignore the professor part.
+- "Rate my Professor for CSC 200 transfer" → primary: transfer (CSC 200). Ignore the rating part.
+
+Only fall back to "unknown" when the query has NO supported intent at all (e.g., "good professors", "easy classes", "campus tour times").
+
 Additional output fields:
 
 - student_summary: Always provide a 1-2 sentence plain-English restatement of what the student is asking. Write as if addressing the student directly. Example: "You're asking whether ENG 111 transfers to George Mason."


### PR DESCRIPTION
## Problem

Verified failure on prod with query "who teaches ENG 111 and where does it transfer":

\`\`\`json
{
  "classification": {
    "intent": { "type": "unknown" },
    "secondaryIntent": null,
    "studentSummary": "You're asking two things: who teaches ENG 111 and whether it transfers...",
    "reasoning": "Query contains two distinct intents: (1) finding instructor info (not a supported intent type), and (2) transfer eligibility for ENG 111 (transfer intent)."
  }
}
\`\`\`

The LLM correctly identified both intents AND named transfer as supported, but classified the WHOLE query as \`unknown\` rather than answering the supported half. The user gets the generic "I'm not sure what you're asking" hint card instead of the transfer answer they explicitly asked for.

## Fix

One paragraph added to SYSTEM_PROMPT covering "supported + unsupported" combinations. The supported intent becomes primary, the unsupported part is ignored. Only fall back to unknown when the ENTIRE query is out of scope.

Examples added to the prompt:
- "who teaches ENG 111 and where does it transfer" → transfer (ENG 111)
- "easy A math classes online" → course (keyword: math, mode: online)
- "best professor for BIO 256 prereqs" → prereqs (BIO 256)
- "Rate my Professor for CSC 200 transfer" → transfer (CSC 200)

## Test plan

- [x] 312 tests pass, typecheck clean
- [ ] After merge: "who teaches ENG 111 and where does it transfer" → transfer answer card with ENG 111 transfer destinations
- [ ] "good professors" → still falls to unknown (no supported intent at all)
- [ ] "Does ENG 111 transfer to GMU?" → unchanged (single supported intent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)