### PR TITLE
adsense: document NEXT_PUBLIC_ADSENSE_ID env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ NEXT_PUBLIC_SITE_URL=https://communitycollegepath.com
 # Anthropic API (https://console.anthropic.com/) — natural-language search
 # classifier. Used by lib/search-intent and scripts/eval-search-intent.ts.
 ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
+
+# Google AdSense — set to your publisher ID to enable ads (e.g. ca-pub-xxxxxxxxxxxxxxxx).
+# Leave unset to disable ads entirely (AdSenseScript returns null when missing).
+NEXT_PUBLIC_ADSENSE_ID=ca-pub-xxxxxxxxxxxxxxxx


### PR DESCRIPTION
## Summary
- Documents `NEXT_PUBLIC_ADSENSE_ID` in `.env.example` — the AdSense publisher ID needed to enable ads
- `AdSenseScript` component and its root layout import already existed; this is purely a docs/env change
- If the var is unset, `AdSenseScript` returns `null` (no script injected, no errors)

## To activate in production
Add `NEXT_PUBLIC_ADSENSE_ID=ca-pub-6556125154958128` to Vercel → Settings → Environment Variables, then redeploy.

## Test plan
- [ ] Verify Vercel env var is set
- [ ] After redeploy, confirm `pagead2.googlesyndication.com` script appears in page source on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)