### PR TITLE
feat: pathway answers with real degree requirement data

### DIFF
--- a/components/AnswerCard.tsx
+++ b/components/AnswerCard.tsx
@@ -5,6 +5,7 @@
 //   transfer     → TransferBody (status-driven: yes / partial / no / etc.)
 //   prereqs      → PrereqsBody  (status-driven: found / no-prereqs / etc.)
 //   eligibility  → EligibilityBody (per-college breakdown + state summary)
+//   pathway      → PathwayBody  (found-degree / no-data / missing-entity)
 //   none         → null (no card; UI just renders course search results)
 //
 // Every typed answer carries a SourceCitation; footer renders that as a
@@ -79,6 +80,7 @@ export default function AnswerCard({ answer, state, classification, onFollowupCl
         {answer.type === "transfer" && <TransferBody answer={answer} />}
         {answer.type === "prereqs" && <PrereqsBody answer={answer} state={state} />}
         {answer.type === "eligibility" && <EligibilityBody answer={answer} />}
+        {answer.type === "pathway" && <PathwayBody answer={answer} state={state} />}
         {classification?.clarifyingQuestion && (
           <ClarifyingPrompt
             question={classification.clarifyingQuestion}
@@ -462,6 +464,138 @@ function EligibilityBody({
         </p>
       )}
     </>
+  );
+}
+
+// ─── Pathway (degree requirements) ──────────────────────────────────────
+
+function PathwayBody({
+  answer,
+  state,
+}: {
+  answer: Extract<Answer, { type: "pathway" }>;
+  state: string;
+}) {
+  if (answer.status === "found-degree" && answer.degreeRequirements?.length) {
+    return (
+      <>
+        <Headline tone="success" icon="📋">
+          {answer.degreeRequirements.length === 1
+            ? `Found degree requirements${answer.college ? ` at ${answer.college.name}` : ""}`
+            : `Found ${answer.degreeRequirements.length} matching programs${answer.college ? ` at ${answer.college.name}` : ""}`}
+        </Headline>
+        <div className="space-y-3">
+          {answer.degreeRequirements.map((req, i) => (
+            <div
+              key={i}
+              className="border border-slate-200 dark:border-slate-700 rounded-md px-3 py-2"
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                  {req.title}
+                </span>
+                <span className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+                  {req.credential.toUpperCase()}
+                </span>
+              </div>
+              <div className="flex items-center gap-3 mt-1 text-xs text-slate-500 dark:text-slate-400">
+                {req.total_credits != null && (
+                  <span>{req.total_credits} credits</span>
+                )}
+                {req.gpa_minimum != null && (
+                  <span>{req.gpa_minimum} GPA min</span>
+                )}
+                {req.groups.length > 0 && (
+                  <span>
+                    {req.groups.length}{" "}
+                    {req.groups.length === 1
+                      ? "requirement group"
+                      : "requirement groups"}
+                  </span>
+                )}
+              </div>
+              {req.groups.length > 0 && (
+                <ul className="mt-1.5 space-y-0.5">
+                  {req.groups.slice(0, 6).map((g, gi) => (
+                    <li
+                      key={gi}
+                      className="text-xs text-slate-600 dark:text-slate-300 flex items-baseline gap-1.5"
+                    >
+                      <span className="text-slate-400 dark:text-slate-500">
+                        •
+                      </span>
+                      {g.name}
+                      {g.credits_required != null && (
+                        <span className="text-slate-400 dark:text-slate-500">
+                          ({g.credits_required} cr)
+                        </span>
+                      )}
+                      {g.course_count > 0 && (
+                        <span className="text-slate-400 dark:text-slate-500">
+                          · {g.course_count}{" "}
+                          {g.course_count === 1 ? "course" : "courses"}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                  {req.groups.length > 6 && (
+                    <li className="text-xs text-slate-400 dark:text-slate-500 italic">
+                      + {req.groups.length - 6} more groups
+                    </li>
+                  )}
+                </ul>
+              )}
+              {req.catalog_url && (
+                <a
+                  href={req.catalog_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-teal-600 dark:text-teal-400 hover:underline mt-1 inline-block"
+                >
+                  View in catalog →
+                </a>
+              )}
+            </div>
+          ))}
+        </div>
+        {answer.college && (
+          <Note>
+            <a
+              href={`/${state}/college/${answer.college.slug}/programs`}
+              className="text-teal-600 dark:text-teal-400 hover:underline"
+            >
+              Browse all programs at {answer.college.name} →
+            </a>
+          </Note>
+        )}
+      </>
+    );
+  }
+
+  if (answer.status === "no-data") {
+    const entity = answer.college?.name ?? answer.university?.name ?? "this college";
+    return (
+      <Headline tone="info" icon="📋">
+        Degree requirement data isn&apos;t available yet for {entity}. Check
+        back soon — we&apos;re adding more colleges regularly.
+      </Headline>
+    );
+  }
+
+  if (answer.status === "unknown-university") {
+    return (
+      <Headline tone="info" icon="🔍">
+        We couldn&apos;t find that university in our data. Try a different
+        spelling or check the transfer equivalency tool.
+      </Headline>
+    );
+  }
+
+  return (
+    <Headline tone="info" icon="📋">
+      Tell us which college or university you&apos;re interested in so we can
+      look up requirements.
+    </Headline>
   );
 }
 

--- a/lib/search-intent/__tests__/classify-llm.test.ts
+++ b/lib/search-intent/__tests__/classify-llm.test.ts
@@ -193,6 +193,8 @@ describe("llmClassifier", () => {
       type: "pathway",
       university: "gmu",
       major: "computer-science",
+      college: null,
+      credential: null,
     });
   });
 
@@ -208,6 +210,8 @@ describe("llmClassifier", () => {
       type: "pathway",
       university: "vt",
       major: null,
+      college: null,
+      credential: null,
     });
   });
 

--- a/lib/search-intent/answer/__tests__/index.test.ts
+++ b/lib/search-intent/answer/__tests__/index.test.ts
@@ -47,7 +47,7 @@ describe("lookupAnswer dispatch", () => {
 
   it("dispatches pathway intents to lookupPathway", async () => {
     await lookupAnswer(
-      { type: "pathway", university: "gmu", major: "computer-science" },
+      { type: "pathway", university: "gmu", major: "computer-science", college: null, credential: null },
       "va",
     );
     expect(lookupPathway).toHaveBeenCalled();

--- a/lib/search-intent/answer/__tests__/pathway.test.ts
+++ b/lib/search-intent/answer/__tests__/pathway.test.ts
@@ -4,27 +4,52 @@ vi.mock("../validate", () => ({
   resolveUniversity: vi.fn(),
 }));
 
+vi.mock("../../../institutions", () => ({
+  loadInstitutions: vi.fn(() => []),
+}));
+
+vi.mock("../../../programs/requirements", () => ({
+  loadCollegePrograms: vi.fn(async () => []),
+  loadProgramAcrossColleges: vi.fn(async () => []),
+}));
+
+vi.mock("../../../programs/matcher", () => ({
+  matchProgramSlug: vi.fn(() => null),
+}));
+
 import { lookupPathway } from "../pathway";
 import { resolveUniversity } from "../validate";
+import { loadProgramAcrossColleges } from "../../../programs/requirements";
 
 const resolveMock = vi.mocked(resolveUniversity);
+const loadProgramsMock = vi.mocked(loadProgramAcrossColleges);
 
 describe("lookupPathway", () => {
-  it("returns missing-entity when no university specified", async () => {
+  it("looks up degree by major when no university or college specified", async () => {
+    loadProgramsMock.mockResolvedValue([]);
     const result = await lookupPathway(
-      { type: "pathway", university: null, major: "nursing" },
+      { type: "pathway", university: null, major: "nursing", college: null, credential: null },
+      "va",
+    );
+    expect(result.type).toBe("pathway");
+    if (result.type !== "pathway") return;
+    expect(result.status).toBe("no-data");
+  });
+
+  it("returns missing-entity when nothing specified", async () => {
+    const result = await lookupPathway(
+      { type: "pathway", university: null, major: null, college: null, credential: null },
       "va",
     );
     expect(result.type).toBe("pathway");
     if (result.type !== "pathway") return;
     expect(result.status).toBe("missing-entity");
-    expect(result.followups).toBeDefined();
   });
 
   it("returns unknown-university when resolution fails", async () => {
     resolveMock.mockResolvedValue({ resolved: null, suggestions: [] });
     const result = await lookupPathway(
-      { type: "pathway", university: "fake-u", major: null },
+      { type: "pathway", university: "fake-u", major: null, college: null, credential: null },
       "va",
     );
     expect(result.type).toBe("pathway");
@@ -38,7 +63,7 @@ describe("lookupPathway", () => {
       suggestions: [],
     });
     const result = await lookupPathway(
-      { type: "pathway", university: "gmu", major: "computer-science" },
+      { type: "pathway", university: "gmu", major: "computer-science", college: null, credential: null },
       "va",
     );
     expect(result.type).toBe("pathway");
@@ -56,7 +81,7 @@ describe("lookupPathway", () => {
       suggestions: [],
     });
     const result = await lookupPathway(
-      { type: "pathway", university: "vcu", major: "nursing" },
+      { type: "pathway", university: "vcu", major: "nursing", college: null, credential: null },
       "va",
     );
     if (result.type !== "pathway") return;

--- a/lib/search-intent/answer/pathway.ts
+++ b/lib/search-intent/answer/pathway.ts
@@ -1,16 +1,185 @@
 // Pathway answer lookup.
 //
-// "What do I need to transfer to GMU for Computer Science?"
-//
-// Stub implementation: returns a helpful no-data response pointing students
-// to the transfer equivalency tool. Real pathway data (articulation
-// agreements per university per major) is a separate data-ingestion project.
+// Two modes:
+//   1. CC degree: "nursing degree at NOVA" → look up program requirements
+//   2. Transfer pathway: "transfer to GMU for CS" → stub (future work)
 
 import type { PathwayIntent } from "../types";
-import type { Answer, PathwayAnswer } from "./types";
+import type { Answer, PathwayAnswer, DegreeRequirementSummary } from "./types";
 import { resolveUniversity } from "./validate";
+import { loadInstitutions } from "../../institutions";
+import {
+  loadCollegePrograms,
+  loadProgramAcrossColleges,
+} from "../../programs/requirements";
+import { matchProgramSlug } from "../../programs/matcher";
 
 export async function lookupPathway(
+  intent: PathwayIntent,
+  state: string,
+): Promise<Answer> {
+  if (intent.college) {
+    return lookupDegree(intent, state);
+  }
+
+  if (intent.major && !intent.university) {
+    return lookupDegreeByMajor(intent, state);
+  }
+
+  return lookupTransferPathway(intent, state);
+}
+
+async function lookupDegree(
+  intent: PathwayIntent,
+  state: string,
+): Promise<Answer> {
+  const college = resolveCollege(state, intent.college!);
+  if (!college) {
+    return makeAnswer({
+      status: "missing-entity",
+      university: null,
+      major: intent.major,
+      college: null,
+      state,
+      followups: [
+        "What degree programs are available?",
+        "What courses are available online?",
+      ],
+    });
+  }
+
+  const programs = await loadCollegePrograms(state, college.college_slug);
+
+  if (programs.length === 0) {
+    return makeAnswer({
+      status: "no-data",
+      university: null,
+      major: intent.major,
+      college: { slug: college.id, name: college.name },
+      state,
+      followups: [
+        `What courses are offered at ${college.name}?`,
+        "What are the prereqs for ENG 111?",
+      ],
+    });
+  }
+
+  let filtered = programs;
+  if (intent.major) {
+    const slug = matchProgramSlug(intent.major.replace(/-/g, " "));
+    if (slug) {
+      filtered = programs.filter((p) => p.matched_program_slug === slug);
+    }
+    if (filtered.length === 0) {
+      filtered = programs.filter(
+        (p) =>
+          p.title.toLowerCase().includes(intent.major!.replace(/-/g, " ")),
+      );
+    }
+  }
+
+  if (intent.credential) {
+    const cred = intent.credential.toUpperCase();
+    const credFiltered = filtered.filter(
+      (p) => p.credential.toUpperCase() === cred,
+    );
+    if (credFiltered.length > 0) filtered = credFiltered;
+  }
+
+  if (filtered.length === 0) filtered = programs.slice(0, 5);
+
+  const degreeRequirements: DegreeRequirementSummary[] = filtered
+    .slice(0, 5)
+    .map((p) => ({
+      title: p.title,
+      credential: p.credential,
+      total_credits: p.total_credits,
+      gpa_minimum: p.gpa_minimum,
+      catalog_url: p.catalog_url,
+      groups: p.requirement_groups.map((g) => ({
+        name: g.name,
+        credits_required: g.credits_required,
+        course_count: g.courses.length,
+      })),
+    }));
+
+  const majorLabel = intent.major?.replace(/-/g, " ") ?? null;
+
+  return makeAnswer({
+    status: "found-degree",
+    university: null,
+    major: intent.major,
+    college: { slug: college.id, name: college.name },
+    degreeRequirements,
+    state,
+    followups: [
+      `View all programs at ${college.name}`,
+      ...(majorLabel
+        ? [`Search for ${majorLabel} courses`]
+        : []),
+      `What courses are offered at ${college.name}?`,
+    ],
+  });
+}
+
+async function lookupDegreeByMajor(
+  intent: PathwayIntent,
+  state: string,
+): Promise<Answer> {
+  const slug = matchProgramSlug(intent.major!.replace(/-/g, " "));
+  const programSlug = slug ?? intent.major!;
+
+  const entries = await loadProgramAcrossColleges(state, programSlug);
+
+  if (entries.length === 0) {
+    return makeAnswer({
+      status: "no-data",
+      university: null,
+      major: intent.major,
+      college: null,
+      state,
+      followups: [
+        `Search for ${intent.major!.replace(/-/g, " ")} courses`,
+        "What programs are available?",
+      ],
+    });
+  }
+
+  const degreeRequirements: DegreeRequirementSummary[] = [];
+  for (const entry of entries.slice(0, 3)) {
+    for (const p of entry.programs.slice(0, 2)) {
+      degreeRequirements.push({
+        title: `${p.title} — ${entry.college.name}`,
+        credential: p.credential,
+        total_credits: p.total_credits,
+        gpa_minimum: p.gpa_minimum,
+        catalog_url: p.catalog_url,
+        groups: p.requirement_groups.map((g) => ({
+          name: g.name,
+          credits_required: g.credits_required,
+          course_count: g.courses.length,
+        })),
+      });
+    }
+  }
+
+  const majorLabel = intent.major!.replace(/-/g, " ");
+
+  return makeAnswer({
+    status: "found-degree",
+    university: null,
+    major: intent.major,
+    college: null,
+    degreeRequirements,
+    state,
+    followups: [
+      `${majorLabel} courses available this term`,
+      `What are the prereqs for common ${majorLabel} courses?`,
+    ],
+  });
+}
+
+async function lookupTransferPathway(
   intent: PathwayIntent,
   state: string,
 ): Promise<Answer> {
@@ -19,6 +188,7 @@ export async function lookupPathway(
       status: "missing-entity",
       university: null,
       major: intent.major,
+      college: null,
       state,
       followups: [
         "Does ENG 111 transfer?",
@@ -33,6 +203,7 @@ export async function lookupPathway(
       status: "unknown-university",
       university: null,
       major: intent.major,
+      college: null,
       state,
       followups: [
         "Does ENG 111 transfer?",
@@ -42,23 +213,51 @@ export async function lookupPathway(
   }
 
   const { slug, name } = resolution.resolved;
-  const majorLabel = intent.major
-    ? intent.major.replace(/-/g, " ")
-    : null;
+  const majorLabel = intent.major?.replace(/-/g, " ") ?? null;
 
   return makeAnswer({
     status: "no-data",
     university: { slug, name },
     major: intent.major,
+    college: null,
     state,
     followups: [
       `What courses transfer to ${name}?`,
-      ...(majorLabel
-        ? [`Search for ${majorLabel} courses`]
-        : []),
+      ...(majorLabel ? [`Search for ${majorLabel} courses`] : []),
       "What are the prereqs for ENG 111?",
     ],
   });
+}
+
+function resolveCollege(
+  state: string,
+  slugOrName: string,
+): { id: string; name: string; college_slug: string } | null {
+  const institutions = loadInstitutions(state);
+  const normalized = slugOrName.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+  for (const inst of institutions) {
+    if (inst.id === slugOrName || inst.college_slug === slugOrName) {
+      return inst;
+    }
+  }
+
+  for (const inst of institutions) {
+    const normId = inst.id.replace(/[^a-z0-9]/g, "");
+    const normSlug = inst.college_slug.replace(/[^a-z0-9]/g, "");
+    if (normId === normalized || normSlug === normalized) {
+      return inst;
+    }
+  }
+
+  for (const inst of institutions) {
+    const normName = inst.name.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (normName.includes(normalized) || normalized.includes(normName)) {
+      return inst;
+    }
+  }
+
+  return null;
 }
 
 function makeAnswer(
@@ -69,9 +268,9 @@ function makeAnswer(
     type: "pathway",
     ...rest,
     source: {
-      source: "transfer-equiv",
+      source: "supabase-courses",
       state,
-      reference: `data/${state}/transfer-equiv.json`,
+      reference: `data/${state}/programs/`,
     },
   };
 }

--- a/lib/search-intent/answer/types.ts
+++ b/lib/search-intent/answer/types.ts
@@ -124,15 +124,31 @@ export interface EligibilityAnswer {
 
 export type PathwayStatus =
   | "found" //              pathway data exists for this university/major
+  | "found-degree" //       CC degree requirement data found
   | "no-data" //            no pathway data available yet
   | "unknown-university" // university not recognized
   | "missing-entity"; //    no university specified
+
+export interface DegreeRequirementSummary {
+  title: string;
+  credential: string;
+  total_credits: number | null;
+  gpa_minimum: number | null;
+  catalog_url: string;
+  groups: Array<{
+    name: string;
+    credits_required: number | null;
+    course_count: number;
+  }>;
+}
 
 export interface PathwayAnswer {
   type: "pathway";
   status: PathwayStatus;
   university: { slug: string; name: string } | null;
   major: string | null;
+  college: { slug: string; name: string } | null;
+  degreeRequirements?: DegreeRequirementSummary[];
   source: SourceCitation;
   followups?: string[];
 }

--- a/lib/search-intent/classify-llm.ts
+++ b/lib/search-intent/classify-llm.ts
@@ -146,6 +146,8 @@ function toSecondarySearchIntent(
         type: "pathway",
         university: secondary.university ?? null,
         major: null,
+        college: null,
+        credential: null,
       };
     case "prereqs":
       return { type: "prereqs", course: courseRef, direction: "forward" };
@@ -190,6 +192,8 @@ function toSearchIntent(rawQuery: string, input: ClassifierToolInput): SearchInt
         type: "pathway",
         university: input.university ?? null,
         major: input.major ?? null,
+        college: input.college ?? null,
+        credential: input.credential ?? null,
       };
     case "prereqs":
       return {

--- a/lib/search-intent/prompt.ts
+++ b/lib/search-intent/prompt.ts
@@ -23,8 +23,12 @@ Intent types:
 1. "transfer" — student is asking whether a community-college course transfers to a university (or asking generically about transfer). Can be a specific course ("Does ENG 111 transfer to GMU?") OR a subject-level browse ("are there any English courses that transfer to UVA?"). For subject-level queries, set course_prefix to the subject prefix and leave course_number null.
    Examples: "Does ENG 111 transfer to GMU?", "will math 263 transfer to vcu", "ENG 111 → George Mason", "English courses that transfer to UVA", "what math classes transfer?"
 
-2. "pathway" — student wants to know what courses to take to transfer to a university, possibly for a specific major. No single course in mind — they want a plan or set of requirements.
-   Examples: "what do I need to transfer to GMU for CS?", "transfer requirements for nursing at UNC", "how do I get into UMass Boston for business?", "courses needed to transfer to Virginia Tech"
+2. "pathway" — student wants to know what courses to take for a degree or to transfer to a university. Two sub-types:
+   a) Transfer pathway: student wants to transfer to a 4-year university, possibly for a specific major.
+   b) CC degree: student wants to know what courses are required for a community college degree (AA, AS, AAS, certificate).
+   For CC degree queries, set "college" to the community college slug and leave "university" null. For transfer queries, set "university" and leave "college" null.
+   Examples (transfer): "what do I need to transfer to GMU for CS?", "transfer requirements for nursing at UNC", "courses needed to transfer to Virginia Tech"
+   Examples (CC degree): "nursing degree requirements at NOVA", "what courses do I need for an AA in business?", "AAS in IT at Germanna", "what do I need to graduate with an AS in biology?", "degree requirements for criminal justice"
 
 3. "prereqs" — student is asking about prerequisites, in one of two directions:
    - Forward (default): what do I need to take BEFORE this course? Set prereq_direction to "forward".
@@ -162,6 +166,15 @@ export const CLASSIFY_TOOL = {
         type: ["string", "null"],
         description: "Major or field of study, lowercase hyphenated, e.g. 'computer-science', 'nursing', 'business'. Null if not specified.",
       },
+      college: {
+        type: ["string", "null"],
+        description: "Community college slug for CC degree queries (e.g. 'nova', 'gcc', 'pvcc'). Use the source_college alias table to resolve names. Null for transfer pathway queries or when no college specified.",
+      },
+      credential: {
+        type: ["string", "null"],
+        enum: ["AA", "AS", "AAS", "certificate", null],
+        description: "Degree type for CC degree queries: 'AA', 'AS', 'AAS', or 'certificate'. Null if not specified or for transfer pathway queries.",
+      },
       // Eligibility-specific
       topic: {
         type: ["string", "null"],
@@ -258,6 +271,8 @@ export interface ClassifierToolInput {
   prereq_direction?: "forward" | "inverse" | null;
   university?: string | null;
   major?: string | null;
+  college?: string | null;
+  credential?: string | null;
   topic?: "senior" | "audit" | "cost" | "veteran" | null;
   age?: number | null;
   keyword?: string | null;

--- a/lib/search-intent/types.ts
+++ b/lib/search-intent/types.ts
@@ -59,6 +59,8 @@ export interface PathwayIntent {
   type: "pathway";
   university: string | null;
   major: string | null;
+  college: string | null;
+  credential: string | null;
 }
 
 export interface UnknownIntent {


### PR DESCRIPTION
## Summary

- **PathwayIntent** extended with `college` and `credential` fields for CC degree queries (e.g. "nursing degree at NOVA", "AAS in IT at Germanna")
- **Classifier prompt** updated with CC degree query examples and new tool schema fields (`college`, `credential`)
- **Pathway answer lookup** replaced the stub with real lookups: queries program requirement data via `loadCollegePrograms` and `loadProgramAcrossColleges`
- Three lookup modes: by college+major, by major across all colleges, transfer pathway (still stub)
- **PathwayBody** added to AnswerCard — renders degree requirement summaries with credential type, credit totals, requirement group breakdowns, and catalog links

Builds on #222 (program requirements UI).

## Test plan

- [ ] `npx vitest run lib/search-intent/` — all 110 tests pass
- [ ] `npx tsc --noEmit` — clean
- [ ] On `/va/courses`, search "nursing degree at NOVA" → answer card shows degree requirements (requires valid ANTHROPIC_API_KEY in env)
- [ ] Search "business degree requirements" → shows programs across colleges
- [ ] Search "transfer to GMU for CS" → existing transfer pathway stub still works
- [ ] Empty/no-data states render graceful messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)