### PR TITLE
feat: register program scrapers in StateConfig + monthly cron

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -31,12 +31,13 @@ on:
     - cron: "0 6 * * 1,3,5" # Mon/Wed/Fri 06:00 UTC — courses
     - cron: "0 10 * * 3,6"  # Wed/Sat 10:00 UTC — transfers
     - cron: "0 7 * * 0"     # Sun 07:00 UTC — prereqs
+    - cron: "0 8 1 * *"     # 1st of month 08:00 UTC — programs
   workflow_dispatch:
     inputs:
       datatype:
         description: "Which data type to scrape"
         type: choice
-        options: [courses, transfers, prereqs]
+        options: [courses, transfers, prereqs, programs]
         default: courses
 
 permissions:
@@ -71,6 +72,7 @@ jobs:
               "0 6 * * 1,3,5") dt="courses" ;;
               "0 10 * * 3,6")  dt="transfers" ;;
               "0 7 * * 0")     dt="prereqs" ;;
+              "0 8 1 * *")     dt="programs" ;;
               *) echo "Unexpected schedule: ${{ github.event.schedule }}"; exit 1 ;;
             esac
           fi

--- a/lib/states/ct/config.ts
+++ b/lib/states/ct/config.ts
@@ -62,6 +62,7 @@ const ctConfig: StateConfig = {
     courses: [{ scripts: ["scripts/ct/scrape-banner.ts"], runner: "http" }],
     transfers: [{ scripts: ["scripts/ct/scrape-transfer-all.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/ct/scrape-catalog-prereqs.ts"], runner: "http" }],
+    programs: [{ scripts: ["scripts/ct/scrape-programs.ts"], runner: "http" }],
   },
 };
 

--- a/lib/states/dc/config.ts
+++ b/lib/states/dc/config.ts
@@ -74,6 +74,7 @@ const dcConfig: StateConfig = {
     courses: [{ scripts: ["scripts/dc/scrape-banner.ts"], runner: "http" }],
     // manual-only: transfers — DC has no in-state CC→4yr articulation pipeline; see `transferSupported` comment above.
     prereqs: { source: "aggregate-from-courses" },
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/de/config.ts
+++ b/lib/states/de/config.ts
@@ -70,6 +70,7 @@ const deConfig: StateConfig = {
       },
     ],
     prereqs: [{ scripts: ["scripts/de/scrape-catalog-prereqs.ts"], runner: "http" }],
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/ga/config.ts
+++ b/lib/states/ga/config.ts
@@ -104,6 +104,7 @@ const gaConfig: StateConfig = {
       { scripts: ["scripts/ga/scrape-transfer-usg.ts"], runner: "playwright" },
     ],
     prereqs: { source: "aggregate-from-courses" },
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -88,6 +88,7 @@ const maConfig: StateConfig = {
         runner: "http",
       },
     ],
+    programs: [{ scripts: ["scripts/ma/scrape-programs.ts"], runner: "http" }],
   },
 };
 

