### PR TITLE
feat: degree/program requirements — foundation, scraper, and VA data

### DIFF
--- a/data/va/programs/gcc.json
+++ b/data/va/programs/gcc.json
@@ -1,0 +1,20560 @@
+{
+  "college_slug": "gcc",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.germanna.edu",
+  "scraped_at": "2026-05-06T21:23:56.741Z",
+  "programs": [
+    {
+      "title": "Technical Studies - AAS",
+      "credential": "AAS",
+      "program_code": "718",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1559",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Technical-Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "106",
+              "title": "First Aid and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Technical Foundations:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "127",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "101",
+              "title": "Construction Management I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "110",
+              "title": "Introduction to Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "115",
+              "title": "Building Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "195",
+              "title": "Topics In",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "133",
+              "title": "Practical Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Technical-Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "133",
+              "title": "Practical Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "106",
+              "title": "First Aid and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "127",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "101",
+              "title": "Construction Management I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "110",
+              "title": "Introduction to Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "115",
+              "title": "Building Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social & Behavioral Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "195",
+              "title": "Topics In",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Track Courses",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Asphalt Technician",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIV",
+              "number": "170",
+              "title": "Principles of Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "193",
+              "title": "Studies In Construction Inspector Level I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "195",
+              "title": "Topics In Construction Inspector Level 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "196",
+              "title": "On-Site Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "193",
+              "title": "Studies In Slurry Surfacing &amp; Surface Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "195",
+              "title": "Topics In Asphalt Mix Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Carpentry Technician",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "131",
+              "title": "Carpentry Framing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "132",
+              "title": "Carpentry Framing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "133",
+              "title": "Carpentry Framing III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Construction Craft Technician",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "102",
+              "title": "Construction Management II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "125",
+              "title": "Introduction to Carpentry Trades",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "135",
+              "title": "Building Construction Carpentry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "187",
+              "title": "Structure Completion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "193",
+              "title": "Studies In Properties and Placement of Concrete",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fundamentals of Welding",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "100",
+              "title": "Fundamentals of Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "120",
+              "title": "Introduction to Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Gas Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "161",
+              "title": "Flux Cored Arc Welding (FCAW)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Heavy Equipment Operator",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIV",
+              "number": "195",
+              "title": "Topics In Construction Inspector Level 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "225",
+              "title": "Soil Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVE",
+              "number": "161",
+              "title": "Heavy Equipment Operation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVE",
+              "number": "195",
+              "title": "Topics In Heavy Equipment Operator II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "HVAC Mechanic",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "122",
+              "title": "Air Conditioning and Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "123",
+              "title": "Air Conditioning and Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "124",
+              "title": "Air Conditioning and Refrigeration IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "276",
+              "title": "Refrigerant Usage EPA Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "135",
+              "title": "Electrical and Electronic Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Industrial Electrician",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "127",
+              "title": "Residential Wiring Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "173",
+              "title": "Commercial Wiring Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "245",
+              "title": "Industrial Wiring",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Industrial Machinist",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machine Trade Theory and Computation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "126",
+              "title": "Introductory CNC Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "161",
+              "title": "Machine Shop Practices I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Plumbing Technician",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "140",
+              "title": "Principles of Plumbing Trade I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "141",
+              "title": "Principles of Plumbing Trade II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "142",
+              "title": "Principles of Plumbing Trade III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "143",
+              "title": "Plumbing Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "144",
+              "title": "Plumbing Code and Certification Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical Studies - AAS - 718 - Civil Construction Advising Pathway",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1615",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Technical-Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "110",
+              "title": "Introduction to Civil Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "135",
+              "title": "Construction Management and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "193",
+              "title": "Studies In Construction Inspector Level I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIV",
+              "number": "172",
+              "title": "Surveying II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "195",
+              "title": "Topics In Construction Inspector Level 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "225",
+              "title": "Soil Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVE",
+              "number": "161",
+              "title": "Heavy Equipment Operation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIV",
+              "number": "256",
+              "title": "Global Positioning Systems for Land Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVE",
+              "number": "195",
+              "title": "Topics In Heavy Equipment Operator II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "195",
+              "title": "Topics In Asphalt Mix Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Carpentry Technician - CSC - 221-989-34",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1613",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "131",
+              "title": "Carpentry Framing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "132",
+              "title": "Carpentry Framing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "133",
+              "title": "Carpentry Framing III",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Asphalt Technician - CSC - 221-990-07",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1602",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "170",
+              "title": "Principles of Surveying",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "193",
+              "title": "Studies In Construction Inspector Level I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "195",
+              "title": "Topics In Construction Inspector Level 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "196",
+              "title": "On-Site Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "193",
+              "title": "Studies In Slurry Surfacing &amp; Surface Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "195",
+              "title": "Topics In Asphalt Mix Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Craft Technician - CSC - 221-917-03",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1616",
+      "total_credits": 22,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "101",
+              "title": "Construction Management I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "102",
+              "title": "Construction Management II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "125",
+              "title": "Introduction to Carpentry Trades",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "135",
+              "title": "Building Construction Carpentry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "187",
+              "title": "Structure Completion",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Civil Construction - CSC - 221-989-08",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1621",
+      "total_credits": 21,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "110",
+              "title": "Introduction to Civil Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "135",
+              "title": "Construction Management and Estimating",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "172",
+              "title": "Surveying II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "256",
+              "title": "Global Positioning Systems for Land Surveying",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data Center Operations Technician - CSC - 221-229-35",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1623",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "175",
+              "title": "Schematics and Mechanical Drawings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "146",
+              "title": "Electric Motor Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "148",
+              "title": "Power Distribution Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "250",
+              "title": "Fiber Optic Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts and Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Technician - CSC - 221-989-00",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1603",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Technical-Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "127",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "101",
+              "title": "Construction Management I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "110",
+              "title": "Introduction to Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "115",
+              "title": "Building Codes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "133",
+              "title": "Practical Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrician Technician - CSC - 221-942-01",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1585",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "127",
+              "title": "Residential Wiring Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "173",
+              "title": "Commercial Wiring Methods",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "245",
+              "title": "Industrial Wiring",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fundamentals of Welding - CSC - 221-995-03",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1617",
+      "total_credits": 22,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "100",
+              "title": "Fundamentals of Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "120",
+              "title": "Introduction to Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Gas Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "161",
+              "title": "Flux Cored Arc Welding (FCAW)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Heating, Ventilation and Air Conditioning (HVAC) Technician - CSC - 221-903-10",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1601",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "122",
+              "title": "Air Conditioning and Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "123",
+              "title": "Air Conditioning and Refrigeration III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "124",
+              "title": "Air Conditioning and Refrigeration IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "276",
+              "title": "Refrigerant Usage EPA Certification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "135",
+              "title": "Electrical and Electronic Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Heavy Equipment Operator - CSC - 221-899-34",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1618",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "195",
+              "title": "Topics In Construction Inspector Level 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "225",
+              "title": "Soil Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVE",
+              "number": "161",
+              "title": "Heavy Equipment Operation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HVE",
+              "number": "195",
+              "title": "Topics In Heavy Equipment Operator II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Machinist - CSC - 221-952-03",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1619",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machine Trade Theory and Computation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "126",
+              "title": "Introductory CNC Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "161",
+              "title": "Machine Shop Practices I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance Technology - CSC - 221-990-00",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1586",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "127",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "154",
+              "title": "Mechanical Maintenance I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Plumbing Technician - CSC - 221-989-80",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1620",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "140",
+              "title": "Principles of Plumbing Trade I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "141",
+              "title": "Principles of Plumbing Trade II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "142",
+              "title": "Principles of Plumbing Trade III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "143",
+              "title": "Plumbing Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "144",
+              "title": "Plumbing Code and Certification Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts - AA - 648 - College Everywhere Accelerated Program - Can Be Completed Online",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1591",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "Beginning Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "Beginning Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "201",
+              "title": "Intermediate Spanish I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "202",
+              "title": "Intermediate Spanish II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts - AA - 648 - Can Be Completed Online",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1555",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art, Humanities & Literature (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ART",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lab Sciences (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Quantitative/Statistics Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Calculus Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature (I)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities, & Literature (III)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Business Administration - AS - 213 - College Everywhere Advising Pathway- Can Be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1588",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Statistical Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Graphic Communications - Certificate - 524 - Can Be Completed Online",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1538",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Life Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "283",
+              "title": "Computer Graphics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "284",
+              "title": "Computer Graphics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "287",
+              "title": "Portfolio and Resume Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Graphics Elective1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Life Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "283",
+              "title": "Computer Graphics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "284",
+              "title": "Computer Graphics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any graphic design elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "287",
+              "title": "Portfolio and Resume Preparation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration - AS - 213 - Can Be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1539",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (2cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art, Humanities, & Literature (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ART",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements (21cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BUS",
+                  "number": "200",
+                  "title": "Principles of Management"
+                }
+              ]
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Statistical Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective(s) (6-7cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "154",
+                  "title": "Quantitative Reasoning"
+                }
+              ]
+            },
+            {
+              "prefix": "BUS",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Natural Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "154",
+                  "title": "Quantitative Reasoning"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature Elective I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Statistical Analysis for Business",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I"
+                }
+              ]
+            },
+            {
+              "prefix": "BUS",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature Elective II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management - AAS - 212 - Can Be Completed Online",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1537",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any other course from ECO, GEO, HIS, PLS, PSY or SOC",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Requirements (33cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Statistical Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MTH/SCI Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Statistical Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management - AAS - 212 - College Everywhere Advising Pathway - Can Be Completed Online",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1594",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Principles of Supervision I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Statistical Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting - CSC - 221-203-02 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1540",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting - CSC - 221-203-02 - College Everywhere Advising Pathway - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1592",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements/Suggested Scheduling",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Advanced Accounting - CSC - 221-203-07 - College Everywhere Advising Pathway - Can be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1606",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "217",
+              "title": "Analyzing Financial Statements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "240",
+              "title": "Fraud Examination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Auditing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Principles of Federal Taxation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "217",
+              "title": "Analyzing Financial Statements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Auditing I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Principles of Federal Taxation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "240",
+              "title": "Fraud Examination",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Advanced Accounting - CSC - 221-203-07 - Can be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1610",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "217",
+              "title": "Analyzing Financial Statements",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Intermediate Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "240",
+              "title": "Fraud Examination",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Auditing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Principles of Federal Taxation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Entrepreneurship - CSC - 221-212-10 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1542",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Core - CSC - 221-208-10 - Can be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1541",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Supervision - CSC - 221-212-25 -Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1543",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Principles of Supervision I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business-Related Elective - Any course from ACC, BUS, ECO, FIN, or MKT",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies - AS - 699 - Can Be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1554",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art & Humanities (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Quantitative/Statistics Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Calculus Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "ITE 152 and Required General Education Electives (12)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Second Math Course from the list above",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies - AS - 699 - College Everywhere Accelerated Advising Pathway-Can Be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1590",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition and Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Social Science - AS - 882 - Psychology Advising Pathway - Can be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1634",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "225",
+              "title": "Theories of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Social Science - AS - 882 - College Everywhere Accelerated Criminal Justice Pathway - Can be completed online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1632",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence and Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Social Science - AS - 882 - Can be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1631",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "112",
+                  "title": "College Composition II"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Art, Humanities & Literature (6 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lab Science (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Quantitative/Statistics Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Calculus Pathway",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Science - AS - 882 - Criminal Justice Advising Pathway - Can be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1633",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Lab Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "General Studies - AS - 699 - Early College Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1635",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Junior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Junior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Precalculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Senior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Senior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Computer Science - AS",
+      "credential": "AS",
+      "program_code": "246",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1614",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Arts, Humanities, and Literature (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social and Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (7cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "UCGS General Education Elective (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any World Language",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements (17cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CSC",
+                  "number": "205",
+                  "title": "Computer Organization"
+                },
+                {
+                  "prefix": "CSC",
+                  "number": "208",
+                  "title": "Introduction to Discrete Structure"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Transfer Electives (Prerequisites if needed) (7-10)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select Additional Science from the list of science options",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Natural Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CSC",
+                  "number": "205",
+                  "title": "Computer Organization"
+                }
+              ]
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "208",
+              "title": "Introduction to Discrete Structure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Uniform Certificate of General Studies (UCGS) - 695 - Can Be Completed Online",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1595",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Written Communication (6 Cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "112",
+                  "title": "College Composition II"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Art",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences-Select one course (3 Cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences-Select One Course (4 Cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Quantitative/Statistics Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Calculus Pathway",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Precalculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History-Select One Course (3 Cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Specialized General Education Requirements-Select Two Courses (6-8 Cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "Beginning American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "Beginning American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "Intermediate American Sign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "Intermediate American Sign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "Three-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Foreign Language I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Foreign Language II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Foreign Language III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Foreign Language IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Fundamentals of Music",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Information System Technology - Networking - AAS - 199 - Can Be Completed Online",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1558",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "IST Program Core:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "251",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Networking Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "154",
+              "title": "Networking Fundamentals -Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "155",
+              "title": "Switching, Wireless, and WAN Technologies (ICND2) - Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "156",
+              "title": "Basic Switching and Routing - Cisco",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "171",
+                  "title": "Unix 1"
+                }
+              ]
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crimes and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E Commerce Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "113",
+              "title": "Active Directory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "154",
+              "title": "Networking Fundamentals -Cisco",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "171",
+                  "title": "Unix 1"
+                }
+              ]
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "113",
+              "title": "Active Directory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "155",
+              "title": "Switching, Wireless, and WAN Technologies (ICND2) - Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E Commerce Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "251",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crimes and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "156",
+              "title": "Basic Switching and Routing - Cisco",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology - Information Management Concentration, Cloud Computing Concentration, or General IST Concentration - AAS - 299 - Can Be Completed Online",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1557",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "IST Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "130",
+              "title": "Database Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "251",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Cloud Computing Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "213",
+              "title": "Information Storage and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing: Infrastructure and Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E Commerce Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "254",
+              "title": "Virtual Infrastructure: Installation and Configuration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Information Management",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "210",
+              "title": "Web Page Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "220",
+              "title": "e-commerce Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to e-Commerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "180",
+              "title": "Help Desk Support Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "140",
+              "title": "Client Side Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E Commerce Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "267",
+              "title": "Legal Topics in Network Security",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "101",
+                  "title": "Introduction to Network Concepts"
+                }
+              ]
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITD",
+                  "number": "130",
+                  "title": "Database Fundamentals"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "251",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information System Technology - Cybersecurity - AAS - 345 - Can Be Completed Online",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1556",
+      "total_credits": 14,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "IST Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "107",
+                  "title": "PC Hardware and Troubleshooting"
+                }
+              ]
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Cybersecurity Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crimes and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security and Authentication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E Commerce Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "276",
+              "title": "Computer Forensics I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "267",
+                  "title": "Legal Topics in Network Security"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "101",
+                  "title": "Introduction to Network Concepts"
+                }
+              ]
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "171",
+              "title": "Unix 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E Commerce Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "276",
+              "title": "Computer Forensics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crimes and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security and Authentication",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "267",
+                  "title": "Legal Topics in Network Security"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Arts, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity & Networking Foundations - CSC - 221-732-08 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1587",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "101",
+                  "title": "Introduction to Network Concepts"
+                },
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "101",
+                  "title": "Introduction to Network Concepts"
+                },
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity - CSC - 221-732-09 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1563",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or ITN 154 Networking Fundamentals -Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crimes and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security and Authentication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E Commerce Security",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "267",
+              "title": "Legal Topics in Network Security",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "276",
+                  "title": "Computer Forensics I"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Advanced Networking - CSC - 221-199-01 - Can be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1560",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements/Suggested Scheduling",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "154",
+              "title": "Networking Fundamentals -Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "155",
+              "title": "Switching, Wireless, and WAN Technologies (ICND2) - Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "156",
+              "title": "Basic Switching and Routing - Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data Center IT Technician - CSC - 221-299-16 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1584",
+      "total_credits": 28,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "101",
+                  "title": "Introduction to Network Concepts"
+                },
+                {
+                  "prefix": "ITN",
+                  "number": "170",
+                  "title": "Linux System Administration"
+                }
+              ]
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITN",
+                  "number": "263",
+                  "title": "Internet/Intranet Firewalls and E Commerce Security"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "E-Commerce - CSC - 221-251-01 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1564",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "210",
+              "title": "Web Page Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "220",
+              "title": "e-commerce Administration",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "160",
+                  "title": "Introduction to e-Commerce"
+                }
+              ]
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "140",
+              "title": "Client Side Scripting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Microcomputer Applications for Business - CSC - 221-299-03 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1565",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "130",
+              "title": "Database Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "100",
+              "title": "Introduction to Information Systems",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "160",
+                  "title": "Introduction to e-Commerce"
+                }
+              ]
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Networking - CSC- 221-732-00 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1566",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "155",
+              "title": "Switching, Wireless, and WAN Technologies (ICND2) - Cisco",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AS",
+      "credential": "AS",
+      "program_code": "625",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1579",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English (6 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art, Humanities & Literature (6 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Sciences (8 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106",
+              "title": "Life Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication Studies (3cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Education (12 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "UCGS and Transfer Electives (15 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "111",
+              "title": "Law Enforcement Organization and Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "161",
+              "title": "Introduction to Computer Crime",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence and Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "233",
+              "title": "Multiculturalism in Policing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "215",
+              "title": "History Of Modern Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Life Drawing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any ARA (Arabic) Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Statistical Analysis for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "280",
+              "title": "Introduction to International Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any CHI (Chinese) Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Computer Organization",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "208",
+              "title": "Introduction to Discrete Structure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "122",
+              "title": "Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "125",
+              "title": "Introduction to Computer Programming for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "231",
+              "title": "Mass and Energy Balances",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "232",
+              "title": "Chemical Engineering Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "240",
+              "title": "Solid Mechanics (Statics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "245",
+              "title": "Engineering Mechanics - Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "246",
+              "title": "Mechanics of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "248",
+              "title": "Thermodynamics for Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "270",
+              "title": "Fundamentals of Computer Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "271",
+              "title": "Electrical Circuits I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "272",
+              "title": "Electric Circuits II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any FRE (French) Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "200",
+              "title": "Introduction to Physical Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any GER (German) Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "203",
+              "title": "History of African Civilizations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "254",
+              "title": "History of Asian Civilizations II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HLT",
+                  "number": "110",
+                  "title": "Concepts of Personal and Community Health"
+                }
+              ]
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "260",
+              "title": "Contemporary Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any ITA (Italian) Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any JPN (Japanese) Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Fundamentals of Music",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "225",
+              "title": "History of Jazz",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PHI",
+                  "number": "100",
+                  "title": "Introduction to Philosophy"
+                }
+              ]
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "200",
+              "title": "Introduction to Political and Democratic Theory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "225",
+              "title": "Theories of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "233",
+              "title": "Introduction to Islam",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "238",
+              "title": "Religions of the West",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any RUS (Russian) Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "266",
+              "title": "Race and Ethnicity",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any SPA (Spanish) Course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS MATH I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Natural Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS MATH II or UCGS General Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Transfer Elective I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Transfer Elective II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AS - 625 - Elementary Education Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1627",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "154",
+                  "title": "Quantitative Reasoning"
+                },
+                {
+                  "prefix": "HIS",
+                  "number": "121",
+                  "title": "United States History to 1877"
+                },
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Literature (ENG 250 Preferred)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ART",
+                  "number": "101",
+                  "title": "History of Art: Prehistoric to Gothic"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Natural Science II (Different Subject from Natural Science I)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AS - 625 - Future Educators Academy Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1624",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester Junior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Junior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fall Semester Senior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester Senior Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "GOL",
+                  "number": "105",
+                  "title": "Physical Geology"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Development - AAS",
+      "credential": "AAS",
+      "program_code": "636",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1580",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (9 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any one Literature course (ENG 230-279)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics/Science (3 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Health (3 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (6 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lab Science (4 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science and Social Studies for Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and participation in Early Childhood/Primary Settings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Introduction to Exceptional Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Childhood Programs, School, and Social Change",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "265",
+              "title": "Advanced Observation and Participation in Early Childhood/ Primary Settings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "270",
+              "title": "Administration of Childcare Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and participation in Early Childhood/Primary Settings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science and Social Studies for Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "270",
+              "title": "Administration of Childcare Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Introduction to Exceptional Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Childhood Programs, School, and Social Change",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "265",
+              "title": "Advanced Observation and Participation in Early Childhood/ Primary Settings",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HIS",
+                  "number": "121",
+                  "title": "United States History to 1877"
+                },
+                {
+                  "prefix": "BIO",
+                  "number": "101",
+                  "title": "General Biology I"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG (Literature)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Education - AS - 625 - Special Education Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1626",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "154",
+                  "title": "Quantitative Reasoning"
+                },
+                {
+                  "prefix": "HIS",
+                  "number": "121",
+                  "title": "United States History to 1877"
+                },
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Sciences I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Natural Science II (Different Subject from Natural Science I)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education - AS - 625 - Secondary Education Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1625",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities, & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Natural Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Development - Certificate",
+      "credential": "certificate",
+      "program_code": "632",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1581",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and participation in Early Childhood/Primary Settings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science and Social Studies for Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "270",
+              "title": "Administration of Childcare Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development - CSC - 221-636-06",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1582",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and participation in Early Childhood/Primary Settings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Health Science - AS",
+      "credential": "AS",
+      "program_code": "620",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1628",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "112",
+                  "title": "College Composition II"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Art, Humanities & Literature (6 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ART",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lab Science (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communications (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements (18cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition and Human Development",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PSY",
+                  "number": "230",
+                  "title": "Developmental Psychology"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Transfer Electives (9cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional UCGS Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "101",
+                  "title": "General Biology I"
+                }
+              ]
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition and Human Development",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "102",
+                  "title": "General Biology II"
+                },
+                {
+                  "prefix": "BIO",
+                  "number": "141",
+                  "title": "Human Anatomy and Physiology I"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Science - AS - 620 - Pre-BSN Advising Pathway - Can be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1630",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition and Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature (Suggest Literature)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Science - AS - 620 - College Everywhere Accelerated Program - Pre-BSN Advising Pathway - Can be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1629",
+      "total_credits": 10,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition and Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Science - AS - 620 - Kinesiology Advising Pathway - Can be Completed Online",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1636",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Concepts of Personal and Community Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I"
+                },
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition and Human Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene - AAS",
+      "credential": "AAS",
+      "program_code": "118",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1596",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (3 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sciences (8 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science Elective (4 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Requirements in Sequence (48 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "111",
+              "title": "Oral Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "115",
+              "title": "Histology/Head and Neck Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "120",
+              "title": "Management of Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "130",
+              "title": "Oral Radiology for the Dental Hygienist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "141",
+              "title": "Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "142",
+              "title": "Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "143",
+              "title": "Dental Hygiene III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "145",
+              "title": "General and Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "146",
+              "title": "Periodontics for the Dental Hygienist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "214",
+              "title": "Practical Materials for Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "216",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "226",
+              "title": "Public Health Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "227",
+              "title": "Public Health Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "230",
+              "title": "Office Practice &amp; Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "235",
+              "title": "Management of Dental Pain and Anxiety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "244",
+              "title": "Dental Hygiene IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "245",
+              "title": "Dental Hygiene V",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "111",
+              "title": "Oral Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "115",
+              "title": "Histology/Head and Neck Anatomy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "130",
+              "title": "Oral Radiology for the Dental Hygienist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "141",
+              "title": "Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "142",
+              "title": "Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "216",
+              "title": "Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "120",
+              "title": "Management of Emergencies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "146",
+              "title": "Periodontics for the Dental Hygienist",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "145",
+              "title": "General and Oral Pathology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "143",
+              "title": "Dental Hygiene III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "226",
+              "title": "Public Health Dental Hygiene I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "235",
+              "title": "Management of Dental Pain and Anxiety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "214",
+              "title": "Practical Materials for Dental Hygiene",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "244",
+              "title": "Dental Hygiene IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "245",
+              "title": "Dental Hygiene V",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "230",
+              "title": "Office Practice &amp; Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "227",
+              "title": "Public Health Dental Hygiene II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - AAS - 156-01 - Part-time Advising Pathway",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1598",
+      "total_credits": 10,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature or Transfer Elective (student must have one of each to complete the program)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature or Transfer Elective (student should take a course from the category they did not select in the first five)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Seventh Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Eighth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - AAS - 156-01",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1544",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lab Sciences (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science Elective (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major requirement(s) in sequence (39cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature or Transfer Elective (student must have one of each to complete the program)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature or Transfer Elective (student should take a course from the category they did not select in the first five)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Emergency Medical Services - Paramedic - AAS",
+      "credential": "AAS",
+      "program_code": "146",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1600",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education - 17 Credit Hours",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "EMS Core (48cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician-Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support (ACLS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatric Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician-Clinical",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "145",
+                  "title": "Basic Human Anatomy &amp; Physiology"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "SDV",
+                  "number": "101",
+                  "title": "Orientation to (Specific Discipline)"
+                }
+              ]
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "any General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "227",
+              "title": "Bio-Medical Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support (ACLS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatric Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Licensed Practical Nurses for Advanced Standing - LPN to RN - AAS - 156-02",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1545",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lab Sciences (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Science Elective (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Transfer Elective (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "250",
+              "title": "General Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Requirements in Sequence (27cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "115",
+              "title": "Healthcare Concepts for Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "115",
+              "title": "Healthcare Concepts for Transition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Transfer Elective I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Dental Assisting - Certificate",
+      "credential": "certificate",
+      "program_code": "120",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1547",
+      "total_credits": 40,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "103",
+              "title": "Introduction to Oral Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "108",
+              "title": "Dental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "110",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "113",
+              "title": "Chairside Assisting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "134",
+              "title": "Dental Radiology and Practicum",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "114",
+              "title": "Chairside Assisting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "190",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "119",
+              "title": "Dental Therapeutics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "120",
+              "title": "Community Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "130",
+              "title": "Dental Office Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "140",
+              "title": "Externship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - AAS",
+      "credential": "AAS",
+      "program_code": "180",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1546",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biology or Natural Sciences (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CPR (1cr) (Completed within two years of anticipated graduation)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PTA Technical Courses (46cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTH",
+              "number": "105",
+              "title": "Introduction to Physical Therapist Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "115",
+              "title": "Kinesiology for the Physical Therapist Assistant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "121",
+              "title": "Therapeutic Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "122",
+              "title": "Therapeutic Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "131",
+              "title": "Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "151",
+              "title": "Musculoskeletal Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "210",
+              "title": "Psychological Aspects of Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "225",
+              "title": "Rehabilitation Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "226",
+              "title": "Therapeutic Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "227",
+              "title": "Pathological Conditions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "251",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "252",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "255",
+              "title": "Seminar in Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "105",
+              "title": "Introduction to Physical Therapist Assisting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "121",
+              "title": "Therapeutic Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "151",
+              "title": "Musculoskeletal Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTH",
+              "number": "115",
+              "title": "Kinesiology for the Physical Therapist Assistant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "122",
+              "title": "Therapeutic Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "131",
+              "title": "Clinical Education I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "225",
+              "title": "Rehabilitation Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "251",
+              "title": "Clinical Practicum I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "210",
+              "title": "Psychological Aspects of Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTH",
+              "number": "226",
+              "title": "Therapeutic Exercise",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "227",
+              "title": "Pathological Conditions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "255",
+              "title": "Seminar in Physical Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "252",
+              "title": "Clinical Practicum II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing - Certificate",
+      "credential": "certificate",
+      "program_code": "157",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1548",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Transfer Elective (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core Requirements (26cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PNE",
+              "number": "145",
+              "title": "Trends in Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "158",
+              "title": "Mental Health and Psychiatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "162",
+              "title": "Nursing in Health Changes II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "164",
+              "title": "Nursing in Health Changes IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "174",
+              "title": "Applied Pharmacology for Practical Nurses",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HLT",
+                  "number": "143",
+                  "title": "Medical Terminology I"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PNE",
+              "number": "162",
+              "title": "Nursing in Health Changes II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "174",
+              "title": "Applied Pharmacology for Practical Nurses",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PNE",
+              "number": "164",
+              "title": "Nursing in Health Changes IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "145",
+              "title": "Trends in Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "158",
+              "title": "Mental Health and Psychiatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Health Professions Preparation - CSC - 221-190-01 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1549",
+      "total_credits": 4,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PSY",
+                  "number": "230",
+                  "title": "Developmental Psychology"
+                },
+                {
+                  "prefix": "BIO",
+                  "number": "141",
+                  "title": "Human Anatomy and Physiology I"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature or Transfer Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            },
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "Health Care Technician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "102",
+              "title": "Health Care Technician II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "115",
+              "title": "Medication Administration Training",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician-Clinical",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PSY",
+                  "number": "230",
+                  "title": "Developmental Psychology"
+                },
+                {
+                  "prefix": "BIO",
+                  "number": "141",
+                  "title": "Human Anatomy and Physiology I"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UGS Arts, Humanities & Literature or Transfer Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "CSC Completion (7cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Dental (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "EMT (9cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician-Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Health Care Technician- CNA (7cr) / Medication Aide (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "Health Care Technician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "102",
+              "title": "Health Care Technician II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "115",
+              "title": "Medication Administration Training",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Nursing (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Introductory Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PTA (7cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Respiratory Therapist (4cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic - Certificate",
+      "credential": "certificate",
+      "program_code": "145",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1665",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "*CoAEMSP requirements state EMS 249 cannot be started until 90% of the course work has been completed. EMS 246 and EMS 249 would be offered as 5 (Summer) or 7 (Fall or Spring) week courses to adhere to this requirement. *General education courses are not required for certification and can be completed after the EMS courses.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "175",
+              "title": "Paramedic Clinical Experience I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting II - Expanded Functions Dental Assisting, Career Studies Certificate-221-120-07",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1553",
+      "total_credits": 3,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "103",
+              "title": "Introduction to Oral Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "108",
+              "title": "Dental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "110",
+              "title": "Dental Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "214",
+              "title": "Indirect Restoration Techniques",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "212",
+              "title": "Composite Resin Restorations: Placing and Shaping",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "210",
+              "title": "Amalgam Restorations: Placing, Packing, Carving, and Polishing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pharmacy Technician - CSC - 221-190-08",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1550",
+      "total_credits": 4,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "250",
+              "title": "General Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "261",
+              "title": "Basic Pharmacy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "262",
+              "title": "Basic Pharmacy II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "263",
+              "title": "Basic Pharmacy I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "250",
+              "title": "General Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "261",
+              "title": "Basic Pharmacy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "262",
+              "title": "Basic Pharmacy II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "263",
+              "title": "Basic Pharmacy I Lab",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology - Automotive Diagnostician - CSC - 221-909-01",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1561",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Shop Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "121",
+              "title": "Automotive Fuel Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Automotive Fuel Systems II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Auto Power Trains I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "236",
+              "title": "Automotive Climate Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "241",
+              "title": "Automotive Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "245",
+              "title": "Automotive Electronics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Criminal Justice - AAS - 456 - Can Be Completed Online",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1567",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Health/Physical Education (2cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "100",
+              "title": "First Aid and Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HLT",
+                  "number": "106",
+                  "title": "First Aid and Safety"
+                }
+              ]
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition and Human Development",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Sciences (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any Social Science course from ECO,PLS,PSY,SOC,GEO,HIS (courses must differ from any listed in the History requirements above or major requirements below)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Communication (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Computer Applications & Concepts (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Core requirements - (24cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence and Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Elective Course Options (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any two ADJ courses (not listed above) or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "255",
+              "title": "Psychological Aspects of Criminal Behavior",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MTH/SCI Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ADJ Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence and Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ADJ Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Automotive Technology - Automotive Technician, CSC - 221-909-69",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1562",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Shop Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Automotive Engines I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "112",
+              "title": "Automotive Engines II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "136",
+              "title": "Automotive Vehicle Inspection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "266",
+              "title": "Auto Alignment, Suspension and Steering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "267",
+              "title": "Automotive Suspension and Braking Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "241",
+              "title": "Automotive Electricity I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Foundations of Criminal Justice - Certificate - 412 - Can Be Completed Online",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1568",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HLT",
+                  "number": "100",
+                  "title": "First Aid and Cardiopulmonary Resuscitation"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities - one course (3cr) from PHI, ENG Literature or ART Passport Course or Humanities from approved Transfer Elective List",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health/Physical Ed",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Foundations of Criminal Justice - CSC - 221-400-01 - Can Be Completed Online",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1569",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                },
+                {
+                  "prefix": "ENG",
+                  "number": "111",
+                  "title": "College Composition I"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Science - AS",
+      "credential": "AS",
+      "program_code": "880",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1572",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "112",
+                  "title": "College Composition II"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Art, Humanities & Literature (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ART",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Lab Science (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and MTH 162 Precalculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science - AS - 880 - Biology Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1573",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MTH 167 Precalculus with Trigonometry or Transfer Elective I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                },
+                {
+                  "prefix": "PHI",
+                  "number": "100",
+                  "title": "Introduction to Philosophy"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Sciences I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Science - AS - 880 - Chemistry Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1574",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "167",
+                  "title": "Precalculus with Trigonometry"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "241",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "245",
+              "title": "Organic Chemistry Laboratory I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PHI",
+                  "number": "100",
+                  "title": "Introduction to Philosophy"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "242",
+              "title": "Organic Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "246",
+              "title": "Organic Chemistry Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science - AS - 880 - Applied Mathematics Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1593",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Lab Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Lab Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select one of the following courses: MTH 246 Statistics II or MTH 267 Differential Equations or MTH 288 Discrete Mathematics or CSC 208 Introduction to Discrete Structure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science - AS - 880 - Environmental Science Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1575",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "101",
+                  "title": "General Biology I"
+                },
+                {
+                  "prefix": "MTH",
+                  "number": "167",
+                  "title": "Precalculus with Trigonometry"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "102",
+                  "title": "General Biology II"
+                }
+              ]
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "264",
+                  "title": "Calculus II"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science - AS - 880 - Geology Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1576",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science - AS - 880 - Physics Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1577",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "167",
+                  "title": "Precalculus with Trigonometry"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "266",
+                  "title": "Linear Algebra"
+                },
+                {
+                  "prefix": "PHI",
+                  "number": "100",
+                  "title": "Introduction to Philosophy"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering - AS - 831 - Biomedical Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1609",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts & Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "122",
+                  "title": "Engineering Design"
+                }
+              ]
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Sciences I (Preferred ECO 202 Principles of Microeconomics )",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "240",
+                  "title": "Solid Mechanics (Statics)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering - AS - 831 - Chemical Engineering Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1622",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science (ECO 202 Principles of Microeconomics, Preferred)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "122",
+              "title": "Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "231",
+              "title": "Mass and Energy Balances",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "125",
+                  "title": "Introduction to Computer Programming for Engineers"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "232",
+              "title": "Chemical Engineering Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "125",
+              "title": "Introduction to Computer Programming for Engineers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering - AS",
+      "credential": "AS",
+      "program_code": "831",
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1578",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Student Development (1cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Written Communication (6cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art, Humanities & Literature (6 cr.)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Art",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "Introduction to Women and Gender Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "220",
+              "title": "Introduction to African-American Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to Philosophy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Eastern Religions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in America",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Reading Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "World Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "258",
+              "title": "African American Literature",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "Women&#039;s Literature",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilizations Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social & Behavioral Sciences (3cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Mathematics (14cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and Choose two (2) of the following courses",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "288",
+              "title": "Discrete Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science (8cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Advising Pathway Specific Requirements (11-14cr)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Choose 3 EGR or CSC courses from the following: EGR 122, EGR 125, EGR 231, EGR 232, EGR 240, EGR 245, EGR 246, EGR 248, EGR 270, EGR 271, EGR 272, CSC 221, CSC 222, or CSC 223.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CHM",
+                  "number": "111",
+                  "title": "General Chemistry I"
+                }
+              ]
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities and Literature I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "122",
+                  "title": "Engineering Design"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering - AS - 831 - Civil Engineering Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1608",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts & Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "122",
+                  "title": "Engineering Design"
+                }
+              ]
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Sciences I (Preferred ECO 202 Principles of Microeconomics )",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "240",
+              "title": "Solid Mechanics (Statics)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "PHY",
+                  "number": "242",
+                  "title": "University Physics II"
+                },
+                {
+                  "prefix": "MTH",
+                  "number": "266",
+                  "title": "Linear Algebra"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "245",
+              "title": "Engineering Mechanics - Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "246",
+              "title": "Mechanics of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering - AS - 831 - Electrical/Computer Engineering Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1607",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art & Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "122",
+                  "title": "Engineering Design"
+                }
+              ]
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "125",
+                  "title": "Introduction to Computer Programming for Engineers"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "270",
+              "title": "Fundamentals of Computer Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "271",
+              "title": "Electrical Circuits I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Sciences (Preferred ECO 202 Principles of Microeconomics )",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "272",
+              "title": "Electric Circuits II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "265",
+                  "title": "Calculus III"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS History",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering - AS - 831 - Mechanical/Aerospace Engineering Advising Pathway",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1604",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Five",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Specific Discipline)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Arts & Humanities I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "122",
+              "title": "Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "125",
+                  "title": "Introduction to Computer Programming for Engineers"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "240",
+              "title": "Solid Mechanics (Statics)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "EGR",
+                  "number": "248",
+                  "title": "Thermodynamics for Engineering"
+                }
+              ]
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Social & Behavioral Science I (ECO 202 Principles of Microeconomics preferred)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "245",
+              "title": "Engineering Mechanics - Dynamics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "246",
+              "title": "Mechanics of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "UCGS Art, Humanities & Literature II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering - CADD - CSC - 221-729-01",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1583",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements/Suggested Scheduling",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Computer Aided Drafting and Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "241",
+              "title": "Parametric Solid Modeling I",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CAD",
+                  "number": "235",
+                  "title": "Applications for Additive Manufacturing"
+                },
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Technology in Mechatronics - CSC - 221-736-05",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1605",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements/Suggested Scheduling",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ITE",
+                  "number": "152",
+                  "title": "Introduction to Digital and Information Literacy and Computer Applications"
+                }
+              ]
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "D.C. and A.C. Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Introduction to Mechatronics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "162",
+              "title": "Applied Hydraulics and Pneumatics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technology in Mechatronics - CSC - 221-736-01",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.germanna.edu/preview_program.php?catoid=15&poid=1597",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Core Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "127",
+              "title": "Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Computer Aided Drafting and Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "113",
+              "title": "Materials and Processes of Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "295",
+              "title": "Topics In Industrial Engineering Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/va/programs/mecc.json
+++ b/data/va/programs/mecc.json
@@ -1,0 +1,12201 @@
+{
+  "college_slug": "mecc",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.mecc.edu",
+  "scraped_at": "2026-05-06T21:24:34.977Z",
+  "programs": [
+    {
+      "title": "Business Administration, AS",
+      "credential": "AS",
+      "program_code": "213",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=585",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective - Any Humanities Course with (HUM prefix), Philosophy Course (PHI prefix) OR Religion Course (REL prefix) Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science - BIO 101 General Biology OR CHM 111 General Chemistry OR PHY 201 General College Physics Credits / Units: 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History - HIS 101 Western Civilizations Pre-1600 OR HIS 102 Western Civilizations Post-1500 OR HIS 121 United States History Until 1877 OR HIS 122 United States History Since 1865 Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Physical Education Elective OR HLT 105: Cardiopulmonary Resuscitation Credits / Units: 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science - BIO 102: General Biology OR CHM 112 General Chemistry II OR PHY 202 General College Physics II Credits / Units: 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Business Statistics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature - ENG 245 British Literature OR ENG 246 American Literature OR ENG 255 World Literature Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "200",
+              "title": "Transfer Readiness Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Liberal Arts, AA",
+      "credential": "AA",
+      "program_code": "648",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=587",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Electives: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "255",
+              "title": "&#160;",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR SPRING",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Transfer Elective: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "200",
+              "title": "Transfer Readiness Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Engineering, AS",
+      "credential": "AS",
+      "program_code": "831",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=591",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "122",
+              "title": "Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EGR - Approved Sophomore Engineering Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EGR - Approved Sophomore Engineering Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EGR - Approved Sophomore Engineering Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG - Literature 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EGR - Approved Sophomore Engineering Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "200",
+              "title": "Transfer Readiness Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Education, AS",
+      "credential": "AS",
+      "program_code": "625",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=589",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG Literature: (ENG 245, 246, or 255)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U. S. Government &amp; Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Intro to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "200",
+              "title": "Transfer Readiness Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies, AS",
+      "credential": "AS",
+      "program_code": "699",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=680",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST YEAR FALL",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST YEAR SPRING",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Pre-Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR FALL",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "English Literature Elective3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Transfer Elective4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR SPRING",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "200",
+              "title": "Transfer Readiness Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Transfer Electives (4x3 hour courses for 12 hours)4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Science, AS",
+      "credential": "AS",
+      "program_code": "881",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=590",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science2 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "FIRST YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective1 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science2 4 credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Pre-Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "​Social Science Elective3 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR FALL:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science3 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND YEAR SPRING:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Natural Science2 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "200",
+              "title": "Transfer Readiness Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Support Technology - Medical Office Specialist, AAS",
+      "credential": "AAS",
+      "program_code": "298-02",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=593",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "102",
+              "title": "Keyboarding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "107",
+              "title": "Editing/Proofreading Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "150",
+              "title": "Health Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "113",
+              "title": "Medical Terminology &amp; Disease Process I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "130",
+              "title": "Healthcare Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "271",
+              "title": "Medical Office Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "114",
+              "title": "Medical Terminology &amp; Disease Process II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "143",
+              "title": "Electronic Billing in Med Prac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "243",
+              "title": "Office Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "244",
+              "title": "Office Administration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities or Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Support Technology, AAS",
+      "credential": "AAS",
+      "program_code": "298",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=602",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "107",
+              "title": "Editing/Proofreading Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "137",
+              "title": "Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "236",
+              "title": "Specialized Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "243",
+              "title": "Office Administration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Business Law I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "244",
+              "title": "Office Administration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "170",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CMT - Mechatronics Specialization, AAS",
+      "credential": "AAS",
+      "program_code": "726-03",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=651",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "154",
+              "title": "Mechanical Maintenance I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "143",
+              "title": "Devices and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "125",
+              "title": "Installation and Preventive Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "218",
+              "title": "Industrial Electronics Circuit",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "177",
+              "title": "Industrial Robotics and Robotics Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "230",
+              "title": "Mechatronic Process Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "266",
+              "title": "Fluid Mechanic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "298",
+              "title": "Seminar &amp; Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts &amp; Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "102",
+              "title": "Computers and Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Software Specialist, AAS",
+      "credential": "AAS",
+      "program_code": "222",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=664",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "171",
+              "title": "Unix 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing:  Infrastructure and Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "131",
+              "title": "Survey of Internet Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "150",
+              "title": "Desktop Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "140",
+              "title": "Client Side Scripting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structured Query Language",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "225",
+              "title": "Web Scripting Languages",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Physical Education Elective/Health Elective 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science or Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "298",
+              "title": "Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer-Aided Drafting and Design Technology, AAS",
+      "credential": "AAS",
+      "program_code": "729",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=621",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "200",
+              "title": "Survey Computer Aided Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "107",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Remote Pilot Ground School",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "233",
+              "title": "Computer Aided Drafting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Geog Info Systems II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "201",
+              "title": "Computer Aided Drafting &amp; Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Personal Development Elective 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "122",
+              "title": "3D Printing Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "231",
+              "title": "Computer Aided Drafting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "205",
+              "title": "GIS 3 Dimensional Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "110",
+              "title": "Introduction to Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "210",
+              "title": "Understanding Geographic Data",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "172",
+              "title": "Surveying II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "232",
+              "title": "Computer Aided Drafting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "298",
+              "title": "Seminar &amp; Project in Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "290",
+              "title": "Coordinated Internship in Drafting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Networking Technology, AAS",
+      "credential": "AAS",
+      "program_code": "732",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=663",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing:  Infrastructure and Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "131",
+              "title": "Survey of Internet Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "154",
+              "title": "Introduction to Networks - CISCO",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "270",
+              "title": "Advanced Linux Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "111",
+              "title": "Server Administration (Server 2022)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "155",
+              "title": "Switching, Routing and Wireless Essentials - CISCO",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Technical Professional Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "112",
+              "title": "Network Infrastructure (PAN)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "156",
+              "title": "Enterprise Networking, Security, and Automation - CISCO",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computerized Manufacturing Technology, AAS",
+      "credential": "AAS",
+      "program_code": "726",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=650",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "113",
+              "title": "Mat/Proc Indus",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "266",
+              "title": "Fluid Mechanic",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "200",
+              "title": "Survey Computer Aided Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "101",
+              "title": "Quality Assurance Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts &amp; Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "IND 250 - Intro to Basic Computer Integrated Manufacturing 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Correctional Services, AAS",
+      "credential": "AAS",
+      "program_code": "462",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=659",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "171",
+              "title": "Forensic Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "107",
+              "title": "Survey of Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "146",
+              "title": "Adult Correctional Institution",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "172",
+              "title": "Forensic Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "245",
+              "title": "Management of Correctional Facility",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "127",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ADJ or Transfer Elective Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "241",
+              "title": "Correctional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "234",
+              "title": "Terrorism/Counter Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "246",
+              "title": "Correctional Counseling",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "296",
+              "title": "On Site Training in ADJ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technology, AAS",
+      "credential": "AAS",
+      "program_code": "820",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=615",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Condition &amp; Refrigeration Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "112",
+              "title": "Air Condition &amp; Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "154",
+              "title": "Heating Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "210",
+              "title": "Air Conditioning and Refrigeration Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "116",
+              "title": "Duct Construction and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "110",
+              "title": "Solar Power Installations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "102",
+              "title": "Computers and Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electrical Code II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "290",
+              "title": "Coordinated Internship in ELE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services Paramedic, AAS",
+      "credential": "AAS",
+      "program_code": "146",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=630",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician-Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician Basic - Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Education Elective - 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support - ACLS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatric Care (EPC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice, AAS",
+      "credential": "AAS",
+      "program_code": "456",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=662",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "131",
+              "title": "Legal Evidence",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "171",
+              "title": "Forensic Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "107",
+              "title": "Survey of Criminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "130",
+              "title": "Introduction to Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "138",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "172",
+              "title": "Forensic Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "111",
+              "title": "Law Enfor Org &amp; Adm I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "234",
+              "title": "Terrorism/Counter Terrorism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "296",
+              "title": "On Site Training in ADJ",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Energy Technology - Electrical Specialization, AAS",
+      "credential": "AAS",
+      "program_code": "820-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=616",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Condition &amp; Refrigeration Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "112",
+              "title": "Air Condition &amp; Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Home Electric Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electrical Code II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "143",
+              "title": "Devices and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "102",
+              "title": "Computers and Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENE",
+              "number": "110",
+              "title": "Solar Power Installations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "177",
+              "title": "Photovoltaic Energy Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "290",
+              "title": "Coordinated Internship in ELE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science - Water/Wastewater Specialization, AAS",
+      "credential": "AAS",
+      "program_code": "828-02",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=624",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "Intro Waste/Water Trmt Tech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "220",
+              "title": "Environmental Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "Water Purification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAS",
+              "number": "106",
+              "title": "Conservation of Natural Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "General Elective Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "108",
+              "title": "Environmental Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "149",
+              "title": "Wastewater Treatment Plant Ope",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "227",
+              "title": "Environmental Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "246",
+              "title": "Water Resource Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health or PE Elective 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEC",
+              "number": "265",
+              "title": "Fluid Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "211",
+              "title": "Sanitary Biology &amp; Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENV 290 - Coordinated Internship in Environmental Science 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science, AAS",
+      "credential": "AAS",
+      "program_code": "828",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=623",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "220",
+              "title": "Environmental Problems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "100",
+              "title": "Introduction to Forestry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "General Environmental Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "137",
+              "title": "Environmental Factors in Plant Growth",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAS",
+              "number": "106",
+              "title": "Conservation of Natural Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "122",
+              "title": "General Environmental Science II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "205",
+              "title": "Soil Fertility and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "227",
+              "title": "Environmental Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "210",
+              "title": "Understanding Geographic Data",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "235",
+              "title": "Soil Conservat &amp; Spoils Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Health/Physical Education Credits / Units: 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "208",
+              "title": "Insect Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "246",
+              "title": "Water Resource Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "211",
+              "title": "Sanitary Biology &amp; Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Forest Science, AAS",
+      "credential": "AAS",
+      "program_code": "839",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=625",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "100",
+              "title": "Introduction to Forestry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "115",
+              "title": "Dendrology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "246",
+              "title": "Water Resource Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAS",
+              "number": "106",
+              "title": "Conservation of Natural Resources",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Technical Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FOR",
+              "number": "215",
+              "title": "Applied Silviculture",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "237",
+              "title": "Wildlife Ecology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "205",
+              "title": "Soil Fertility and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "227",
+              "title": "Environmental Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "210",
+              "title": "Understanding Geographic Data",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "208",
+              "title": "Insect Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "172",
+              "title": "Surveying II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "245",
+              "title": "Forest Products I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FOR",
+              "number": "290",
+              "title": "Coordinated Internship Forstry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HLT or PED 1 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Management, AAS",
+      "credential": "AAS",
+      "program_code": "152",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=595",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "111",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "113",
+              "title": "Medical Terminology &amp; Disease Process I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "193",
+              "title": "Studies in Excel for Healthcare Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "130",
+              "title": "Healthcare Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "150",
+              "title": "Health Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "112",
+              "title": "Medical Terminology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "114",
+              "title": "Medical Terminology &amp; Disease Process II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "253",
+              "title": "Health Records Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective - 3 Credits Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "149",
+              "title": "Introduction to Medical Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "151",
+              "title": "Reimbursement Issues in Medical Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "249",
+              "title": "Supervision and Management Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "254",
+              "title": "Advanced Coding and Reimbursement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAS",
+              "number": "171",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "229",
+              "title": "Performance Improvement in Health Care Settings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "235",
+              "title": "Emerging Technologies in Health IT",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "265",
+              "title": "Facility Based Medical Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "280",
+              "title": "HIM Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "260",
+              "title": "Pharmacology for Health Information Technoloyg",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective - 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Management, AAS",
+      "credential": "AAS",
+      "program_code": "212",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=605",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "149",
+              "title": "Workplace Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Current Issues in Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "170",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Principles of Supervision I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Leadership Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective - 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economics Essentials: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Nursing - Track 1: Two-Year, AAS",
+      "credential": "AAS",
+      "program_code": "156",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=644",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prior to Nursing Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LBR",
+              "number": "105",
+              "title": "Library Skills For Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practitioners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion &amp; Assessment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Laboratory Technology (WCC), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=637",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MDL 101 - Intro to Med Lab Techniques 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MDL 127 - Hematology 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MDL 126 - Clinical Immunohematology & Immunology I&nbsp;4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MDL 261 - Clinical Chemistry & Instrumentation I&nbsp;4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - Track 3: Part-Time Evening/Weekend, AAS",
+      "credential": "AAS",
+      "program_code": "156",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=646",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LBR",
+              "number": "105",
+              "title": "Library Skills For Research",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practitioners",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion &amp; Assessment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant (SWCC), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=639",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 100 - Introduction to OT 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 195 - Topics in OT for Physical Dysfunction 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 201 - OT with Psychosocial 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 205 - Therapeutic Media 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "NAS 177 - Upper Extremity Anatomy & Kinesiology&nbsp;2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities/Fine Arts Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - Track 4: Part-Time Evening/Weekend Advanced Placement Option LPN Transition, AAS",
+      "credential": "AAS",
+      "program_code": "156",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=647",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LBR",
+              "number": "105",
+              "title": "Library Skills For Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "115",
+              "title": "Health Care Concepts for Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion &amp; Assessment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Track 2: Advanced Placement Option for LPN Transition, AAS",
+      "credential": "AAS",
+      "program_code": "156",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=645",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LBR",
+              "number": "105",
+              "title": "Library Skills For Research",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "115",
+              "title": "Health Care Concepts for Transition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion &amp; Assessment",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Paralegal Studies, AAS",
+      "credential": "AAS",
+      "program_code": "260",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=606",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "120",
+              "title": "Legal Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "110",
+              "title": "Law/Legal Asst",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "200",
+              "title": "Ethics for the Paralegal",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "170",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "115",
+              "title": "Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "117",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "127",
+              "title": "Legal Research and Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LGL",
+              "number": "195",
+              "title": "Topics in Paralegal Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "216",
+              "title": "Trial Preparation &amp; Discovery Practice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "218",
+              "title": "Criminal Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U. S. Government &amp; Politics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "265",
+              "title": "Legal Office Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "230",
+              "title": "Legal Transactions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "222",
+              "title": "Information Technology for the Paralegal",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapy Assistant (WCC), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=641",
+      "total_credits": null,
+      "gpa_minimum": 2.5,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PTH 105 - Introduction to Physical Therapy 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PTH 110 - Medical Reporting 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PTH 115 - Kinesiology for the Physical Therapy 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PTH 121 - Therapeutic Procedures I 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PTH 151 - Musculoskeletal Structure & Function&nbsp;3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Precision Machining, AAS",
+      "credential": "AAS",
+      "program_code": "718-05",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=685",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "101",
+              "title": "Machine Shop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "102",
+              "title": "Machine Shop II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "209",
+              "title": "Standards, Measurements, and Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "151",
+              "title": "Machine Tool Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "215",
+              "title": "Machining Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "217",
+              "title": "Precision Machining Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "298",
+              "title": "Seminar and Project",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "106",
+              "title": "First Aid and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding, AAS",
+      "credential": "AAS",
+      "program_code": "718-02",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=655",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "110",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "100",
+              "title": "Fundamentals of Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "115",
+              "title": "Arc and Gas Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding (Basic)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "101",
+              "title": "Quality Assurance Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "198",
+              "title": "Seminar &amp; Project in Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "153",
+              "title": "Layout and Fitting for Welders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "130",
+              "title": "Inert Gas Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Gas Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "129",
+              "title": "Pipefitting and Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "126",
+              "title": "Pipe Welding I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "200",
+              "title": "Survey Computer Aided Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG 113 - Technical-Professional Writing 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math/Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts &amp; Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "266",
+              "title": "Fluid Mechanic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "sUAS Operations Technician Technical Studies, AAS",
+      "credential": "AAS",
+      "program_code": "718-04",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=673",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "101",
+              "title": "Quality Assurance Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "107",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Remote Pilot Ground School",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "120",
+              "title": "Human Relations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG 115 - Technical Writing 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAS",
+              "number": "125",
+              "title": "Meteorology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "111",
+              "title": "Small Unmanned Aircraft Systems (sUAS) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETR",
+              "number": "218",
+              "title": "Industrial Electronics Circuit",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "200",
+              "title": "Survey Computer Aided Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "177",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Components and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U. S. Government &amp; Politics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PED or HLT Elective 2-3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts &amp; Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "211",
+              "title": "Small Unmanned Aircraft Systems (sUAS) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "290",
+              "title": "Coordinated Internship in sUAS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "296",
+              "title": "On-Site Training in Unmanned Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography Technology (SWCC), AAS",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=643",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 195 - Topics in Ethics, Teamwork, & Professional Development - 1 credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 105 - Introduction to Radiography, Protection, and Patient Care - 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 110 - Imaging Equipment & Protection&nbsp;3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 121 - Radiographic Procedures I 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 112 - Radiologic Science II 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 221 - Radiologic Procedures II 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 290 - Coordinated Internship 6 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 246 - Special Procedures 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 270 - Digital Acquisition and Display 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration, C",
+      "credential": "other",
+      "program_code": "903",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=610",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Condition &amp; Refrigeration Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "281",
+              "title": "Energy Management I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "112",
+              "title": "Air Condition &amp; Refrigeration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "154",
+              "title": "Heating Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "210",
+              "title": "Air Conditioning and Refrigeration Analysis",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "116",
+              "title": "Duct Construction and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy, AAS",
+      "credential": "AAS",
+      "program_code": "181",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=648",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAS",
+              "number": "171",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "102",
+              "title": "Integrated Sciences for Respiratory Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "110",
+              "title": "Fundamental Theory &amp; Procedures for Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science/Humanities/General Transfer Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "111",
+              "title": "Anatomy &amp; Physiology for the Cardiopulmonary System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "131",
+              "title": "Respiratory Care Theory &amp; Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "145",
+              "title": "Pharmacology for Respiratory Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "151",
+              "title": "Fundamental Clinical Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "112",
+              "title": "Pathology of the Cardiopulmonary System",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "121",
+              "title": "Cardiopulmonary Science I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "132",
+              "title": "Respiratory Care Theory &amp; Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "152",
+              "title": "Fundamental Clinical Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "135",
+              "title": "Respiratory Care Diagnostic &amp; Therapeutic Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "224",
+              "title": "Integrated Respiratory Therapy Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "253",
+              "title": "Advanced Clinical Procedures III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "226",
+              "title": "Theory of Neonatal &amp; Pediatric Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "254",
+              "title": "Advanced Clinical Procedures IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "227",
+              "title": "Integrated Respiratory Therapy Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "267",
+              "title": "12 Lead Electrocardiographic Diagnostics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "265",
+              "title": "Current Issues in Respiratory Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Clerical Assistant, C",
+      "credential": "other",
+      "program_code": "218",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=603",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "102",
+              "title": "Keyboarding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "107",
+              "title": "Editing/Proofreading Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "236",
+              "title": "Specialized Software Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "170",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "137",
+              "title": "Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Legal Office Assisting, C",
+      "credential": "other",
+      "program_code": "261",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=604",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "120",
+              "title": "Legal Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "110",
+              "title": "Law/Legal Asst",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "200",
+              "title": "Ethics for the Paralegal",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKT",
+              "number": "170",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "115",
+              "title": "Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "117",
+              "title": "Family Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Maintenance, C",
+      "credential": "other",
+      "program_code": "990",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=652",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "198",
+              "title": "Seminar &amp; Project in Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "266",
+              "title": "Fluid Mechanic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts &amp; Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Summer/Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "205",
+              "title": "Piping &amp; Auxiliary Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "125",
+              "title": "Installation and Preventive Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing Leading to LPN, C",
+      "credential": "other",
+      "program_code": "157",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=642",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "143",
+              "title": "Applied Nursing Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "155",
+              "title": "Body Structure and Function",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "161",
+              "title": "Nursing in Health Changes I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "173",
+              "title": "Pharmacology for Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "174",
+              "title": "Applied Pharmacology for Practical Nurses",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PNE",
+              "number": "162",
+              "title": "Nursing In Health Changes II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "158",
+              "title": "Mental Health and Psychiatric Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "159",
+              "title": "Care of Pediatric Clients",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "164",
+              "title": "Nursing in Health Changes IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "132",
+              "title": "Care of Maternal and Newborn Clients",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "145",
+              "title": "Trends in Practical Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "130",
+              "title": "Nutrition and Diet Therapy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Uniform Certificate of General Studies, C",
+      "credential": "certificate",
+      "program_code": "695",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=592",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "FIRST SEMESTER",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Art/Mus Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to the Theatre",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music in Society",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Natural Science",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post-1600 CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "World Civilization Post-1500CE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SECOND SEMESTER",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Transfer Elective - See advisor for approved courses. It is recommended to take a second natural science, math, or history course. 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Transfer Elective - See advisor for approved courses. It is recommended to take a second science, math, or history course. 3-4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Humanities Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "256",
+              "title": "Comparative Mythology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "259",
+              "title": "The Greek and Roman Tradition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics and Society",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "200",
+              "title": "Survey of the Old Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "210",
+              "title": "Survey of the New Testament",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "230",
+              "title": "Religions of the World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "240",
+              "title": "Religions in the U.S.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Social Science Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Intro to Cultural Geography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U. S. Government &amp; Politics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "211",
+              "title": "Cultural Anthropology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Medical Office Coding and Procedures, C",
+      "credential": "other",
+      "program_code": "285",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=596",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "113",
+              "title": "Medical Terminology &amp; Disease Process I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "130",
+              "title": "Healthcare Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "150",
+              "title": "Health Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "114",
+              "title": "Medical Terminology &amp; Disease Process II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "253",
+              "title": "Health Records Coding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "265",
+              "title": "Facility Based Medical Coding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "149",
+              "title": "Introduction to Medical Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "151",
+              "title": "Reimbursement Issues in Medical Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "254",
+              "title": "Advanced Coding and Reimbursement",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NAS",
+              "number": "171",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science or Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding, C",
+      "credential": "other",
+      "program_code": "995",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=656",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "100",
+              "title": "Fundamentals of Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "110",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "115",
+              "title": "Arc and Gas Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding (Basic)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "110",
+              "title": "Introduction to Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "130",
+              "title": "Inert Gas Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Gas Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "153",
+              "title": "Layout and Fitting for Welders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "198",
+              "title": "Seminar &amp; Project in Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "126",
+              "title": "Pipe Welding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "129",
+              "title": "Pipefitting and Fabrication",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "3-D Design, CSC",
+      "credential": "other",
+      "program_code": "221-727-09",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=620",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "200",
+              "title": "Survey Computer Aided Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "298",
+              "title": "Seminar &amp; Project in Drafting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "233",
+              "title": "Computer Aided Drafting III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "122",
+              "title": "3D Printing Engineering Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Science, CSC",
+      "credential": "other",
+      "program_code": "221-190-00",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=713",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "241",
+              "title": "Organic Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "245",
+              "title": "Organic Chemistry I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "See your advisor for possible substitutions based on your field of study. Credits / Units: 16",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "242",
+              "title": "Organic Chemisty II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "246",
+              "title": "Organic Chemistry II Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "260",
+              "title": "Introductory Biochemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Please see your advisor about any possible course substitutions. Credits / Units: 13",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bioprocessing Operator, CSC",
+      "credential": "other",
+      "program_code": "221-335-35",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=678",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration, CSC",
+      "credential": "other",
+      "program_code": "221-903-10",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=611",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Condition &amp; Refrigeration Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "210",
+              "title": "Air Conditioning and Refrigeration Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemical Process Operator, CSC",
+      "credential": "other",
+      "program_code": "221-845-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=649",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "101",
+              "title": "Quality Assurance Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "205",
+              "title": "Piping &amp; Auxiliary Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "107",
+              "title": "Career Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "131",
+              "title": "Applied Physics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Construction - Electrical Emphasis, CSC",
+      "credential": "other",
+      "program_code": "221-989-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=612",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "105",
+              "title": "Shop Practices &amp; Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "110",
+              "title": "Introduction to Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG 100 - Basic Occupational English 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Home Electric Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Clinical Research Coordinator, CSC",
+      "credential": "other",
+      "program_code": "221-152-08",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=594",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computed Tomography (SWCC), CSC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=628",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 295 - Topics in CT Registry Preparation 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 196 - Clinical Internship in CT 2 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Health Care Personnel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Corrections Management and Supervision, CSC",
+      "credential": "other",
+      "program_code": "221-462-88",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=660",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "198",
+              "title": "Sem &amp; Proj Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "241",
+              "title": "Correctional Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "245",
+              "title": "Management of Correctional Facility",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "246",
+              "title": "Correctional Counseling",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Community Health Worker, CSC",
+      "credential": "other",
+      "program_code": "221-480-04",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=681",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Personal &amp; Community Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PBH",
+              "number": "110",
+              "title": "Introduction to Health and Disease",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "228",
+              "title": "Introduction to Public Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "162",
+              "title": "Communication Skills for Human Services Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "190",
+              "title": "Coordinated Internship for Community Health Worker",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PBH",
+              "number": "130",
+              "title": "Nutrition for Public Health",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "150",
+              "title": "Cross Cultural Health and Wellness Practices",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "241",
+              "title": "Global Health Perspectives",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "290",
+              "title": "Coordinated Internship for Community Health Worker",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "107",
+              "title": "Personal Finance",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CSS - Mobile Application Development, CSC",
+      "credential": "other",
+      "program_code": "221-299-00",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=665",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "225",
+              "title": "Web Scripting Languages",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity, CSC",
+      "credential": "other",
+      "program_code": "221-732-09",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=666",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing:  Infrastructure and Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "112",
+              "title": "Network Infrastructure (PAN)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime and Hacking",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "270",
+              "title": "Advanced Linux Network Administration",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Early Childhood Development Special Needs",
+      "credential": "other",
+      "program_code": "221-636-11",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=675",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "164",
+              "title": "Working with Infants and Toddlers in Inclusive Settings",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Introduction to Exceptional Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Introduction to Autism Spectrum Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "271",
+              "title": "Methodologies and Curriculum Development for Children with Autism Spectrum Disorders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "290",
+              "title": "Coordinated Internship in Early Childhood Special Needs Program",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development, CSC",
+      "credential": "other",
+      "program_code": "221-636-04",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=619",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "135",
+              "title": "Child Health and Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation &amp; Participation in Early Childhood/Primary Settings",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electricity, CSC",
+      "credential": "other",
+      "program_code": "221-941-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=614",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Condition &amp; Refrigeration Controls I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Home Electric Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician Plus, CSC",
+      "credential": "other",
+      "program_code": "221-146-02",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=632",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician-Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician Basic - Clinical",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Fabricator, CSC",
+      "credential": "other",
+      "program_code": "221-942-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=677",
+      "total_credits": 17,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Home Electric Power",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electrical Code II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "143",
+              "title": "Devices and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician Advanced, CSC",
+      "credential": "other",
+      "program_code": "221-146-08",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=633",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician-Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician Basic - Clinical",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy &amp; Physiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Technician, CSC",
+      "credential": "other",
+      "program_code": "221-146-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=631",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall or First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician-Basic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician Basic - Clinical",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "EMT Advanced and RN Bridge to Paramedic Bridge, CSC",
+      "credential": "other",
+      "program_code": "221-146-05",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=634",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Laboratory",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care Laboratory II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support - ACLS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatric Care (EPC)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Energy Technology - Electrical Emphasis, CSC",
+      "credential": "other",
+      "program_code": "221-820-05",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=617",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Fundamentals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electrical Code II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "143",
+              "title": "Devices and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geographic Information Systems, CSC",
+      "credential": "other",
+      "program_code": "221-719-71",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=622",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Geog Info Systems II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "205",
+              "title": "GIS 3 Dimensional Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "210",
+              "title": "Understanding Geographic Data",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "298",
+              "title": "Seminar &amp; Project in Drafting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "290",
+              "title": "Coordinated Internship in Drafting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technology - HVAC Emphasis, CSC",
+      "credential": "other",
+      "program_code": "221-820-06",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=618",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "281",
+              "title": "Energy Management I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "154",
+              "title": "Heating Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "210",
+              "title": "Air Conditioning and Refrigeration Analysis",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Technology Analyst, CSC",
+      "credential": "other",
+      "program_code": "221-152-02",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=674",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "136",
+              "title": "Database Management Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "132",
+              "title": "Health-IT Infrastructure Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "193",
+              "title": "Studies in Excel for Healthcare Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "170",
+              "title": "Project Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "233",
+              "title": "Electronic Health Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "130",
+              "title": "Introduction to Computers in Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "298",
+              "title": "Seminar &amp; Project",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Sciences, CSC",
+      "credential": "other",
+      "program_code": "221-190-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=635",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy &amp; Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy &amp; Physiology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective - 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Electives - 10 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services, CSC",
+      "credential": "other",
+      "program_code": "221-480-44",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=712",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "121",
+              "title": "Basic Counseling Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Management and Supervision, CSC",
+      "credential": "other",
+      "program_code": "221-463-89",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=661",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "111",
+              "title": "Law Enfor Org &amp; Adm I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "112",
+              "title": "Law Enforcement Organization &amp; Administration II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "198",
+              "title": "Sem &amp; Proj Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Machine Operator II, CSC",
+      "credential": "other",
+      "program_code": "221-952-06",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=683",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "102",
+              "title": "Machine Shop II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "151",
+              "title": "Machine Tool Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "209",
+              "title": "Standards, Measurements, and Calculations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machinery Maintenance, CSC",
+      "credential": "other",
+      "program_code": "221-985-52",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=653",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "140",
+              "title": "Basic Electricity &amp; Machinery",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "154",
+              "title": "Mechanical Maintenance I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "101",
+              "title": "Quality Assurance Technology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Operator III, CSC",
+      "credential": "other",
+      "program_code": "221-952-07",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=684",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "215",
+              "title": "Machining Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "217",
+              "title": "Precision Machining Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "298",
+              "title": "Seminar and Project",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Machine Operator I, CSC",
+      "credential": "other",
+      "program_code": "221-952-05",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=682",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "101",
+              "title": "Machine Shop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics Technology, CSC",
+      "credential": "other",
+      "program_code": "221-736-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=654",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "143",
+              "title": "Devices and Applications I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "266",
+              "title": "Fluid Mechanic",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "125",
+              "title": "Installation and Preventive Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "113",
+              "title": "Mat/Proc Indus",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mammography Advanced Studies (SWCC), CSC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=636",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Receptionist, CSC",
+      "credential": "other",
+      "program_code": "221-286-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=597",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "102",
+              "title": "Keyboarding II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "107",
+              "title": "Editing/Proofreading Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "150",
+              "title": "Health Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "113",
+              "title": "Medical Terminology &amp; Disease Process I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "130",
+              "title": "Healthcare Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Assistant, CSC",
+      "credential": "other",
+      "program_code": "221-285-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=714",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "107",
+              "title": "Editing/Proofreading Skills",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "113",
+              "title": "Medical Terminology &amp; Disease Process I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "130",
+              "title": "Healthcare Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Eligible for HDM Corporation HIPAA Certification upon completion of HIM 130.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "149",
+              "title": "Introduction to Medical Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "233",
+              "title": "Electronic Health Records Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "170",
+              "title": "Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Upon completion of the curriculum, students are eligible to take the NHA Certified Electronic Health Record Specialist (CEHRS) certification, Microsoft Office Specialist (MOS) Word Core, Excel Core, and Outlook certifications.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Records Technician, CSC",
+      "credential": "other",
+      "program_code": "221-285-73",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=598",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "271",
+              "title": "Medical Office Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "114",
+              "title": "Medical Terminology &amp; Disease Process II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "143",
+              "title": "Electronic Billing in Med Prac",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "175",
+              "title": "Email Essentials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Assistant (CNA), CSC",
+      "credential": "other",
+      "program_code": "221-157-06",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=638",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "Health Care Technician I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "102",
+              "title": "Health Care Technician II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Electives (from approved list) 7 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Old Time Music, CSC",
+      "credential": "other",
+      "program_code": "221-529-30",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=601",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "153",
+              "title": "Introduction to Appalachian Studies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "150",
+              "title": "Old Time String Band",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "133",
+              "title": "Recording Systems Services I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective Instrument Class 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "218",
+              "title": "Traditional Music and Musicians of Central Appalachia",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective Instrument Class Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective class Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective class Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy, CSC",
+      "credential": "other",
+      "program_code": "221-151-02",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=640",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester (Summer or Fall)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "111",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "100",
+              "title": "First Aid and CPR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Health Care Personnel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "105",
+              "title": "Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester (Fall or Spring)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "112",
+              "title": "Medical Terminology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "107",
+              "title": "Career Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "106",
+              "title": "Clinical Phlebotomy",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Small Business Management, CSC",
+      "credential": "other",
+      "program_code": "221-212-24",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=608",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Applied Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "149",
+              "title": "Workplace Ethics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "100",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "134",
+              "title": "Small Business Taxes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "165",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Pharmacy Technician, CSC",
+      "credential": "other",
+      "program_code": "221-190-07",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=599",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "111",
+              "title": "Medical Terminology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "121",
+              "title": "Substance Abuse: Prevention and Treatment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Health Care Personnel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "107",
+              "title": "Career Education",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "112",
+              "title": "Medical Terminology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "261",
+              "title": "Basic Pharmacy I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "262",
+              "title": "Basic Pharmacy II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "263",
+              "title": "Basic Pharmacy I Lab",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "190",
+              "title": "Coordinated Internship: Pharmacy Technician",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "250",
+              "title": "General Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Real Estate, CSC",
+      "credential": "other",
+      "program_code": "221-273-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=607",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "Information Literacy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "115",
+              "title": "Real Estate Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REA",
+              "number": "100",
+              "title": "Principles of Real Estate",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "107",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Remote Pilot Ground School",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Smart Farming - Crop Production, Management, and Processing, CSC",
+      "credential": "other",
+      "program_code": "221-335-34",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=679",
+      "total_credits": 22,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "142",
+              "title": "Introduction to Plant Science and Technology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "143",
+              "title": "Introduction to Agribusiness and Financial Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "295",
+              "title": "Grain Terminal Storage and Operations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "205",
+              "title": "Soil Fertility and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "231",
+              "title": "Agribusiness Marketing, Risk Management, and Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "234",
+              "title": "Chemical Application and Pest Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "233",
+              "title": "Food Production, Safety, Biosecurity, and Quality Control",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Smart Farming II, CSC",
+      "credential": "other",
+      "program_code": "221-335-33",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=670",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "UMS",
+              "number": "290",
+              "title": "Coordinated Internship in sUAS",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "296",
+              "title": "On-Site Training in Unmanned Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "112",
+              "title": "Introduction to Environmental and Science Technology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "137",
+              "title": "Environmental Factors in Plant Growth",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "208",
+              "title": "Insect Control",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Smart Farming I, CSC",
+      "credential": "other",
+      "program_code": "221-335-32",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=669",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "UMS",
+              "number": "107",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Remote Pilot Ground School",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "111",
+              "title": "Small Unmanned Aircraft Systems (sUAS) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "235",
+              "title": "Soil Conservat &amp; Spoils Mgmt",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "111",
+              "title": "Introduction to Environmental &amp; Science Technology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "205",
+              "title": "Soil Fertility and Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development I, CSC",
+      "credential": "other",
+      "program_code": "221-299-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=671",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction Network Concepts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing:  Infrastructure and Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sports Medicine Assistant, CSC",
+      "credential": "other",
+      "program_code": "221-197-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=600",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "2 - Orientation to Careers in Health Sciences",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Health Care Personnel",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "130",
+              "title": "Nutrition and Diet Therapy",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "100",
+              "title": "First Aid and CPR",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "125",
+              "title": "Anatomy and Physiology for Exercise Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "156",
+              "title": "Healthcare for Athletic Injuries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Approved Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Solar Installer I, CSC",
+      "credential": "other",
+      "program_code": "221-835-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=676",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electrical Code II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "102",
+              "title": "Computers and Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENE",
+              "number": "110",
+              "title": "Solar Power Installations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Software Development II, CSC",
+      "credential": "other",
+      "program_code": "221-299-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=672",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "131",
+              "title": "Survey of Internet Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "150",
+              "title": "Desktop Database Software",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "140",
+              "title": "Client Side Scripting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Wastewater Plant Operator, CSC",
+      "credential": "other",
+      "program_code": "221-828-68",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=626",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "108",
+              "title": "Environmental Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "Intro Waste/Water Trmt Tech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "149",
+              "title": "Wastewater Treatment Plant Ope",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "148",
+              "title": "Math Water/Wastewater Oper",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "211",
+              "title": "Sanitary Biology &amp; Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "265",
+              "title": "Fluid Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "227",
+              "title": "Environmental Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Water Plant Operator, CSC",
+      "credential": "other",
+      "program_code": "221-828-67",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=627",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "108",
+              "title": "Environmental Microbiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "Intro Waste/Water Trmt Tech",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "Water Purification",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "148",
+              "title": "Math Water/Wastewater Oper",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "211",
+              "title": "Sanitary Biology &amp; Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "265",
+              "title": "Fluid Mechanics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "227",
+              "title": "Environmental Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding Operator I, CSC",
+      "credential": "other",
+      "program_code": "221-995-01",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=657",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "110",
+              "title": "Welding Processes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "115",
+              "title": "Arc and Gas Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "100",
+              "title": "Fundamentals of Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding (Basic)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "110",
+              "title": "Introduction to Construction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Welding Operator II, CSC",
+      "credential": "other",
+      "program_code": "221-995-02",
+      "catalog_url": "https://catalog.mecc.edu/preview_program.php?catoid=6&poid=658",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "160",
+              "title": "Machine Blueprint Reading",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Gas Metal Arc Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "153",
+              "title": "Layout and Fitting for Welders",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "130",
+              "title": "Inert Gas Welding",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "198",
+              "title": "Seminar &amp; Project in Welding",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    }
+  ]
+}

