### PR TITLE
feat: PDF program scraper for Jackson State CC (closes #232)

### DIFF
--- a/data/tn/programs/jackson-state.json
+++ b/data/tn/programs/jackson-state.json
@@ -1,0 +1,5175 @@
+{
+  "college_slug": "jackson-state",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+  "scraped_at": "2026-05-07T02:48:49.891Z",
+  "programs": [
+    {
+      "title": "Accounting",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1710",
+              "title": "Precalculus Algebra/Finite Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1830",
+              "title": "Applied Calculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1010",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2100",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2200",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Agriculture-Agricultural Business",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2100",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2200",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1010",
+              "title": "Intro to Agriculutural Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1020",
+              "title": "Introduction to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Statistics or Applied Calculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1030",
+              "title": "Introduction to Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Agriculture-Animal Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1020",
+              "title": "Intro to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1030",
+              "title": "Introduction to Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1120",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Agriculture-Plant and Soil Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1020",
+              "title": "Intro to Animal Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1030",
+              "title": "Introduction to Plant Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1120",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGRI",
+              "number": "1050",
+              "title": "Introduction to Soil Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "1340",
+              "title": "Foundations Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2000",
+              "title": "Art History Survey I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1350",
+              "title": "Foundations Studio II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2020",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "1020",
+              "title": "Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "1010",
+              "title": "Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1045",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "1050",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1120",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2010",
+              "title": "Organic Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2020",
+              "title": "Organic Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1710",
+              "title": "Precalculus Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1830",
+              "title": "Applied Calculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1010",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2100",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2200",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Chemistry",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1120",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1920",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2110",
+              "title": "Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2010",
+              "title": "Organic Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "2020",
+              "title": "Organic Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2120",
+              "title": "Calculus Based Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Civil Engineering",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1920",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2110",
+              "title": "Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2120",
+              "title": "Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2110",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2120",
+              "title": "Calculus Based Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2120",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2110",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1920",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISP",
+              "number": "1010",
+              "title": "Computer Science I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISP",
+              "number": "1020",
+              "title": "Computer Science II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2110",
+              "title": "Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2120",
+              "title": "Calculus BasedPhysics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCI",
+              "number": "1010",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1010",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1020",
+              "title": "Introduction to the Legal Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2020",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2010",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Electrical Engineering",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1920",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2110",
+              "title": "Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2130",
+              "title": "Circuits I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2120",
+              "title": "Calculus Based Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2120",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CISP",
+              "number": "1010",
+              "title": "Computer Science I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2110",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "English",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "1010",
+              "title": "Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "1020",
+              "title": "Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "2020",
+              "title": "Intermediate Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "2010",
+              "title": "Intermediate Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Foreign Language",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "1010",
+              "title": "Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "1020",
+              "title": "Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "2020",
+              "title": "Intermediate Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPAN",
+              "number": "2010",
+              "title": "Intermediate Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "History",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2310",
+              "title": "Early World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2320",
+              "title": "Modern World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2010",
+              "title": "Early United States History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "2020",
+              "title": "Modern United States History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1630",
+              "title": "Finite Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1830",
+              "title": "Applied Calculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1010",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2100",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2200",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mass Communication",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1020",
+              "title": "Media Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "1010",
+              "title": "Intro to Mass Comm",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1920",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro.Programming & Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2110",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2120",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Introduction to Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Engineering",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1920",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2110",
+              "title": "Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2120",
+              "title": "Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "2110",
+              "title": "Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2120",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2120",
+              "title": "Calculus Based Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Introduction to Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2110",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Philosophy",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1030",
+              "title": "Intro. to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1040",
+              "title": "Intro. to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Education",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHED",
+              "number": "2050",
+              "title": "Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHED",
+              "number": "2010",
+              "title": "First Aid & Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHED",
+              "number": "2040",
+              "title": "Intro. to Physical Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "2000",
+              "title": "Introduction to Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHED",
+              "number": "2060",
+              "title": "Individual & Team Sports",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1910",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1920",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. Programming & Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2110",
+              "title": "Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2120",
+              "title": "Calculus Based Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2010",
+              "title": "Introduction to Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2120",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "2110",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Political Science",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POLS",
+              "number": "1030",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2100",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Health Professions",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1120",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Occupational Therapy",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "1110",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1720",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "Non-Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Physical Therapy",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1720",
+              "title": "Precalculus Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1120",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "1110",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Social Work",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCI",
+              "number": "1010",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SWRK",
+              "number": "2010",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1030",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOCI",
+              "number": "1010",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "1040",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Teaching",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1020",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COL",
+              "number": "1030",
+              "title": "College to Career Navigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POLS",
+              "number": "1030",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "2000",
+              "title": "Intro. to Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "2220",
+              "title": "Intro. to Exc. Learner/Special Educ.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1420",
+              "title": "Geometry Concepts for Teachers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1410",
+              "title": "Number Concepts for Teachers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "2210",
+              "title": "Educational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSCI",
+              "number": "1010",
+              "title": "Principles of Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "2010",
+              "title": "World Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business — Management",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "1305",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1310",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1300",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1370",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1010",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "1020",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2370",
+              "title": "Legal Environment of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "2380",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2100",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "2200",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1320",
+              "title": "Business Calculations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "1380",
+              "title": "Supervisory Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cisco CCNA",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1303",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Intro. to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1351",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1300",
+              "title": "Beginning HTML & CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2321",
+              "title": "CCNA III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1332",
+              "title": "UNIX/Linux Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2199",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2351",
+              "title": "Cisco Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2326",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud Computing",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1303",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Intro. to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1367",
+              "title": "Intro. to Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1351",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1300",
+              "title": "Beginning HTML & CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2326",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2320",
+              "title": "Window Servers Admin.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2199",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2382",
+              "title": "Cloud Computing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1332",
+              "title": "UNIX/Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Defense",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1303",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Intro. to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1351",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1300",
+              "title": "Beginning HTML & CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2351",
+              "title": "Cisco Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1324",
+              "title": "CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2199",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1332",
+              "title": "UNIX/Linux Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2326",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2352",
+              "title": "Digital Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1303",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Intro. to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1351",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1300",
+              "title": "Beginning HTML & CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2321",
+              "title": "CCNA III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1324",
+              "title": "CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2199",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1332",
+              "title": "UNIX/Linux Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2326",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2320",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. to Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1303",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Intro. to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2376",
+              "title": "Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1351",
+              "title": "Principles of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1300",
+              "title": "Beginning HTML & CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1310",
+              "title": "Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2199",
+              "title": "Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2344",
+              "title": "Database SQL Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1311",
+              "title": "Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1332",
+              "title": "Unix/Linux Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRMJ",
+              "number": "1010",
+              "title": "Intro. to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1020",
+              "title": "Intro. to Legal Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2010",
+              "title": "Intro. to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2020",
+              "title": "Intro. to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2120",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFS",
+              "number": "1010",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2340",
+              "title": "Investigative Reporting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1340",
+              "title": "Criminal Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2396",
+              "title": "CJ Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "2311",
+              "title": "Juvenile Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRMJ",
+              "number": "1355",
+              "title": "Understanding Terrorism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "1040",
+              "title": "Introduction to Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "EMS Paramedic",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMSP",
+              "number": "1311",
+              "title": "Paramedic Clinical I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "2412",
+              "title": "Paramedic Clinicall II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "1801",
+              "title": "Fundamentals of Paramedic I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "2802",
+              "title": "Fundamentals of Paramedic II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "1401",
+              "title": "Paramedic Skills Lab I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "2402",
+              "title": "Paramedic Skills Lab II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "2403",
+              "title": "Paramedic Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "2303",
+              "title": "Paramedic Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMSP",
+              "number": "2513",
+              "title": "Paramedic Field Internship",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multi Skilled Maintenance Tech",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENST",
+              "number": "1360",
+              "title": "Mechanical Power Transmission",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENST",
+              "number": "1350",
+              "title": "Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "1311",
+              "title": "Electrical Circuits I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENST",
+              "number": "1370",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENST",
+              "number": "1311",
+              "title": "Computer Aided Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "2331",
+              "title": "PLC I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "2361",
+              "title": "Instrumentation Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "2333",
+              "title": "Industrial Electronic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "2350",
+              "title": "Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EETC",
+              "number": "2332",
+              "title": "PLC II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENST",
+              "number": "2361",
+              "title": "Fluid Power Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENST",
+              "number": "2390",
+              "title": "Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "2010",
+              "title": "Non-Calculus Based Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENST",
+              "number": "2350",
+              "title": "Lean Manufacturing Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "1301",
+              "title": "Intro to Medical Lab Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2403",
+              "title": "Clinical Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2402",
+              "title": "Hemotology & Hemostasis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2401",
+              "title": "Clinical Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2201",
+              "title": "Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2202",
+              "title": "Urinalysis & Body Fluids",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2301",
+              "title": "Immunohematology/Blood Bank",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "1510",
+              "title": "Clinical Practicum I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2150",
+              "title": "Special Topics/ MLT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2250",
+              "title": "Special Topics/Med. Lab. Tech.",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "1520",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2510",
+              "title": "Clinical Practicum III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2520",
+              "title": "Clinical Practicum IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2270",
+              "title": "Seminar II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technician",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "1301",
+              "title": "Intro to Medical Lab Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2403",
+              "title": "Clinical Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2402",
+              "title": "Hemotology & Hemostasis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2401",
+              "title": "Clinical Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2201",
+              "title": "Immunology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2202",
+              "title": "Urinalysis & Body Fluids",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2301",
+              "title": "Immunohematology/Blood Bank",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "1510",
+              "title": "Clinical Practicum I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2150",
+              "title": "Special Topics/ MLT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2250",
+              "title": "Special Topics/Med. Lab. Tech.",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "1520",
+              "title": "Clinical Practicum II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2510",
+              "title": "Clinical Practicum III",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2520",
+              "title": "Clinical Practicum IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLAB",
+              "number": "2270",
+              "title": "Seminar II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "110",
+              "title": "Foundations of Nursing I",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "2130",
+              "title": "Life Span Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "120",
+              "title": "Foundations of Nursing II",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "214",
+              "title": "Adult Health Nursing I",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "220",
+              "title": "Adult Health Nursing II",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing LPN to RN Career Pathway",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "140",
+              "title": "Nursing Transitions",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "190",
+              "title": "Intro to Human Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "220",
+              "title": "Adult Health Nursing II",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "214",
+              "title": "Adult Health Nursing I",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Physical Therapist Assistant",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSCI",
+              "number": "1010",
+              "title": "Principles of Physical Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2200",
+              "title": "Intro to Physical Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2440",
+              "title": "Biophysical Agents for PTA",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2460",
+              "title": "Patient Care Skills for the PTA",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2410",
+              "title": "Kinesiology for the PTA",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2370",
+              "title": "Professional Development for the PTA",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "2025",
+              "title": "Fundamentals of Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2492",
+              "title": "Integrated Clinical Education",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2280",
+              "title": "Seminar for the PTA",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTAT",
+              "number": "2493",
+              "title": "Terminal Clinical Education I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 75,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 75,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1220",
+              "title": "Introduction to Clinical Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1310",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1225",
+              "title": "Cardiopulmonary Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1420",
+              "title": "Fundamentals of Resp. Care 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1320",
+              "title": "Cardiopulmonary Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1410",
+              "title": "Fundamentals of Resp. Care 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2339",
+              "title": "Introduction to Clinical 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2440",
+              "title": "Mechanical Ventilation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2444",
+              "title": "Critical Care Practice 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2442",
+              "title": "Cardiopulmonary Diagnostic Testing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2445",
+              "title": "Adv. Concepts of Mech. Ventilation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2690",
+              "title": "Special Topics in Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2456",
+              "title": "Comp.Credentialing Preparation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2465",
+              "title": "Critical Care Practice 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2455",
+              "title": "Pediatric Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Care",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 73,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "2020",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "2010",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1220",
+              "title": "Introduction to Clinical Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "1010",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1310",
+              "title": "Cardiopulmonary Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "1530",
+              "title": "Introductory Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1225",
+              "title": "Cardiopulmonary Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1420",
+              "title": "Fundamentals of Resp. Care 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1320",
+              "title": "Cardiopulmonary Physiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "1410",
+              "title": "Fundamentals of Resp. Care 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2339",
+              "title": "Introduction to Clinical 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "1030",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2440",
+              "title": "Mechanical Ventilation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2444",
+              "title": "Critical Care Practice 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2442",
+              "title": "Cardiopulmonary Diagnostic Testing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2445",
+              "title": "Adv. Concepts of Mech. Ventilation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2690",
+              "title": "Special Topics in Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2456",
+              "title": "Comp.Credentialing Preparation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2465",
+              "title": "Critical Care Practice 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "2455",
+              "title": "Pediatric Respiratory Care",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CCNA Routing and Switching Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1367",
+              "title": "Intro. to Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1324",
+              "title": "CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2320",
+              "title": "Windows Server Admin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2321",
+              "title": "CCNA III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2381",
+              "title": "Cloud Computing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2326",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2382",
+              "title": "Cloud Computing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cloud Computing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1367",
+              "title": "Intro. to Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1324",
+              "title": "CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2320",
+              "title": "Windows Server Admin",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2321",
+              "title": "CCNA III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2381",
+              "title": "Cloud Computing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2326",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2382",
+              "title": "Cloud Computing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1324",
+              "title": "CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1351",
+              "title": "Prin. of Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2326",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2351",
+              "title": "Cisco Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2352",
+              "title": "Digital Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1300",
+              "title": "Beginning HTML & CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. to Programming and Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1303",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1310",
+              "title": "Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1324",
+              "title": "CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1311",
+              "title": "Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2344",
+              "title": "Database SQL Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2320",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2376",
+              "title": "Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Computer Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CITC",
+              "number": "1302",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1300",
+              "title": "Beginning HTML & CSS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1301",
+              "title": "Intro. to Programming and Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1303",
+              "title": "Database Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1323",
+              "title": "CCNA I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1310",
+              "title": "Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1324",
+              "title": "CCNA II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "1311",
+              "title": "Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2344",
+              "title": "Database SQL Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2320",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CITC",
+              "number": "2376",
+              "title": "Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/tn/config.ts
+++ b/lib/states/tn/config.ts
@@ -88,7 +88,13 @@ const tnConfig: StateConfig = {
     courses: [{ scripts: ["scripts/tn/scrape-banner-ssb.ts"], runner: "http" }],
     transfers: [{ scripts: ["scripts/tn/transfer/scrape-all.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/tn/scrape-catalog-prereqs.ts"], runner: "http" }],
-    programs: [{ scripts: ["scripts/tn/scrape-programs.ts"], runner: "http" }],
+    programs: [
+      { scripts: ["scripts/tn/scrape-programs.ts"], runner: "http" },
+      {
+        scripts: ["scripts/tn/scrape-jscc-pdf-programs.ts"],
+        runner: "http",
+      },
+    ],
   },
 };
 

--- a/scripts/tn/scrape-jscc-pdf-programs.ts
+++ b/scripts/tn/scrape-jscc-pdf-programs.ts
@@ -1,0 +1,545 @@
+/**
+ * scrape-jscc-pdf-programs.ts — extract degree/certificate program
+ * requirements for Jackson State Community College (TN) from their
+ * PDF-only catalog.
+ *
+ * JSCC is the one TBR community college that doesn't publish an Acalog
+ * catalog (other than Roane State, which is excluded for SAML reasons).
+ * Their catalog is distributed as a single combined PDF. This scraper
+ * downloads the latest PDF, runs `pdftotext -layout`, and parses the
+ * "Program Requirements" → "Sample Schedule" sections into the same
+ * CollegePrograms shape the Acalog scraper produces.
+ *
+ * Requires: pdftotext (poppler) on PATH.  brew install poppler
+ *
+ * Usage:
+ *   npx tsx scripts/tn/scrape-jscc-pdf-programs.ts
+ *   npx tsx scripts/tn/scrape-jscc-pdf-programs.ts --pdf=/tmp/jscc.pdf
+ *   npx tsx scripts/tn/scrape-jscc-pdf-programs.ts --keep-text   # keep /tmp/.txt for inspection
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequiredCourse,
+  RequirementGroup,
+} from "../../lib/types.js";
+
+const COLLEGE_SLUG = "jackson-state";
+const CATALOG_INDEX_URL =
+  "https://www.jscc.edu/academics/academic-services/course-catalog/";
+// The combined catalog PDF link is published on the catalog index page.
+// Falls back to a known-good 2025-26 URL if discovery fails.
+const FALLBACK_PDF_URL =
+  "https://jscc.edu/media/jackson-state/content-assets/documents/academics-/academic-catalogs/25.26-catalog6.24_compressed_Combined.pdf";
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+function getArg(name: string): string | null {
+  const args = process.argv.slice(2);
+  const eq = args.find((a) => a.startsWith(`--${name}=`));
+  if (eq) return eq.split("=").slice(1).join("=");
+  const flat = args.indexOf(`--${name}`);
+  if (flat >= 0 && args[flat + 1] && !args[flat + 1].startsWith("--")) {
+    return args[flat + 1];
+  }
+  return null;
+}
+
+const ARG_PDF_PATH = getArg("pdf");
+const ARG_KEEP = process.argv.includes("--keep-text");
+
+// ---------------------------------------------------------------------------
+// Step 1: discover and download the latest catalog PDF
+// ---------------------------------------------------------------------------
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: {
+      "User-Agent": UA,
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "Accept-Language": "en-US,en;q=0.9",
+    },
+    redirect: "follow",
+  });
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return res.text();
+}
+
+async function discoverPdfUrl(): Promise<string> {
+  try {
+    const html = await fetchText(CATALOG_INDEX_URL);
+    // Pick the first absolute or relative href that looks like a JSCC catalog PDF
+    const re =
+      /href="((?:https:\/\/jscc\.edu)?\/media\/jackson-state\/content-assets\/documents\/academics-?\/academic-catalogs\/[^"]+\.pdf)"/gi;
+    const matches: string[] = [];
+    let m;
+    while ((m = re.exec(html)) !== null) matches.push(m[1]);
+    if (matches.length > 0) {
+      const first = matches[0];
+      return first.startsWith("http") ? first : `https://jscc.edu${first}`;
+    }
+  } catch (e) {
+    console.warn(`  discovery failed (${e}); falling back to known URL`);
+  }
+  return FALLBACK_PDF_URL;
+}
+
+async function downloadPdf(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, { headers: { "User-Agent": UA } });
+  if (!res.ok) throw new Error(`download ${url} -> HTTP ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  fs.writeFileSync(dest, buf);
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: pdftotext
+// ---------------------------------------------------------------------------
+
+function pdfToText(pdfPath: string, txtPath: string): void {
+  execFileSync("pdftotext", ["-layout", pdfPath, txtPath], {
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: parse credential from a "for the X: Title" header line
+// ---------------------------------------------------------------------------
+
+function parseCredentialAndTitle(
+  forTheLine: string,
+): { credential: ProgramCredential; title: string } | null {
+  // Strip leading whitespace and the "for the " prefix
+  const m = forTheLine.match(/^\s*for the (.+)$/);
+  if (!m) return null;
+  const rest = m[1].trim();
+  // Patterns we see in the JSCC catalog:
+  //   "Associate of Science: Accounting"
+  //   "Associate of Arts: Art"
+  //   "Associate of Arts/Science: Criminal Justice"
+  //   "Associate of Science in Teaching"
+  //   "Associate of Applied Science: Business--Management"
+  let credential: ProgramCredential = "other";
+  let title = rest;
+  if (/^Associate of Applied Science\b/i.test(rest)) {
+    credential = "AAS";
+    title = rest.replace(/^Associate of Applied Science[: ]+/i, "").trim();
+  } else if (/^Associate of Arts\/Science\b/i.test(rest)) {
+    credential = "AA"; // hybrid AA/AS — pick AA, the more permissive label
+    title = rest.replace(/^Associate of Arts\/Science[: ]+/i, "").trim();
+  } else if (/^Associate of Arts\b/i.test(rest)) {
+    credential = "AA";
+    title = rest.replace(/^Associate of Arts[: ]+/i, "").trim();
+  } else if (/^Associate of Science in Teaching\b/i.test(rest)) {
+    credential = "AS";
+    title = "Teaching";
+  } else if (/^Associate of Science\b/i.test(rest)) {
+    credential = "AS";
+    title = rest.replace(/^Associate of Science[: ]+/i, "").trim();
+  } else if (/Certificate\b/i.test(rest)) {
+    credential = "certificate";
+  }
+  // Replace double-dashes with em-style separator
+  title = title.replace(/\s*--\s*/g, " — ");
+  if (!title) return null;
+  return { credential, title };
+}
+
+// ---------------------------------------------------------------------------
+// Step 4: parse a course-row line for one or more PREFIX NUMBER ... HRS tuples
+// ---------------------------------------------------------------------------
+
+const COURSE_RE =
+  /\b([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)(?:\/\d{3,4}[A-Z]?)?\s+([A-Za-z][A-Za-z0-9 \-/&,'.]{2,80}?)\s{2,}(\d+)(?=\s|$)/g;
+
+// Drop XXXX placeholders ("HIST XXXX", "MATH XXXX", etc.)
+function isPlaceholderNumber(num: string): boolean {
+  return /^X{3,}$/i.test(num);
+}
+
+interface ParsedCourseRow {
+  prefix: string;
+  number: string;
+  title: string;
+  credits: number;
+}
+
+function parseCourseRows(line: string): ParsedCourseRow[] {
+  const out: ParsedCourseRow[] = [];
+  COURSE_RE.lastIndex = 0;
+  let m;
+  while ((m = COURSE_RE.exec(line)) !== null) {
+    const [, prefix, number, title, credits] = m;
+    if (isPlaceholderNumber(number)) continue;
+    // Filter out obvious non-course matches (e.g. "TBR 2046")
+    if (prefix === "TBR" || prefix === "PDF" || prefix === "ID") continue;
+    out.push({
+      prefix,
+      number,
+      title: title.trim(),
+      credits: parseInt(credits, 10),
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Step 5: parse total credits from "(The X requires N - M college level credits...)"
+// ---------------------------------------------------------------------------
+
+function parseTotalCredits(line: string): number | null {
+  const m = line.match(
+    /requires\s+(\d+)(?:\s*-\s*(\d+))?\s+college level credits/i,
+  );
+  if (!m) return null;
+  // If a range, take the upper bound (it's the maximum students may need)
+  return parseInt(m[2] ?? m[1], 10);
+}
+
+// ---------------------------------------------------------------------------
+// Step 6: walk the text, building ProgramRequirement entries
+// ---------------------------------------------------------------------------
+
+interface ProgramBlock {
+  startLine: number;
+  forTheLine: number;
+  forThe: string;
+}
+
+function findProgramBlocks(lines: string[]): ProgramBlock[] {
+  const blocks: ProgramBlock[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*Program Requirements\s*$/.test(lines[i])) {
+      // The "for the X" line is usually 1 to 3 lines below for AS/AA programs,
+      // but AAS program pages insert blank lines and a "Professional and
+      // Technical Programs" running header — search up to 12 lines.
+      for (let j = i + 1; j < Math.min(i + 14, lines.length); j++) {
+        if (/^\s*for the [A-Z]/.test(lines[j])) {
+          blocks.push({ startLine: i, forTheLine: j, forThe: lines[j] });
+          break;
+        }
+      }
+    }
+  }
+  return blocks;
+}
+
+const STOP_SENTINELS = [
+  /^Career and Salary Information/i,
+  /^Projected Income/i,
+  /^Additional Information/i,
+  /^Contact Information/i,
+  /^Note:/i,
+  /JACKSON STATE COMMUNITY COLLEGE\s*$/,
+  /^Program Requirements\s*$/,
+  /^Technical Certificate/i,
+];
+
+function isStop(line: string): boolean {
+  return STOP_SENTINELS.some((re) => re.test(line.trim()));
+}
+
+function dedupCourses(courses: RequiredCourse[]): RequiredCourse[] {
+  const seen = new Set<string>();
+  const out: RequiredCourse[] = [];
+  for (const c of courses) {
+    const key = `${c.prefix} ${c.number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c);
+  }
+  return out;
+}
+
+function buildProgramFromBlock(
+  lines: string[],
+  block: ProgramBlock,
+  catalogUrl: string,
+): ProgramRequirement | null {
+  const meta = parseCredentialAndTitle(block.forThe);
+  if (!meta) return null;
+
+  // Look for "(... requires N credits)" within ~10 lines after the for-the header
+  let totalCredits: number | null = null;
+  for (
+    let i = block.forTheLine + 1;
+    i < Math.min(block.forTheLine + 12, lines.length);
+    i++
+  ) {
+    const c = parseTotalCredits(lines[i]);
+    if (c !== null) {
+      totalCredits = c;
+      break;
+    }
+  }
+
+  // Find Sample Schedule header within ~250 lines after the program header
+  let scheduleStart = -1;
+  for (
+    let i = block.forTheLine + 1;
+    i < Math.min(block.forTheLine + 260, lines.length);
+    i++
+  ) {
+    if (/Sample Schedule\s*$/.test(lines[i])) {
+      scheduleStart = i + 1;
+      break;
+    }
+  }
+  if (scheduleStart < 0) return null;
+
+  // Walk the schedule, collecting course rows until we hit a stop sentinel,
+  // a long blank stretch, or another Program Requirements header.
+  const courses: RequiredCourse[] = [];
+  let blankRun = 0;
+  for (let i = scheduleStart; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      blankRun++;
+      if (blankRun >= 6) break; // 6 consecutive blanks = end of schedule
+      continue;
+    }
+    blankRun = 0;
+    if (isStop(line)) break;
+    const rows = parseCourseRows(line);
+    for (const r of rows) {
+      courses.push({
+        prefix: r.prefix,
+        number: r.number,
+        title: r.title,
+        credits: r.credits,
+        or_alternatives: [],
+      });
+    }
+    // Cap to avoid runaway capture (typical schedule is 4 semesters of 5 courses)
+    if (i - scheduleStart > 200) break;
+  }
+
+  if (courses.length === 0) return null;
+  const deduped = dedupCourses(courses);
+
+  const requirementGroup: RequirementGroup = {
+    name: "Recommended Course Sequence",
+    credits_required: totalCredits,
+    choose_n: null,
+    courses: deduped,
+  };
+
+  return {
+    title: meta.title,
+    credential: meta.credential,
+    program_code: null,
+    catalog_url: catalogUrl,
+    total_credits: totalCredits,
+    gpa_minimum: 2.0,
+    description: null,
+    requirement_groups: [requirementGroup],
+    matched_program_slug: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Step 7: parse Technical Certificate programs (different layout than degrees)
+// ---------------------------------------------------------------------------
+//
+// Each certificate has a header line ending in "Certificate", followed
+// (within ~6 lines) by a "Rubric / Course / Hrs" header and then a table.
+// We capture rows up to a "Total Credits" line.
+
+function extractCertificateTitlesFromLine(line: string): string[] {
+  // A certificate title is typically Title-Case words ending in "Certificate".
+  // Some lines have two side-by-side titles (two-column layout).
+  const titles: string[] = [];
+  const re =
+    /([A-Z][A-Za-z0-9 &/'-]+?Certificate)(?=\s{2,}|$)/g;
+  let m;
+  while ((m = re.exec(line)) !== null) {
+    const t = m[1].trim();
+    if (t.length < 6 || t.length > 80) continue;
+    if (/^Technical Certificate of Credit$/i.test(t)) continue;
+    if (/^Career Technical Certificate$/i.test(t)) continue;
+    if (/^Academic Certificate$/i.test(t)) continue;
+    if (/^Tennessee.+Technical Certificate$/i.test(t)) continue;
+    titles.push(t);
+  }
+  return titles;
+}
+
+function buildCertificateProgram(
+  lines: string[],
+  startIdx: number,
+  title: string,
+  catalogUrl: string,
+): ProgramRequirement | null {
+  // Find the next Rubric/Course/Hrs header within ~20 lines (some certs have
+  // a description paragraph before the table).
+  let tableStart = -1;
+  for (let j = startIdx + 1; j < Math.min(startIdx + 25, lines.length); j++) {
+    if (/Rubric\s+Course\s+Hrs/.test(lines[j])) {
+      tableStart = j + 1;
+      break;
+    }
+  }
+  if (tableStart < 0) return null;
+
+  const courses: RequiredCourse[] = [];
+  let totalCredits: number | null = null;
+  for (let j = tableStart; j < Math.min(tableStart + 40, lines.length); j++) {
+    const line = lines[j];
+    const tcMatch = line.match(/Total Credits\s+(\d+)/);
+    if (tcMatch) {
+      totalCredits = parseInt(tcMatch[1], 10);
+      break;
+    }
+    const rows = parseCourseRows(line);
+    for (const r of rows) {
+      courses.push({
+        prefix: r.prefix,
+        number: r.number,
+        title: r.title,
+        credits: r.credits,
+        or_alternatives: [],
+      });
+    }
+  }
+  if (courses.length === 0) return null;
+
+  return {
+    title,
+    credential: "certificate",
+    program_code: null,
+    catalog_url: catalogUrl,
+    total_credits: totalCredits,
+    gpa_minimum: 2.0,
+    description: null,
+    requirement_groups: [
+      {
+        name: "Required Courses",
+        credits_required: totalCredits,
+        choose_n: null,
+        courses: dedupCourses(courses),
+      },
+    ],
+    matched_program_slug: null,
+  };
+}
+
+function parseCertificates(
+  lines: string[],
+  catalogUrl: string,
+): ProgramRequirement[] {
+  const certs: ProgramRequirement[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const titles = extractCertificateTitlesFromLine(lines[i]);
+    for (const title of titles) {
+      const program = buildCertificateProgram(lines, i, title, catalogUrl);
+      if (program) certs.push(program);
+    }
+  }
+  // Dedup certificate programs by title (the same cert can appear multiple
+  // times across the catalog; keep the entry with the most courses).
+  const byTitle = new Map<string, ProgramRequirement>();
+  for (const c of certs) {
+    const existing = byTitle.get(c.title);
+    if (
+      !existing ||
+      existing.requirement_groups[0].courses.length <
+        c.requirement_groups[0].courses.length
+    ) {
+      byTitle.set(c.title, c);
+    }
+  }
+  return Array.from(byTitle.values());
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const tmp = os.tmpdir();
+  const pdfPath = ARG_PDF_PATH ?? path.join(tmp, "jscc-catalog.pdf");
+  const txtPath = path.join(tmp, "jscc-catalog.txt");
+
+  let catalogUrl: string;
+  if (ARG_PDF_PATH) {
+    catalogUrl = CATALOG_INDEX_URL;
+    console.log(`Using local PDF: ${pdfPath}`);
+  } else {
+    console.log("Discovering latest JSCC catalog PDF...");
+    catalogUrl = await discoverPdfUrl();
+    console.log(`  PDF URL: ${catalogUrl}`);
+    console.log(`  Downloading -> ${pdfPath}`);
+    await downloadPdf(catalogUrl, pdfPath);
+  }
+
+  console.log(`Running pdftotext -layout -> ${txtPath}`);
+  pdfToText(pdfPath, txtPath);
+
+  const text = fs.readFileSync(txtPath, "utf8");
+  const lines = text.split(/\r?\n/);
+  console.log(`  Loaded ${lines.length} lines of text`);
+
+  // Parse Associate degree programs
+  const blocks = findProgramBlocks(lines);
+  console.log(`  Found ${blocks.length} "Program Requirements" blocks`);
+  const degreePrograms: ProgramRequirement[] = [];
+  for (const block of blocks) {
+    const p = buildProgramFromBlock(lines, block, catalogUrl);
+    if (p) degreePrograms.push(p);
+  }
+  console.log(`  Parsed ${degreePrograms.length} degree programs`);
+
+  // Parse Technical Certificate programs
+  const certPrograms = parseCertificates(lines, catalogUrl);
+  console.log(`  Parsed ${certPrograms.length} certificate programs`);
+
+  const programs = [...degreePrograms, ...certPrograms];
+
+  // Run program-slug matcher
+  const { matched, unmatched } = applyProgramMatching(programs);
+  console.log(
+    `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+  );
+
+  // Determine catalog year from URL or filename if possible
+  const yearMatch = catalogUrl.match(/(\d{2})[.-](\d{2})/);
+  const catalogYear = yearMatch
+    ? `20${yearMatch[1]}-20${yearMatch[2]}`
+    : "";
+
+  const data: CollegePrograms = {
+    college_slug: COLLEGE_SLUG,
+    catalog_year: catalogYear,
+    catalog_url: catalogUrl,
+    scraped_at: new Date().toISOString(),
+    programs,
+  };
+
+  const outDir = path.join(process.cwd(), "data", "tn", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${COLLEGE_SLUG}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+  console.log(`\n✓ Wrote ${programs.length} programs to ${outPath}`);
+
+  if (!ARG_KEEP) {
+    fs.unlinkSync(txtPath);
+  } else {
+    console.log(`  text kept at ${txtPath}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #232.

## Summary

Adds a PDF-based program scraper for Jackson State Community College, the one TBR community college that doesn't publish an Acalog catalog. Brings TN program coverage from 11/12 → 12/12 active TBR colleges.

| Credential | Programs |
|---|---|
| Associate of Arts | 12 |
| Associate of Science | 19 |
| Associate of Applied Science | 16 |
| Certificate | 5 |
| **Total** | **52** (597 unique course rows) |

## Approach

1. Discover the latest catalog PDF link from JSCC's public catalog index page (with a known-good 2025-26 fallback URL).
2. Download to `/tmp` and run `pdftotext -layout` (poppler — already used elsewhere in the repo, e.g. `scripts/tn/transfer/scrape-apsu.ts`).
3. Walk the text for `Program Requirements` → `for the X` header pairs to extract title + credential, then locate the matching `Sample Schedule` block and capture rubric'd course rows until a stop sentinel (career info, page footer, next program block).
4. Separately scan the catalog for `X Certificate` headers and parse the simpler Rubric/Course/Hrs tables that follow.
5. Run `applyProgramMatching()` to assign registry program slugs.

## Limitations (worth follow-ups, not blockers)

- Sample Schedule layout is wider/messier than Acalog's structured program detail pages, so each program collapses into a single `Recommended Course Sequence` requirement group. We don't yet capture the `Choose ONE Mathematics Course` / `Choose THREE Humanities Courses` alternative-set semantics that Acalog gives us natively.
- 7 of 52 programs return `total_credits: null` — the parenthetical credit-hours line is absent for some AAS / health-sciences programs that publish credits as a range or footnote.
- 5 prose-described certificates (e.g. "The Correctional Officer Technical Certificate offers...") aren't captured because the title isn't on its own line. Catching them risks false positives; left for follow-up if needed.

## Verification

- `npx tsx scripts/tn/scrape-jscc-pdf-programs.ts` runs end-to-end (live PDF discovery + download → pdftotext → parse → write JSON).
- `scripts/check-scraper-coverage.ts` passes. TN now declares two program scrapers: `scripts/tn/scrape-programs.ts` (Acalog, 11 colleges) + `scripts/tn/scrape-jscc-pdf-programs.ts` (PDF, 1 college).
- Local dev `/tn/college/jackson-state/programs` renders all 52 programs grouped by credential. Expanding "Accounting (AS)" shows the full Recommended Course Sequence with live section counts cross-referenced against the course catalog (the cross-ref feature from #226 works against this data).

## Test plan

- [x] Live download path works (no `--pdf=` cache)
- [x] Output validates against `CollegePrograms` schema (existing reader at `lib/programs/requirements.ts:148` parses it)
- [x] Local dev page renders 52 programs grouped by credential
- [x] Course-section badges populate from cross-reference
- [ ] Post-merge: confirm `https://communitycollegepath.com/tn/college/jackson-state/programs` shows 52 programs in prod

## Notes

- Requires `pdftotext` (poppler) on PATH. Same dependency as `scripts/tn/transfer/scrape-apsu.ts` and `scripts/nc/scrape-cleveland.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)