--- a/lib/states/md/config.ts
+++ b/lib/states/md/config.ts
@@ -159,6 +159,7 @@ const mdConfig: StateConfig = {
     ],
     transfers: [{ scripts: ["scripts/md/scrape-transfer-artsys.ts"], runner: "http" }],
     prereqs: { source: "aggregate-from-courses" },
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/me/config.ts
+++ b/lib/states/me/config.ts
@@ -70,6 +70,7 @@ const meConfig: StateConfig = {
     courses: [{ scripts: ["scripts/me/scrape-mccs.ts"], runner: "playwright" }],
     // manual-only: transfers — CT.Net has zero in-state targets for ME; MaineStreet PeopleSoft scraper is the real fix. See `transferSupported` comment above.
     // manual-only: prereqs — ME prereq scraper not yet built. Tracked in #106.
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/nc/config.ts
+++ b/lib/states/nc/config.ts
@@ -152,6 +152,7 @@ const ncConfig: StateConfig = {
       },
     ],
     prereqs: { source: "aggregate-from-courses" },
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/nh/config.ts
+++ b/lib/states/nh/config.ts
@@ -71,6 +71,7 @@ const nhConfig: StateConfig = {
       },
     ],
     prereqs: [{ scripts: ["scripts/nh/scrape-catalog-prereqs.ts"], runner: "http" }],
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/nj/config.ts
+++ b/lib/states/nj/config.ts
@@ -89,6 +89,7 @@ const njConfig: StateConfig = {
     ],
     transfers: [{ scripts: ["scripts/nj/scrape-transfer.ts"], runner: "http" }],
     prereqs: { source: "aggregate-from-courses" },
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 
   branding: {

--- a/lib/states/ny/config.ts
+++ b/lib/states/ny/config.ts
@@ -101,6 +101,7 @@ const nyConfig: StateConfig = {
     courses: [{ scripts: ["scripts/ny/scrape-cuny.ts"], runner: "http" }],
     transfers: [{ scripts: ["scripts/ny/scrape-transfer-trex.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/ny/scrape-catalog-prereqs.ts"], runner: "playwright" }],
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/pa/config.ts
+++ b/lib/states/pa/config.ts
@@ -69,6 +69,7 @@ const paConfig: StateConfig = {
       { scripts: ["scripts/pa/scrape-pitt-tes.ts"], runner: "http" },
     ],
     prereqs: [{ scripts: ["scripts/pa/scrape-catalog-prereqs.ts"], runner: "http" }],
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/registry.ts
+++ b/lib/states/registry.ts
@@ -56,6 +56,8 @@ export interface ScraperCoverage {
    * scraped independently.
    */
   prereqs?: ScrapeJob[] | { source: "aggregate-from-courses" };
+  /** Degree/program requirement scrapers, writing data/{state}/programs/**. */
+  programs?: ScrapeJob[];
 }
 
 export interface StateConfig {
@@ -200,4 +202,9 @@ export function hasPrereqsCoverage(slug: string): boolean {
   const p = cfg.scrapers.prereqs;
   // Either a list of scrape jobs OR the aggregate-from-courses sentinel.
   return Array.isArray(p) ? p.length > 0 : p.source === "aggregate-from-courses";
+}
+
+export function hasProgramsCoverage(slug: string): boolean {
+  const cfg = configs[slug];
+  return (cfg?.scrapers?.programs ?? []).length > 0;
 }

--- a/lib/states/ri/config.ts
+++ b/lib/states/ri/config.ts
@@ -60,6 +60,7 @@ const riConfig: StateConfig = {
     courses: [{ scripts: ["scripts/ri/scrape-banner8.ts"], runner: "http" }],
     transfers: [{ scripts: ["scripts/ri/scrape-transfer.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/ri/scrape-catalog-prereqs.ts"], runner: "http" }],
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/sc/config.ts
+++ b/lib/states/sc/config.ts
@@ -125,6 +125,7 @@ const scConfig: StateConfig = {
       },
     ],
     prereqs: { source: "aggregate-from-courses" },
+    // manual-only: programs — Acalog program scraper not yet wired up for this state.
   },
 };
 

--- a/lib/states/tn/config.ts
+++ b/lib/states/tn/config.ts
@@ -88,6 +88,7 @@ const tnConfig: StateConfig = {
     courses: [{ scripts: ["scripts/tn/scrape-banner-ssb.ts"], runner: "http" }],
     transfers: [{ scripts: ["scripts/tn/transfer/scrape-all.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/tn/scrape-catalog-prereqs.ts"], runner: "http" }],
+    programs: [{ scripts: ["scripts/tn/scrape-programs.ts"], runner: "http" }],
   },
 };
 

--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -81,6 +81,7 @@ const vaConfig: StateConfig = {
       },
     ],
     prereqs: { source: "aggregate-from-courses" },
+    programs: [{ scripts: ["scripts/va/scrape-programs.ts"], runner: "http" }],
   },
 };
 

--- a/lib/states/vt/config.ts
+++ b/lib/states/vt/config.ts
@@ -58,6 +58,7 @@ const vtConfig: StateConfig = {
     courses: [{ scripts: ["scripts/vt/scrape-colleague.ts"], runner: "playwright" }],
     transfers: [{ scripts: ["scripts/vt/scrape-transfer.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/vt/scrape-catalog-prereqs.ts"], runner: "http" }],
+    programs: [{ scripts: ["scripts/vt/scrape-programs.ts"], runner: "http" }],
   },
 };
 

--- a/scripts/check-scraper-coverage.ts
+++ b/scripts/check-scraper-coverage.ts
@@ -19,7 +19,7 @@ import { resolve } from "node:path";
 import { getAllStates, type ScraperCoverage } from "../lib/states/registry";
 
 const ROOT = resolve(__dirname, "..");
