### PR TITLE
feat: program requirements UI — hub page & per-college page

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -210,6 +210,18 @@ export default async function CollegeDetailPage(props: PageProps) {
             </span>
           )}
         </div>
+
+        <div className="mt-3">
+          <Link
+            href={`/${state}/college/${id}/programs`}
+            className="inline-flex items-center gap-1 text-sm text-teal-600 dark:text-teal-400 hover:underline"
+          >
+            View degree &amp; certificate programs
+            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
+        </div>
       </div>
 
       {/* Campus map */}

--- a/app/[state]/college/[id]/programs/page.tsx
+++ b/app/[state]/college/[id]/programs/page.tsx
@@ -1,0 +1,120 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { loadInstitutions } from "@/lib/institutions";
+import { requireStateConfig } from "@/lib/states/route-helpers";
+import { getAllStates } from "@/lib/states/registry";
+import { loadCollegePrograms } from "@/lib/programs/requirements";
+import { ProgramList } from "@/components/ProgramRequirements";
+import Breadcrumbs from "@/components/Breadcrumbs";
+
+export const revalidate = 604800; // 7 days
+
+type PageProps = {
+  params: Promise<{ state: string; id: string }>;
+};
+
+function siteUrl() {
+  return (
+    process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"
+  );
+}
+
+export async function generateStaticParams() {
+  return [];
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { state, id } = await props.params;
+  const institutions = loadInstitutions(state);
+  const institution = institutions.find((i) => i.id === id);
+  if (!institution) return { title: "Not Found" };
+
+  const config = requireStateConfig(state);
+  const title = `Degree Programs at ${institution.name} | Community College Path`;
+  const description = `Browse degree and certificate programs at ${institution.name}. See requirements, courses, and credits needed for graduation.`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/${state}/college/${id}/programs` },
+  };
+}
+
+export default async function CollegeProgramsPage(props: PageProps) {
+  const { state, id } = await props.params;
+  const config = requireStateConfig(state);
+  const institutions = loadInstitutions(state);
+  const institution = institutions.find((i) => i.id === id);
+  if (!institution) notFound();
+
+  const programs = await loadCollegePrograms(
+    state,
+    institution.college_slug,
+  );
+
+  const url = siteUrl();
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <Breadcrumbs
+        siteUrl={url}
+        items={[
+          { name: "Home", href: "/" },
+          { name: config.name, href: `/${state}` },
+          { name: institution.name, href: `/${state}/college/${id}` },
+          {
+            name: "Programs",
+            href: `/${state}/college/${id}/programs`,
+          },
+        ]}
+      />
+
+      <header className="mb-8">
+        <p className="text-sm font-medium text-teal-600 dark:text-teal-400 mb-1">
+          <Link
+            href={`/${state}/college/${id}`}
+            className="hover:underline"
+          >
+            {institution.name}
+          </Link>
+        </p>
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
+          Degree &amp; Certificate Programs
+        </h1>
+        {programs.length > 0 ? (
+          <p className="text-gray-600 dark:text-slate-400 mt-2">
+            {programs.length}{" "}
+            {programs.length === 1 ? "program" : "programs"} available.
+            Expand any program to see the courses required for graduation.
+          </p>
+        ) : (
+          <p className="text-gray-600 dark:text-slate-400 mt-2">
+            Program requirement data is not yet available for{" "}
+            {institution.name}. Check back soon or visit the{" "}
+            <Link
+              href={`/${state}/college/${id}`}
+              className="text-teal-600 dark:text-teal-400 hover:underline"
+            >
+              college page
+            </Link>{" "}
+            to browse available courses.
+          </p>
+        )}
+      </header>
+
+      {programs.length > 0 && (
+        <ProgramList state={state} programs={programs} />
+      )}
+
+      <div className="mt-10 pt-6 border-t border-gray-200 dark:border-slate-700">
+        <Link
+          href={`/${state}/college/${id}`}
+          className="text-sm text-teal-600 dark:text-teal-400 hover:underline"
+        >
+          &larr; Back to {institution.name}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -21,7 +21,9 @@ import {
   getProgramBySlug,
   PROGRAMS,
 } from "@/lib/programs";
+import { loadProgramAcrossColleges } from "@/lib/programs/requirements";
 import Breadcrumbs from "@/components/Breadcrumbs";
+import ProgramRequirements from "@/components/ProgramRequirements";
 
 export const revalidate = 604800; // 7 days
 
@@ -91,7 +93,10 @@ export default async function ProgramPage(props: PageProps) {
   if (!data || !qualifies(data)) notFound();
 
   const config = requireStateConfig(state);
-  const term = await getCurrentTerm(state);
+  const [term, requirementEntries] = await Promise.all([
+    getCurrentTerm(state),
+    loadProgramAcrossColleges(state, slug),
+  ]);
   const url = siteUrl();
 
   const itemListLd = {
@@ -201,6 +206,11 @@ export default async function ProgramPage(props: PageProps) {
             </table>
           </div>
         </section>
+
+        <ProgramRequirements
+          state={state}
+          entries={requirementEntries}
+        />
 
         {data.sampleCourses.length > 0 && (
           <section className="mb-10">

--- a/components/ProgramRequirements.tsx
+++ b/components/ProgramRequirements.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { ProgramRequirement } from "@/lib/types";
+import type { Institution } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Per-college expandable card
+// ---------------------------------------------------------------------------
+
+function ProgramCard({
+  program,
+  state,
+  defaultOpen,
+}: {
+  program: ProgramRequirement;
+  state: string;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen ?? false);
+
+  const credLabel =
+    program.credential === "other"
+      ? ""
+      : ` (${program.credential.toUpperCase()})`;
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left transition hover:bg-gray-50 dark:hover:bg-slate-800"
+        aria-expanded={open}
+      >
+        <div className="min-w-0">
+          <span className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+            {program.title}
+          </span>
+          {credLabel && (
+            <span className="ml-1.5 text-xs text-gray-500 dark:text-slate-400">
+              {credLabel}
+            </span>
+          )}
+          <div className="flex items-center gap-3 mt-0.5 text-xs text-gray-500 dark:text-slate-400">
+            {program.total_credits != null && (
+              <span>{program.total_credits} credits</span>
+            )}
+            {program.gpa_minimum != null && (
+              <span>{program.gpa_minimum} GPA min</span>
+            )}
+            {program.requirement_groups.length > 0 && (
+              <span>
+                {program.requirement_groups.length}{" "}
+                {program.requirement_groups.length === 1
+                  ? "group"
+                  : "groups"}
+              </span>
+            )}
+          </div>
+        </div>
+        <svg
+          className={`h-4 w-4 shrink-0 text-gray-400 dark:text-slate-500 transition-transform ${open ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="border-t border-gray-200 dark:border-slate-700 px-4 py-3 space-y-4">
+          {program.description && (
+            <p className="text-sm text-gray-600 dark:text-slate-400">
+              {program.description}
+            </p>
+          )}
+
+          {program.requirement_groups.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-slate-400 italic">
+              Detailed course requirements are not yet available for this
+              program.{" "}
+              {program.catalog_url && (
+                <a
+                  href={program.catalog_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-teal-600 dark:text-teal-400 underline"
+                >
+                  View in college catalog
+                </a>
+              )}
+            </p>
+          ) : (
+            program.requirement_groups.map((group, gi) => (
+              <RequirementGroupBlock
+                key={gi}
+                group={group}
+                state={state}
+              />
+            ))
+          )}
+
+          {program.catalog_url && (
+            <p className="text-xs text-gray-500 dark:text-slate-400 pt-1 border-t border-gray-100 dark:border-slate-800">
+              Source:{" "}
+              <a
+                href={program.catalog_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-teal-600 dark:text-teal-400 hover:underline"
+              >
+                College catalog
+              </a>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Requirement group (e.g. "Core Requirements", "General Education")
+// ---------------------------------------------------------------------------
+
+function RequirementGroupBlock({
+  group,
+  state,
+}: {
+  group: ProgramRequirement["requirement_groups"][number];
+  state: string;
+}) {
+  return (
+    <div>
+      <div className="flex items-baseline gap-2 mb-1.5">
+        <h4 className="text-sm font-medium text-gray-900 dark:text-slate-100">
+          {group.name}
+        </h4>
+        {group.credits_required != null && (
+          <span className="text-xs text-gray-500 dark:text-slate-400">
+            {group.credits_required} credits
+          </span>
+        )}
+        {group.choose_n != null && (
+          <span className="text-xs text-teal-600 dark:text-teal-400">
+            choose {group.choose_n}
+          </span>
+        )}
+      </div>
+
+      {group.courses.length > 0 ? (
+        <ul className="space-y-0.5">
+          {group.courses.map((course, ci) => (
+            <li key={ci} className="flex items-baseline gap-1.5 text-sm">
+              <Link
+                href={`/${state}/course/${course.prefix.toLowerCase()}-${course.number.toLowerCase()}`}
+                className="font-mono text-xs font-medium text-teal-600 dark:text-teal-400 hover:underline whitespace-nowrap"
+              >
+                {course.prefix} {course.number}
+              </Link>
+              <span className="text-gray-700 dark:text-slate-300 truncate">
+                {course.title}
+              </span>
+              {course.credits != null && (
+                <span className="text-xs text-gray-400 dark:text-slate-500 whitespace-nowrap">
+                  ({course.credits} cr)
+                </span>
+              )}
+              {course.or_alternatives.length > 0 && (
+                <span className="text-xs text-gray-500 dark:text-slate-400">
+                  or{" "}
+                  {course.or_alternatives.map((alt, ai) => (
+                    <span key={ai}>
+                      {ai > 0 && " or "}
+                      <Link
+                        href={`/${state}/course/${alt.prefix.toLowerCase()}-${alt.number.toLowerCase()}`}
+                        className="font-mono text-teal-600 dark:text-teal-400 hover:underline"
+                      >
+                        {alt.prefix} {alt.number}
+                      </Link>
+                    </span>
+                  ))}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-gray-500 dark:text-slate-400 italic">
+          See catalog for course list
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exported component: requirements section for the program hub page
+// ---------------------------------------------------------------------------
+
+export default function ProgramRequirements({
+  state,
+  entries,
+}: {
+  state: string;
+  entries: Array<{ college: Institution; programs: ProgramRequirement[] }>;
+}) {
+  if (entries.length === 0) return null;
+
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-1">
+        Degree requirements by college
+      </h2>
+      <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
+        Expand a college to see the courses required for graduation. Data
+        sourced from each college&apos;s official catalog.
+      </p>
+
+      <div className="space-y-4">
+        {entries.map(({ college, programs }) => (
+          <div key={college.id}>
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-slate-100 mb-2 flex items-center gap-2">
+              <Link
+                href={`/${state}/college/${college.id}`}
+                className="text-teal-600 dark:text-teal-400 hover:underline"
+              >
+                {college.name}
+              </Link>
+              <span className="text-xs font-normal text-gray-500 dark:text-slate-400">
+                {programs.length}{" "}
+                {programs.length === 1 ? "program" : "programs"}
+              </span>
+            </h3>
+            <div className="space-y-2 ml-0 sm:ml-4">
+              {programs.map((prog, pi) => (
+                <ProgramCard
+                  key={pi}
+                  program={prog}
+                  state={state}
+                  defaultOpen={programs.length === 1}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Standalone component for per-college programs page
+// ---------------------------------------------------------------------------
+
+export function ProgramList({
+  state,
+  programs,
+}: {
+  state: string;
+  programs: ProgramRequirement[];
+}) {
+  const byCredential = new Map<string, ProgramRequirement[]>();
+  for (const p of programs) {
+    const key = p.credential;
+    if (!byCredential.has(key)) byCredential.set(key, []);
+    byCredential.get(key)!.push(p);
+  }
+
+  const credOrder = ["AS", "AA", "AAS", "certificate", "diploma", "other"];
+  const credLabels: Record<string, string> = {
+    AS: "Associate of Science (AS)",
+    AA: "Associate of Arts (AA)",
+    AAS: "Associate of Applied Science (AAS)",
+    certificate: "Certificates",
+    diploma: "Diplomas",
+    other: "Other Programs",
+  };
+
+  const sorted = [...byCredential.entries()].sort(
+    (a, b) => credOrder.indexOf(a[0]) - credOrder.indexOf(b[0]),
+  );
+
+  return (
+    <div className="space-y-8">
+      {sorted.map(([cred, progs]) => (
+        <section key={cred}>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            {credLabels[cred] ?? cred}
+            <span className="ml-2 text-sm font-normal text-gray-500 dark:text-slate-400">
+              ({progs.length})
+            </span>
+          </h2>
+          <div className="space-y-2">
+            {progs
+              .sort((a, b) => a.title.localeCompare(b.title))
+              .map((prog, pi) => (
+                <ProgramCard key={pi} program={prog} state={state} />
+              ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/lib/programs/requirements.ts
+++ b/lib/programs/requirements.ts
@@ -1,0 +1,185 @@
+/**
+ * Server-side data layer for program/degree requirements.
+ *
+ * Reads from the `programs` table in Supabase (populated by the import
+ * pipeline). Falls back to local JSON files when Supabase is unavailable
+ * (same pattern as lib/transfer.ts).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { supabase } from "@/lib/supabase";
+import { loadInstitutions } from "@/lib/institutions";
+import type {
+  ProgramRequirement,
+  RequirementGroup,
+  RequiredCourse,
+} from "@/lib/types";
+import type { Institution } from "@/lib/types";
+
+// Re-export types for convenience
+export type { ProgramRequirement, RequirementGroup, RequiredCourse };
+
+interface ProgramRow {
+  title: string;
+  credential: string;
+  program_code: string | null;
+  catalog_url: string;
+  total_credits: number | null;
+  gpa_minimum: number | null;
+  description: string | null;
+  matched_program_slug: string | null;
+  requirement_groups: RequirementGroup[];
+  college_slug: string;
+  catalog_year: string;
+}
+
+function rowToProgram(row: ProgramRow): ProgramRequirement {
+  return {
+    title: row.title,
+    credential: row.credential as ProgramRequirement["credential"],
+    program_code: row.program_code,
+    catalog_url: row.catalog_url,
+    total_credits: row.total_credits,
+    gpa_minimum: row.gpa_minimum,
+    description: row.description,
+    matched_program_slug: row.matched_program_slug,
+    requirement_groups: row.requirement_groups ?? [],
+  };
+}
+
+/**
+ * Load all programs at one college from Supabase, falling back to local JSON.
+ */
+export async function loadCollegePrograms(
+  state: string,
+  collegeSlug: string,
+): Promise<ProgramRequirement[]> {
+  try {
+    const { data, error } = await supabase
+      .from("programs")
+      .select("*")
+      .eq("state", state)
+      .eq("college_slug", collegeSlug)
+      .order("title");
+
+    if (!error && data && data.length > 0) {
+      return data.map(rowToProgram);
+    }
+  } catch {
+    // Supabase unavailable — fall through to local JSON
+  }
+
+  return loadCollegeProgramsFromFile(state, collegeSlug);
+}
+
+/**
+ * Load all colleges offering a given program category.
+ * Returns programs grouped by college with institution metadata.
+ */
+export async function loadProgramAcrossColleges(
+  state: string,
+  programSlug: string,
+): Promise<
+  Array<{ college: Institution; programs: ProgramRequirement[] }>
+> {
+  let rows: ProgramRow[] = [];
+
+  try {
+    const { data, error } = await supabase
+      .from("programs")
+      .select("*")
+      .eq("state", state)
+      .eq("matched_program_slug", programSlug)
+      .order("college_slug")
+      .order("title");
+
+    if (!error && data) {
+      rows = data as ProgramRow[];
+    }
+  } catch {
+    // Fall through to local JSON
+  }
+
+  if (rows.length === 0) {
+    rows = loadProgramsBySlugFromFiles(state, programSlug);
+  }
+
+  if (rows.length === 0) return [];
+
+  const institutions = loadInstitutions(state);
+  const byCollege = new Map<string, ProgramRow[]>();
+  for (const row of rows) {
+    const slug = row.college_slug;
+    if (!byCollege.has(slug)) byCollege.set(slug, []);
+    byCollege.get(slug)!.push(row);
+  }
+
+  const results: Array<{
+    college: Institution;
+    programs: ProgramRequirement[];
+  }> = [];
+
+  for (const [slug, collegeRows] of byCollege) {
+    const inst = institutions.find(
+      (i) => i.college_slug === slug || i.id === slug,
+    );
+    if (!inst) continue;
+    results.push({
+      college: inst,
+      programs: collegeRows.map(rowToProgram),
+    });
+  }
+
+  return results.sort((a, b) => a.college.name.localeCompare(b.college.name));
+}
+
+// ---------------------------------------------------------------------------
+// Local JSON fallbacks
+// ---------------------------------------------------------------------------
+
+function loadCollegeProgramsFromFile(
+  state: string,
+  collegeSlug: string,
+): ProgramRequirement[] {
+  const filePath = path.join(
+    process.cwd(),
+    "data",
+    state,
+    "programs",
+    `${collegeSlug}.json`,
+  );
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    return (data.programs ?? []) as ProgramRequirement[];
+  } catch {
+    return [];
+  }
+}
+
+function loadProgramsBySlugFromFiles(
+  state: string,
+  programSlug: string,
+): ProgramRow[] {
+  const dir = path.join(process.cwd(), "data", state, "programs");
+  if (!fs.existsSync(dir)) return [];
+
+  const rows: ProgramRow[] = [];
+  for (const file of fs.readdirSync(dir).filter((f) => f.endsWith(".json"))) {
+    try {
+      const raw = fs.readFileSync(path.join(dir, file), "utf-8");
+      const data = JSON.parse(raw);
+      const collegeSlug = file.replace(".json", "");
+      for (const p of data.programs ?? []) {
+        if (p.matched_program_slug === programSlug) {
+          rows.push({ ...p, college_slug: collegeSlug, catalog_year: data.catalog_year ?? "" });
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+  return rows;
+}


### PR DESCRIPTION
## Summary

- **Program hub pages** (e.g. `/va/program/nursing`) now show a "Degree requirements by college" section below the existing college table, with expandable per-program cards showing semester-by-semester course lists, credits, and linked course codes
- **New per-college programs page** at `/{state}/college/{id}/programs` lists all degree and certificate programs grouped by credential type (AS, AA, AAS, Certificate) — e.g. NOVA shows 125 programs
- **Server-side data layer** (`lib/programs/requirements.ts`) queries Supabase `programs` table with local JSON fallback, matching the pattern of `lib/courses.ts` and `lib/transfer.ts`
- **College detail pages** now link to the programs page ("View degree & certificate programs")
- Empty states handled gracefully when a college has no scraped program data

Builds on #221 (foundation + VA scraper data).

## Test plan

- [ ] `/va/program/nursing` — scroll past college table, see "Degree requirements by college" with GCC, PVCC, NOVA, MECC entries
- [ ] Expand a program card — requirement groups render with course codes as teal links
- [ ] `/va/college/nova/programs` — 125 programs grouped by credential type
- [ ] `/va/college/tcc/programs` — empty state message (no program data)
- [ ] `/va/college/nova` — "View degree & certificate programs" link visible
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)