### PR TITLE
fix: prereq chain shows accurate message when chain data is missing

### DIFF
--- a/components/PrereqChain.tsx
+++ b/components/PrereqChain.tsx
@@ -120,7 +120,9 @@ export default function PrereqChain({
         <div className="mt-2 rounded-lg bg-slate-50/80 dark:bg-slate-800/60 border border-slate-200/60 dark:border-slate-700/60 p-3">
           {tree.children.length === 0 ? (
             <p className="text-[10px] text-slate-500 dark:text-slate-400 italic">
-              No course prerequisites in the chain (test scores or placement only)
+              {/[A-Z]{2,5}\s+\d{3,4}/.test(prereqText)
+                ? "No deeper chain data available — see prerequisites listed above."
+                : "No course prerequisites in the chain (test scores or placement only)"}
             </p>
           ) : (
             <PrereqFlowChart tree={tree} />


### PR DESCRIPTION
## Summary
- When the prereq chain API returns empty children but the badge text clearly lists course codes (e.g. "AFF 1010 and AFF 1015"), the expanded panel now shows **"No deeper chain data available — see prerequisites listed above."** instead of the misleading **"No course prerequisites in the chain (test scores or placement only)"**
- The original "test scores or placement only" message is preserved for prereqs that genuinely contain no course codes (e.g. placement tests, ACT scores)
- Affects thousands of courses across all 15 states with prereq data — the root cause is that `prereqs.json` only contains courses that *have* prereqs, so prerequisite courses with no prereqs of their own aren't in the map, causing the chain to come back empty

## Test plan
- [ ] Find a course with course-code prereqs (e.g. VT AFF 1020 requires AFF 1010 + AFF 1015) → click "view chain" → should show "No deeper chain data available" not "test scores or placement only"
- [ ] Find a course with placement-only prereqs → click "view chain" → should still show "test scores or placement only"
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)