-const DATATYPES = ["courses", "transfers", "prereqs"] as const;
+const DATATYPES = ["courses", "transfers", "prereqs", "programs"] as const;
 type Datatype = (typeof DATATYPES)[number];
 
 const errors: string[] = [];
@@ -43,7 +43,7 @@ function hasDatatypeMarker(source: string, dt: Datatype): boolean {
 
 function hasBlanketMarker(source: string): boolean {
   // A `manual-only:` whose next non-whitespace token is NOT a datatype keyword.
-  return /manual-only:(?!\s*(?:courses|transfers|prereqs)\b)/i.test(source);
+  return /manual-only:(?!\s*(?:courses|transfers|prereqs|programs)\b)/i.test(source);
 }
 
 function declaredScriptPaths(scrapers: ScraperCoverage): string[] {
@@ -53,6 +53,7 @@ function declaredScriptPaths(scrapers: ScraperCoverage): string[] {
   if (Array.isArray(scrapers.prereqs)) {
     for (const job of scrapers.prereqs) paths.push(...job.scripts);
   }
+  for (const job of scrapers.programs ?? []) paths.push(...job.scripts);
   return paths;
 }
 
@@ -93,7 +94,7 @@ if (errors.length > 0) {
     `\n${errors.length} issue(s) across ${getAllStates().length} registered state(s).`
   );
   console.error(
-    "\nEvery state × {courses, transfers, prereqs} must either be declared in `scrapers` or carry a `manual-only:` marker. See issues #59 and #111."
+    "\nEvery state × {courses, transfers, prereqs, programs} must either be declared in `scrapers` or carry a `manual-only:` marker. See issues #59 and #111."
   );
   process.exit(1);
 }

--- a/scripts/lib/scraper-matrix.ts
+++ b/scripts/lib/scraper-matrix.ts
@@ -25,13 +25,13 @@
 import { getAllStates } from "../../lib/states/registry";
 import type { ScrapeJob, ScraperCoverage } from "../../lib/states/registry";
 
-type DataType = "courses" | "transfers" | "prereqs";
+type DataType = "courses" | "transfers" | "prereqs" | "programs";
 
 const args = process.argv.slice(2);
 const dtIdx = args.indexOf("--datatype");
 const datatype = (dtIdx >= 0 ? args[dtIdx + 1] : null) as DataType | null;
-if (!datatype || !["courses", "transfers", "prereqs"].includes(datatype)) {
-  console.error("Usage: scraper-matrix.ts --datatype courses|transfers|prereqs [--mode scrape|states]");
+if (!datatype || !["courses", "transfers", "prereqs", "programs"].includes(datatype)) {
+  console.error("Usage: scraper-matrix.ts --datatype courses|transfers|prereqs|programs [--mode scrape|states]");
   process.exit(1);
 }
 const modeIdx = args.indexOf("--mode");
@@ -40,6 +40,7 @@ const mode = (modeIdx >= 0 ? args[modeIdx + 1] : "scrape") as "scrape" | "states
 function jobsFor(scrapers: ScraperCoverage, dt: DataType): ScrapeJob[] {
   if (dt === "courses") return scrapers.courses ?? [];
   if (dt === "transfers") return scrapers.transfers ?? [];
+  if (dt === "programs") return scrapers.programs ?? [];
   const p = scrapers.prereqs;
   // `aggregate-from-courses` states have no separate scrape job — the
   // courses scrape already captured `prerequisite_text` per section and a


### PR DESCRIPTION
## Summary

- Add `programs` field to `ScraperCoverage` interface and `hasProgramsCoverage()` helper to the state registry
- Declare `programs` scraper jobs for VA, CT, TN, VT, MA (the 5 states with program scrapers)
- Add `// manual-only: programs` markers to the remaining 13 states
- Extend `scraper-matrix.ts` to emit programs matrix entries
- Add monthly cron schedule (1st of each month, 08:00 UTC) to `scheduled-scrape.yml`
- Update `check-scraper-coverage.ts` to validate programs as a 4th datatype

## Test plan

- [x] `npx tsx scripts/check-scraper-coverage.ts` → "18 states × 4 datatypes accounted for"
- [x] `npx tsx scripts/lib/scraper-matrix.ts --datatype programs` → 5 matrix entries (VA, CT, TN, VT, MA)
- [x] `npx tsx scripts/lib/scraper-matrix.ts --datatype courses` → unchanged (no regression)
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)