### PR TITLE
feat: program scrapers for 4 MA Acalog colleges (MA coverage 1/15 → 5/15)

### DIFF
--- a/data/ma/programs/bhcc.json
+++ b/data/ma/programs/bhcc.json
@@ -1,0 +1,6179 @@
+{
+  "college_slug": "bhcc",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.bhcc.edu",
+  "scraped_at": "2026-05-07T03:23:06.263Z",
+  "programs": [
+    {
+      "title": "Biomedical Engineering Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1710",
+      "total_credits": 18,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students must complete MAT-197 with a C+ or better before taking CHM-201 .",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Accounting Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1660",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving *",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Biological Sciences: Medical Professions Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1712",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Elective Option elective courses: BIO-203 Anatomy/Physiology I & Lab , BIO-204 Anatomy/Physiology II & Lab , BIO-205 Microbiology & Lab , BIO-208 Genetics and Lab , CHM-252 Organic Chemistry II and Lab , MAT-181 Statistics I , MAT-282 Calculus II , NHP-180 Medical Terminology , COM-171 Public Speaking and Professional Comm , SCI-221 Interpretation and Presentation of Scientific Research , HON-200 Honors Seminar , BIO-120 Introduction to Biotechnology , INT-299STM Learn & Earn STEM Internship , SCI-299 Science Internship See semester advising note.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Elective Option elective courses: BIO-203 Anatomy/Physiology I & Lab , BIO-204 Anatomy/Physiology II & Lab , BIO-205 Microbiology & Lab , BIO-208 Genetics and Lab , CHM-252 Organic Chemistry II and Lab , MAT-181 Statistics I , MAT-282 Calculus II , NHP-180 Medical Terminology , COM-171 Public Speaking and Professional Comm , SCI-221 Interpretation and Presentation of Scientific Research , HON-200 Honors Seminar , BIO-120 Introduction to Biotechnology , INT-299STM Learn & Earn STEM Internship , SCI-299 Science Internship See semester advising note.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biological Sciences: Biotechnology Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1713",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students in the Biotechnology option should take BIO-120 in their first semester.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students in the Biotechnology option must complete BIO-120 before taking BIO-261 .",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Completing BIO-208 before taking BIO-262 is recommended but not required.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Completing BIO-208 before taking BIO-262 is recommended but not required.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective Elective Options: BIO-205 Microbiology & Lab , ENV-211 Environmental Microbiology/Lab , CHM-121 Principles of Organic & Chemistry W/Lab , CHM-251 Organic Chemistry I and Lab , CHM-252 Organic Chemistry II and Lab , CIT-113 Information Technology Problem Solving , MAT-181 Statistics I , MAT-281 Calculus I , MAT-282 Calculus II , SCI-221 Interpretation and Presentation of Scientific Research , SCI-150 Forensic Science and Lab , HON-200 Honors Seminar , INT-299STM Learn & Earn STEM Internship , SCI-299 Science Internship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Biology Transfer Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1711",
+      "total_credits": 14,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective Elective Options: BIO-120 Introduction to Biotechnology , BIO-210 Population Ecology & Lab , ENV-211 Environmental Microbiology/Lab , BIO-261 Advanced Laboratory Techniques in Biotechnology , BIO-262 Principles of Molecular Biotechnology , CHM-251 Organic Chemistry I and Lab , CHM-252 Organic Chemistry II and Lab , MAT-181 Statistics I , MAT-282 Calculus II , SCI-221 Interpretation and Presentation of Scientific Research , HON-200 Honors Seminar , INT-299STM Learn & Earn STEM Internship , SCI-299 Science Internship , ENV-120 Tropical Field Studies (waiver required)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective Elective Options: BIO-120 Introduction to Biotechnology , BIO-210 Population Ecology & Lab , ENV-211 Environmental Microbiology/Lab , BIO-261 Advanced Laboratory Techniques in Biotechnology , BIO-262 Principles of Molecular Biotechnology , CHM-251 Organic Chemistry I and Lab , CHM-252 Organic Chemistry II and Lab , MAT-181 Statistics I , MAT-282 Calculus II , SCI-221 Interpretation and Presentation of Scientific Research , HON-200 Honors Seminar , INT-299STM Learn & Earn STEM Internship , SCI-299 Science Internship , ENV-120 Tropical Field Studies (waiver required)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective Elective Options: BIO-120 Introduction to Biotechnology , BIO-210 Population Ecology & Lab , ENV-211 Environmental Microbiology/Lab , BIO-261 Advanced Laboratory Techniques in Biotechnology , BIO-262 Principles of Molecular Biotechnology , CHM-251 Organic Chemistry I and Lab , CHM-252 Organic Chemistry II and Lab , MAT-181 Statistics I , MAT-282 Calculus II , SCI-221 Interpretation and Presentation of Scientific Research , HON-200 Honors Seminar , INT-299STM Learn & Earn STEM Internship , SCI-299 Science Internship , ENV-120 Tropical Field Studies (waiver required)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Chemistry Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1709",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective See Semester Advising Notes for list of options.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Transfer Option, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1662",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one course designated with the prefix LIT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose any ACC, BUS, FIN or MAN prefixed course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Social Science Elective *Note: ECO-201 Macroeconomics is required to fulfill this requirement.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cardiac Sonography Option Full-time, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1640",
+      "total_credits": 4,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend a mandatory information session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MATH College Algebra or Statistics Completion of any 3 credit College Algebra or Statistics course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "TEAS Complete the Test of Essential Academic Skills (TEAS) Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Before Starting the Program",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1652",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving MAT-181 Statistics I or MAT-174 Quantitative Reasoning recommended",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1673",
+      "total_credits": 19,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Mathematics Elective Choose one college-level MAT course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one LIT course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Computer Elective Computer Elective Options: CIT-118 Principles of Internet & Info Security , CSC-120 Intro to Comp Sci & Object Oriented Prog , CIT-128 Database Design with MS Access , CIT-162 CISCO Networking I , CSC-242 Data Structures , CIT-268 Operating Systems , CSC-284 Advanced C++/OOP",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Transfer Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1706",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose one course from General Education Community and Cultural Contexts Menu",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1707",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MAT-197 is waived for students placing higher on Accuplacer test; student should take MAT-281 . If MAT-197 is waived students can replace with one of the math electives CSC-237 , CSC-243 , CSC-287 , or MAT-281 or MAT-291 .",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Criminal Justice Transfer Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1692",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving MAT-181 Statistics I is strongly recommended.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning SCI-150 Forensic Science and Lab is recommended.",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose from any non-required CRJ course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose from any non-required CRJ course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice Career Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1691",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving MAT-181 Statistics I is strongly recommended.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning SCI-150 Forensic Science and Lab is recommended.",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective See semester advising note",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective See semester advising note",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose from any non-required CRJ course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose from any non-required CRJ course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose from any non-required CRJ course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Open Elective Recommended electives include Communication, Political Science, Computer, or Foreign Language courses.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Culinary Arts Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1725",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Uniforms and tools required for this course.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Uniforms and tools required for this course.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Uniforms and tools required for this course.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Recommended: PSY-101 or SOC-101 or MAN-112",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Uniforms and tools required for this course.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Uniforms and tools required for this course.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Uniforms and tools required for this course.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Uniforms and tools required for this course.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data Analytics Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1678",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose one four credit Science/Lab course (see semester four advising note)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1676",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- CIT Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Early Childhood Development, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1696",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective Career Elective Electives: ECE-108 Infant/Toddler Curriculum Development , ECE-207 Literacy Development and Learning for Children , ECE-209 Math Concepts & Learning for Children , ECE-210 Science Concepts & Learning for Children , ECE-118 Pedagogy of Play , SOC-211 The Family , SOC-203 Social Problems , PSY-201 Learning and Memory , ECE-202 Issues in Early Childhood Education , ECE-119 Field Experience in ECE , LIT-218 Children’s Literature II , ECE-213 Child Care Administration I , ECE-215 Supervisor in Early Childhood Education , ECE-223 CDA Professional Portfolio&Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective Career Elective Electives: ECE-108 Infant/Toddler Curriculum Development , ECE-207 Literacy Development and Learning for Children , ECE-209 Math Concepts & Learning for Children , ECE-210 Science Concepts & Learning for Children , ECE-118 Pedagogy of Play , SOC-211 The Family , SOC-203 Social Problems , PSY-201 Learning and Memory , ECE-202 Issues in Early Childhood Education , ECE-119 Field Experience in ECE , LIT-218 Children’s Literature II , ECE-213 Child Care Administration I , ECE-215 Supervisor in Early Childhood Education , ECE-223 CDA Professional Portfolio&Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective Career Elective Electives: ECE-108 Infant/Toddler Curriculum Development , ECE-207 Literacy Development and Learning for Children , ECE-209 Math Concepts & Learning for Children , ECE-210 Science Concepts & Learning for Children , ECE-118 Pedagogy of Play , SOC-211 The Family , SOC-203 Social Problems , PSY-201 Learning and Memory , ECE-202 Issues in Early Childhood Education , ECE-119 Field Experience in ECE , LIT-218 Children’s Literature II , ECE-213 Child Care Administration I ECE-215 Supervisor in Early Childhood Education ECE-223 CDA Professional Portfolio&Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Education Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1728",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective * See semester advising note.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose a course from the Creative Work Menu",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electric Power Utility Program - A Partnership with EVERSOURCE, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1680",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma Possess a High School Diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Other See Admissions Requirements below",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Test Take College Placement Test",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Transfer Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1701",
+      "total_credits": 17,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Students must complete ENG-111 and MAT-197 with a C+ or better before taking CHM-201 .",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Offered in Fall only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Career elective selection must be recommended and approved by the Engineering Advisor and/or the Engineering and Physical Sciences Department.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Career elective selection must be recommended and approved by the Engineering Advisor and/or the Engineering and Physical Sciences Department.",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "English Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1653",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective * HUM-120 satisfies the Learning Community Requirement or choose one college-level course as an elective.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Global Language Elective * Choose one course from Global Languages.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one LIT course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Math Elective Choose one college-level MAT course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Global Language Elective Choose one course from Global Languages.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - English Elective Choose one college-level ENG course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one LIT course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning *",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Engineering Transfer Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1703",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective * Choose one course from Career Elective Options: CHM-201 General Chemistry I & Lab , MAT-291 Linear Algebra , CSC-120 Intro to Comp Sci & Object Oriented Prog , CSC-237 C++ Programming",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Offered in Fall only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective * Choose one course from Career Elective Options: CHM-201 General Chemistry I & Lab , MAT-291 Linear Algebra , CSC-120 Intro to Comp Sci & Object Oriented Prog , CSC-237 C++ Programming",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "English: Creative Writing Option, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1654",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Global Language Elective * Choose one course from Global Languages.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Global Language Elective Choose one course from Global Languages.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Students must take ENG-231 , ENG-232 , ENG-233 , or THR-115 to satisfy this requirement.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral or Social Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral or Social Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning *",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1664",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose any ACC, BUS, FIN or MAN course.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1700",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose one of the following: ENV-111 Survey of Renewable Energy or, ENV-113 Introduction to Oceanography/Lab or, ENV-115 Earth Science or, ENV-120 Tropical Field Studies",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective Option Elective: BIO-210 Population Ecology & Lab , ENV-211 Environmental Microbiology/Lab , ENV-250 Global Environmental Change , MAT-281 Calculus I , (see semester advising note), PHY-202 General Physics II/Lab , PHY-252 Physics II/Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Option Elective Option Electives: BIO-210 Population Ecology & Lab , ENV-211 Environmental Microbiology/Lab , ENV-250 Global Environmental Change , MAT-281 Calculus I , (see semester advising note), PHY-202 General Physics II/Lab , PHY-252 Physics II/Lab",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Finance Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1665",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Protection and Safety Program, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1694",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Career Electives: FPS-125 Hazardous Materials Chemistry , FPS-127 Fire Protection Hydraulics and Water Supply , FPS-221 Strategy and Tactics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Gaming/Computer Artist Track Simulation Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1687",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts Recommended: SOC-101",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Gaming/Computer Programming Track Simulation Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1688",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts Recommended: SOC-101",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Global Languages Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1655",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective- 101 Global Language-1 * Example: FRE-101 Elementary French I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective- 101 Global Language-2 * Example: SPN-101 Elementary Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose a course from the General Education Creative Work Menu.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective- 102 Global Language-1 * Example: FRE-102 Elementary French II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective- 102 Global Language-2 * Example: SPN-102 Elementary Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts Choose one: GEO-101 ; REL-111 ; SOC-101 ; PSC-101 ; PSC-220 .",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective- 201 Global Language * Example: SPN-201 Intermediate Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- History Elective Credit: 3 * Choose from HIS-102 or HIS-103 or HIS-111 or HIS-112",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective Choose one: GEO-101 ; REL-111 ; SOC-101 ; PSC-101 ; PSC-220",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective- 202 Global Language Example: SPN-202 Intermediate Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Mathematics Elective or 4 Choose one college-level MAT course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- History Elective * Choose from HIS-102 or HIS-103 or HIS-111 or HIS-112",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1731",
+      "total_credits": 17,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving *",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective Choose any college-level course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Social Science Elective Choose one HIS or PSC course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature, Humanities or Fine Arts Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective Choose any college-level course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Sonography Option Full-time, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1642",
+      "total_credits": 3,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend a mandatory Information session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MATH College Algebra or Statistics Completion of any 3 credit College Algebra or Statistics course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "TEAS Complete the Test of Essential Academic Skills (TEAS) Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Before Starting the Program",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "History Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1630",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective ​- Global Language Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Global Language Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Other specialized department-approved course *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- 100-level History course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Aligned Interdisciplinary Course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Natural or Physical Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities and Fine Arts Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Integrated Media Design Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1716",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Satisfies Learning Community Seminar requirement",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology Transfer Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1684",
+      "total_credits": 17,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective or CIT Elective Recommended Electives: CIT-118 , CIT-121 , CIT-219 , CIT-221 , CIT-223 , CSC-240 ,CIT-264 , CIT-282 , CRJ-103 , CRJ-245 , CRJ-202 , Any other programming course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective or CIT Elective Recommended Electives: CIT-118 , CIT-121 , CIT-219 , CIT-221 , CIT-223 , CSC-240 ,CIT-264 , CIT-282 , CRJ-103 , CRJ-245 , CRJ-202 , Any other programming course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective or CIT Elective Recommended Electives: CIT-118 , CIT-121 , CIT-219 , CIT-221 , CIT-223 , CSC-240 , CIT-264 , CIT-282 , CRJ-103 , CRJ-245 , CRJ-202 , Any other programming course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective or CIT Elective Recommended Electives: CIT-118 , CIT-121 , CIT-219 , CIT-221 , CIT-223 , CSC-240 ,CIT-264 , CIT-282 , CRJ-103 , CRJ-245 , CRJ-202 , Any other programming course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Hospitality Management, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1736",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Semester",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community and Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Mathematics Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1698",
+      "total_credits": 14,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose one course from Creative Work Menu",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Social Science Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Radiography Option Full-time, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1646",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend a mandatory Information session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MATH College Algebra or Statistics Completion of any 3 credit College Algebra or Statistics course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "TEAS Complete the Test of Essential Academic Skills (TEAS) Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1656",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective Choose one college-level course. The first semester of a two-semester global language sequence is recommended.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective Choose one college-level course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Medical Laboratory Technician, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1697",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend Mandatory information session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Credits for Anatomy and Physiology/Lab that were earned more than five (5) years prior to enrollment in the MLT program are not accepted. Must earn a grade of C or better.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Credits for Anatomy and Physiology/Lab that were earned more than five (5) years prior to enrollment in the MLT program are not accepted. Must earn a grade of C or better.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must earn a grade of C or better",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1 Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must earn a grade of B- or higher.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must earn a grade of B- or higher.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Management Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1666",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving *",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose one course from ACC or BUS or FIN or MAN",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose one course from ACC or BUS or FIN or MAN",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective ​",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Imaging, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1639",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1632",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving *",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Students may choose a course from: GEO-101 , PSC-101 or REL-111",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective *",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1657",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Performance Ensemble Elective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS - Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Spring only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Performance Ensemble Elective See semester advising note",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fall only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral or Social Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Performance Ensemble Elective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fall only",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose a course from the Scientific Reasoning Menu",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral or Social Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Spring only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Performance Ensemble Elective",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Music Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1638",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School Diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend a mandatory Information Session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "License Submit a copy of valid driver’s license or obtain prior to the start of classes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EMT Submit copy of valid EMT card or obtain prior to the start of classes",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CPR Possess a current American Heart Association, Basic Life Support Health Care Provider Card",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1717",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts Recommended courses: PSY-101 or SOC-101",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning Recommended courses: BIO-115 or ENV-105",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective Recommended: PSY-101 or SOC-101",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Paralegal Option Elective Paralegal Option Elective Courses: CRJ-103 Criminal Law , PLG-201 Family Law , PLG-203 Real Estate Law , PLG-204 Wills, Estates and Trusts , PLG-299 Paralegal Internship , PLG-105 Practical Legal Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective Recommended course: BIO-115 or ENV-105",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective Recommended course: PSY-107",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Paralegal Option Elective Paralegal Option Elective Courses: CRJ-103 Criminal Law , PLG-201 Family Law , PLG-203 Real Estate Law , PLG-204 Wills, Estates and Trusts , PLG-299 Paralegal Internship , PLG-105 Practical Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Paralegal Option Elective Paralegal Option Elective Courses: CRJ-103 Criminal Law , PLG-201 Family Law , PLG-203 Real Estate Law , PLG-204 Wills, Estates and Trusts , PLG-299 Paralegal Internship , PLG-105 Practical Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1699",
+      "total_credits": 17,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Computer Elective Choose one CIT course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Social Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one LIT course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work VMA-104 is strongly recommended due to the extensive diagram drawing involved in solving physics problems.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one LIT course.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective Choose a course from the General Education Community and Cultural Context Menu",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Radiography Option Part-time, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1647",
+      "total_credits": 5,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend a mandatory Information session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MATH College Algebra or Statistics Completion of any 3 credit College Algebra or Statistics course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "TEAS Complete the Test of Essential Academic Skills (TEAS) Allied Health",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Work Transfer, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1737",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work *",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Mathematics Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Registered Nursing Program: Day/Alternative Options, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1648",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend mandatory information session, must have attended in the last year.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "TEAS Complete the ATI Test of Essential Academic Skills (TEAS) Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Chem One year of high school chemistry with lab or one semester of college chemistry with lab *",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math MAT-097 Foundations of Algebra or placement above MAT 097 *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving Statistics is recommended.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Political Science Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1631",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities or Fine Arts Elective This course satisfies Learning Communities requirement.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Approved PSC 200-level course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Natural or Physical Science Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities and Fine Arts Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities and Fine Arts Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1629",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Natural & Physical Sciences OR Humanities & Fine Arts OR Behavioral & Social Sciences *",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one LIT course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1628",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Natural & Physical Sciences OR Humanities & Fine Arts OR Behavioral & Social Sciences *",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective A Social Science elective is highly recommended in order to comply with Mass Transfer guidelines.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning *",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Psychology Elective Elective Options: PSY-201 Learning and Memory , PSY-203 Psychology of Personal Adjustment , PSY-215 Counseling , PSY-223 Personality , PSY-227 Abnormal Psychology , PSY-233 Intro to Psychiatric Rehabilitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective Sequence courses in a foreign language starting at 102 levels are highly recommended as most four-year colleges require intermediate proficiency in a foreign language.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Liberal Arts Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Lab Science Elective",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Psychology Elective Elective Options: PSY-201 Learning and Memory , PSY-203 Psychology of Personal Adjustment , PSY-215 Counseling , PSY-223 Personality , PSY-227 Abnormal Psychology , PSY-233 Intro to Psychiatric Rehabilitation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective Sequence courses in a foreign language starting at 102 levels are highly recommended as most four-year colleges require intermediate proficiency in a foreign language.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Humanities Elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Literature Elective Choose one LIT course",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Sport Management Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1671",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Surgical Technology Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1732",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend Mandatory information session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Test Take College Placement Test",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4 Fall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5 Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Studio Arts Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1715",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Satisfies Learning Community Requirement",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Spring only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Fall only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Career Elective Choose one VMA course not already required for the program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Spring Only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Spring only",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Choose one VMA course not already required for the program.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre Concentration, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1658",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Theatre Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral or Social Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CCC Community & Cultural Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Behavioral or Social Science Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Theatre Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Design Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1714",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Satisfies the Learning Community Requirement",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Pre/Co requisite for VMA-232 Visual Design Lab I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This course provides important skills needed to succeed in core courses.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This course provides important skills needed to succeed in core courses.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Prerequisite for VMA-233 Visual Design Lab II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Career Elective * Career Elective Courses: VMA-103 , VMA-118 , VMA-130 , VMA-140 , VMA-205 , VMA-207 , VMA-261 , VMA-262 , VMA-299 , INT-299AHC",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Career Elective * Career Elective Courses: VMA-103 , VMA-118 , VMA-130 , VMA-140 , VMA-205 , VMA-207 , VMA-261 , VMA-262 , VMA-299 , INT-299AHC",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Development Option, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1690",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -QPS Quantitative Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -SR Scientific Reasoning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -CW Creative Work *",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective Career Elective Options: VMA-132 Typography I, Form, Style, & Hierarchy , CMT-299 Web Development Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "GenEd -E General Education Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Information Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1659",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective Choose Concentration Elective from: ACC-202 Intermediate Accounting II , ACC-207 Cost Accounting , ACC-203 Personal Income Tax , FIN-106 Introduction to Corporate Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective Choose Concentration Elective from: ACC-202 Intermediate Accounting II , ACC-207 Cost Accounting , ACC-203 Personal Income Tax ,FIN-106 Introduction to Corporate Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Central Processing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1650",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend mandatory information session",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Test Complete the College Placement Test",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1738",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Baking and Pastry Arts Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1741",
+      "total_credits": 14,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Certified Nursing Assistant/Patient Care Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1636",
+      "total_credits": 8,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This is a day course taken in person on the Chelsea Campus. This is a 7-week course 100% attendance is mandatory in accordance with the Department of Public Health regulation for taking the state certification exam. Must achieve a B- or higher.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must be taken before or during this semester.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "This is a 7 week day course, in person on the Chelsea campus. 100% attendance is mandatory. The student must show proficiency in all skills to participate in a clinical practicum. The student must achieve a B- or higher.",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Data Analytics Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1677",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data Management (Fast-Track) Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1679",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1663",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Development Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1695",
+      "total_credits": 10,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Excel Applications Support Specialist Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1681",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Protection and Safety Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1693",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Career Elective * Choose from the following options: FPS-125 Hazardous Materials Chemistry , FPS-127 Fire Protection Hydraulics and Water Supply , FPS-221 Strategy and Tactics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geographic Information Systems Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1742",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health IT Systems Support Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1683",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hotel and Restaurant Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1724",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Spring course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "IT Support Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1734",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1634",
+      "total_credits": 13,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend Mandatory information session",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective Choose one college-level course. Recommended: College Writing 1 (ENG-111 ); Principles of Sociology (SOC-101 ); Human Biology/Lab (BIO-108 ).",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Magnetic Resonance (MR) Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1643",
+      "total_credits": 6,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Microsoft Applications Support Specialist Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1669",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1645",
+      "total_credits": 7,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma High School diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend Mandatory information session",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking and Security Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1733",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Object Oriented Computer Programming and Design Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1704",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Department strongly recommends students complete CSC-239 with a B- or higher.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "May need department chair approval if taking at the same time as CSC-285 and CSC-284 .",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paraeducator Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1739",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1718",
+      "total_credits": 15,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective Paralegal Option Electives: PLG-201 Family Law , PLG-203 Real Estate Law , CRJ-103 Criminal Law , PLG-204 Wills, Estates and Trusts , PLG-105 Practical Legal Writing , PLG-299 Paralegal Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective Paralegal Option Electives: PLG-201 Family Law , PLG-203 Real Estate Law , CRJ-103 Criminal Law , PLG-204 Wills, Estates and Trusts , PLG-105 Practical Legal Writing , PLG-299 Paralegal Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective Paralegal Option Electives: PLG-201 Family Law , PLG-203 Real Estate Law , CRJ-103 Criminal Law , PLG-204 Wills, Estates and Trusts , PLG-105 Practical Legal Writing , PLG-299 Paralegal Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective- Concentration Elective Paralegal Option Electives: PLG-201 Family Law , PLG-203 Real Estate Law , CRJ-103 Criminal Law , PLG-204 Wills, Estates and Trusts , PLG-105 Practical Legal Writing , PLG-299 Paralegal Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1637",
+      "total_credits": 8,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Must complete with B- or better",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sport Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1670",
+      "total_credits": 12,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Elective Elective Options: ACC-101 Principles of Accounting I , FIN-112 Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Pharmacy Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1649",
+      "total_credits": 16,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Admission Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Diploma Possess a High School Diploma or GED",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Session Attend a mandatory Information session",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Human Services Work Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1633",
+      "total_credits": 9,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective - Career Elective Career Elective Options: PSY-233 Intro to Psychiatric Rehabilitation , HSV-215 Introduction to Substance Abuse Counseling , HSV-219 Current Issues for the Community Health Worker , AHE-104 Understd Hum Beh for Health Care Prof, Behavior for the Health Care Professional",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Development Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.bhcc.edu/preview_program.php?catoid=15&poid=1689",
+      "total_credits": 3,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ma/programs/hcc.json
+++ b/data/ma/programs/hcc.json
@@ -1,0 +1,8588 @@
+{
+  "college_slug": "hcc",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.hcc.edu",
+  "scraped_at": "2026-05-07T03:23:13.096Z",
+  "programs": [
+    {
+      "title": "Mass Transfer Block General Education Requirements",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1576",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "ENGLISH COMPOSITION: 6 CREDITS",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SOCIAL SCIENCES: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "HUMANITIES / FINE AND PERFORMING ARTS: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "MATHEMATICS: 3-4 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "NATURAL & PHYSICAL SCIENCES: 8 CREDITS",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology Option, Arts and Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1499",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 15 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 19-20 CREDITS",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 11-12 credits from the following:1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "BIO 229(E) - Microbiology Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "BIO 230(E) - Ecology Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Applied Technology Option, Liberal Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1481",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23-24 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 36-38 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-62 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Behavioral Neuroscience Transfer Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1591",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 37 CREDITS",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 61 CREDITS",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1500",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 30 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 32",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 8 CREDITS",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 62 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Accounting, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1493",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "170",
+              "title": "Mathematics for Business Decisions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 36 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "205",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Federal Income Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Certified Bookkeeper Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Spreadsheets",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "211",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 3 from the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "113",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "114",
+              "title": "Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Introduction to Digital Assets and Cryptocurrency",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 62 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Business Administration Mass Transfer Option, Business Administration, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1503",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 32 CREDITS",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 30-31 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "205",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "111",
+              "title": "Computer Concepts with Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "211",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62-63 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Option, Business Administration, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1598",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23-24 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "170",
+              "title": "Mathematics for Business Decisions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 27 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "211",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 3 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "113",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "114",
+              "title": "Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Introduction to Digital Assets and Cryptocurrency",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "GENERAL ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 62-63 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Chemistry Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1504",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 36 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 8 CREDITS",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 16 CREDITS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemistry Option, Arts and Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1608",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 30 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 20 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 10 CREDITS",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1485",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Fundamentals of Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "113",
+              "title": "Journalism I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "141",
+              "title": "Practicum in Communication, Media, or Theater Arts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "142",
+              "title": "Practicum in Journalism",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "218",
+              "title": "Voice and Diction",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 4 CREDITS",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication, Media & Theater Arts Integrated Studies (CMTA) Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1486",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 21 CREDITS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COM or THE Elective Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COM or THE Elective Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COM or THE Elective Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COM or THE Elective Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COM or THE Elective Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "COM or THE Elective Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL ELECTIVES: 4 CREDITS",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Child and Family Studies, Liberal Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1580",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23-24 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 41",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 15 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DVD",
+              "number": "110",
+              "title": "Introduction to Developmental Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "208",
+              "title": "Inclusionary Practice in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "141",
+              "title": "Foundations of Trauma and Trauma Informed Care/Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL ELECTIVES: 22 CREDITS",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Computer Science Option, Computer Information Systems, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1585",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 31 CREDITS",
+          "credits_required": 31,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSI",
+              "number": "106",
+              "title": "Programming Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "111",
+              "title": "Computer Concepts with Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "218",
+              "title": "Programming Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "242",
+              "title": "Applied Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "254",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "258",
+              "title": "Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 6-8 CREDITS",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSI",
+              "number": "105",
+              "title": "Principles of Information Security and Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "121",
+              "title": "Foundations of Linux",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "214",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "251",
+              "title": "Network Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "264",
+              "title": "Disaster Recovery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 63-65 CREDITS",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Creative Writing Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1536",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26-27 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 18 CREDITS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "200 Level English Literature Course Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CMTA (Communication, Media, Theater) Elective Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "CMTA (Communication, Media, Theater) Elective Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 16 CREDITS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1535",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 21 CREDITS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "103",
+              "title": "Introduction to Corrections",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "112",
+              "title": "Criminal Law and Procedure",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "230",
+              "title": "Capstone in Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 15 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select 2 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "278",
+              "title": "Social Sciences Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Critical Social Thought Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1597",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 32",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 21 CREDITS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 6 credits of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL ELECTIVES: 4 CREDITS",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security & Digital Forensics Option, Computer Information Systems, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1584",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 27 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "105",
+              "title": "Principles of Information Security and Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "106",
+              "title": "Programming Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "111",
+              "title": "Computer Concepts with Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "121",
+              "title": "Foundations of Linux",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "242",
+              "title": "Applied Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "251",
+              "title": "Network Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "264",
+              "title": "Disaster Recovery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62-63 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts, Applied Science, A.A.S.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1590",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "SEMESTER ONE: 15 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Culinary Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "101",
+              "title": "Culinary Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "104",
+              "title": "Professional Standards for the Food Service Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "111",
+              "title": "Sanitation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "114",
+              "title": "Baking and Pastry Arts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "116",
+              "title": "Mise En Place",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER TWO: 15 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "107",
+              "title": "Pantry and Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "108",
+              "title": "Stocks, Soups, and Sauces",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "109",
+              "title": "Entree Preparation and Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "113",
+              "title": "Introduction to Food Service Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "214",
+              "title": "Baking and Pastry Arts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Culinary Explorations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER THREE: 14 CREDITS",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "112",
+              "title": "Dining Room Service: Theory and Application",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "203",
+              "title": "Nutrition for Food Service Professionals",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "281",
+              "title": "Culinary Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SEMESTER FOUR: 17 CREDITS",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "215",
+              "title": "Food Service Cost Control",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "280",
+              "title": "Advanced Culinary Service Techniques",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "291",
+              "title": "Food Styling and Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 61 CREDITS",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education, Grades PreK-2, Early Childhood Education, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1532",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 32",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 32",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 43",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 25 CREDITS",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Introduction to Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "120",
+              "title": "Guiding Children&#039;s Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "175",
+              "title": "MTEL-CLS Test Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "208",
+              "title": "Inclusionary Practice in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Curriculum in Early Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "213",
+              "title": "Student Teaching Practicum and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Deaf Studies Option, Arts and Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1534",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26-27 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 30 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFS",
+              "number": "110",
+              "title": "Lived Experiences in the Deaf World",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFS",
+              "number": "210",
+              "title": "Introduction to ASL/English Interpreting",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "GENERAL ELECTIVE: 0-1 CREDITS",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Data Science Option, Mathematics, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1605",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 25 CREDITS",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSI",
+              "number": "106",
+              "title": "Programming Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "242",
+              "title": "Applied Database Management",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSI",
+              "number": "111",
+              "title": "Computer Concepts with Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "218",
+              "title": "Programming Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "258",
+              "title": "Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 63 CREDITS",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Education and Care Option, Birth-Age 8, Early Childhood Education, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1581",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 34-36 CREDITS",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Introduction to Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "118",
+              "title": "Practicum in Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "213",
+              "title": "Student Teaching Practicum and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "120",
+              "title": "Guiding Children&#039;s Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Health, Safety, and Nutrition for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "208",
+              "title": "Inclusionary Practice in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "209",
+              "title": "Early Intervention and Inclusion: Birth to age 5",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Curriculum in Early Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "217",
+              "title": "Infant and Toddler Development, Learning, and Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "141",
+              "title": "Foundations of Trauma and Trauma Informed Care/Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-62 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Education - Elementary Education Option, Grades 1-6, Liberal Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1530",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 32",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 44",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 19 CREDITS",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "120",
+              "title": "Guiding Children&#039;s Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "175",
+              "title": "MTEL-CLS Test Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "208",
+              "title": "Inclusionary Practice in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "260",
+              "title": "Foundations of Teaching and Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "271",
+              "title": "Introduction to Teaching Reading and Writing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 6 CREDITS",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "276",
+              "title": "Education Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "141",
+              "title": "Foundations of Trauma and Trauma Informed Care/Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Engineering Option, Engineering Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1528",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 20 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 27 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any 4-credit BIO course Credit(s): 42",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "109",
+              "title": "Introduction to Electronic Digital Circuits with Verilog",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "117",
+              "title": "Introduction to Engineering with Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "221",
+              "title": "Mechanics I - Statics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12-24 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Mechanical, Civil or Industrial Engineering: 13-14 Credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 3 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "203",
+              "title": "Introduction to Materials Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "222",
+              "title": "Mechanics II - Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "223",
+              "title": "System Analysis (Circuit Analysis I)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "250",
+              "title": "Thermodynamics",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Electrical Engineering or Computer Systems: 23-24 Credits",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "118",
+              "title": "Introduction to Programming For Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "223",
+              "title": "System Analysis (Circuit Analysis I)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "203",
+              "title": "Introduction to Materials Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "222",
+              "title": "Mechanics II - Strength of Materials",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Engineering: 12 Credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "GENERAL ELECTIVE: 0-2 CREDITS",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-71 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Education - Secondary Education Option, Grades 5-12 and Specializations, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1529",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 33",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 33",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-44",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 14 CREDITS",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "175",
+              "title": "MTEL-CLS Test Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "208",
+              "title": "Inclusionary Practice in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "276",
+              "title": "Education Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Arts and Science Elective Credit(s): 35",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 61-62 CREDITS",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "English Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1526",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 of the following: literature elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "SPA 214(C) - The Spanish Short Story Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following: literature/journalism/creative writing elective",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "Journalism I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "113",
+              "title": "Journalism I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG 208(C) - Latinx Literature Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "LAX 208(C) - Latinx Literature Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG 224(C) - Children’s Literature Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "ENG 235(C) - African-American Literature Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "GENERAL ELECTIVES: 4 CREDITS",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Science Option, Engineering Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1527",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 20 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 16 CREDITS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "109",
+              "title": "Introduction to Electronic Digital Circuits with Verilog",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "117",
+              "title": "Introduction to Engineering with Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "118",
+              "title": "Introduction to Programming For Engineers",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 20-24 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Chemistry Course(s) Credit(s): 4-12 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Engineering Course(s) Credit(s): 3-12 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Course(s) Credit(s): 3-12 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Biology Course(s) Credit(s): 4-12",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Environmental Science Course(s) Credit(s): 3-12",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Sustainability Course(s) Credit(s) 4-12 5",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL ELECTIVES: 0-4 CREDITS",
+          "credits_required": 0,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-64 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Science Field Technician Option, Environmental Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1545",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 20 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 36-37 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "Environmental Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "125",
+              "title": "Mapping with Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "230",
+              "title": "Principles of Environmental Site Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "270",
+              "title": "Environmental Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-42",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 4 CREDITS",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Integrated Studies Option, Liberal Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1482",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23-24 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credits(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "​Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 36-37 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Environmental Science Transfer Option, Environmental Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1514",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 20 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 39-41 CREDITS",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "115",
+              "title": "Environmental Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "125",
+              "title": "Mapping with Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "230",
+              "title": "Principles of Environmental Site Assessment",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-41",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-41",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 6-8 CREDITS",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 65-69 CREDITS",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Foundations of Health, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1524",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 42",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 42",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 13 CREDITS",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTH",
+              "number": "101",
+              "title": "Introduction to Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "101",
+              "title": "Introduction to Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 44",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12-15 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DVD",
+              "number": "110",
+              "title": "Introduction to Developmental Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "141",
+              "title": "Foundations of Trauma and Trauma Informed Care/Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTH",
+              "number": "114",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTH",
+              "number": "202",
+              "title": "Epidemiology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 60-64 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science:Natural Resources Studies Transfer Option, Environmental Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1589",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 30 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any HIS elective Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 30 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "125",
+              "title": "Mapping with Geographic Information Systems",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 4 CREDITS",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 64 CREDITS",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphics Option, Visual Art, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1489",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26-27 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "252",
+              "title": "Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "256",
+              "title": "Digital Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "263",
+              "title": "Graphic Design Foundations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "257",
+              "title": "Digital Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "264",
+              "title": "Introduction to Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "265",
+              "title": "Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "266",
+              "title": "Interactive Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62-63 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resource Management Option, Business Administration, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1570",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "170",
+              "title": "Mathematics for Business Decisions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 33 CREDITS",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "211",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "218",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "231",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Select 3 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "113",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "114",
+              "title": "Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Introduction to Digital Assets and Cryptocurrency",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 62 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Technology Management Option, Computer Information Systems, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1568",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 27-28 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSI",
+              "number": "106",
+              "title": "Programming Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "111",
+              "title": "Computer Concepts with Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "121",
+              "title": "Foundations of Linux",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "214",
+              "title": "Systems Analysis and Design",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "242",
+              "title": "Applied Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "251",
+              "title": "Network Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "218",
+              "title": "Programming Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "254",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62-64 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Human Services, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1519",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-41",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 16 CREDITS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "113",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "122",
+              "title": "Diversity and Social Justice for the Service Practitioner",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "123",
+              "title": "Helping Skills, Techniques, and Ethics in Human Services and Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "288",
+              "title": "Practicum in Human Services I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 12-13 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DVD",
+              "number": "110",
+              "title": "Introduction to Developmental Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DVD",
+              "number": "210",
+              "title": "Current Issues in Developmental Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Health, Safety, and Nutrition for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "208",
+              "title": "Inclusionary Practice in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTH",
+              "number": "101",
+              "title": "Introduction to Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "101",
+              "title": "Introduction to Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any HSV, PSY, or SOC course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any HSV, PSY, or SOC course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any HSV, PSY, or SOC course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any HSV, PSY, or SOC course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 63-65 CREDITS",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Latinx Studies Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1583",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "278",
+              "title": "Humanities Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "278",
+              "title": "Social Sciences Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "113",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "122",
+              "title": "Diversity and Social Justice for the Service Practitioner",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAX",
+              "number": "111",
+              "title": "Introduction to Community Organizing",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL ELECTIVES: 3-4 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing Option, Business Administration, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1518",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "170",
+              "title": "Mathematics for Business Decisions",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 36 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Spreadsheets",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "211",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "110",
+              "title": "Retailing and e-Commerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "226",
+              "title": "Advertising and Promotion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "227",
+              "title": "Sales and Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 3 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "113",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "114",
+              "title": "Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Introduction to Digital Assets and Cryptocurrency",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "278",
+              "title": "Internship in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Fundamentals of Video",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "235",
+              "title": "Entrepreneurship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Liberal Arts and Science Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1483",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 19 CREDITS",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "GENERAL ELECTIVES: 6 CREDITS",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "INTEGRATIVE LEARNING REQUIREMENT: 6 CREDITS",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Mathematics Option, Arts and Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1604",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 20 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 14-16 CREDITS",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSI",
+              "number": "106",
+              "title": "Programming Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "218",
+              "title": "Programming Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "254",
+              "title": "Java Programming I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "258",
+              "title": "Data Structures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "118",
+              "title": "Introduction to Programming For Engineers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Additional Engineering",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 60-62 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1556",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26-27 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 38 CREDITS",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Aural Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Aural Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "233",
+              "title": "Aural Skills III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "234",
+              "title": "Aural Skills IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "135",
+              "title": "Class Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "136",
+              "title": "Class Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "237",
+              "title": "Class Piano III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "238",
+              "title": "Class Piano IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "171",
+              "title": "Applied Music for Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "172",
+              "title": "Applied Music for Majors II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "273",
+              "title": "Applied Music for Majors III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "274",
+              "title": "Applied Music for Majors IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "161",
+              "title": "College Chorale I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "162",
+              "title": "College Chorale II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "263",
+              "title": "College Chorale III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "264",
+              "title": "College Chorale IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3-4 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 67-69 CREDITS",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1557",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 30 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NTR",
+              "number": "101",
+              "title": "Introduction to Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 40 CREDITS",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "170",
+              "title": "Fundamentals of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "180",
+              "title": "Health Promotion and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "270",
+              "title": "Acute Care Across the Lifespan",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "280",
+              "title": "Complex Care Across the Lifespan",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "282",
+              "title": "Role Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "171",
+              "title": "Pharmacology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "181",
+              "title": "Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "271",
+              "title": "Pharmacology III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "281",
+              "title": "Pharmacology IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 70 CREDITS",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Physics Mass Transfer Option, Arts and Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1547",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 36 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 8 CREDITS",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 16 CREDITS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any 4-Credit BIO Course Credit(s): 4 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any CHM Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any CSI Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any EGR Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any 4-Credit Physical Science Course Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics General Transfer Option, Arts and Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1546",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 20 CREDITS",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 12 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 28 CREDITS",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any BIO Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any CHM Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any CSI Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any EGR Course",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1561",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 36 CREDITS",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 15 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "SUGGESTED ELECTIVES: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1559",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 37 CREDITS",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 12-15 CREDITS",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1-3 of the following:2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 0-2 of the following:2",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3-6 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "GENERAL ELECTIVES: 5 CREDITS",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Radiologic Technology, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1560",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 27 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTH",
+              "number": "114",
+              "title": "Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 41 CREDITS",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RDL",
+              "number": "102",
+              "title": "Radiographic Positioning and Patient Care Lab 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "103",
+              "title": "Radiographic Positioning and Patient Care Lab 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "115",
+              "title": "Introduction to the Radiologic Sciences and Patient Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "122",
+              "title": "Radiation Physics, Instrumentation, and Image Production 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "123",
+              "title": "Radiation Physics, Instrumentation, and Image Production 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "132",
+              "title": "Radiographic Procedures and Related Anatomy 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "133",
+              "title": "Radiographic Procedures and Related Anatomy 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "141",
+              "title": "Clinical Education 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "142",
+              "title": "Clinical Education 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "202",
+              "title": "Radiologic Technology Seminar 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "203",
+              "title": "Radiologic Technology Seminar 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "221",
+              "title": "Radiation Physics, Instrumentation, and Image Production 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "223",
+              "title": "Radiation Physics, Instrumentation, and Image Production 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "233",
+              "title": "Advanced Radiographic Procedures",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "234",
+              "title": "Radiobiology and Radiation Protection",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "241",
+              "title": "Clinical Education 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "242",
+              "title": "Clinical Education 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RDL",
+              "number": "251",
+              "title": "Clinical Internship",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 68 CREDITS",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theater Arts Option, Arts and Science, A.A.",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1539",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 19 CREDITS",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THE",
+              "number": "141",
+              "title": "Practicum in Theater Arts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "142",
+              "title": "Practicum in Theater Arts II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 8 CREDITS",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THE",
+              "number": "120",
+              "title": "Movement for Actors",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "181",
+              "title": "Musical Theater Workshop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "182",
+              "title": "Musical Theater Workshop II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "210",
+              "title": "Acting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "218",
+              "title": "Voice and Diction",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "243",
+              "title": "Practicum in Theater Arts III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "244",
+              "title": "Practicum in Theater Arts IV",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62-63 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sport Management, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1549",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 32 CREDITS",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 30 CREDITS",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPO",
+              "number": "110",
+              "title": "Introduction to Sport Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPO",
+              "number": "211",
+              "title": "Sport Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "231",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "226",
+              "title": "Advertising and Promotion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "227",
+              "title": "Sales and Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 62 CREDITS",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Veterinary Technician Option, Veterinary & Animal Science, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1538",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 23 CREDITS",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 31",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "130",
+              "title": "Veterinary Math",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 44 CREDITS",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "140",
+              "title": "Principles of Animal Health Care",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "145",
+              "title": "Veterinary Medical Terminology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "147",
+              "title": "Veterinary Practice Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "153",
+              "title": "Animal Diseases",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "160",
+              "title": "Veterinary Laboratory Procedures I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "165",
+              "title": "Veterinary Laboratory Procedures II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "202",
+              "title": "Animal Science Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "247",
+              "title": "Animal Nursing I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "248",
+              "title": "Animal Nursing II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "258",
+              "title": "Clinical Competency for Veterinary Technicians",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "261",
+              "title": "Animal Facilities Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "263",
+              "title": "Exotic Pets",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "264",
+              "title": "Veterinary Pharmacology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "265",
+              "title": "Veterinary Radiology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "268",
+              "title": "Reproduction and Large Animal Medicine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "282",
+              "title": "Externship for Veterinary Technicians I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "283",
+              "title": "Externship for Veterinary Technicians II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 67 CREDITS",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "University Without Walls Option, Liberal Studies, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1484",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 35-36 CREDITS",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective (C) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-42",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "GENERAL ELECTIVES: 13 CREDITS",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Visual Art, A.S.",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1491",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "GENERAL EDUCATION REQUIREMENTS: 26-27 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective (B) Credit(s): 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Mathematics Elective (D) Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective (E) Credit(s): 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM REQUIREMENTS: 21 CREDITS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 13 CREDITS",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 60-61 CREDITS",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1582",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Computerized Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Intermediate Accounting I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "205",
+              "title": "Managerial Accounting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Federal Income Taxation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Certified Bookkeeper Preparation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "113",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Spreadsheets",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 26 CREDITS",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Child Development Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1599",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 18 CREDITS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Semester One: 9 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Introduction to Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "108",
+              "title": "CDA I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Semester Two: 9 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "109",
+              "title": "CDA II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "120",
+              "title": "Guiding Children&#039;s Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Health, Safety, and Nutrition for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 18 CREDITS",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Addiction Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1495",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "113",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "209",
+              "title": "Addiction Prevention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "214",
+              "title": "Adult Addiction Treatment Methodologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "215",
+              "title": "Child and Adolescent Addiction Treatment Methodologies",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "218",
+              "title": "Health Aspects of Addiction and Recovery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1586",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 27 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "105",
+              "title": "Principles of Information Security and Assurance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "106",
+              "title": "Programming Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "111",
+              "title": "Computer Concepts with Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "121",
+              "title": "Foundations of Linux",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "242",
+              "title": "Applied Database Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "251",
+              "title": "Network Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "264",
+              "title": "Disaster Recovery",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 27 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Community Leadership Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1601",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24-25 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Semester One: 12 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAX",
+              "number": "111",
+              "title": "Introduction to Community Organizing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Semester Two: 12-13 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 from the following:1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "278",
+              "title": "Education Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "288",
+              "title": "Practicum in Human Services I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "278",
+              "title": "Humanities Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "278",
+              "title": "Social Sciences Internship",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 1 from the following:",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24-25 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1510",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Semester One: 12 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "100",
+              "title": "Culinary Fundamentals I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "101",
+              "title": "Culinary Fundamentals II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "104",
+              "title": "Professional Standards for the Food Service Industry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "111",
+              "title": "Sanitation and Safety",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "114",
+              "title": "Baking and Pastry Arts I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "116",
+              "title": "Mise En Place",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Semester Two: 12 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "107",
+              "title": "Pantry and Garde Manger",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "108",
+              "title": "Stocks, Soups, and Sauces",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "109",
+              "title": "Entree Preparation and Presentation",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "113",
+              "title": "Introduction to Food Service Operations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "214",
+              "title": "Baking and Pastry Arts II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "290",
+              "title": "Culinary Explorations",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Developmental Disabilities Direct Support Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1511",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 28 CREDITS",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DVD",
+              "number": "110",
+              "title": "Introduction to Developmental Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DVD",
+              "number": "210",
+              "title": "Current Issues in Developmental Disabilities",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "113",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "122",
+              "title": "Diversity and Social Justice for the Service Practitioner",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "123",
+              "title": "Helping Skills, Techniques, and Ethics in Human Services and Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "288",
+              "title": "Practicum in Human Services I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "141",
+              "title": "Foundations of Trauma and Trauma Informed Care/Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 28 CREDITS",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Deaf Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1487",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DFS",
+              "number": "110",
+              "title": "Lived Experiences in the Deaf World",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Resource Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1571",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "211",
+              "title": "Business Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "218",
+              "title": "Employment Law",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "231",
+              "title": "Human Resource Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 3 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "113",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "114",
+              "title": "Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Introduction to Digital Assets and Cryptocurrency",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Early Childhood Education (ECE) Foundational Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1606",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 16 CREDITS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Introduction to Early Childhood",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "118",
+              "title": "Practicum in Early Childhood Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "120",
+              "title": "Guiding Children&#039;s Behavior",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "210",
+              "title": "Curriculum in Early Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "217",
+              "title": "Infant and Toddler Development, Learning, and Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 16 CREDITS",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Graphic Design Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1517",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "252",
+              "title": "Typography",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "256",
+              "title": "Digital Design I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "257",
+              "title": "Digital Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "263",
+              "title": "Graphic Design Foundations",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "264",
+              "title": "Introduction to Motion Graphics",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "265",
+              "title": "Digital Imaging",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "266",
+              "title": "Interactive Design",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mental Health Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1600",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "105",
+              "title": "Crisis Intervention",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "113",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "122",
+              "title": "Diversity and Social Justice for the Service Practitioner",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "123",
+              "title": "Helping Skills, Techniques, and Ethics in Human Services and Social Work",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "141",
+              "title": "Foundations of Trauma and Trauma Informed Care/Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "TOTAL: 27 CREDITS",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1569",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "113",
+              "title": "Introduction to Human Services",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 15-16 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Health, Safety, and Nutrition for Young Children",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "208",
+              "title": "Inclusionary Practice in Education",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTH",
+              "number": "101",
+              "title": "Introduction to Health Careers",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NTR",
+              "number": "101",
+              "title": "Introduction to Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Any course with a DVD, HSV, PSY, or SOC designation Credit(s): 3-4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24-25 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Performance Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1555",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 21 CREDITS",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Aural Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Aural Skills II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "135",
+              "title": "Class Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "136",
+              "title": "Class Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "161",
+              "title": "College Chorale I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "162",
+              "title": "College Chorale II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "171",
+              "title": "Applied Music for Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "172",
+              "title": "Applied Music for Majors II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "*2 credits of sequential instrumental or vocal ensembles",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Orchestra I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Orchestra II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Instrumental &amp; Vocal Ensemble I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122",
+              "title": "Instrumental &amp; Vocal Ensemble II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "127",
+              "title": "Ensemble I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "128",
+              "title": "Ensemble II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Jazz Ensemble I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "142",
+              "title": "Jazz Ensemble II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 3-4 CREDITS",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Jazz Improvisation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "152",
+              "title": "Jazz Improvisation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Music Production and Recording 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "181",
+              "title": "Musical Theater Workshop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "181",
+              "title": "Musical Theater Workshop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "182",
+              "title": "Musical Theater Workshop II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "182",
+              "title": "Musical Theater Workshop II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24-25 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1567",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MGT",
+              "number": "230",
+              "title": "Principles of Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "115",
+              "title": "Computer Applications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Business Communications",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "110",
+              "title": "Retailing and e-Commerce",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "226",
+              "title": "Advertising and Promotion",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "227",
+              "title": "Sales and Customer Service",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "240",
+              "title": "Principles of Marketing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 3 of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Professional Etiquette",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "113",
+              "title": "Ethics in Business",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "114",
+              "title": "Money Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "117",
+              "title": "Introduction to Digital Assets and Cryptocurrency",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 24 CREDITS",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Music Production and Recording Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1607",
+      "total_credits": 24,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 15 CREDITS",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "135",
+              "title": "Class Piano I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "161",
+              "title": "College Chorale I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Music Production and Recording 1",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "183",
+              "title": "Music Production and Recording 2",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 credits of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "191",
+              "title": "Applied Music (Non-Major) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "192",
+              "title": "Applied Music (Non-Major) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "171",
+              "title": "Applied Music for Majors I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "select 2 credits of the following:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Orchestra I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Orchestra II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Instrumental &amp; Vocal Ensemble I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122",
+              "title": "Instrumental &amp; Vocal Ensemble II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "127",
+              "title": "Ensemble I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "128",
+              "title": "Ensemble II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Jazz Ensemble I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "142",
+              "title": "Jazz Ensemble II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "PROGRAM ELECTIVES: 9 CREDITS",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Aural Skills I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "136",
+              "title": "Class Piano II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "Jazz Improvisation I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "152",
+              "title": "Jazz Improvisation II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "162",
+              "title": "College Chorale II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "172",
+              "title": "Applied Music for Majors II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "181",
+              "title": "Musical Theater Workshop I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "191",
+              "title": "Applied Music (Non-Major) I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "192",
+              "title": "Applied Music (Non-Major) II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "293",
+              "title": "Applied Music (Non-Major) III",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "294",
+              "title": "Applied Music (Non-Major) IV",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "181",
+              "title": "Musical Theater Workshop I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1558",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 45 CREDITS",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NTR",
+              "number": "101",
+              "title": "Introduction to Nutrition",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "171",
+              "title": "Pharmacology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "181",
+              "title": "Pharmacology II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "170",
+              "title": "Fundamentals of Nursing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "173",
+              "title": "Practical Nurse Skills Workshop",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "180",
+              "title": "Health Promotion and Maintenance",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "182",
+              "title": "Practical Nurse Role Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "190",
+              "title": "Practical Nurse Acute and Complex Care",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 45 CREDITS",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Veterinary Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.hcc.edu/preview_program.php?catoid=13&poid=1596",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "PROGRAM REQUIREMENTS: 10 CREDITS",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VEA",
+              "number": "110",
+              "title": "Veterinary Assistant I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEA",
+              "number": "182",
+              "title": "Veterinary Assistant Externship I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEA",
+              "number": "112",
+              "title": "Veterinary Assistant II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VEA",
+              "number": "183",
+              "title": "Veterinary Assistant Externship II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "TOTAL: 10 CREDITS",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ma/programs/massbay.json
+++ b/data/ma/programs/massbay.json
@@ -1,0 +1,4294 @@
+{
+  "college_slug": "massbay",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://massbay.catalog.acalog.com",
+  "scraped_at": "2026-05-07T03:23:32.741Z",
+  "programs": [
+    {
+      "title": "General Studies: Automotive Technology All-Brand",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1683",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Automotive Technology Toyota/Lexus",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1651",
+      "total_credits": 73,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3: Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5: Spring",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective or Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology Stellantis (Chrysler)",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1649",
+      "total_credits": 73,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology BMW",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1648",
+      "total_credits": 66,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3: Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "105",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "General Studies: Automotive Technology All-Brand Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1820",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Automotive Technology Toyota/Lexus Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1667",
+      "total_credits": 52,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technology General Motors",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1650",
+      "total_credits": 72,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Accounting: MassTransfer Option",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1630",
+      "total_credits": 66,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Economics Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1629",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Economics Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "General Business: Hospitality Management",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1635",
+      "total_credits": 63,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "General Business",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1634",
+      "total_credits": 66,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Economics Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1631",
+      "total_credits": 68,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "General Business: International Business",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1636",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Sequence 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Business Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Sequence 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1638",
+      "total_credits": 25,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Entrepreneurship Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1641",
+      "total_credits": 26,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Business: Hospitality Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1642",
+      "total_credits": 22,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Advanced Cybersecurity Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1666",
+      "total_credits": 24,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Interior Design Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1643",
+      "total_credits": 27,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Management Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1645",
+      "total_credits": 25,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Marketing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1646",
+      "total_credits": 25,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1632",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Criminal Justice Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Criminal Justice Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science (Lab) Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Criminal Justice Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Criminal Justice Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Liberal Arts: Political Science",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1682",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "&",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "&",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "&",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Paralegal Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1647",
+      "total_credits": 27,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1637",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Economics Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math/ Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts: Elementary Education",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1627",
+      "total_credits": 63,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1633",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credits / Units: 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective Credits / Units: 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Liberal Arts: Early Childhood Education",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1626",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education: Infant-Toddler Teacher Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1640",
+      "total_credits": 18,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Liberal Arts: Behavioral Health",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1690",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective Credits / Units: 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Human Services: Direct Support Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1679",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services: Substance Abuse Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1681",
+      "total_credits": 28,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts: Human Services",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1628",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Language Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective** 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective** 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Laboratory Science (4 credit) and Science Elective:",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Behavioral Health Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1692",
+      "total_credits": 25,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Human Services Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1644",
+      "total_credits": 25,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Emergency Medical Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1615",
+      "total_credits": 8,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedicine - Day Option Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1616",
+      "total_credits": 37,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedicine - Evening Option Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1617",
+      "total_credits": 37,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology - Flex Option,",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1613",
+      "total_credits": 78,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1612",
+      "total_credits": 78,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Central Processing Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1614",
+      "total_credits": 4,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1684",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Year: Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computed Tomography Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1678",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Skills Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1618",
+      "total_credits": 6,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(6 weeks)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(6 weeks)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1691",
+      "total_credits": 20,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(15-weeks Hybrid) Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing - Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1619",
+      "total_credits": 44,
+      "gpa_minimum": 2.5,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Coding Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1686",
+      "total_credits": 27,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - AS - Advanced Placement",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1687",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1 (Winter Intersession)",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Before or During Program:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Must be taken before entry to ADN)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(before second semester of ADN AP program)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing -",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1611",
+      "total_credits": null,
+      "gpa_minimum": 2.5,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1685",
+      "total_credits": 26,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Administrative Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1610",
+      "total_credits": 26,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1621",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math/Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Laboratory Science Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1622",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Sequence 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Sequence 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Laboratory Science Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: English",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1674",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "English Concentration Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "English Concentration Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "English Concentration Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "English Concentration Elective:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or any college-level English, Communication or Literature course",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Laboratory Science Elective:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "BI 216 Anatomy and Physiology I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Psychology/Sociology",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1624",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Science Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Communication",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1623",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Laboratory Science Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1655",
+      "total_credits": 68,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1 or 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Information Systems",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1654",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1677",
+      "total_credits": 64,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities/Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Systems Technology & Management: Management Concentration",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1662",
+      "total_credits": 63,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Networking Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1680",
+      "total_credits": 27,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Optional)*",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1670",
+      "total_credits": 26,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Information Systems Technology & Management: Technology Concentration",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1663",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cybersecurity Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1669",
+      "total_credits": 17,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Technology Support Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1671",
+      "total_credits": 25,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Developer Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1673",
+      "total_credits": 26,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Life Sciences",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1664",
+      "total_credits": 60,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Requirement 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Physics Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Advanced Laboratory Science Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Computer Science Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Advanced Laboratory Science Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Sciences & Safety",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1659",
+      "total_credits": 63,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Math Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective or Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies: Science",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1660",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Computer Science Elective 3/4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Sequence 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Sequence 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Electrical & Computer Engineering",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1656",
+      "total_credits": 66,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Credits / Units: 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "General Studies: Mathematics",
+      "credential": "AA",
+      "program_code": "AA",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1661",
+      "total_credits": 66,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "History Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Sequence 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Laboratory Science Sequence 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Literature Sequence 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "History Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Laboratory Science Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Literature Sequence:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "and",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Engineering",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1658",
+      "total_credits": 62,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective Credits / Units: 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Civil/Environmental Engineering:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(UMass Lowell-Civil Engineering)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(UMass Lowell)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Northeastern University)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Northeastern University-Civil Engineering)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Wentworth Institute of Technology)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Chemical Engineering:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Northeastern University)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Biomedical Engineering:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Wentworth Institute of Technology and Northesatern University)",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Wentworth Institute of Technology)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Design",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1657",
+      "total_credits": 61,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical and Industrial Engineering",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1665",
+      "total_credits": 71,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Career Pathway Elective 3/4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Career Pathway Electives:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "110",
+              "title": "",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Computer-Aided Design (CAD) Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1668",
+      "total_credits": 20,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Innovation Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1676",
+      "total_credits": 24,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 1",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "2 or more program electives required.",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "MN 201 CO-OP DIALOGUE (optional) 1 credit",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Manufacturing Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1675",
+      "total_credits": 24,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Coding Electives(s) 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Program Elective 4 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1652",
+      "total_credits": 66,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Computer Science Elective Credits / Units: 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Sciences Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Biotechnology: Genomics & Biomanufacturing",
+      "credential": "AS",
+      "program_code": "AS",
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1653",
+      "total_credits": 67,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Computer Science Elective Credits / Units: 3/4",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Humanities Electives 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3 Credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "Social Science Elective 3",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Year: Summer",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "OR",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Biomanufacturing Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massbay.catalog.acalog.com/preview_program.php?catoid=15&poid=1689",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ma/programs/stcc.json
+++ b/data/ma/programs/stcc.json
@@ -1,0 +1,2638 @@
+{
+  "college_slug": "stcc",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.stcc.edu",
+  "scraped_at": "2026-05-07T03:23:26.463Z",
+  "programs": [
+    {
+      "title": "Building Automation - ESBA.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7576",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 20 credits",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art - FINE.AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7447",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Psychology - APSY.AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7573",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Architecture and Building Technology - ARBT.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7446",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EL SOC - General Behavioral/Social Science Elective 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology Transfer - BIOL.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7468",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Building Construction Management - PMGT.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7534",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EL SOC - General Behavioral/Social Science Elective 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Advanced Manufacturing Technology - MECH.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7529",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemistry Transfer - CHEM.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7474",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business - BUSN.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7470",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Communication and Digital Media Transfer CDMT.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7564",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Transfer - CSCI.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7478",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12-13 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Business Transfer - BTCM.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7471",
+      "total_credits": null,
+      "gpa_minimum": 3,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice Transfer CRJT.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7565",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice - LECJ.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7521",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Systems Engineering Tech - CSET.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7479",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Cybersecurity - CITS.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7477",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dental Hygiene - DHYG.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7495",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Transfer - ECTR.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7568",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Digital Media Production Technology - TPRD.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7555",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Medical Sonography - DMIS.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7548",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Investigation Transfer - FITR.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7578",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Photography - DPHO.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7497",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Systems Technology - ENGY.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7503",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Foundations of Nursing - FOUN.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7583",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "General Studies - LTGS.AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7511",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EL-GEN - General Elective 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Electrical Engineering Technology - ELEC.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7501",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "English Communication and Professional Writing Transfer - ENGL.AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7580",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Select one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Note 1)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Select one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Note 1)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Select one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "(Note 1)",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Protection and Safety Technology - FIRE.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7510",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Transfer - ENGR.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7504",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EL-ENG - Engineering & Science Transfer 3 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-17 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Health Information Technology - HIIM.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7558",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16-18 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Graphic Design - CART.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7512",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Science - HLTH.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7571",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13-15 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services/Social Work - HSSW.AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7526",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Select one:",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "or",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Total: 15-16 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Landscape Design and Management Technology Transfer - LANT.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7519",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Mathematics Transfer - MATH.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7528",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant - MAST.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7530",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Interactive Media and Animation Design Technology - MLTD.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7533",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing - NURS.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7535",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Landscape Design and Management Technology - LAND.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7518",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 19-20 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Occupational Therapy Assistant - OCCP.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7536",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Administrative Assistant Professional - OAAP.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7541",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing (Accelerated) - NURA.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7584",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 30 Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 8 credits",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 1 credit",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Coding and Billing Specialist - MCBS.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7531",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics Transfer - PHYS.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7539",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 18 credits",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12-13 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant - PTAS.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7538",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programmer - PROG.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7542",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16-17 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17-18 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology - DMIR.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7544",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 6 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Laser Optics Technology - LEOT.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7520",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technician - CLLS.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7476",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 19 credits",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 22 credits",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 1 credit",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 11 credits",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 3 credits",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Care - RSPC.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7545",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 10 credits",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences Transfer - SOSC.AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7581",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology - SURG.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7550",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 17 credits",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 4 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Building Construction Management - BCMT.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7569",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Alcohol and Drug Counseling - HSSW.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7582",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Design - ARCH.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7508",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Teacher Education Transfer - Elementary - EDEL.AA",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7551",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "STEM Studies - STEM.AS",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7585",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Clerical Office Assistant - CLER.CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7498",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "CNC Operations - CNCO.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7493",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12-13 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Systems Engineering Tech - CSET.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7490",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1-2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELEC",
+              "number": "XXX",
+              "title": "EL-CSE - Computer Systems Engineering Elective 4 credits",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Dental Assistant - DAST.CRT",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7487",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 9 credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice - LECJ.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7461",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 27 credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Cybersecurity - CITS.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7562",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Digital Media - ACMM.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7454",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Select three (9 credits):",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology - FIRE.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7482",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 27 credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education - CDA.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7575",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Heating/Ventilation/Air Conditioning - ENGY.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7465",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Landscape Design & Management Technology - LAND.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7464",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 13-14 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Electrical/Robotics Technology - EROB.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7484",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Photography - DPHO.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7486",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding and Billing Specialist - MEDC.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7458",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design - DPUB.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7485",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Administrative Assistant - MOAA.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7457",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Help Desk Associate - MCRC.COC",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7456",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 26-27 credits",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assistant - MEDA.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7459",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 14 credits",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Media Strategy and Design - SMSD.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7579",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 15 credits",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 12 credits",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Laser Optics Technology - LEOT.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7462",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 13 credits",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Total: 16 credits",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programmer - PROG.COC",
+      "credential": "other",
+      "program_code": null,
+      "catalog_url": "https://catalog.stcc.edu/preview_program.php?catoid=32&poid=7453",
+      "total_credits": null,
+      "gpa_minimum": null,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Total: 26 credits",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/scripts/ma/scrape-programs.ts
+++ b/scripts/ma/scrape-programs.ts
@@ -2,8 +2,19 @@
  * scrape-programs.ts — scrape degree/program requirements for Massachusetts
  * community colleges from Acalog catalogs.
  *
- * Not all MA community colleges use Acalog. This scraper covers the ones
- * that do. Others (Coursedog-based like GCC) need a separate scraper.
+ * Coverage as of 2026-05: 5 of 15 MA community colleges. The other 10
+ * use non-Acalog catalog systems and are tracked in their own follow-up
+ * issues:
+ *   gcc        — Coursedog (existing prereq scraper handles courses)
+ *   berkshire  — Smart Catalog IQ
+ *   northshore — Smart Catalog IQ
+ *   necc       — Smart Catalog IQ
+ *   massasoit  — PDF-only catalog
+ *   qcc        — PDF-only catalog
+ *   mwcc       — CourseLeaf
+ *   bristol    — custom Drupal-based catalog
+ *   capecod    — static HTML, last update 2019-2020
+ *   rcc        — catalog page sparse / unclear system
  *
  * Usage:
  *   npx tsx scripts/ma/scrape-programs.ts
@@ -23,6 +34,34 @@ const COLLEGES: AcalogProgramConfig[] = [
     catoidFallback: 35,
     programNavoids: [3315],
     autoDiscoverCatoid: true,
+  },
+  {
+    collegeSlug: "bhcc",
+    baseUrl: "https://catalog.bhcc.edu",
+    catoidFallback: 15,
+    programNavoids: [786, 806, 807, 813],
+    autoDiscoverCatoid: false,
+  },
+  {
+    collegeSlug: "hcc",
+    baseUrl: "https://catalog.hcc.edu",
+    catoidFallback: 13,
+    programNavoids: [562, 97],
+    autoDiscoverCatoid: false,
+  },
+  {
+    collegeSlug: "stcc",
+    baseUrl: "https://catalog.stcc.edu",
+    catoidFallback: 32,
+    programNavoids: [6835],
+    autoDiscoverCatoid: false,
+  },
+  {
+    collegeSlug: "massbay",
+    baseUrl: "https://massbay.catalog.acalog.com",
+    catoidFallback: 15,
+    programNavoids: [583],
+    autoDiscoverCatoid: false,
   },
 ];
 


### PR DESCRIPTION
Closes the MA phase of #228.

## Summary

Adds Acalog program-scraper configs for the 4 of 14 missing MA community colleges that turned out to use Acalog. Brings MA program coverage from **1 of 15 (middlesex only) → 5 of 15**. ~316 new programs.

| College | Programs |
|---|---|
| bhcc (Bunker Hill CC) | 88 |
| hcc (Holyoke CC) | 71 |
| stcc (Springfield Tech CC) | 78 |
| massbay (MassBay CC) | 79 |

## Out of scope (10 colleges, all on non-Acalog systems)

After researching each MA college's catalog system, the remaining 10 fall into 6 distinct buckets — each with its own follow-up issue:

| Catalog system | Colleges | Issue |
|---|---|---|
| Smart Catalog IQ | berkshire, northshore, necc | [#238](https://github.com/rohan-c0de/cc-coursemap/issues/238) |
| PDF-only | massasoit, qcc | [#239](https://github.com/rohan-c0de/cc-coursemap/issues/239) |
| CourseLeaf | mwcc | [#240](https://github.com/rohan-c0de/cc-coursemap/issues/240) (alongside brcc in [#234](https://github.com/rohan-c0de/cc-coursemap/issues/234)) |
| Custom Drupal | bristol | [#241](https://github.com/rohan-c0de/cc-coursemap/issues/241) |
| Static HTML (outdated) | capecod | [#242](https://github.com/rohan-c0de/cc-coursemap/issues/242) |
| Investigate further | rcc | [#243](https://github.com/rohan-c0de/cc-coursemap/issues/243) |
| Coursedog | gcc | [#230](https://github.com/rohan-c0de/cc-coursemap/issues/230) (existing) |

## Verification

- `npx tsx scripts/ma/scrape-programs.ts` runs end-to-end for all 5 MA colleges (middlesex + 4 new)
- `scripts/check-scraper-coverage.ts` passes
- Local dev confirmed for all 4 new colleges:
  - `/ma/college/bhcc/programs` → "88 programs available"
  - `/ma/college/hcc/programs` → "71 programs available"
  - `/ma/college/stcc/programs` → "78 programs available"
  - `/ma/college/massbay/programs` → "79 programs available"

## Test plan

- [x] All 5 MA programs files validate against the program schema
- [x] Each new college's program page renders with credential groupings
- [ ] Post-merge: confirm `https://communitycollegepath.com/ma/college/bhcc/programs` shows 88 programs in prod

## Notes

- No lib changes needed for this PR — the WAF-resilient headers from #231 + the same-origin/Referer headers from #237 are already on main and Just Work for these MA Acalog catalogs.
- This closes the MA scoping line of #228; the remaining MA gaps are non-Acalog and properly scoped to dedicated follow-up issues with appropriate scraper-system context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)