--- a/data/va/programs/nova.json
+++ b/data/va/programs/nova.json
@@ -1,0 +1,19180 @@
+{
+  "college_slug": "nova",
+  "catalog_year": "",
+  "catalog_url": "https://nvcc.catalog.acalog.com",
+  "scraped_at": "2026-05-06T21:24:27.627Z",
+  "programs": [
+    {
+      "title": "Automotive Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3716",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Automotive Engines I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Shop Practice (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "197",
+              "title": "Automotive Cooperative Education  (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "241",
+              "title": "Automotive Electricity I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "242",
+              "title": "Automotive Electricity II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "265",
+              "title": "Automotive Braking Systems (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "266",
+              "title": "Auto Alignment, Suspension, and Steering (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "111",
+                  "title": "Basic Technical Mathematics (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "121",
+              "title": "Automotive Fuel Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "236",
+              "title": "Automotive Climate Control (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "112",
+              "title": "Automotive Engines II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Automotive Fuel Systems II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Auto Power Trains I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Auto Power Trains II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "245",
+              "title": "Automotive Electronics (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Engineering Technology: Data Center Operations Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3759",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "123",
+              "title": "Intro to Lean Manufacturing and Six Sigma (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts in Problem Solving (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "111",
+                  "title": "Basic Technical Mathematics (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10 (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "175",
+              "title": "Schematics and Mechanical Diagrams (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "146",
+              "title": "Electric Motor Control (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "148",
+              "title": "Power Distribution Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "233",
+              "title": "Programmable Logic Controller Systems I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "108",
+              "title": "Intro to Data Center Operations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "189",
+              "title": "Data Cabling Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "228",
+              "title": "Building Automation &amp; Energy Management Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "281",
+              "title": "Digital Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "270",
+              "title": "Computation for Engineering Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "211",
+              "title": "Electrical Machines I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "250",
+              "title": "Fiber Optic Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "208",
+              "title": "Critical Site Operations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3757",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "123",
+              "title": "Intro to Lean Manufacturing and Six Sigma (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts in Problem Solving (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Introduction to Mechatronics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10 (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "175",
+              "title": "Schematics and Mechanical Diagrams (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "146",
+              "title": "Electric Motor Control (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "233",
+              "title": "Programmable Logic Controller Systems I (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "111",
+                  "title": "Basic Technical Mathematics (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "MEC",
+              "number": "230",
+              "title": "Mechatronics Process Control (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "281",
+              "title": "Digital Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "233",
+              "title": "Process Control Integration (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "270",
+              "title": "Computation for Engineering Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "211",
+              "title": "Electrical Machines I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "266",
+              "title": "Application of Fluid Mechanics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Architecture Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3714",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "123",
+              "title": "Architectural Graphics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "133",
+              "title": "Construction Methodology and Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "200",
+              "title": "History of Architecture (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Computer Aided Drafting and Design I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "124",
+              "title": "Architectural Graphics II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "134",
+              "title": "Construction Methodology and Procedures II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "138",
+              "title": "Structures for Architects (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "298",
+              "title": "Seminar and Project (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "PreCalculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14-15 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Site Planning and Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "231",
+              "title": "Architectural Design and Graphics I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "243",
+              "title": "Environmental Systems (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "202",
+              "title": "Computer Aided Drafting and Design II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "203",
+              "title": "Computer Aided Drafting and Design III (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "232",
+              "title": "Architectural Design and Graphics II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "240",
+              "title": "Designing Sustainable Built Environments (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "116",
+              "title": "Lifetime Fitness and Wellness (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Construction Management Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3738",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "133",
+              "title": "Construction Methodology and Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "243",
+              "title": "Environmental Systems (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "101",
+              "title": "Construction Management I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "165",
+              "title": "Architectural Blueprint Reading (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "PreCalculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Site Planning and Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "215",
+              "title": "OSHA 30 Construction Safety (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "231",
+              "title": "Construction Estimating I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "165",
+              "title": "Construction Field Operations (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "200",
+              "title": "Sustainable Construction (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "241",
+              "title": "Construction Management III (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "247",
+              "title": "Construction Planning and Scheduling (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "134",
+              "title": "Construction Methodology and Procedures II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "232",
+              "title": "Construction Estimating II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "242",
+              "title": "Construction Management IV (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "228",
+              "title": "Concrete Technology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "229",
+              "title": "Concrete Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Air Conditioning and Refrigeration, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3707",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Conditioning and Refrigeration Controls I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "111",
+                  "title": "Basic Technical Mathematics (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "122",
+              "title": "Air Conditioning and Refrigeration II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "134",
+              "title": "Circuits and Controls I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "154",
+              "title": "Heating Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "276",
+              "title": "Refrigerant Usage EPA Certification (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "238",
+              "title": "Advanced Troubleshooting and Service (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 14-15 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architecture Technology: Computer Aided Drafting and Design, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3762",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Computer Aided Drafting and Design I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "202",
+              "title": "Computer Aided Drafting and Design II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "— — - Technical Elective (2-3 CR.) 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9-10 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architecture Technology: Architecture, C.S.C",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3834",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "123",
+              "title": "Architectural Graphics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "133",
+              "title": "Construction Methodology and Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "124",
+              "title": "Architectural Graphics II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "134",
+              "title": "Construction Methodology and Procedures II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12-14 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration: HVAC-R and Facilities Services Technology, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3710",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Conditioning and Refrigeration Controls I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "154",
+              "title": "Heating Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "106",
+              "title": "Preparation for Employment (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "122",
+              "title": "Air Conditioning and Refrigeration II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "134",
+              "title": "Circuits and Controls I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "276",
+              "title": "Refrigerant Usage EPA Certification (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "115",
+                  "title": "Technical Writing (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning and Refrigeration, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3709",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Conditioning and Refrigeration Controls I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "154",
+              "title": "Heating Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "276",
+              "title": "Refrigerant Usage EPA Certification (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "122",
+              "title": "Air Conditioning and Refrigeration II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "134",
+              "title": "Circuits and Controls I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "111",
+                  "title": "Basic Technical Mathematics (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Automotive Technology: Automotive Diagnosis and Repair, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3825",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Shop Practice (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Automotive Engines I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "241",
+              "title": "Automotive Electricity I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "265",
+              "title": "Automotive Braking Systems (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "136",
+              "title": "Automotive Vehicle Inspection (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "197",
+              "title": "Automotive Cooperative Education  (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "236",
+              "title": "Automotive Climate Control (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "242",
+              "title": "Automotive Electricity II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "266",
+              "title": "Auto Alignment, Suspension, and Steering (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Diesel Basic Repair, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3826",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "137",
+              "title": "Basic Diesel Engine Systems (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "150",
+              "title": "Mobile Hydraulics and Pneumatics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "155",
+              "title": "Heavy Duty Suspension and Service (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "161",
+              "title": "Air Brake Systems I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "162",
+              "title": "Air Brake Systems II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Diesel Preventative Maintenance, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3827",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "135",
+              "title": "Introduction to Diesel Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "143",
+              "title": "Diesel Truck Electrical Systems (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "145",
+              "title": "Medium/Heavy Duty Truck Preventative Maintenance Inspection (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "153",
+              "title": "Power Trains I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Electric, Hybrid, and Autonomous Vehicles, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3841",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "242",
+              "title": "Automotive Electricity II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "233",
+              "title": "Hybrid Electric Vehicle Technology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "236",
+              "title": "Automotive Climate Control (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "245",
+              "title": "Automotive Electronics (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology: Maintenance and Light Repair, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3718",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "100",
+              "title": "Introduction to Automotive Shop Practice (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "197",
+              "title": "Automotive Cooperative Education  (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "241",
+              "title": "Automotive Electricity I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "265",
+              "title": "Automotive Braking Systems (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Automotive Engines I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "266",
+              "title": "Auto Alignment, Suspension, and Steering (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Collision Repair Technology, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3719",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUB",
+              "number": "106",
+              "title": "Basic Sheet Metal Operations (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "118",
+              "title": "Automotive Paint Preparation (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "127",
+              "title": "Introduction to Collision Repair Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUB",
+              "number": "115",
+              "title": "Damage Repair Estimating (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "116",
+              "title": "Auto Body Repair (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "119",
+              "title": "Automotive Painting (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUB",
+              "number": "125",
+              "title": "Auto Body Welding (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Technology: Data Center Operations, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3832",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "175",
+              "title": "Schematics and Mechanical Diagrams (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts in Problem Solving (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "111",
+                  "title": "Basic Technical Mathematics (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10 (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "146",
+              "title": "Electric Motor Control (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "148",
+              "title": "Power Distribution Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "250",
+              "title": "Fiber Optic Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "108",
+              "title": "Intro to Data Center Operations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Construction Management Technology: Construction Supervision, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3740",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "133",
+              "title": "Construction Methodology and Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "101",
+              "title": "Construction Management I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "165",
+              "title": "Construction Field Operations (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "165",
+              "title": "Architectural Blueprint Reading (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "215",
+              "title": "OSHA 30 Construction Safety (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "231",
+              "title": "Construction Estimating I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Liberal Arts: Art History Major, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3815",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13-14 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "215",
+              "title": "History of Modern Art (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Engineering Technology: Engineering Technology Technician, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3831",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "175",
+              "title": "Schematics and Mechanical Diagrams (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "111",
+                  "title": "Basic Technical Mathematics (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10 (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "146",
+              "title": "Electric Motor Control (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "250",
+              "title": "Fiber Optic Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "123",
+              "title": "Intro to Lean Manufacturing and Six Sigma (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts in Problem Solving (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Introduction to Mechatronics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Construction Management Technology: Site Development, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3763",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLD",
+              "number": "165",
+              "title": "Construction Field Operations (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "201",
+              "title": "Computer Aided Drafting and Design I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "225",
+              "title": "Soil Mechanics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "165",
+              "title": "Architectural Blueprint Reading (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Site Planning and Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "280",
+              "title": "Introduction to Environmental Engineering (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "228",
+              "title": "Concrete Technology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "229",
+              "title": "Concrete Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Liberal Arts, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3813",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13-16 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13-14 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "298",
+              "title": "Seminar and Project Liberal Arts (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-19 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Communication Studies Major, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3817",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13-14 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "114",
+              "title": "Introduction to Mass Media (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "115",
+              "title": "Small Group Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "201",
+              "title": "Introduction to Communication Theory (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "298",
+              "title": "Seminar and Project Liberal Arts (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Welding: Basic Techniques, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3760",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "120",
+              "title": "Introduction to Welding (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "121",
+              "title": "Arc Welding (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "122",
+              "title": "Welding II (Electric Arc) (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "150",
+              "title": "Welding Drawing and Interpretation (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "130",
+              "title": "Inert Gas Welding (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Semi-Automatic Welding (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Liberal Arts: International Studies Major, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3816",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14-15 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "298",
+              "title": "Seminar and Project Liberal Arts (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Deaf Studies Major, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3777",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "Beginning American Sign Language I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "Beginning American Sign Language II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "Intermediate American Sign Language I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "Intermediate American Sign Language II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "125",
+              "title": "History of the U.S. Deaf Community (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "261",
+              "title": "Advanced American Sign Language I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13-14 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "220",
+              "title": "Comparative Linguistics: ASL and English (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "262",
+              "title": "Advanced American Sign Language II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "298",
+              "title": "Seminar and Project Liberal Arts (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: English Major, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3818",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14-15 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "American Sign Language to English Interpretation, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3711",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "261",
+              "title": "Advanced American Sign Language I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "105",
+              "title": "Interpreting Foundations I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "142",
+              "title": "Discourse Analysis (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "262",
+              "title": "Advanced American Sign Language II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "106",
+              "title": "Interpreting Foundations II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "107",
+              "title": "Translation Skills (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester (Summer)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "141",
+              "title": "Transliterating I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "130",
+              "title": "Interpreting: Introduction to Profession (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "133",
+              "title": "ASL-to-English Interpretation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "134",
+              "title": "English-to-ASL Interpretation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective or Science Elective (3-4 CR.) 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12-13 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "233",
+              "title": "ASL-to-English Interpretation II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "234",
+              "title": "English-to-ASL Interpretation II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "237",
+              "title": "Interpreting ASL in Safe Settings (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "6th Semester (summer)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INT",
+              "number": "250",
+              "title": "Dialogic Interpretation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "INT 290 Coordinated Internship (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3773",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "140",
+              "title": "Introduction to Graphic Skills (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "116",
+              "title": "Design for the Web I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "135",
+              "title": "Visual Communications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "141",
+              "title": "Typography I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "251",
+              "title": "Communication Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "270",
+              "title": "Digital Imaging I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "142",
+              "title": "Typography II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "217",
+              "title": "Graphic Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "265",
+              "title": "Graphic Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "281",
+              "title": "Illustration for Designers (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "218",
+              "title": "Graphic Design II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "250",
+              "title": "History of Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "268",
+              "title": "Professional Practices in Communication Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "287",
+              "title": "Portfolio and Resume (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design: Interactive Design Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3775",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "140",
+              "title": "Introduction to Graphic Skills (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "116",
+              "title": "Design for the Web I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Introduction to Multimedia (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "135",
+              "title": "Visual Communications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "251",
+              "title": "Communication Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "270",
+              "title": "Digital Imaging I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "141",
+              "title": "Typography I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "250",
+              "title": "History of Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "263",
+              "title": "Interactive Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "270",
+              "title": "Motion Graphics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "142",
+              "title": "Typography II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "203",
+              "title": "Animation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "264",
+              "title": "Interactive Design II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "287",
+              "title": "Portfolio and Resume (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cinema, A.F.A.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3733",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "160",
+              "title": "Film Production (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "115",
+              "title": "Small Group Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "120",
+              "title": "Screenwriting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "140",
+              "title": "Acting for the Camera (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "152",
+              "title": "Film Appreciation II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "198",
+              "title": "Seminar and Project: Portfolio (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "161",
+              "title": "Cinematography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "250",
+              "title": "The Art of the Film (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "274",
+              "title": "Digital Film Editing and Post Production (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "270",
+              "title": "Film Directing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "290",
+              "title": "Coordinated Internship (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "298",
+              "title": "Seminar and Project [Portfolio] (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Art, A.F.A.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3761",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "140",
+              "title": "Introduction to Graphic Skills (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "101",
+              "title": "Photography I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "Three-Dimensional Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Life Drawing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "298",
+              "title": "Visual Art Portfolio Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "History of Non-Western Art (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music A.F.A.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3838",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Music Theory I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Class Piano I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Music Theory II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "142",
+              "title": "Class Piano II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Advanced Music Theory I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221",
+              "title": "History of Western Music Pre-1750 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "241",
+              "title": "Advanced Class Piano I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "212",
+              "title": "Advanced Music Theory II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "History of Western Music 1750 to Present (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "242",
+              "title": "Advanced Class Piano II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "276",
+              "title": "Portfolio and Career Preparation for Performing Arts (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts: Theatre, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3814",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to the Theatre (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "141",
+              "title": "Theatre Appreciation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "131",
+              "title": "Acting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "136",
+              "title": "Theatre Workshop (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "136",
+              "title": "Theatre Workshop (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CST Elective (3 CR.) 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Interior Design, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3811",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "100",
+              "title": "Theory and Techniques of Interior Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "105",
+              "title": "Architectural Drafting for Interior Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "106",
+              "title": "Three-Dimensional Drawing and Rendering (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "245",
+              "title": "Computer Aided Drafting for Interior Designers (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "109",
+              "title": "Styles of Furniture and Interiors (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "205",
+              "title": "Materials and Sources (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "215",
+              "title": "Theory and Research in Commercial Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDS",
+              "number": "206",
+              "title": "Lighting Design for Interiors (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "221",
+              "title": "Designing Commercial Interiors I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "285",
+              "title": "Portfolio and Resume Preparation for Interior Designers (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "225",
+              "title": "Business Procedures (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IDS",
+              "number": "290",
+              "title": "Coordinated Internship (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language (ASL), C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3713",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "100",
+              "title": "Orientation to Acquisition of ASL as an Adult (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "Beginning American Sign Language I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "Beginning American Sign Language II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "125",
+              "title": "History of the U.S. Deaf Community (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "115",
+              "title": "Fingerspelling and Number Use in ASL (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "Intermediate American Sign Language I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "Intermediate American Sign Language II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "220",
+              "title": "Comparative Linguistics: ASL and English (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Photography and Media, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3786",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "101",
+              "title": "Photography I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "110",
+              "title": "History of Photography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "102",
+              "title": "Photography II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "130",
+              "title": "Video I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "270",
+              "title": "Digital Imaging I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHT",
+              "number": "201",
+              "title": "Advanced Photography I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "221",
+              "title": "Studio Lighting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHT",
+              "number": "202",
+              "title": "Advanced Photography II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "227",
+              "title": "Careers in Photography and Media (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "228",
+              "title": "Professional Practices for Photographers (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Recording Technology, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3791",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "MUS",
+              "number": "130",
+              "title": "Overview of the Recording Industry (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "140",
+              "title": "Introduction to Recording Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "157",
+              "title": "Sound Studio Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "158",
+              "title": "Recording Studio Electronics: Theory and Maintenance (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "165",
+              "title": "Small Business Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "179",
+              "title": "Music Copyright Law (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "227",
+              "title": "Editing and Mixdown Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "235",
+              "title": "Advanced Recording Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "288",
+              "title": "Recording Problems Seminar (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Technical and Professional Writing, C.S.C",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3785",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Technical-Professional Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "205",
+              "title": "Technical Editing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Advanced Composition (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "295",
+              "title": "Topics in Proposal Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "298",
+              "title": "Seminar and Project in Professional Writing (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice, A.A.S",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3696",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "164",
+              "title": "Case Studies in Murder/Violent Crime (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence, and Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "216",
+              "title": "Organized Crime and Corruption (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "234",
+              "title": "Terrorism and Counter-Terrorism (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "248",
+              "title": "Probation, Parole, and Treatment (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence, and Procedures II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Accounting, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3690",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "227",
+              "title": "Business and Professional Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Principles of Federal Taxation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Intermediate Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Auditing I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Introduction to Business Statistics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics and Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Criminology and Criminal Justice, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3744",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ADJ",
+                  "number": "211",
+                  "title": "Criminal Law, Evidence, and Procedures I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "ADJ",
+              "number": "234",
+              "title": "Terrorism and Counter-Terrorism (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "SOC",
+                  "number": "266",
+                  "title": "Race and Ethnicity (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ADJ",
+                  "number": "110",
+                  "title": "Introduction to Law Enforcement (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "ADJ",
+              "number": "233",
+              "title": "Multiculturalism in Policing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Religions of the East (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Contract Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3741",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CON",
+              "number": "100",
+              "title": "Shaping Business Arrangements (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "104",
+              "title": "Federal Acquisition Regulation (FAR) Fundamentals I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CON",
+              "number": "105",
+              "title": "Federal Acquisition Regulation (FAR) Fundamentals II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "121",
+              "title": "Strategic Focused Contracting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "170",
+              "title": "Fundamentals of Cost and Price Analysis (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "214",
+              "title": "Business Decisions for Contracting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Introduction to Business Statistics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "124",
+              "title": "Contract Execution (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "127",
+              "title": "Contract Administration (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "216",
+              "title": "Legal Considerations in Contracting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CON",
+              "number": "217",
+              "title": "Cost Analysis and Negotiation Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3723",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "PreCalculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Business Statistics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "280",
+              "title": "Introduction to International Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12-15 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3724",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Introduction to Business Statistics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3698",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence, and Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence, and Procedures II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Accounting: Bookkeeping, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3695",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "227",
+              "title": "Business and Professional Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Substance Abuse Rehabilitation Counselor, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3768",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "121",
+              "title": "Basic Counseling Skills I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "141",
+              "title": "Group Dynamics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Substance Abuse I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "266",
+              "title": "Counseling Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMS",
+              "number": "142",
+              "title": "Group Dynamics II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "145",
+              "title": "Effects of Psychoactive Drugs (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "252",
+              "title": "Substance Abuse II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "258",
+              "title": "Case Management and Substance Abuse (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HMS 290 - Coordinated Internship (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Elective (3 CR.) 2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting: Accounting Information Security with Data Analytics, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3828",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Auditing I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "263",
+              "title": "Data Analytics and Statistics in Accounting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Paralegal Studies, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3789",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "110",
+              "title": "Introduction to Law and the Paralegal Assistant (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "117",
+              "title": "Family Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "125",
+              "title": "Legal Research (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "126",
+              "title": "Legal Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "215",
+              "title": "Torts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "218",
+              "title": "Criminal Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "115",
+              "title": "Real Estate Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "217",
+              "title": "Trial Practice and the Law of Evidence (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "235",
+              "title": "Legal Aspects of Business Organizations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "225",
+              "title": "Estate Planning and Probate (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LGL",
+              "number": "230",
+              "title": "Legal Transactions (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice: Homeland Security Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3697",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "234",
+              "title": "Terrorism and Counter-Terrorism (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "163",
+              "title": "Crime Analysis and Intelligence (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "111",
+              "title": "Law Enforcement Organization and Administration I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "230",
+              "title": "Political Geography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "250",
+              "title": "Global Security Concepts for Law Enforcement and National Security (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence, and Procedures II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "228",
+              "title": "Narcotics and Dangerous Drugs (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence, and Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "243",
+              "title": "Homeland Security and Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "240",
+              "title": "Techniques of Interviewing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "237",
+              "title": "Religions of the East (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Accounting, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3694",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "219",
+              "title": "Governmental and Not-for-Profit Accounting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Principles of Federal Taxation I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Intermediate Accounting II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "230",
+              "title": "Advanced Accounting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Auditing I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "262",
+              "title": "Principles of Federal Taxation II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Management: Entrepreneurship, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3729",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "220",
+              "title": "Accounting for Small Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "116",
+              "title": "Entrepreneurship (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "165",
+              "title": "Small Business Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "260",
+              "title": "Planning for Small Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "260",
+              "title": "Financial Management for Small Business (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management: Digital Marketing, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3805",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "282",
+              "title": "Principles of E-Commerce (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "115",
+                  "title": "Technical Writing (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "ENG",
+              "number": "116",
+              "title": "Writing for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "228",
+              "title": "Promotion (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice: Advanced Forensic Investigation, C.S.C. Discontinued Fall 2025",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3701",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "172",
+              "title": "Forensic Science II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14-16 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 9-10 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Business Management: Leadership Development, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3731",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Principles of Supervision I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Behavior (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "116",
+              "title": "Writing for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Leadership Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "297",
+              "title": "Cooperative Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management: Promotion and Public Relations, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3803",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "215",
+              "title": "Sales and Marketing Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ENG",
+                  "number": "115",
+                  "title": "Technical Writing (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "ENG",
+              "number": "116",
+              "title": "Writing for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "221",
+              "title": "Public Relations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "228",
+              "title": "Promotion (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice: National Security, C.S.C. ​Discontinued Fall 2025",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3703",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "234",
+              "title": "Terrorism and Counter-Terrorism (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "163",
+              "title": "Crime Analysis and Intelligence (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "250",
+              "title": "Global Security Concepts for Law Enforcement and National Security (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "252",
+              "title": "Counterintelligence Concepts for Law Enforcement and National Security (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice: General Forensic Investigation, C.S.C. ​Discontinued Fall 2025",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3700",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "171",
+              "title": "Forensic Science I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "212",
+              "title": "Criminal Law, Evidence, and Procedures II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "275",
+              "title": "Forensic Pathology (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "ADJ",
+                  "number": "298",
+                  "title": "Homicide Seminar (3 CR.)"
+                },
+                {
+                  "prefix": "BIO",
+                  "number": "101",
+                  "title": "General Biology I (4 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9-10 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Business Management: Business Information Technology, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3728",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Project Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Behavior (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Social Sciences: Geospatial Specialization, A.S. - Discontinued Effective Fall 2025",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3776",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "101",
+              "title": "Introduction to Geospatial Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "200",
+              "title": "Introduction to Physical Geography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Geographical Information Systems II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "203",
+              "title": "Cartography for GIS (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "205",
+              "title": "Geographical Information Systems: 3-Dimensional Analysis (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3746",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime, and Hacking (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security, and Authentication (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E-Commerce Security (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "266",
+              "title": "Network Security Layers (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3745",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Information Technology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "221",
+              "title": "Personal Computer Hardware and OS Architecture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "171",
+              "title": "UNIX I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime, and Hacking (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security, and Authentication (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E-Commerce Security (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "266",
+              "title": "Network Security Layers (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "276",
+              "title": "Computer Forensics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Systems Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3799",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Information Technology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "170",
+              "title": "Multimedia Software (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "221",
+              "title": "Personal Computer Hardware and OS Architecture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geographic Information Systems (GIS), C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3771",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Geographical Information Systems II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "203",
+              "title": "Cartography for GIS (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "255",
+              "title": "Exploring Our Earth: Introduction to Remote Sensing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "205",
+              "title": "Geographical Information Systems: 3-Dimensional Analysis (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "290",
+              "title": "Internship (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3735",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "PreCalculus with Trigonometry (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object Oriented Programming (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "208",
+              "title": "Introduction to Discrete Structures (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "288",
+              "title": "Discrete Mathematics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Computer Organization (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CSC",
+                  "number": "215",
+                  "title": "Computer Systems (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-18 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Systems Technology: Cloud Computing Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3802",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing: Infrastructure and Services (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "221",
+              "title": "Personal Computer Hardware and OS Architecture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "213",
+              "title": "Information Storage and Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "254",
+              "title": "Virtual Infrastructure: Installation and Configuration (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: Artificial Intelligence and Data Analytics, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3835",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structured Query Language (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "145",
+              "title": "Applied Data Science Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "245",
+              "title": "Advanced Applied Data Science Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "140",
+              "title": "Machine Learning I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: Application Programming, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3801",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "220",
+              "title": "Java Programming (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "250",
+              "title": "Advanced Python Programming (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: Cloud Computing, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3830",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing: Infrastructure and Services (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Information Technology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "213",
+              "title": "Information Storage and Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "254",
+              "title": "Virtual Infrastructure: Installation and Configuration (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3797",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "PreCalculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Information Technology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Systems Technology: Mobile Application Development, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3829",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Information Technology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "137",
+              "title": "Programming IOS Devices (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "226",
+              "title": "Mobile Java Development (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "227",
+              "title": "Advanced Android Application Development (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: Fiber and Network Technician, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3846",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "A.C. and D.C. Circuit Fundamentals (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "108",
+              "title": "Intro to Data Center Operations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10 (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "250",
+              "title": "Fiber Optic Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "270",
+              "title": "Computation for Engineering Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: IT Technical Support, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3806",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing: Infrastructure and Services (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: Network Administration, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3807",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "171",
+              "title": "UNIX I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "200",
+              "title": "Administration of Network Resources (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: Network Engineering (Specialist), C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3809",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "154",
+              "title": "Introduction to Networks - Cisco (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "155",
+              "title": "Switching, Wireless, And Wireless Essentials - Cisco (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "156",
+              "title": "Enterprise Networking, Security, and Automation - Cisco (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "157",
+              "title": "WAN Technologies: Cisco (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "295",
+              "title": "Cyber Operations and Analysis (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Information Systems Technology: Database Specialist, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3804",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structured Query Language (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "260",
+              "title": "Data Modeling and Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Information Technology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "134",
+              "title": "PL/SQL Programming (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology: Web Design and Development, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3810",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "170",
+              "title": "Multimedia Software (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "210",
+              "title": "Web Page Design II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "270",
+              "title": "Advanced Multimedia Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "140",
+              "title": "Client Side Scripting (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "225",
+              "title": "Web Scripting Languages (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3778",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education: Grades 6-12 Social Studies Education Major, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3842",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "154",
+                  "title": "Quantitative Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "British Literature (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "Foundations of Environmental Science (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "History of World Civilization Post-1500 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "GOL",
+                  "number": "105",
+                  "title": "Physical Geology (4 CR.)"
+                },
+                {
+                  "prefix": "GOL",
+                  "number": "106",
+                  "title": "Historical Geology (4 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "150",
+              "title": "Elements of Astronomy (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences: History Major, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3944",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilizations Pre-1600 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilizations Post 1600 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "History of World Civilization Post-1500 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 13-14 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education: Elementary Education Major, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3843",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "206",
+              "title": "Classroom and Behavioral Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "Foundations of Environmental Science (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Introduction to Instructional Technologies (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "GOL",
+                  "number": "105",
+                  "title": "Physical Geology (4 CR.)"
+                },
+                {
+                  "prefix": "GOL",
+                  "number": "106",
+                  "title": "Historical Geology (4 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "150",
+              "title": "Elements of Astronomy (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "World Civilizations Pre-1500 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "112",
+              "title": "History of World Civilization Post-1500 CE (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education: K-12 Special Education Adapted and General Curriculum Major, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3844",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "206",
+              "title": "Classroom and Behavioral Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "Foundations of Environmental Science (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "280",
+              "title": "Introduction to Instructional Technologies (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Introduction to Autism Spectrum Disorders (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "GOL",
+                  "number": "105",
+                  "title": "Physical Geology (4 CR.)"
+                },
+                {
+                  "prefix": "GOL",
+                  "number": "106",
+                  "title": "Historical Geology (4 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "150",
+              "title": "Elements of Astronomy (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "220",
+              "title": "World Regional Geography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences: Political Science Major, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3774",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "241",
+              "title": "Introduction to International Relations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PLS",
+              "number": "136",
+              "title": "State and Local Government and Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "140",
+              "title": "Introduction to Comparative Politics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PLS",
+              "number": "200",
+              "title": "Introduction to Political and Democratic Theory (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Driver Education Instructor, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3748",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CST/ENG Elective (3 CR.) 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "114",
+              "title": "Driver Task Analysis (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "214",
+              "title": "Instructional Principles of Driver Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3823",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Statistics for Behavioral Sciences (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "211",
+              "title": "Research Methodology for Behavioral Sciences (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Education, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3769",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "PreCalculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Teaching (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Development, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3751",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science, and Social Studies for Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Learning, Family, Community, and Social Change (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3749",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science, and Social Studies for Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Learning, Family, Community, and Social Change (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Children with Exceptionalities (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "265",
+              "title": "Advanced Observation and Participation in Early Childhood/Primary Settings (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "270",
+              "title": "Administration of Childcare Programs (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children&#039;s Literature (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "246",
+              "title": "American Literature (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865 (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development: Infant and Toddler Care, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3754",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "164",
+              "title": "Working with Infants and Toddlers in Inclusive Settings (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3752",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Education: Emerging Educator, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3845",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "206",
+              "title": "Classroom and Behavioral Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education: Teaching Professional, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3836",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Teaching (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "206",
+              "title": "Classroom and Behavioral Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "290",
+              "title": "Coordinated Internship (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences: Public Health Major, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3945",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "PreCalculus I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "228",
+              "title": "Introduction to Public Health (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Personal and Community Health (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public History and Historic Preservation, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3784",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "180",
+              "title": "Historical Archaeology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "181",
+              "title": "Introduction to Historic Preservation (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "183",
+              "title": "Survey of Museum Practice (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "187",
+              "title": "Interpreting Material Culture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "190",
+              "title": "Coordinated Internship (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Uniform Certificate of General Studies",
+      "credential": "certificate",
+      "program_code": "UCGS",
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3765",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Technical-Professional Writing (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3767",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Principles of Computer Science (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Diagnostic Medical Sonography: Abdominal Sonography-Extended and Obstetrics and Gynecology Sonography Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3753",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "100",
+              "title": "Orientation to the Sonography Profession (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 20 credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "190",
+              "title": "Clinical Education I/Coordinated Internship (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "206",
+              "title": "Introduction to Sonography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Sectional Anatomy (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "208",
+              "title": "Ultrasound Physics and Instrumentation I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Sectional Anatomy Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "218",
+              "title": "Ultrasound Physics and Instrumental Laboratory I (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "220",
+              "title": "Concepts of Disease (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "196",
+              "title": "Clinical Education/Coordinated Internship II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "209",
+              "title": "Ultrasound Physics and Instrumentation II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "211",
+              "title": "Abdominal Sonography (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "212",
+              "title": "Obstetrical and Gynecological Sonography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "219",
+              "title": "Ultrasound Physics and Instrumental Laboratory II (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Clinical Education I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "241",
+              "title": "Advanced Abdominal Sonography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "242",
+              "title": "Advanced Obstetrical and Gynecological Sonography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "222",
+              "title": "Sonography Registry Review (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "223",
+              "title": "Introduction to Vascular Ultrasound (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Clinical Education II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography: Vascular Sonography Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3747",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "100",
+              "title": "Orientation to the Sonography Profession (1 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 20 credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "190",
+              "title": "Clinical Education I/Coordinated Internship (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "206",
+              "title": "Introduction to Sonography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Sectional Anatomy (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "208",
+              "title": "Ultrasound Physics and Instrumentation I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Sectional Anatomy Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "218",
+              "title": "Ultrasound Physics and Instrumental Laboratory I (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "220",
+              "title": "Concepts of Disease (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "196",
+              "title": "Clinical Education/Coordinated Internship II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "209",
+              "title": "Ultrasound Physics and Instrumentation II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "219",
+              "title": "Ultrasound Physics and Instrumental Laboratory II (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "260",
+              "title": "Vascular Sonography II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "160",
+              "title": "Vascular Sonography I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Clinical Education I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "265",
+              "title": "Vascular Case Study Review (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "204",
+              "title": "Introduction to General Sonography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Clinical Education II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "266",
+              "title": "Vascular Ultrasound Registry Review (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3758",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "111",
+              "title": "Oral Anatomy (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "115",
+              "title": "Histology/Head and Neck Anatomy (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "130",
+              "title": "Oral Radiography for the Dental Hygienist (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "141",
+              "title": "Dental Hygiene I (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "120",
+              "title": "Management of Emergencies (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "142",
+              "title": "Dental Hygiene II (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "145",
+              "title": "General and Oral Pathology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "146",
+              "title": "Periodontics for the Dental Hygienist (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "216",
+              "title": "Pharmacology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "143",
+              "title": "Dental Hygiene III (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "214",
+              "title": "Practical Materials for Dental Hygiene (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "150",
+              "title": "Nutrition (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "226",
+              "title": "Public Health Dental Hygiene I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "235",
+              "title": "Management of Dental Pain and Anxiety in the Dental Office (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "244",
+              "title": "Dental Hygiene IV (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNH",
+              "number": "227",
+              "title": "Public Health Dental Hygiene II (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "230",
+              "title": "Office Practice and Ethics (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNH",
+              "number": "245",
+              "title": "Dental Hygiene V (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3822",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "111",
+              "title": "Medical Terminology I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography: Echocardiography Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3750",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "100",
+              "title": "Orientation to the Sonography Profession (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 20 credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "190",
+              "title": "Clinical Education I/Coordinated Internship (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "206",
+              "title": "Introduction to Sonography (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Sectional Anatomy (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "208",
+              "title": "Ultrasound Physics and Instrumentation I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "217",
+              "title": "Sectional Anatomy Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "218",
+              "title": "Ultrasound Physics and Instrumental Laboratory I (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "220",
+              "title": "Concepts of Disease (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "150",
+              "title": "Echocardiography I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "196",
+              "title": "Clinical Education/Coordinated Internship II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "209",
+              "title": "Ultrasound Physics and Instrumentation II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "219",
+              "title": "Ultrasound Physics and Instrumental Laboratory II (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Clinical Education I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "250",
+              "title": "Echocardiography II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "256",
+              "title": "Echocardiography Case Study Review (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "223",
+              "title": "Introduction to Vascular Ultrasound (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Clinical Education II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "255",
+              "title": "Echocardiography Registry Review (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3742",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Anatomy and Physiology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician (7 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician - Clinical (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Laboratory (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care Laboratory II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12-13 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support (AMLS) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support (ACLS) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatrics Course (EPC) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics and Society (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Management, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3734",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "111",
+              "title": "Medical Terminology I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "110",
+              "title": "Introduction to Human Pathology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "130",
+              "title": "Healthcare Information Systems (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "141",
+              "title": "Fundamentals of Health Information Systems I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "116",
+              "title": "Lifetime Fitness and Wellness (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "142",
+              "title": "Fundamentals of Health Information Systems II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "220",
+              "title": "Health Statistics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "250",
+              "title": "Health Data Classification Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "260",
+              "title": "Pharmacology for Health Information Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "229",
+              "title": "Performance Improvement in Healthcare Settings (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "230",
+              "title": "Information Systems and Technology in Healthcare (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "249",
+              "title": "Supervision and Management Practices for HIM (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "251",
+              "title": "Clinical Practice I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "233",
+              "title": "Electronic Health Records Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "252",
+              "title": "Clinical Practice II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "254",
+              "title": "Advanced Coding and Reimbursement (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "255",
+              "title": "Health Data Classification Systems II: CPT (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "280",
+              "title": "HIM Capstone (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Occupational Therapy Assistant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3708",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Anatomy and Physiology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9-13 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OCT",
+              "number": "100",
+              "title": "Introduction to Occupational Therapy (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "205",
+              "title": "Therapeutic Media (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "206",
+              "title": "Dyadic and Group Dynamics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "225",
+              "title": "Neurological Concepts for Occupational Therapy Assistants (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 190 - Coordinated Internship (Pediatrics) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "203",
+              "title": "Occupational Therapy with Developmental Disabilities (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "207",
+              "title": "Therapeutic Skills (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Psychopathology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 190 - Coordinated Internship in OT (Psychosocial Dysfunction) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 195 - Topics in Evidence Based Practice in Occupational Therapy (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "201",
+              "title": "Occupational Therapy with Psychosocial Dysfunction (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OCT 190 - Coordinated Internship in OT (Physical Dysfunction) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "202",
+              "title": "Occupational Therapy with Physical Disabilities (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "208",
+              "title": "Occupational Therapy Service Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OCT",
+              "number": "210",
+              "title": "Assistive Technology in Occupational Therapy (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiation Oncology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3705",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3691",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester–LEVEL 1 Nursing",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts (4 CR)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practice (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester-LEVEL 2 Nursing",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts (6 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester-LEVEL 3 Nursing",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester-LEVEL 4 Nursing",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Physical Therapist Assistant, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3706",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Anatomy and Physiology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTH",
+              "number": "105",
+              "title": "Introduction to Physical Therapy (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "121",
+              "title": "Therapeutic Procedures I (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "151",
+              "title": "Musculoskeletal Structure and Function (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "115",
+              "title": "Kinesiology for the Physical Therapist Assistant (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "122",
+              "title": "Therapeutic Procedures II (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTH",
+              "number": "131",
+              "title": "Clinical Education I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTH",
+              "number": "225",
+              "title": "Rehabilitation Procedures (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "231",
+              "title": "Clinical Education II (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTH",
+              "number": "210",
+              "title": "Psychological Aspects of Therapy (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "227",
+              "title": "Pathological Conditions (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "232",
+              "title": "Clinical Education III (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTH",
+              "number": "245",
+              "title": "Professional Issues (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3725",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "101",
+              "title": "Introduction to Medical Laboratory Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "125",
+              "title": "Clinical Hematology I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "140",
+              "title": "Clinical Urinalysis (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "215",
+              "title": "Immunology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "130",
+              "title": "Basic Clinical Microbiology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "225",
+              "title": "Clinical Hematology II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "260",
+              "title": "Laboratory Instrumentation I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "265",
+              "title": "Advanced Clinical Chemistry (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDL",
+              "number": "266",
+              "title": "Clinical Chemistry Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "276",
+              "title": "Clinical Hematology Techniques (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDL",
+              "number": "216",
+              "title": "Blood Banking (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "236",
+              "title": "Parasitology and Virology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "251",
+              "title": "Clinical Microbiology I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDL",
+              "number": "277",
+              "title": "Clinical Blood Banking Techniques (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "278",
+              "title": "Clinical Microbiology Techniques II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "281",
+              "title": "Clinical Correlations (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiography, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3702",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "105",
+              "title": "Introduction to Radiology, Protection, and Patient Care (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "121",
+              "title": "Radiographic Procedures I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "Patient Care Procedures (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "141",
+              "title": "Principles of Radiographic Quality I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RAD 196 - On-Site Training (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "131",
+              "title": "Elementary Clinical Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "142",
+              "title": "Principles of Radiographic Quality II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "221",
+              "title": "Radiographic Procedures II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social/Behavioral Science Elective (3 CR.) 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "135",
+              "title": "Elementary Clinical Procedures II (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 5 credits",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "205",
+              "title": "Radiation Protection and Radiobiology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "231",
+              "title": "Advanced Clinical Procedures I (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "246",
+              "title": "Special Procedures (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "255",
+              "title": "Radiographic Equipment (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "232",
+              "title": "Advanced Clinical Procedures II (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "240",
+              "title": "Radiographic Pathology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assisting, Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3756",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Anatomy and Physiology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DNA",
+              "number": "100",
+              "title": "Introduction to Oral Health Professions (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "108",
+              "title": "Dental Science (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "110",
+              "title": "Dental Materials (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "113",
+              "title": "Chairside Assisting I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "134",
+              "title": "Dental Radiology and Practicum (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "114",
+              "title": "Chairside Assisting II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "119",
+              "title": "Dental Therapeutics (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "120",
+              "title": "Community Health (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "130",
+              "title": "Dental Office Management (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DNA",
+              "number": "140",
+              "title": "Externship (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Management: Clinical Data Coding, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3732",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "111",
+              "title": "Medical Terminology I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "141",
+              "title": "Fundamentals of Health Information Systems I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "250",
+              "title": "Health Data Classification Systems I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIM",
+              "number": "110",
+              "title": "Introduction to Human Pathology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "199",
+              "title": "Supervised Study: ICD 10 (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "254",
+              "title": "Advanced Coding and Reimbursement (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "255",
+              "title": "Health Data Classification Systems II: CPT (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "260",
+              "title": "Pharmacology for Health Information Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Veterinary Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3766",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "133",
+              "title": "Mathematics for Health Professions (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "111",
+              "title": "Anatomy and Physiology of Domestic Animals (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "105",
+              "title": "Introduction to Veterinary Technology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "116",
+              "title": "Animal Breeds and Behavior (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "121",
+              "title": "Clinical Practices I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "211",
+              "title": "Animal Diseases I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "131",
+              "title": "Clinical Pathology I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "135",
+              "title": "Anesthesia of Domestic Animals (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "214",
+              "title": "Animal Dentistry (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "216",
+              "title": "Animal Pharmacology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "217",
+              "title": "Introduction to Laboratory, Zoo, and Wildlife Medicine (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "122",
+              "title": "Clinical Practices II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "132",
+              "title": "Clinical Pathology II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "212",
+              "title": "Animal Diseases II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "221",
+              "title": "Advanced Clinical Practices III (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "133",
+              "title": "Clinical Pathology III (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "235",
+              "title": "Animal Hospital Management and Client Relations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Coordinated Internship: A Preceptorship in Veterinary Technology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technology: Phlebotomy, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3712",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "One Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Healthcare Personnel (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "105",
+              "title": "Phlebotomy (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "106",
+              "title": "Clinical Phlebotomy (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technology: Medical Laboratory Assistant (MLA), C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3726",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDL",
+              "number": "105",
+              "title": "Phlebotomy (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "100",
+              "title": "Introduction to Medical Laboratory Technology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "106",
+              "title": "Clinical Phlebotomy (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "140",
+              "title": "Clinical Urinalysis (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Healthcare Personnel (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "130",
+              "title": "Basic Clinical Microbiology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "196",
+              "title": "Topics in: On Site Training (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "260",
+              "title": "Laboratory Instrumentation I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Therapy, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3699",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "Prerequisites:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "120",
+              "title": "Fundamental Theory for Respiratory Care (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Healthcare (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "102",
+              "title": "Integrated Science for Respiratory Care II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "111",
+              "title": "Anatomy and Physiology of the Cardiopulmonary System (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "145",
+              "title": "Pharmacology for Respiratory Care I (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "151",
+              "title": "Fundamental Clinical Procedures I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "229",
+              "title": "Intercultural Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "121",
+              "title": "Cardiopulmonary Science I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "131",
+              "title": "Respiratory Care Theory and Procedures I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RTH 196 - On-Site Training in Respiratory Care I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "245",
+              "title": "Pharmacology for Respiratory Care II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "135",
+              "title": "Diagnostic and Therapeutic Procedures I (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RTH 296 - On-Site Training in Respiratory Care II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTH",
+              "number": "215",
+              "title": "Pulmonary Rehabilitation (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "222",
+              "title": "Cardiopulmonary Science II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RTH 223 - Cardiopulmonary Science III (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "236",
+              "title": "Critical Care Monitoring (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RTH 290 - Adult ICU rotation (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PED",
+              "number": "116",
+              "title": "Lifetime Fitness and Wellness (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "225",
+              "title": "Neonatal and Pediatric Respiratory Procedures (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTH",
+              "number": "227",
+              "title": "Integrated Respiratory Therapy Skills II (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "RTH 290 - NEO/PEDS/Precepting (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Personal Training, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3788",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "111",
+              "title": "Weight Training I (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "116",
+              "title": "Lifetime Fitness and Wellness (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Personal and Community Health (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "BUS, FIN, or MKT Elective (3 CR.) 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14-15 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "PED Elective (1 CR.) 6",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "206",
+              "title": "Introduction to Kinesiology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIT",
+              "number": "121",
+              "title": "Nutrition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "168",
+              "title": "Basic Personal Trainer Preparation (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "220",
+              "title": "Adult Health and Development (2-3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12-13 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3692",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "PreCalculus with Trigonometry (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-18 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3824",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "PreCalculus with Trigonometry (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "207",
+              "title": "General Zoology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "110",
+                  "title": "Introduction to Human Communication (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "245",
+                  "title": "Statistics I (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 13-14 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "206",
+              "title": "Cell Biology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "264",
+                  "title": "Calculus II (4 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Biotechnology Lab Technician, C.S.C.",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3722",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "147",
+              "title": "Basic Laboratory Calculations for Biotechnology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "165",
+              "title": "Principles in Regulatory and Quality Environments for Biotechnology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biotechnology Research Methods and Skills (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "253",
+              "title": "Biotechnology Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "180",
+              "title": "Introduction to Careers in Biotechnology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "251",
+              "title": "Protein Applications in Biotechnology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Nucleic Acid Methods (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "254",
+              "title": "Capstone Seminar in Biotechnology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "255",
+              "title": "Bioinformatics and Computer Applications in Biotechnology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "296",
+              "title": "On-site training in Biotechnology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Horticulture Technology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3783",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "100",
+              "title": "Introduction to Horticulture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "127",
+              "title": "Horticultural Botany (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "160",
+              "title": "Applied Mathematics for the Green Industry (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "201",
+              "title": "Landscape Plants I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 18-19 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "115",
+              "title": "Plant Propagation (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "120",
+              "title": "History of Garden Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "202",
+              "title": "Landscape Plants II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "135",
+              "title": "Training for Commercial Pesticide Application (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "HRT",
+                  "number": "125",
+                  "title": "Chemicals in Horticulture (3 CR.)"
+                },
+                {
+                  "prefix": "CHM",
+                  "number": "101",
+                  "title": "Introductory Chemistry (4 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "231",
+              "title": "Planting Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "245",
+              "title": "Woody Plants (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "259",
+              "title": "Arboriculture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "269",
+              "title": "Professional Turf Care (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "205",
+              "title": "Soils (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "207",
+              "title": "Plant Pest Management (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "275",
+              "title": "Landscape Construction and Maintenance (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HRT 290 - Coordinated Internship (1 CR.) OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HRT 297 - Cooperative Education (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3721",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "161",
+                  "title": "PreCalculus I (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Biotechnology/Science Elective (4 CR.) 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 7 credits",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "147",
+              "title": "Basic Laboratory Calculations for Biotechnology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "165",
+              "title": "Principles in Regulatory and Quality Environments for Biotechnology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "General Microbiology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biotechnology Research Methods and Skills (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "253",
+              "title": "Biotechnology Concepts (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "5th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "180",
+              "title": "Introduction to Careers in Biotechnology (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "206",
+              "title": "Cell Biology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "251",
+              "title": "Protein Applications in Biotechnology (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Nucleic Acid Methods (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "254",
+              "title": "Capstone Seminar in Biotechnology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "255",
+              "title": "Bioinformatics and Computer Applications in Biotechnology (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "6th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "296",
+              "title": "On-site training in Biotechnology (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Horticulture Technology: Landscape Design Specialization, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3787",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "100",
+              "title": "Introduction to Horticulture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "160",
+              "title": "Applied Mathematics for the Green Industry (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "201",
+              "title": "Landscape Plants I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "231",
+              "title": "Planting Design I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "120",
+              "title": "History of Garden Design (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "202",
+              "title": "Landscape Plants II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "230",
+              "title": "Site Analysis (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "232",
+              "title": "Planting Design II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "245",
+              "title": "Woody Plants (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "259",
+              "title": "Arboriculture (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning (3 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "155",
+                  "title": "Statistical Reasoning (3 CR.)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Total 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "233",
+              "title": "Landscape Drawing Applications (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "244",
+              "title": "Computer Aided Drafting and Design (CADD) for Landscape Designers (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "250",
+              "title": "Plant Composition (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "275",
+              "title": "Landscape Construction and Maintenance (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HRT 290 - Coordinated Internship (2 CR.) OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HRT 297 - Cooperative Education/Special Studio Project (2 CR.) OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "HRT 298 - Seminar and Project (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science: Mathematics Major, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3781",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "PreCalculus with Trigonometry (5 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 14-15 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://nvcc.catalog.acalog.com/preview_program.php?catoid=15&poid=3755",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": "Powered by Modern Campus Catalog™.",
+      "requirement_groups": [
+        {
+          "name": "1st Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering (2 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (a Specific Discipline) (1 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "2nd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II (4 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "3rd Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 16-18 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "4th Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III (4 CR.)",
+              "credits": null,
+              "or_alternatives": [
+                {
+                  "prefix": "MTH",
+                  "number": "266",
+                  "title": "Linear Algebra (3 CR.)"
+                }
+              ]
+            },
+            {
+              "prefix": "MTH",
+              "number": "288",
+              "title": "Discrete Mathematics (3 CR.)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total 15-18 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    }
+  ]
+}

--- a/data/va/programs/pvcc.json
+++ b/data/va/programs/pvcc.json
@@ -1,0 +1,5713 @@
+{
+  "college_slug": "pvcc",
+  "catalog_year": "2026-2027",
+  "catalog_url": "https://catalog.pvcc.edu",
+  "scraped_at": "2026-05-06T21:24:04.574Z",
+  "programs": [
+    {
+      "title": "Criminal Justice",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1088",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "233",
+              "title": "Multiculturalism in Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": [
+                {
+                  "prefix": "ADJ",
+                  "number": "290",
+                  "title": "Internship in Administration of Justice"
+                }
+              ]
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR ADJ ___ ADJ Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Accounting",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1081",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Principles of Federal Taxation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications and Integration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Diagnostic Medical Sonography",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1083",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required DMS Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DMS",
+              "number": "206",
+              "title": "Introduction to Sonography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "207",
+              "title": "Sectional Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "208",
+              "title": "Ultrasound Physics and Instrumentation I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "209",
+              "title": "Ultrasound Physics and Instrumentation II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "211",
+              "title": "Abdominal Sonography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "212",
+              "title": "Obstetrical &amp; Gynecological Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "219",
+              "title": "Ultrasound Physics and Instrumentation Laboratory II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "231",
+              "title": "Clinical Education I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "232",
+              "title": "Clinical Education II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "242",
+              "title": "Advanced Obstetrical &amp; Gynecological Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "241",
+              "title": "Advanced Abdominal Sonography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "223",
+              "title": "Introduction to Vascular Ultrasound",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "233",
+              "title": "Clinical Education III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "222",
+              "title": "Sonography Registry Review",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DMS",
+              "number": "234",
+              "title": "Clinical Education IV",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1082",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "106",
+              "title": "Principles of Culinary Arts I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "158",
+              "title": "Sanitation and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "107",
+              "title": "Principles of Culinary Arts II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "145",
+              "title": "Gard Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "119",
+              "title": "Applied Nutrition for Food Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAK",
+              "number": "128",
+              "title": "Principles of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "220",
+              "title": "Meat, Seafood, and Poultry Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "251",
+              "title": "Food and Beverage Cost Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "218",
+              "title": "Fruit, Vegetable, and Starch Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "206",
+              "title": "International Cuisine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "207",
+              "title": "American Regional Cuisine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "259",
+              "title": "Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "225",
+              "title": "Menu Planning and Dining Room Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "256",
+              "title": "Principles of Applications of Catering",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total Minimum Credits: 64",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BAK",
+              "number": "280",
+              "title": "Principles of Advanced Baking and Pastry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAK",
+              "number": "281",
+              "title": "Artisan Breads",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "274",
+              "title": "Foundations of Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1187",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services, Paramedic",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1085",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR HLT 105 Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician-Basic",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician-Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR PSY 200 Principles of Psychology OR SOC 268 Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support (ACLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatrics Course (EPC)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR EMS 169 Pediatric Advanced Life Support (PALS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support (AMLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Electronics Technology",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1084",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "DC and AC Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "151",
+              "title": "Engineering Drawing Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "122",
+              "title": "3D Printing for Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "155",
+              "title": "Mechanisms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "DC and AC Fundamentals II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "140",
+              "title": "Introduction to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "237",
+              "title": "Industrial Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "238",
+              "title": "Industrial Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "176",
+              "title": "Introduction to Alternative Energy Including Hybrid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "250",
+              "title": "Introduction to Basic Computer Integrated Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "113",
+              "title": "Materials and Processes in Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1063",
+      "total_credits": 65,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structure Query Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "182",
+              "title": "User Support/Help Desk Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications and Integration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "111",
+              "title": "Server Administration (Windows)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Electronics Technology, Mechanical Engineering Technology Specialization",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1137",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "DC and AC Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "151",
+              "title": "Engineering Drawing Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "140",
+              "title": "Introduction to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "122",
+              "title": "3D Printing for Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "113",
+              "title": "Materials and Processes in Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "250",
+              "title": "Introduction to Basic Computer Integrated Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "176",
+              "title": "Introduction to Alternative Energy Including Hybrid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "155",
+              "title": "Mechanisms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "210",
+              "title": "Machine Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR ETR 237 Industrial Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "212",
+              "title": "Machine Design II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR ETR 238 Industrial Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles and Applications of Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Information Systems Technology, Cybersecurity Specialization",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1064",
+      "total_credits": 63,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications and Integration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "182",
+              "title": "User Support/Help Desk Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structure Query Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "111",
+              "title": "Server Administration (Windows)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime and Hacking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "276",
+              "title": "Computer Forensics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "277",
+              "title": "Computer Forensics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Systems Technology, Programming Specialization",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1136",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications and Integration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "132",
+              "title": "C++ Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structure Query Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "225",
+              "title": "Web Scripting Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "232",
+              "title": "C++ Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "126",
+              "title": "Internet of Things and Big Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "220",
+              "title": "Java Programming II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "240",
+              "title": "Server Side Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "251",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "LPN to RN Bridge Program for Licensed Practical Nurses",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1153",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "115",
+              "title": "Healthcare Concepts for Transition",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR PHI 227 Biomedical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Management",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1086",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or CST 110 Introduction to Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": [
+                {
+                  "prefix": "ECO",
+                  "number": "201",
+                  "title": "Principles of Macroeconomics"
+                }
+              ]
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "204",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Computer Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1087",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisites for Admission",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": [
+                {
+                  "prefix": "PHI",
+                  "number": "220",
+                  "title": "Ethics and Society"
+                }
+              ]
+            },
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Radiography",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1089",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": [
+                {
+                  "prefix": "PSY",
+                  "number": "200",
+                  "title": "Principles of Psychology"
+                },
+                {
+                  "prefix": "PHI",
+                  "number": "220",
+                  "title": "Ethics and Society"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "100",
+              "title": "Introduction to Radiology and Protection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "121",
+              "title": "Radiographic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "125",
+              "title": "Patient Care Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "190",
+              "title": "Coordinated Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "111",
+              "title": "Radiologic Science I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "221",
+              "title": "Radiographic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "131",
+              "title": "Elementary Clinical Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiologic Science II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "231",
+              "title": "Advanced Clinical Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "246",
+              "title": "Special Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "232",
+              "title": "Advanced Clinical Procedures II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "256",
+              "title": "Radiographic Film Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "270",
+              "title": "Digital Image Acquisition and Display",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "205",
+              "title": "Radiation Protection and Radiobiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "240",
+              "title": "Radiographic Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "280",
+              "title": "Terminal Competencies in Radiography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1116",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Prerequisite Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "100",
+              "title": "Introduction to Surgical Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "140",
+              "title": "Surgical Care I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "145",
+              "title": "Surgical Care Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "150",
+              "title": "Surgical Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "240",
+              "title": "Surgical Care II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "245",
+              "title": "Surgical Care Skills II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "250",
+              "title": "Surgical Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "135",
+              "title": "Infection Control",
+              "credits": 2,
+              "or_alternatives": [
+                {
+                  "prefix": "PHI",
+                  "number": "220",
+                  "title": "Ethics and Society"
+                }
+              ]
+            },
+            {
+              "prefix": "SUR",
+              "number": "210",
+              "title": "Surgical Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "260",
+              "title": "Surgical Technology Clinical Practicum",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "296",
+              "title": "On-Site Training",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "298",
+              "title": "Seminar and Project",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SUR",
+              "number": "254",
+              "title": "Professional Issues in Surgical Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual and Performing Arts, Art Major",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1078",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art:  Prehistoric to Gothic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art:  Renaissance to Modern",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1075",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1070",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Computer Organization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "288",
+              "title": "Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR CHM 111 General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR CHM 112 General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Education",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1071",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1062",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "PreCalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "280",
+              "title": "Introduction to International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "274",
+              "title": "Foundations of Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Technical Studies-Software Development",
+      "credential": "AAS",
+      "program_code": "AAS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1146",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "225",
+              "title": "Mobile Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "132",
+              "title": "C++ Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "137",
+              "title": "Programming IOS Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "170",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "175",
+              "title": "Concepts of Programming Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "226",
+              "title": "Mobile Java Android Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "245",
+              "title": "Developing User Interfaces",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1073",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "122",
+              "title": "Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "125",
+              "title": "Introduction to Computer Programming for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR CSC 221 Introduction to Problem Solving and Programming 3 credits OR EGR 271 Electric Circuits I 4 credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "240",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "245",
+              "title": "Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "246",
+              "title": "Mechanics of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR EGR 248 Thermodynamics for Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR EGR 206 Engineering Economics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "General Studies",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1074",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": [
+                {
+                  "prefix": "CST",
+                  "number": "100",
+                  "title": "Principles of Public Speaking"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Physical and Natural Sciences, Biotechnology Major",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1077",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "147",
+              "title": "Basic Laboratory Calculations for Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Biotechnology Research Methods and Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "251",
+              "title": "Protein Applications in Biotechnology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Nucleic Acid Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "253",
+              "title": "Biotechnology Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "255",
+              "title": "Bioinformatics and Computer Applications in Biotechnology",
+              "credits": 2,
+              "or_alternatives": [
+                {
+                  "prefix": "PHI",
+                  "number": "220",
+                  "title": "Ethics and Society"
+                },
+                {
+                  "prefix": "BIO",
+                  "number": "299",
+                  "title": "Supervised Study"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Physical and Natural Sciences",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1076",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR ___ ___ Science w/Lab Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR ___ ___ Science w/Lab Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR ___ ___ Science w/Lab Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical and Natural Sciences: Biology Track",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1123",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "241",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "245",
+              "title": "Organic Chemistry I Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "242",
+              "title": "Organic Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "246",
+              "title": "Organic Chemistry II Laboratory",
+              "credits": 2,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "299",
+                  "title": "Supervised Study"
+                }
+              ]
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "256",
+              "title": "General Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Physical and Natural Sciences: Physics Track",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1126",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "299",
+                  "title": "Supervised Study"
+                }
+              ]
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical and Natural Sciences: Chemistry Track",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1124",
+      "total_credits": 66,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": [
+                {
+                  "prefix": "BIO",
+                  "number": "299",
+                  "title": "Supervised Study"
+                }
+              ]
+            },
+            {
+              "prefix": "CHM",
+              "number": "241",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "245",
+              "title": "Organic Chemistry I Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "242",
+              "title": "Organic Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "246",
+              "title": "Organic Chemistry II Laboratory",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing (C)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1113",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "141",
+              "title": "Introduction to Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PNE",
+              "number": "173",
+              "title": "Pharmacology for Practical Nurses",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "186",
+              "title": "Nursing Concepts I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "187",
+              "title": "Nursing Concepts II",
+              "credits": 9,
+              "or_alternatives": [
+                {
+                  "prefix": "PNE",
+                  "number": "116",
+                  "title": "Nutrition and Diet Therapy"
+                }
+              ]
+            },
+            {
+              "prefix": "PNE",
+              "number": "188",
+              "title": "Nursing Concepts III",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Substance Abuse Counseling (C)",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1154",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "260",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "266",
+              "title": "Counseling Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "290",
+              "title": "Coordinated Internship in Human Services",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "101",
+              "title": "Mental Health Skill Training I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "121",
+              "title": "Substance Abuse Prevention and Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Psychopathology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical and Natural Sciences: Geology Track",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1125",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "167",
+              "title": "Precalculus with Trigonometry",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": [
+                {
+                  "prefix": "PHY",
+                  "number": "201",
+                  "title": "General College Physics I"
+                },
+                {
+                  "prefix": "BIO",
+                  "number": "299",
+                  "title": "Supervised Study"
+                }
+              ]
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "105",
+              "title": "Physical Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "106",
+              "title": "Historical Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOL",
+              "number": "111",
+              "title": "Oceanography I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Uniform Certificate of General Studies (C)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1103",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Administrative Support",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1090",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "243",
+              "title": "Office Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Criminal Justice",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1139",
+      "total_credits": 24,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "290",
+              "title": "Internship in Administration of Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Entrepreneurship",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1102",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "274",
+              "title": "Foundations of Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "160",
+              "title": "Legal Aspects of Small Business Operations",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1186",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Biotechnology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "251",
+              "title": "Protein Applications in Biotechnology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Nucleic Acid Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "299",
+              "title": "Supervised Study",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Emergency Medical Services - Advanced EMT",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1099",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR HLT 105 Cardiopulmonary Resuscitation Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician-Basic",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician-Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services - Advanced Placement Bridge to Paramedic",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1100",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support (ACLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatrics Course (EPC)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR EMS 169 Pediatric Advanced Life Support (PALS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support (AMLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Foundations of Criminal Justice",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1094",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "233",
+              "title": "Multiculturalism in Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Health Science Preparation",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1106",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Technician",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1109",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "151",
+              "title": "Engineering Drawing Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "DC and AC Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "140",
+              "title": "Introduction to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "113",
+              "title": "Materials and Processes in Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "122",
+              "title": "3D Printing for Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "155",
+              "title": "Mechanisms",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Technician",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1130",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "176",
+              "title": "Introduction to Alternative Energy Including Hybrid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "250",
+              "title": "Introduction to Basic Computer Integrated Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles and Applications of Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fundamentals of Programming",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1133",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "120",
+              "title": "Java Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "132",
+              "title": "C++ Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic and Media Arts",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1104",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "141",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "130",
+              "title": "Introduction to Multimedia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "101",
+              "title": "Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "287",
+              "title": "Portfolio and Resume Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services Technician",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1155",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "101",
+              "title": "Mental Health Skill Training I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "226",
+              "title": "Helping Across Cultures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "102",
+              "title": "Mental Health Skill Training II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "290",
+              "title": "Coordinated Internship in Human Services",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Help Desk",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1131",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "131",
+              "title": "Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "182",
+              "title": "User Support/Help Desk Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "150",
+              "title": "Python Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications and Integration",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Support",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1132",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structure Query Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "111",
+              "title": "Server Administration (Windows)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics (Security+)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pharmacy Technician",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1112",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "101",
+              "title": "Introduction to the Role of Pharmacy Technician",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "250",
+              "title": "General Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "261",
+              "title": "Basic Pharmacy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "263",
+              "title": "Basic Pharmacy I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "262",
+              "title": "Basic Pharmacy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "264",
+              "title": "Basic Pharmacy II Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "190",
+              "title": "Coordinated Internship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "295",
+              "title": "Pharmacy Technician Capstone",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Army",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1120",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PVCC Course #",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "111",
+              "title": "Introduction to Army ROTC",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PVCC Course #",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "112",
+              "title": "Introduction to Leadership",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PVCC Course #",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "211",
+              "title": "Leadership Skills",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PVCC Course #",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "212",
+              "title": "Foundations of the Military Profession",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming Concepts",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1134",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITP",
+              "number": "232",
+              "title": "C++ Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "225",
+              "title": "Web Scripting Languages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "126",
+              "title": "Internet of Things and Big Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structure Query Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Cooking",
+      "credential": "other",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1114",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "106",
+              "title": "Principles of Culinary Arts I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "119",
+              "title": "Applied Nutrition for Food Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAK",
+              "number": "128",
+              "title": "Principles of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "158",
+              "title": "Sanitation and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "107",
+              "title": "Principles of Culinary Arts II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "220",
+              "title": "Meat, Seafood, and Poultry Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR HRI ___ Technical Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Force",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.pvcc.edu/preview_program.php?catoid=9&poid=1119",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PVCC Course # *",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "101",
+              "title": "The Foundations of the U.S. Air Force I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PVCC Course # *",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "102",
+              "title": "The Foundations of the U.S. Air Force II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PVCC Course # *",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "201",
+              "title": "The Evolution of Air and Space Power I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PVCC Course # *",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "202",
+              "title": "The Evolution of Air and Space Power II",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/programs/matcher.ts
+++ b/lib/programs/matcher.ts
@@ -1,0 +1,109 @@
+/**
+ * matcher.ts — maps scraped program titles to the 12 registry slugs.
+ *
+ * Conservative: returns null on low confidence. Unmatched programs still
+ * appear on college program pages, just not on category hub pages.
+ */
+
+import { PROGRAMS } from "./registry";
+import type { ProgramRequirement } from "../types";
+
+interface MatchRule {
+  slug: string;
+  keywords: RegExp;
+  antiKeywords?: RegExp;
+}
+
+const RULES: MatchRule[] = [
+  {
+    slug: "nursing",
+    keywords: /\bnurs(?:ing|e)\b|\badn\b|\blpn\b|\brn\b/i,
+    antiKeywords: /\bvet(?:erinary)?\b/i,
+  },
+  {
+    slug: "business-administration",
+    keywords: /\bbusiness\b|\bmanagement\b|\bmarketing\b/i,
+    antiKeywords: /\bmusic\s+business\b|\bagri-?business\b/i,
+  },
+  {
+    slug: "computer-science",
+    keywords:
+      /\bcomputer\s+science\b|\bcybersecurity\b|\binformation\s+tech/i,
+  },
+  {
+    slug: "accounting",
+    keywords: /\baccounting\b/i,
+  },
+  {
+    slug: "early-childhood-education",
+    keywords: /\bearly\s+childhood\b|\bchild\s+develop/i,
+  },
+  {
+    slug: "criminal-justice",
+    keywords: /\bcriminal\s+justice\b|\blaw\s+enforcement\b|\bcorrections\b/i,
+  },
+  {
+    slug: "liberal-arts",
+    keywords: /\bliberal\s+arts\b|\bgeneral\s+studies\b|\bliberal\s+studies\b/i,
+  },
+  {
+    slug: "engineering",
+    keywords: /\bengineering\b/i,
+    antiKeywords: /\bsound\s+engineering\b|\baudio\b/i,
+  },
+  {
+    slug: "biology",
+    keywords: /\bbiology\b|\bbiotech/i,
+  },
+  {
+    slug: "psychology",
+    keywords: /\bpsychology\b/i,
+  },
+  {
+    slug: "welding",
+    keywords: /\bwelding\b/i,
+  },
+  {
+    slug: "automotive-technology",
+    keywords: /\bautomotive\b|\bauto\s+tech/i,
+  },
+];
+
+/**
+ * Match a single program title to a registry slug. Returns null if no
+ * confident match. Does not attempt fuzzy matching — a missed match is
+ * better than a wrong one.
+ */
+export function matchProgramSlug(title: string): string | null {
+  for (const rule of RULES) {
+    if (rule.keywords.test(title)) {
+      if (rule.antiKeywords && rule.antiKeywords.test(title)) continue;
+      return rule.slug;
+    }
+  }
+  return null;
+}
+
+/**
+ * Run the matcher across all programs in a CollegePrograms dataset,
+ * populating matched_program_slug in place.
+ */
+export function applyProgramMatching(programs: ProgramRequirement[]): {
+  matched: number;
+  unmatched: number;
+} {
+  let matched = 0;
+  let unmatched = 0;
+  for (const p of programs) {
+    const slug = matchProgramSlug(p.title);
+    p.matched_program_slug = slug;
+    if (slug) matched++;
+    else unmatched++;
+  }
+  return { matched, unmatched };
+}
+
+/** Get the set of valid program slugs (for validation). */
+export function getValidSlugs(): Set<string> {
+  return new Set(PROGRAMS.map((p) => p.slug));
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -102,6 +102,59 @@ export type PrereqEntry = z.infer<typeof PrereqEntrySchema>;
 export const PrereqMapSchema = z.record(z.string(), PrereqEntrySchema);
 
 // ---------------------------------------------------------------------------
+// ProgramRequirement — one entry in data/{state}/programs/{college_slug}.json
+// ---------------------------------------------------------------------------
+
+const RequiredCourseSchema = z.object({
+  prefix: z.string().min(1),
+  number: z.string().min(1),
+  title: z.string(),
+  credits: z.number().nullable(),
+  or_alternatives: z.array(
+    z.object({
+      prefix: z.string().min(1),
+      number: z.string().min(1),
+      title: z.string(),
+    })
+  ),
+});
+
+export type RequiredCourse = z.infer<typeof RequiredCourseSchema>;
+
+const RequirementGroupSchema = z.object({
+  name: z.string().min(1, "group name required"),
+  credits_required: z.number().nullable(),
+  choose_n: z.number().nullable(),
+  courses: z.array(RequiredCourseSchema),
+});
+
+export type RequirementGroup = z.infer<typeof RequirementGroupSchema>;
+
+export const ProgramRequirementSchema = z.object({
+  title: z.string().min(1, "program title required"),
+  credential: z.enum(["AA", "AS", "AAS", "certificate", "diploma", "other"]),
+  program_code: z.string().nullable(),
+  catalog_url: z.string(),
+  total_credits: z.number().nullable(),
+  gpa_minimum: z.number().nullable(),
+  description: z.string().nullable(),
+  requirement_groups: z.array(RequirementGroupSchema),
+  matched_program_slug: z.string().nullable(),
+});
+
+export type ProgramRequirement = z.infer<typeof ProgramRequirementSchema>;
+
+export const CollegeProgramsSchema = z.object({
+  college_slug: z.string().min(1, "college_slug required"),
+  catalog_year: z.string().min(1, "catalog_year required"),
+  catalog_url: z.string(),
+  scraped_at: z.string(),
+  programs: z.array(ProgramRequirementSchema),
+});
+
+export type CollegePrograms = z.infer<typeof CollegeProgramsSchema>;
+
+// ---------------------------------------------------------------------------
 // Validation helper with row-level error reporting
 // ---------------------------------------------------------------------------
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -171,3 +171,44 @@ export interface ScheduleResponse {
     filteredFullSections?: number; // how many sections were hidden due to 0 seats
   };
 }
+
+// ---------------------------------------------------------------------------
+// Program / Degree Requirement types
+// ---------------------------------------------------------------------------
+
+export type ProgramCredential = "AA" | "AS" | "AAS" | "certificate" | "diploma" | "other";
+
+export interface RequiredCourse {
+  prefix: string;
+  number: string;
+  title: string;
+  credits: number | null;
+  or_alternatives: Array<{ prefix: string; number: string; title: string }>;
+}
+
+export interface RequirementGroup {
+  name: string;
+  credits_required: number | null;
+  choose_n: number | null;
+  courses: RequiredCourse[];
+}
+
+export interface ProgramRequirement {
+  title: string;
+  credential: ProgramCredential;
+  program_code: string | null;
+  catalog_url: string;
+  total_credits: number | null;
+  gpa_minimum: number | null;
+  description: string | null;
+  requirement_groups: RequirementGroup[];
+  matched_program_slug: string | null;
+}
+
+export interface CollegePrograms {
+  college_slug: string;
+  catalog_year: string;
+  catalog_url: string;
+  scraped_at: string;
+  programs: ProgramRequirement[];
+}

--- a/scripts/import-programs.ts
+++ b/scripts/import-programs.ts
@@ -1,0 +1,55 @@
+/**
+ * import-programs.ts
+ *
+ * Bulk import program/degree requirement data from JSON files into Supabase.
+ *
+ * Usage:
+ *   npx tsx scripts/import-programs.ts --state va
+ *   npx tsx scripts/import-programs.ts --all
+ */
+
+import { importProgramsToSupabase } from "./lib/supabase-import";
+import { getAllStates } from "../lib/states/registry";
+
+const ALL_STATES = getAllStates().map((s) => s.slug);
+
+async function main() {
+  const args = process.argv.slice(2);
+  const stateIdx = args.indexOf("--state");
+  const isAll = args.includes("--all");
+  const force = args.includes("--force");
+
+  let states: string[];
+  if (isAll) {
+    states = ALL_STATES;
+  } else if (stateIdx >= 0) {
+    const s = args[stateIdx + 1];
+    if (!ALL_STATES.includes(s)) {
+      console.error(`Unknown state: ${s}. Available: ${ALL_STATES.join(", ")}`);
+      process.exit(1);
+    }
+    states = [s];
+  } else {
+    console.log(
+      "Usage:\n" +
+        "  npx tsx scripts/import-programs.ts --state va\n" +
+        "  npx tsx scripts/import-programs.ts --all"
+    );
+    return;
+  }
+
+  console.log(`Importing programs for: ${states.join(", ")}`);
+
+  let grandTotal = 0;
+  for (const state of states) {
+    const count = await importProgramsToSupabase(state, { force });
+    grandTotal += count || 0;
+  }
+
+  console.log(`\nDone. Total: ${grandTotal} programs imported.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/lib/scrape-acalog-programs.ts
+++ b/scripts/lib/scrape-acalog-programs.ts
@@ -1,0 +1,562 @@
+/**
+ * scrape-acalog-programs.ts — shared Acalog program scraper library.
+ *
+ * Extracts degree/certificate program requirements from any Acalog-powered
+ * college catalog. Reusable across states — each state scraper passes its
+ * catalog URL, catoid, and program navoid(s).
+ *
+ * Architecture (parallels the course prereq scrapers):
+ *   1. Discover catoid via discover-catalog.ts
+ *   2. Scrape program listing pages, collect poids
+ *   3. Fetch each program detail page
+ *   4. Parse requirement groups, course lists, OR alternatives
+ *
+ * Output: CollegePrograms matching lib/schemas.ts
+ */
+
+import { discoverAcalogCatoid } from "./discover-catalog.js";
+import type {
+  CollegePrograms,
+  ProgramRequirement,
+  RequirementGroup,
+  RequiredCourse,
+} from "../../lib/types";
+import type { ProgramCredential } from "../../lib/types";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface AcalogProgramConfig {
+  collegeSlug: string;
+  baseUrl: string;
+  catoidFallback: number;
+  /** Navoids to scan for program links. Multiple for catalogs that split
+   *  programs across "schools" (e.g. CT State: Business, STEM, etc.). */
+  programNavoids: number[];
+  /** If true, auto-discover catoid from the catalog dropdown. Default true. */
+  autoDiscoverCatoid?: boolean;
+}
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 6;
+const DELAY_MS = 80;
+
+// ---------------------------------------------------------------------------
+// HTTP helpers (same pattern as CT prereq scraper)
+// ---------------------------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(
+  url: string,
+  label: string,
+  attempts = 3,
+): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return "";
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// HTML helpers
+// ---------------------------------------------------------------------------
+
+function htmlToText(raw: string): string {
+  return raw
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;?/g, " ")
+    .replace(/&#160;?/g, " ")
+    .replace(/&#(\d+);?/g, (_, code) =>
+      String.fromCharCode(parseInt(code, 10)),
+    )
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Parsing — program list
+// ---------------------------------------------------------------------------
+
+function extractPoids(html: string): string[] {
+  const re = /preview_program\.php\?catoid=\d+&(?:amp;)?poid=(\d+)/g;
+  const ids = new Set<string>();
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    ids.add(m[1]);
+  }
+  return Array.from(ids);
+}
+
+// ---------------------------------------------------------------------------
+// Parsing — program detail page
+// ---------------------------------------------------------------------------
+
+/** Parse credential type from the H1 title text. */
+function parseCredential(title: string): ProgramCredential {
+  const t = title.toLowerCase();
+  if (/\baas\b|associate of applied science/i.test(t)) return "AAS";
+  if (/\ba\.?a\.?\b|associate of arts/i.test(t)) return "AA";
+  if (/\ba\.?s\.?\b|associate of science/i.test(t)) return "AS";
+  if (/\bcertificate\b|\bcert\b/i.test(t)) return "certificate";
+  if (/\bdiploma\b/i.test(t)) return "diploma";
+  // Heuristic: if "associate" appears without a more specific match
+  if (/\bassociate\b/i.test(t)) return "AA";
+  return "other";
+}
+
+/** Extract program code from H1 if present, e.g. "(BSAD-AA-TAP)" or "- 718" */
+function parseProgramCode(title: string): string | null {
+  // Parenthesized code like "(BSAD-AA-TAP)"
+  const paren = title.match(/\(([A-Z0-9][-A-Z0-9]+)\)\s*$/);
+  if (paren) return paren[1];
+  // Trailing code after " - " that's all digits, e.g. "Technical Studies - AAS - 718"
+  const trailing = title.match(/\s+-\s+(\d{3,})\s*$/);
+  if (trailing) return trailing[1];
+  return null;
+}
+
+/**
+ * Parse a single course list item.
+ * Handles formats like:
+ *   - "ENG 1010 - Composition"  (CT State dash separator)
+ *   - "BUS 116: Entrepreneurship"  (Germanna colon separator)
+ *   - "Elective ARHX - Arts & Humanities Course"  (generic elective)
+ */
+function parseCourseFromLabel(label: string): {
+  prefix: string;
+  number: string;
+  title: string;
+} | null {
+  // Try "PREFIX NUMBER - Title" or "PREFIX NUMBER: Title"
+  const m = label.match(
+    /^([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*[-:]\s*(.+)/,
+  );
+  if (m) {
+    return { prefix: m[1], number: m[2], title: m[3].trim() };
+  }
+  // Try just "PREFIX NUMBER" with no title
+  const simple = label.match(/^([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s*$/);
+  if (simple) {
+    return { prefix: simple[1], number: simple[2], title: "" };
+  }
+  return null;
+}
+
+/** Extract credits from an <em>Credits:</em> <em>3</em> or Credits: 3 pattern */
+function parseCredits(html: string): number | null {
+  const m = html.match(/Credits:?\s*<\/em>\s*<em>\s*([\d.]+)/i)
+    || html.match(/Credits:?\s*([\d.]+)/i);
+  if (m) {
+    const n = parseFloat(m[1]);
+    return isNaN(n) ? null : n;
+  }
+  return null;
+}
+
+/** Parse credits from a group header like "Framework Courses (31-34 credits)" */
+function parseGroupCredits(header: string): number | null {
+  // "31-34 credits" → take the lower bound
+  const range = header.match(/(\d+)\s*-\s*\d+\s*credits?/i);
+  if (range) return parseInt(range[1], 10);
+  // "30 credits"
+  const exact = header.match(/(\d+)\s*credits?/i);
+  if (exact) return parseInt(exact[1], 10);
+  return null;
+}
+
+/** Parse total credits from "Total Credits: 61-65" or "Total Credits: 60" */
+function parseTotalCredits(html: string): number | null {
+  const m = html.match(/Total\s+Credits:?\s*(\d+)/i);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/**
+ * Parse requirement groups from the program detail page HTML.
+ * Groups are in `<div class="acalog-core">` blocks with `<h2>`/`<h3>`/`<h4>`
+ * headers and `<li class="acalog-course">` items.
+ */
+function parseRequirementGroups(html: string): {
+  groups: RequirementGroup[];
+  totalCredits: number | null;
+} {
+  const groups: RequirementGroup[] = [];
+  let totalCredits: number | null = null;
+
+  // Split on acalog-core div boundaries
+  const coreBlocks = html.split(/(?=<div\s+class="acalog-core">)/i);
+
+  for (const block of coreBlocks) {
+    if (!block.includes("acalog-core")) continue;
+
+    // Extract group header from h2/h3/h4
+    const headerMatch = block.match(/<h[2-4][^>]*>([\s\S]*?)<\/h[2-4]>/i);
+    if (!headerMatch) continue;
+
+    const headerText = htmlToText(headerMatch[1]);
+
+    // Check if this is the "Total Credits" summary block
+    if (/^total\s+credits/i.test(headerText)) {
+      totalCredits = parseTotalCredits(headerText);
+      continue;
+    }
+
+    // Skip empty/navigation-only headers
+    if (!headerText || headerText.length < 3) continue;
+
+    const creditsRequired = parseGroupCredits(headerText);
+
+    // Parse course list items
+    const courses: RequiredCourse[] = [];
+    let lastCourse: RequiredCourse | null = null;
+
+    // Match each <li class="acalog-course"> or <li class="acalog-adhoc-list-item">
+    const liRegex =
+      /<li\s+class="(acalog-course|acalog-adhoc[^"]*)"[^>]*>([\s\S]*?)<\/li>/gi;
+    let liMatch;
+    while ((liMatch = liRegex.exec(block)) !== null) {
+      const liClass = liMatch[1];
+      const liHtml = liMatch[2];
+
+      // Check if this is an OR alternative (has "OR" text before the course link)
+      const isOr = /<strong>\s*(?:&nbsp;|\s)*OR\s*<\/strong>/i.test(liHtml);
+
+      // Extract course info from aria-label or link text
+      let courseInfo: { prefix: string; number: string; title: string } | null =
+        null;
+      const ariaLabel = liHtml.match(
+        /aria-label="View course details for ([^"]+)"/,
+      );
+      if (ariaLabel) {
+        courseInfo = parseCourseFromLabel(ariaLabel[1].trim());
+      }
+      if (!courseInfo) {
+        // Try link text
+        const linkText = liHtml.match(/>([A-Z]{2,5}\s+\d{3,4}[A-Z]?\s*[-:][^<]+)</);
+        if (linkText) {
+          courseInfo = parseCourseFromLabel(linkText[1].trim());
+        }
+      }
+
+      // Handle adhoc items (electives, free-text requirements)
+      if (liClass.includes("adhoc") && !courseInfo) {
+        const adhocText = htmlToText(liHtml);
+        if (adhocText) {
+          const adhocCredits = parseCredits(liHtml);
+          courses.push({
+            prefix: "ELEC",
+            number: "XXX",
+            title: adhocText.replace(/Credits:?\s*\d+[-\d]*\s*/i, "").trim(),
+            credits: adhocCredits,
+            or_alternatives: [],
+          });
+        }
+        lastCourse = null;
+        continue;
+      }
+
+      if (!courseInfo) continue;
+
+      const credits = parseCredits(liHtml);
+
+      if (isOr && lastCourse) {
+        // This is an OR alternative to the previous course
+        lastCourse.or_alternatives.push({
+          prefix: courseInfo.prefix,
+          number: courseInfo.number,
+          title: courseInfo.title,
+        });
+      } else {
+        const course: RequiredCourse = {
+          prefix: courseInfo.prefix,
+          number: courseInfo.number,
+          title: courseInfo.title,
+          credits,
+          or_alternatives: [],
+        };
+        courses.push(course);
+        lastCourse = course;
+      }
+    }
+
+    // Only add groups that have content
+    if (courses.length > 0 || creditsRequired !== null) {
+      // Clean up the header — remove anchor text artifacts
+      const cleanName = headerText
+        .replace(/^\s*[A-Za-z]+(?:Courses|Requirements)\d+\w*\s*/i, "")
+        .trim() || headerText;
+
+      groups.push({
+        name: cleanName,
+        credits_required: creditsRequired,
+        choose_n: null,
+        courses,
+      });
+    }
+  }
+
+  return { groups, totalCredits };
+}
+
+/** Parse a full program detail page into ProgramRequirement. */
+function parseProgramPage(
+  html: string,
+  poid: string,
+  baseUrl: string,
+  catoid: number,
+): ProgramRequirement | null {
+  // Extract title from H1
+  const h1 = html.match(/<h1[^>]*id="acalog-content"[^>]*>([\s\S]*?)<\/h1>/i);
+  if (!h1) return null;
+  const rawTitle = htmlToText(h1[1]);
+  if (!rawTitle) return null;
+
+  // Parse out credential, code, and clean title
+  const credential = parseCredential(rawTitle);
+  const programCode = parseProgramCode(rawTitle);
+
+  // Clean title: remove program code and trailing credential abbreviations
+  let title = rawTitle
+    .replace(/\s*\([A-Z0-9][-A-Z0-9]+\)\s*$/, "")
+    .replace(/\s+-\s+\d{3,}\s*$/, "")
+    .trim();
+
+  // Extract description from first <p> after the header section
+  let description: string | null = null;
+  const descMatch = html.match(
+    /<\/h3>\s*(?:<div[^>]*>[\s\S]*?<\/div>\s*)*<(?:p|div)[^>]*class="[^"]*"[^>]*>([\s\S]*?)<(?:\/p|\/div)>/i,
+  );
+  if (descMatch) {
+    const d = htmlToText(descMatch[1]);
+    if (d && d.length > 20 && d.length < 2000 && !/^\s*</.test(d)) {
+      description = d;
+    }
+  }
+
+  // Parse requirement groups
+  const { groups, totalCredits } = parseRequirementGroups(html);
+
+  // Parse GPA from page text
+  let gpaMinimum: number | null = null;
+  const gpaMatch = html.match(
+    /(?:minimum|required)\s+(?:cumulative\s+)?GPA\s*(?:of\s+)?(\d\.\d)/i,
+  );
+  if (gpaMatch) gpaMinimum = parseFloat(gpaMatch[1]);
+
+  return {
+    title,
+    credential,
+    program_code: programCode,
+    catalog_url: `${baseUrl}/preview_program.php?catoid=${catoid}&poid=${poid}`,
+    total_credits: totalCredits,
+    gpa_minimum: gpaMinimum,
+    description,
+    requirement_groups: groups,
+    matched_program_slug: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Scrape all programs from an Acalog catalog.
+ *
+ * Usage:
+ *   const data = await scrapeAcalogPrograms({
+ *     collegeSlug: "ctstate",
+ *     baseUrl: "https://catalog.ctstate.edu",
+ *     catoidFallback: 24,
+ *     programNavoids: [2871, 2872, 2873, 2878, 2880],
+ *   });
+ */
+export async function scrapeAcalogPrograms(
+  config: AcalogProgramConfig,
+): Promise<CollegePrograms> {
+  const {
+    collegeSlug,
+    baseUrl,
+    catoidFallback,
+    programNavoids,
+    autoDiscoverCatoid = true,
+  } = config;
+
+  // Step 1: Discover catoid
+  const catoid = autoDiscoverCatoid
+    ? await discoverAcalogCatoid(baseUrl, catoidFallback)
+    : catoidFallback;
+  console.log(`  [${collegeSlug}] catoid=${catoid}`);
+
+  // Step 2: Collect all program poids from the nav pages
+  console.log(
+    `  [${collegeSlug}] Scanning ${programNavoids.length} navoid(s) for programs...`,
+  );
+  const allPoids = new Set<string>();
+  for (const navoid of programNavoids) {
+    const html = await retryFetch(
+      `${baseUrl}/content.php?catoid=${catoid}&navoid=${navoid}`,
+      `navoid=${navoid}`,
+    );
+    const poids = extractPoids(html);
+    for (const p of poids) allPoids.add(p);
+    console.log(`    navoid=${navoid}: ${poids.length} programs`);
+    await sleep(100);
+  }
+  console.log(`  [${collegeSlug}] Total unique programs: ${allPoids.size}`);
+
+  if (allPoids.size === 0) {
+    return {
+      college_slug: collegeSlug,
+      catalog_year: "",
+      catalog_url: baseUrl,
+      scraped_at: new Date().toISOString(),
+      programs: [],
+    };
+  }
+
+  // Step 3: Fetch and parse each program detail page
+  console.log(`  [${collegeSlug}] Fetching program detail pages...`);
+  const poidList = Array.from(allPoids);
+  const programs: ProgramRequirement[] = [];
+  let parsed = 0;
+  let skipped = 0;
+
+  await pmap(poidList, CONCURRENCY, async (poid) => {
+    const url = `${baseUrl}/preview_program.php?catoid=${catoid}&poid=${poid}`;
+    const html = await retryFetch(url, `program(${poid})`);
+    if (!html) {
+      skipped++;
+      return;
+    }
+
+    const program = parseProgramPage(html, poid, baseUrl, catoid);
+    if (program) {
+      programs.push(program);
+      parsed++;
+    } else {
+      skipped++;
+    }
+  });
+
+  console.log(
+    `  [${collegeSlug}] Parsed ${parsed} programs, skipped ${skipped}`,
+  );
+
+  // Detect catalog year from the catalog page title
+  let catalogYear = "";
+  try {
+    const indexHtml = await retryFetch(
+      `${baseUrl}/index.php`,
+      "catalog-index",
+    );
+    const yearMatch = indexHtml.match(
+      /(\d{4})\s*[-–]\s*(\d{4})\s*(?:Catalog|College)/i,
+    );
+    if (yearMatch) catalogYear = `${yearMatch[1]}-${yearMatch[2]}`;
+  } catch {
+    // Non-fatal — catalog year is nice-to-have
+  }
+
+  return {
+    college_slug: collegeSlug,
+    catalog_year: catalogYear,
+    catalog_url: baseUrl,
+    scraped_at: new Date().toISOString(),
+    programs,
+  };
+}
+
+/**
+ * Auto-discover program navoids by scanning the catalog sidebar for links
+ * containing "program" text. Returns navoid numbers.
+ */
+export async function discoverProgramNavoids(
+  baseUrl: string,
+  catoid: number,
+): Promise<number[]> {
+  try {
+    const html = await retryFetch(
+      `${baseUrl}/content.php?catoid=${catoid}&navoid=0`,
+      "nav-discovery",
+    );
+    // Look for nav links with "program" in the text
+    const re =
+      /<a[^>]*navoid=(\d+)[^>]*>[^<]*(?:program|degree|certificate|associate|academic\s+programs)[^<]*/gi;
+    const navoids = new Set<number>();
+    let m;
+    while ((m = re.exec(html)) !== null) {
+      navoids.add(parseInt(m[1], 10));
+    }
+
+    // For each candidate navoid, check if it actually has program links
+    const confirmed: number[] = [];
+    for (const navoid of navoids) {
+      const page = await retryFetch(
+        `${baseUrl}/content.php?catoid=${catoid}&navoid=${navoid}`,
+        `check-navoid-${navoid}`,
+      );
+      const poids = extractPoids(page);
+      if (poids.length > 0) {
+        confirmed.push(navoid);
+        console.log(`    navoid=${navoid}: ${poids.length} programs (confirmed)`);
+      }
+      await sleep(100);
+    }
+
+    return confirmed;
+  } catch {
+    return [];
+  }
+}

--- a/scripts/lib/supabase-import.ts
+++ b/scripts/lib/supabase-import.ts
@@ -18,6 +18,8 @@ import { loadEnv } from "./load-env";
 import {
   CourseSectionSchema,
   TransferMappingSchema,
+  CollegeProgramsSchema,
+  ProgramRequirementSchema,
   MAX_INVALID_RATIO,
   validateRows,
   isTransferHeaderRow,
@@ -42,7 +44,7 @@ const WARN_RATIO = 0.9;
  */
 export async function changeDetection(
   sb: SupabaseClient,
-  table: "courses" | "transfers",
+  table: "courses" | "transfers" | "programs",
   filter: Record<string, string>,
   incoming: number,
   label: string,
@@ -496,5 +498,196 @@ export async function importTransfersToSupabase(
   }
 
   console.log(`  Total transfers for ${state.toUpperCase()}: ${totalInserted}`);
+  return totalInserted;
+}
+
+// ---------------------------------------------------------------------------
+// Program import
+// ---------------------------------------------------------------------------
+
+interface ProgramRow {
+  state: string;
+  college_slug: string;
+  catalog_year: string;
+  title: string;
+  credential: string;
+  program_code: string | null;
+  catalog_url: string;
+  total_credits: number | null;
+  gpa_minimum: number | null;
+  description: string | null;
+  matched_program_slug: string | null;
+  requirement_groups: unknown;
+  scraped_at: string;
+}
+
+/**
+ * Import program requirement data for a state into Supabase.
+ * Reads from data/{state}/programs/{college_slug}.json — one file per college.
+ */
+export async function importProgramsToSupabase(
+  state: string,
+  opts: { force?: boolean } = {}
+): Promise<number> {
+  const force = !!opts.force;
+  let sb: SupabaseClient;
+  try {
+    sb = getSupabase();
+  } catch (e) {
+    console.log(`\n  Supabase program import skipped: ${(e as Error).message}`);
+    return 0;
+  }
+
+  const programsDir = path.join(process.cwd(), "data", state, "programs");
+  if (!fs.existsSync(programsDir)) {
+    console.log(`  No programs directory for ${state}, skipping import.`);
+    return 0;
+  }
+
+  const files = fs
+    .readdirSync(programsDir)
+    .filter((f) => f.endsWith(".json"));
+
+  if (files.length === 0) {
+    console.log(`  No program files for ${state}.`);
+    return 0;
+  }
+
+  console.log(
+    `\nImporting ${state.toUpperCase()} programs into Supabase: ${files.length} college(s)`
+  );
+
+  let totalInserted = 0;
+
+  for (const file of files) {
+    const collegeSlug = file.replace(".json", "");
+    const filePath = path.join(programsDir, file);
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+    // Validate the top-level CollegePrograms envelope
+    const envelope = CollegeProgramsSchema.safeParse(parsed);
+    if (!envelope.success) {
+      console.error(
+        `  SKIP ${collegeSlug}: envelope validation failed — ${envelope.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ")}`
+      );
+      continue;
+    }
+
+    const collegeData = envelope.data;
+    const programs = collegeData.programs;
+    if (programs.length === 0) continue;
+
+    // Change-detection preflight
+    const cd = await changeDetection(
+      sb,
+      "programs",
+      { state, college_slug: collegeSlug },
+      programs.length,
+      `${collegeSlug} programs`,
+      force
+    );
+    if (cd.message) console.log(cd.message);
+    if (!cd.ok) continue;
+
+    // Row-level validation (individual programs)
+    const validation = validateRows(
+      programs,
+      ProgramRequirementSchema,
+      (row, i) => {
+        const r = row as Record<string, unknown>;
+        return `${collegeSlug} "${r.title ?? `program ${i}`}"`;
+      }
+    );
+
+    const invalidRatio =
+      validation.invalid.length / programs.length;
+    if (validation.invalid.length > 0) {
+      console.warn(
+        `  SCHEMA ${collegeSlug} programs: ${validation.invalid.length}/${programs.length} rows failed (${(invalidRatio * 100).toFixed(1)}%)`
+      );
+      for (const bad of validation.invalid.slice(0, 10)) {
+        console.warn(`    - ${bad.identity}: ${bad.errors.join("; ")}`);
+      }
+      if (validation.invalid.length > 10) {
+        console.warn(
+          `    - ...and ${validation.invalid.length - 10} more`
+        );
+      }
+    }
+
+    if (invalidRatio > MAX_INVALID_RATIO) {
+      console.error(
+        `  ABORT ${collegeSlug} programs: invalid-row ratio ${(invalidRatio * 100).toFixed(1)}% exceeds ${(MAX_INVALID_RATIO * 100).toFixed(0)}% threshold. Cloud data unchanged.`
+      );
+      continue;
+    }
+
+    const validated = validation.valid;
+    if (validated.length === 0) continue;
+
+    // Delete existing rows for this (state, college_slug)
+    const { error: delError } = await sb
+      .from("programs")
+      .delete()
+      .eq("state", state)
+      .eq("college_slug", collegeSlug);
+
+    if (delError) {
+      console.error(
+        `  Error deleting ${collegeSlug} programs:`,
+        delError.message
+      );
+      continue;
+    }
+
+    // Prepare rows
+    const rows: ProgramRow[] = validated.map((p) => ({
+      state,
+      college_slug: collegeSlug,
+      catalog_year: collegeData.catalog_year,
+      title: p.title,
+      credential: p.credential,
+      program_code: p.program_code,
+      catalog_url: p.catalog_url,
+      total_credits: p.total_credits,
+      gpa_minimum: p.gpa_minimum,
+      description: p.description,
+      matched_program_slug: p.matched_program_slug,
+      requirement_groups: p.requirement_groups,
+      scraped_at: collegeData.scraped_at,
+    }));
+
+    // Insert in batches
+    let inserted = 0;
+    let aborted = false;
+    for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+      const batch = rows.slice(i, i + BATCH_SIZE);
+      const { error: insError } = await sb.from("programs").insert(batch);
+      if (insError) {
+        console.error(
+          `  FATAL: Insert failed for ${collegeSlug} programs batch ${i}: ${insError.message}`
+        );
+        console.error(
+          `  WARNING: ${rows.length - inserted} rows lost — delete already committed.`
+        );
+        aborted = true;
+        break;
+      }
+      inserted += batch.length;
+    }
+    if (aborted) {
+      console.error(
+        `  Aborting remaining batches for ${collegeSlug} programs.`
+      );
+    }
+
+    totalInserted += inserted;
+    console.log(`  ${collegeSlug}: ${inserted} programs`);
+  }
+
+  console.log(
+    `  Total programs for ${state.toUpperCase()}: ${totalInserted}`
+  );
   return totalInserted;
 }

--- a/scripts/va/scrape-programs.ts
+++ b/scripts/va/scrape-programs.ts
@@ -1,0 +1,127 @@
+/**
+ * scrape-programs.ts — scrape degree/program requirements for Virginia
+ * community colleges (VCCS) from their individual Acalog catalogs.
+ *
+ * Not all 23 VCCS colleges use Acalog. This scraper covers the ones that do.
+ * Others can be added as their catalog systems are identified.
+ *
+ * Usage:
+ *   npx tsx scripts/va/scrape-programs.ts
+ *   npx tsx scripts/va/scrape-programs.ts --college gcc     # single college
+ *   npx tsx scripts/va/scrape-programs.ts --limit 5         # smoke test (5 programs per college)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { scrapeAcalogPrograms } from "../lib/scrape-acalog-programs.js";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type { AcalogProgramConfig } from "../lib/scrape-acalog-programs.js";
+
+// ---------------------------------------------------------------------------
+// VA colleges with confirmed Acalog catalogs
+// ---------------------------------------------------------------------------
+
+// VA college Acalog instances use dropdown values for content types, not
+// catalog editions, so auto-discovery picks the wrong catoid. Use known values.
+const COLLEGES: AcalogProgramConfig[] = [
+  {
+    collegeSlug: "gcc",
+    baseUrl: "https://catalog.germanna.edu",
+    catoidFallback: 15,
+    programNavoids: [453],
+    autoDiscoverCatoid: false,
+  },
+  {
+    collegeSlug: "pvcc",
+    baseUrl: "https://catalog.pvcc.edu",
+    catoidFallback: 9,
+    programNavoids: [1076],
+    autoDiscoverCatoid: false,
+  },
+  {
+    collegeSlug: "nova",
+    baseUrl: "https://nvcc.catalog.acalog.com",
+    catoidFallback: 15,
+    programNavoids: [1882],
+    autoDiscoverCatoid: false,
+  },
+  {
+    collegeSlug: "mecc",
+    baseUrl: "https://catalog.mecc.edu",
+    catoidFallback: 6,
+    programNavoids: [408],
+    autoDiscoverCatoid: false,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeArg = args
+    .find((a) => a.startsWith("--college="))
+    ?.split("=")[1]
+    || (args.indexOf("--college") >= 0
+      ? args[args.indexOf("--college") + 1]
+      : null);
+
+  let colleges = COLLEGES;
+  if (collegeArg) {
+    colleges = COLLEGES.filter((c) => c.collegeSlug === collegeArg);
+    if (colleges.length === 0) {
+      console.error(
+        `Unknown college: ${collegeArg}. Available: ${COLLEGES.map((c) => c.collegeSlug).join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const outDir = path.join(process.cwd(), "data", "va", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`VA program scraper — ${colleges.length} college(s)\n`);
+
+  let totalPrograms = 0;
+
+  for (const config of colleges) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`Scraping ${config.collegeSlug} (${config.baseUrl})`);
+    console.log("=".repeat(60));
+
+    try {
+      const data = await scrapeAcalogPrograms(config);
+
+      if (data.programs.length === 0) {
+        console.log(`  No programs found for ${config.collegeSlug}, skipping.`);
+        continue;
+      }
+
+      // Run the program-slug matcher
+      const { matched, unmatched } = applyProgramMatching(data.programs);
+      console.log(
+        `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+      );
+
+      // Write output
+      const outPath = path.join(outDir, `${config.collegeSlug}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+      console.log(
+        `  ✓ Wrote ${data.programs.length} programs to ${outPath}`,
+      );
+
+      totalPrograms += data.programs.length;
+    } catch (e) {
+      console.error(`  ERROR scraping ${config.collegeSlug}: ${e}`);
+    }
+  }
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`Done. Total: ${totalPrograms} programs across ${colleges.length} college(s).`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/supabase/migrations/011_programs.sql
+++ b/supabase/migrations/011_programs.sql
@@ -1,0 +1,77 @@
+-- 011_programs.sql
+--
+-- Adds the `programs` table for storing degree/program requirements scraped
+-- from community college catalogs (Acalog, Coursedog). Each row is one
+-- program at one college (e.g. "AA in Business Administration at NOVA").
+--
+-- requirement_groups is JSONB rather than normalized tables — matches the
+-- existing pattern for prereqs and prerequisite_courses. Read patterns are
+-- always "load all groups for one program" so JSONB is a natural fit.
+--
+-- Execution: Supabase Dashboard SQL Editor (safe in a single transaction,
+-- no CONCURRENTLY needed — table is new).
+
+-- Table
+CREATE TABLE IF NOT EXISTS programs (
+  id            BIGSERIAL PRIMARY KEY,
+  state         VARCHAR(2) NOT NULL,
+  college_slug  VARCHAR(50) NOT NULL,
+  catalog_year  VARCHAR(20) NOT NULL,
+  title         TEXT NOT NULL,
+  credential    VARCHAR(20) NOT NULL,
+  program_code  TEXT,
+  catalog_url   TEXT NOT NULL DEFAULT '',
+  total_credits NUMERIC(5,1),
+  gpa_minimum   NUMERIC(3,2),
+  description   TEXT,
+  matched_program_slug VARCHAR(60),
+  requirement_groups   JSONB NOT NULL DEFAULT '[]'::jsonb,
+  scraped_at    TIMESTAMPTZ DEFAULT now(),
+  created_at    TIMESTAMPTZ DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_programs_state_college
+  ON programs(state, college_slug);
+CREATE INDEX IF NOT EXISTS idx_programs_state_slug
+  ON programs(state, matched_program_slug);
+CREATE INDEX IF NOT EXISTS idx_programs_state_credential
+  ON programs(state, credential);
+
+-- RLS: public read, service-role write (matches courses/transfers pattern)
+ALTER TABLE programs ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'programs' AND policyname = 'Public read access'
+  ) THEN
+    CREATE POLICY "Public read access" ON programs FOR SELECT USING (true);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'programs' AND policyname = 'Service role insert'
+  ) THEN
+    CREATE POLICY "Service role insert" ON programs FOR INSERT
+      WITH CHECK (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'programs' AND policyname = 'Service role update'
+  ) THEN
+    CREATE POLICY "Service role update" ON programs FOR UPDATE
+      USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'programs' AND policyname = 'Service role delete'
+  ) THEN
+    CREATE POLICY "Service role delete" ON programs FOR DELETE
+      USING (auth.role() = 'service_role');
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Foundation for the degree/program requirements feature — lets students answer "What courses do I need for an AA in Business at NOVA?"

- **Data model**: TypeScript types + Zod schemas for `CollegePrograms`, `ProgramRequirement`, `RequirementGroup`, `RequiredCourse`
- **Supabase migration** (`011_programs.sql`): `programs` table with JSONB `requirement_groups`, RLS, and indexes
- **Import pipeline**: `importProgramsToSupabase()` with change detection, validation, and `import-programs.ts` CLI
- **Shared Acalog scraper** (`scripts/lib/scrape-acalog-programs.ts`): reusable library for any Acalog-powered catalog
- **Program-slug matcher** (`lib/programs/matcher.ts`): maps scraped titles to the 12 registry categories
- **VA prototype**: 368 programs scraped across 4 colleges (Germanna, PVCC, NOVA, MECC), 150 matched to registry slugs

## What's next (separate PRs)

- Phase 3: UI — enhanced program hub pages + per-college programs listing
- Phase 4: Search integration — extend PathwayIntent for degree queries
- Phase 5: Scale to CT, VT, RI, PA, DE, TN, NH, NY, MA

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run lint` — 0 errors (verified)
- [ ] `npx tsx scripts/import-programs.ts --state va` runs cleanly
- [ ] Run migration `011_programs.sql` in Supabase Dashboard
- [ ] Spot-check `data/va/programs/nova.json` — programs have titles, credentials, requirement groups with course codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)