### PR TITLE
feat: CourseLeaf program scraper + Blue Ridge CC (closes #234)

### DIFF
--- a/data/va/programs/brcc.json
+++ b/data/va/programs/brcc.json
@@ -1,0 +1,8812 @@
+{
+  "college_slug": "brcc",
+  "catalog_year": "",
+  "catalog_url": "https://catalog.brcc.edu/programs-study/",
+  "scraped_at": "2026-05-07T03:39:48.486Z",
+  "programs": [
+    {
+      "title": "Accounting — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/accounting/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction To Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "130",
+              "title": "Database Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "105",
+              "title": "Psychology of Personal Adjustment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "275",
+              "title": "Capstone Seminar in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/accounting/",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "124",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Prin. of Federal Taxation I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Advanced Manufacturing Technology — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology/",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/AS-General-Studies/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Manufacturing Engineering Technology — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-manufacturing-engineering/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Precalculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Materials for Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Processes of Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "241",
+              "title": "Parametric Solid Modeling I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "206",
+              "title": "Engineering Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Manufacturing Engineering Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-manufacturing-engineering/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Manufacturing Engineering Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-manufacturing-engineering/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Materials for Industry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Manufacturing Engineering Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-manufacturing-engineering/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Manufacturing Engineering Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-manufacturing-engineering/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Materials for Industry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Manufacturing Engineering Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-manufacturing-engineering/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "241",
+              "title": "Parametric Solid Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "206",
+              "title": "Engineering Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Processes of Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Mechatronics — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-mechatronics/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "124",
+              "title": "Electrical Applications II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "237",
+              "title": "Industrial Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "157",
+              "title": "Mechanisms II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "110",
+              "title": "Principles of Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "D.C. and A.C. Fundamentals II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "177",
+              "title": "Industrial Robotics and Robotics Programming",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles & Applications of Robotics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Mechatronics — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-mechatronics/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Mechatronics — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-mechatronics/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "124",
+              "title": "Electrical Applications II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "237",
+              "title": "Industrial Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "177",
+              "title": "Industrial Robotics and Robotics Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "157",
+              "title": "Mechanisms II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Mechatronics — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-mechatronics/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "123",
+              "title": "Electrical Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "156",
+              "title": "Mechanisms I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Mechatronics — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-mechatronics/",
+      "total_credits": 14,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "124",
+              "title": "Electrical Applications II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "D.C. and A.C. Fundamentals II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "237",
+              "title": "Industrial Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "157",
+              "title": "Mechanisms II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Mechatronics — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-mechatronics/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "156",
+              "title": "Electrical Control Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "110",
+              "title": "Principles of Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Manufacturing Technology: Mechatronics — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/advanced-manufacturing-technology-mechatronics/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IND",
+              "number": "251",
+              "title": "Automated Manufacturing Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "206",
+              "title": "Engineering Economics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "181",
+              "title": "World Class Manufacturing I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "177",
+              "title": "Industrial Robotics and Robotics Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "D.C. and A.C. Fundamentals II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles & Applications of Robotics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/administration-justice/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "138",
+              "title": "Defensive Tactics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Criminal Justice, Law, and Forensics Professions)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "130",
+              "title": "Introduction to Criminal Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "241",
+              "title": "Correctional Law",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "105",
+              "title": "Psychology of Personal Adjustment",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "240",
+              "title": "Techniques of Interviewing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "115",
+              "title": "Patrol Procedures",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "117",
+              "title": "Police Communications and Records",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "150",
+              "title": "Introduction to Security Administration",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Criminal Investigation",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "298",
+              "title": "Seminar and Project",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "266",
+              "title": "Race and Ethnicity",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government & Politics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/administration-justice/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/administration-justice/",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "105",
+              "title": "The Juvenile Justice System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "150",
+              "title": "Spanish for Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/administration-justice/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "211",
+              "title": "Criminal Law, Evidence and Procedures I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/administration-justice/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "110",
+              "title": "Introduction to Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "111",
+              "title": "Law Enforcement Organization & Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "130",
+              "title": "Introduction to Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "298",
+              "title": "Seminar and Project",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Engineering — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/as-engineering/",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "122",
+              "title": "Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "288",
+              "title": "Discrete Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Business Management: Marketing — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management-marketing-specialization/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction To Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "120",
+              "title": "Principles of Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Principles of Computer Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "100",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "118",
+              "title": "Concepts of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "282",
+              "title": "Principles of E-Commerce",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "107",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "130",
+              "title": "Database Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management: Marketing — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management-marketing-specialization/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction To Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "100",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "282",
+              "title": "Principles of E-Commerce",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Aviation Maintenance Technology (Distance Education Program) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/aviation-maintenance-technology-distance-education/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Basic Electricity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Aviation Science for Mechanics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "107",
+              "title": "Aircraft Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "109",
+              "title": "Materials & Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "Federal Aviation Regulations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "261",
+              "title": "Aircraft Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "263",
+              "title": "Aircraft Fuel, Fire & Instrument Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "223",
+              "title": "Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "225",
+              "title": "Assembly & Rigging",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "231",
+              "title": "Aircraft Landing Gear Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Reciprocating Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "251",
+              "title": "Lubrication Systems & Propellers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "253",
+              "title": "Ignition & Starting Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "221",
+              "title": "Non-Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "233",
+              "title": "Communication/Navigation & Control Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "243",
+              "title": "Turbine Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "255",
+              "title": "Fuel Metering Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Aviation Science for Mechanics Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "106",
+              "title": "Aviation Science for Mechanics Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Materials & Processes Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "222",
+              "title": "Non-Metallic Structures & Covering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "224",
+              "title": "Metallic Structures & Finishes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "226",
+              "title": "Assembly and Rigging Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "228",
+              "title": "Airframe Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "232",
+              "title": "Aircraft Landing Gear Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "234",
+              "title": "Communication/Navigation & Control Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "262",
+              "title": "Aircraft Electrical Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "264",
+              "title": "Aircraft Fuel, Fire, & Instrument Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "227",
+              "title": "Airframe Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Reciprocating Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Turbine Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "245",
+              "title": "Powerplant Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "246",
+              "title": "Powerplant Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "252",
+              "title": "Lubrication Systems & Propellers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "254",
+              "title": "Ignition & Starting System Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "256",
+              "title": "Fuel Metering Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technology (Distance Education Program) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/aviation-maintenance-technology-distance-education/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Basic Electricity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Aviation Science for Mechanics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "107",
+              "title": "Aircraft Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "109",
+              "title": "Materials & Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "Federal Aviation Regulations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "261",
+              "title": "Aircraft Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "263",
+              "title": "Aircraft Fuel, Fire & Instrument Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "223",
+              "title": "Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "225",
+              "title": "Assembly & Rigging",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "231",
+              "title": "Aircraft Landing Gear Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "221",
+              "title": "Non-Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "224",
+              "title": "Metallic Structures & Finishes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "226",
+              "title": "Assembly and Rigging Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "227",
+              "title": "Airframe Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "233",
+              "title": "Communication/Navigation & Control Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Aviation Science for Mechanics Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "106",
+              "title": "Aviation Science for Mechanics Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Materials & Processes Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "222",
+              "title": "Non-Metallic Structures & Covering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "228",
+              "title": "Airframe Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "232",
+              "title": "Aircraft Landing Gear Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "234",
+              "title": "Communication/Navigation & Control Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "262",
+              "title": "Aircraft Electrical Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "264",
+              "title": "Aircraft Fuel, Fire, & Instrument Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technology (Distance Education Program) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/aviation-maintenance-technology-distance-education/",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Basic Electricity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Aviation Science for Mechanics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "107",
+              "title": "Aircraft Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "109",
+              "title": "Materials & Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "Federal Aviation Regulations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "261",
+              "title": "Aircraft Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "263",
+              "title": "Aircraft Fuel, Fire & Instrument Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Reciprocating Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "251",
+              "title": "Lubrication Systems & Propellers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "253",
+              "title": "Ignition & Starting Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "243",
+              "title": "Turbine Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "245",
+              "title": "Powerplant Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "255",
+              "title": "Fuel Metering Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Aviation Science for Mechanics Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "106",
+              "title": "Aviation Science for Mechanics Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Materials & Processes Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Reciprocating Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Turbine Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "246",
+              "title": "Powerplant Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "252",
+              "title": "Lubrication Systems & Propellers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "254",
+              "title": "Ignition & Starting System Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "256",
+              "title": "Fuel Metering Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "262",
+              "title": "Aircraft Electrical Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "264",
+              "title": "Aircraft Fuel, Fire, & Instrument Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management/",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "107",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "196",
+              "title": "On-Site Training",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "198",
+              "title": "Seminar and Project",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management/",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "230",
+              "title": "Money and Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "110",
+              "title": "Principles of Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management/",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARC",
+              "number": "133",
+              "title": "Construction Methodology & Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "225",
+              "title": "Site Planning and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "101",
+              "title": "Construction Management I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "165",
+              "title": "Construction Field Operations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLD",
+              "number": "231",
+              "title": "Construction Estimating I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIV",
+              "number": "171",
+              "title": "Surveying I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management/",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "141",
+              "title": "Introduction to Animal Science and Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "142",
+              "title": "Introduction to Plant Science and Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "143",
+              "title": "Introduction to Agribusiness and Financial Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "144",
+              "title": "Agriculture Human Resource Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "205",
+              "title": "Soil Fertility and Management",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "231",
+              "title": "Agribusiness Marketing, Risk Management, and Entrepreneurship",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "241",
+              "title": "Agricultural Policy, Leadership, and Professional Service",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "238",
+              "title": "Word Processing Advanced Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "243",
+              "title": "Office Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction To Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "298",
+              "title": "Seminar and Project",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "165",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/business-management/",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction To Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "118",
+              "title": "Concepts of Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "100",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Automotive Analysis and Repair — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/automotive-analysis-repair/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Automotive Engines I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "136",
+              "title": "Automotive Vehicle Inspection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "197",
+              "title": "Cooperative Education in Automotive Analysisor Supervised Study in Automotive Analysis",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Auto Power Trains I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "275",
+              "title": "Shop Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Auto Power Trains II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "236",
+              "title": "Automotive Climate Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "267",
+              "title": "Automotive Suspension and Braking Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "121",
+              "title": "Automotive Fuel Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "241",
+              "title": "Automotive Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "273",
+              "title": "Automotive Driveability and Tune-Up I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Automotive Fuel Systems II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "217",
+              "title": "Computerized Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "245",
+              "title": "Automotive Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Analysis and Repair — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/automotive-analysis-repair/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Auto Power Trains I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "142",
+              "title": "Auto Power Trains II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "197",
+              "title": "Cooperative Education in Automotive Analysis",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "199",
+              "title": "Supervised Study in Automotive Analysis",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "236",
+              "title": "Automotive Climate Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "267",
+              "title": "Automotive Suspension and Braking Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Analysis and Repair — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/automotive-analysis-repair/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "241",
+              "title": "Automotive Electricity I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "245",
+              "title": "Automotive Electronics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "121",
+              "title": "Automotive Fuel Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "122",
+              "title": "Automotive Fuel Systems II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "217",
+              "title": "Computerized Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Analysis and Repair — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/automotive-analysis-repair/",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AUT",
+              "number": "111",
+              "title": "Automotive Engines I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "136",
+              "title": "Automotive Vehicle Inspection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "141",
+              "title": "Auto Power Trains I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "197",
+              "title": "Cooperative Education in Automotive Analysis",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "199",
+              "title": "Supervised Study in Automotive Analysis",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AUT",
+              "number": "275",
+              "title": "Shop Management",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Aviation Maintenance Technology (On Campus Program) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/aviation-maintenance-technology-on-campus/",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Basic Electricity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Aviation Science for Mechanics Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Aviation Science for Mechanics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "106",
+              "title": "Aviation Science for Mechanics Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "107",
+              "title": "Aircraft Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "109",
+              "title": "Materials & Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Materials & Processes Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "Federal Aviation Regulations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "261",
+              "title": "Aircraft Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "262",
+              "title": "Aircraft Electrical Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "263",
+              "title": "Aircraft Fuel, Fire & Instrument Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "264",
+              "title": "Aircraft Fuel, Fire, & Instrument Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "223",
+              "title": "Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "224",
+              "title": "Metallic Structures & Finishes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "225",
+              "title": "Assembly & Rigging",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "226",
+              "title": "Assembly and Rigging Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "231",
+              "title": "Aircraft Landing Gear Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "232",
+              "title": "Aircraft Landing Gear Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Reciprocating Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Reciprocating Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "251",
+              "title": "Lubrication Systems & Propellers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "252",
+              "title": "Lubrication Systems & Propellers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "253",
+              "title": "Ignition & Starting Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "254",
+              "title": "Ignition & Starting System Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "221",
+              "title": "Non-Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "222",
+              "title": "Non-Metallic Structures & Covering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "227",
+              "title": "Airframe Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "228",
+              "title": "Airframe Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "233",
+              "title": "Communication/Navigation & Control Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "234",
+              "title": "Communication/Navigation & Control Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "243",
+              "title": "Turbine Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Turbine Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "245",
+              "title": "Powerplant Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "246",
+              "title": "Powerplant Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "255",
+              "title": "Fuel Metering Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "256",
+              "title": "Fuel Metering Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition Ior Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technology (On Campus Program) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/aviation-maintenance-technology-on-campus/",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Basic Electricity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Aviation Science for Mechanics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Aviation Science for Mechanics Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "106",
+              "title": "Aviation Science for Mechanics Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "107",
+              "title": "Aircraft Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "109",
+              "title": "Materials & Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Materials & Processes Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "Federal Aviation Regulations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "261",
+              "title": "Aircraft Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "262",
+              "title": "Aircraft Electrical Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "263",
+              "title": "Aircraft Fuel, Fire & Instrument Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "264",
+              "title": "Aircraft Fuel, Fire, & Instrument Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "223",
+              "title": "Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "224",
+              "title": "Metallic Structures & Finishes Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "225",
+              "title": "Assembly & Rigging",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "226",
+              "title": "Assembly and Rigging Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "231",
+              "title": "Aircraft Landing Gear Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "232",
+              "title": "Aircraft Landing Gear Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition Ior Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "221",
+              "title": "Non-Metallic Structures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "222",
+              "title": "Non-Metallic Structures & Covering Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "227",
+              "title": "Airframe Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "228",
+              "title": "Airframe Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "233",
+              "title": "Communication/Navigation & Control Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "234",
+              "title": "Communication/Navigation & Control Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technology (On Campus Program) — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/aviation-maintenance-technology-on-campus/",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "103",
+              "title": "Basic Electricity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "105",
+              "title": "Aviation Science for Mechanics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "104",
+              "title": "Aviation Science for Mechanics Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "106",
+              "title": "Aviation Science for Mechanics Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "107",
+              "title": "Aircraft Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "109",
+              "title": "Materials & Processes",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Materials & Processes Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "111",
+              "title": "Federal Aviation Regulations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "261",
+              "title": "Aircraft Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "262",
+              "title": "Aircraft Electrical Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "263",
+              "title": "Aircraft Fuel, Fire & Instrument Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "264",
+              "title": "Aircraft Fuel, Fire, & Instrument Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "241",
+              "title": "Reciprocating Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "242",
+              "title": "Reciprocating Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "251",
+              "title": "Lubrication Systems & Propellers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "252",
+              "title": "Lubrication Systems & Propellers Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "253",
+              "title": "Ignition & Starting Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "254",
+              "title": "Ignition & Starting System Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition Ior Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "243",
+              "title": "Turbine Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "244",
+              "title": "Turbine Engines Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "245",
+              "title": "Powerplant Inspections",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "246",
+              "title": "Powerplant Inspections Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "255",
+              "title": "Fuel Metering Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "256",
+              "title": "Fuel Metering Systems Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Aided Drafting — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/computer-aided-drafting/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "241",
+              "title": "Parametric Solid Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "242",
+              "title": "Parametric Solid Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARC",
+              "number": "121",
+              "title": "Architectural Drafting I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "243",
+              "title": "Parametric Solid Modeling III",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer and Electronics Technology: Secure Computer Networking — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/computer-electronics-technology-secure-computer-networking-specialization/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "106",
+              "title": "Programming Methods for Electrical/Electronic Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "123",
+              "title": "Electronic Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Precalculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "273",
+              "title": "Computer Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "103",
+              "title": "Administration of Networked Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "274",
+              "title": "Computer Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "296",
+              "title": "On Site Training or Seminar and Project",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime & Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security and Authentication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E-Commerce Security",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer and Electronics Technology: Secure Computer Networking — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/computer-electronics-technology-secure-computer-networking-specialization/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETR",
+              "number": "106",
+              "title": "Programming Methods for Electrical/Electronic Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "123",
+              "title": "Electronic Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "273",
+              "title": "Computer Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer and Electronics Technology: Secure Computer Networking — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/computer-electronics-technology-secure-computer-networking-specialization/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "103",
+              "title": "Administration of Networked Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime & Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer and Electronics Technology — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/computer-electronics-technology/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "106",
+              "title": "Programming Methods for Electrical/Electronic Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "123",
+              "title": "Electronic Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "D.C. and A.C. Fundamentals II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "143",
+              "title": "Devices and Applications I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "100",
+              "title": "Elements of Physics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Precalculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "273",
+              "title": "Computer Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "237",
+              "title": "Industrial Electronics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "274",
+              "title": "Computer Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "296",
+              "title": "On Site Training",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "298",
+              "title": "Seminar and Project",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "241",
+              "title": "Electronic Communications I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles & Applications of Robotics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "103",
+              "title": "Administration of Networked Services",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "107",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Remote Pilot Ground School",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer and Electronics Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/computer-electronics-technology/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETR",
+              "number": "106",
+              "title": "Programming Methods for Electrical/Electronic Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "D.C. and A.C. Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "123",
+              "title": "Electronic Applications I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "273",
+              "title": "Computer Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety - OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer and Electronics Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/computer-electronics-technology/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "D.C. and A.C. Fundamentals II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "143",
+              "title": "Devices and Applications I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "274",
+              "title": "Computer Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art: Creative Design and Marketing — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/creative-des-mkt-1/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "100",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "282",
+              "title": "Principles of E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Art: Creative Design and Marketing — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/creative-des-mkt-1/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "223",
+              "title": "Life Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "287",
+              "title": "Portfolio and Resume Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "165",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "284",
+              "title": "Social Media Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "164",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Early Childhood Development — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/early-childhood-development/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science, and Social Studies for Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Childhood Programs, School, and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Introduction to Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "265",
+              "title": "Advanced Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "270",
+              "title": "Administration of Childcare Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/early-childhood-development/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/early-childhood-development/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science, and Social Studies for Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Introduction to Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Childhood Programs, School, and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "270",
+              "title": "Administration of Childcare Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Education — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/education/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/emergency-medical-services/",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician - Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support (AMLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support (ACLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatric Care (EPC)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/emergency-medical-services/",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician - Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway and Shock Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway and Shock Management Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services — Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/emergency-medical-services/",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care II Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support (PHTLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support (AMLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support (ACLS)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatrics Course (EPC)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/emergency-medical-services/",
+      "total_credits": 10,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician - Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art: Graphic Design — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/graphic-design/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "190",
+              "title": "Coordinated Internship",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "284",
+              "title": "Computer Graphics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "164",
+              "title": "Introduction to Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/health-science/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Introductory Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Technology — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/engineering-technology/",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Materials for Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "241",
+              "title": "Parametric Solid Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Processes of Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Precalculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "225",
+              "title": "Machine Drawing and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "242",
+              "title": "Parametric Solid Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "130",
+              "title": "Statics and Strength of Materials Engineering Tech",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "245",
+              "title": "Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "247",
+              "title": "Mechanics of Materials Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "285",
+              "title": "Capstone Project",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "211",
+              "title": "Machine Design I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "202",
+              "title": "General College Physics II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/engineering-technology/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "140",
+              "title": "Technical Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "111",
+              "title": "Materials for Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "112",
+              "title": "Processes of Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Engineering Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/engineering-technology/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CAD",
+              "number": "241",
+              "title": "Parametric Solid Modeling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Precalculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "201",
+              "title": "General College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CAD",
+              "number": "242",
+              "title": "Parametric Solid Modeling II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Human Services — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/human-services/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction To Business",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "121",
+              "title": "Substance Abuse: Prevention and Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "101",
+              "title": "Mental Health Skill Training I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government & Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "141",
+              "title": "Group Dynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "260",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Psychopathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "285",
+              "title": "Advanced Client Interviewing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "225",
+              "title": "Counseling Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "290",
+              "title": "Coord Pract: Mental Health/Human Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "266",
+              "title": "Race and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/human-services/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "121",
+              "title": "Substance Abuse: Prevention and Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "101",
+              "title": "Mental Health Skill Training I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/human-services/",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "260",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "225",
+              "title": "Counseling Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "290",
+              "title": "Coord Pract: Mental Health/Human Service",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/human-services/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "121",
+              "title": "Substance Abuse: Prevention and Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "101",
+              "title": "Mental Health Skill Training I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "260",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "225",
+              "title": "Counseling Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEN",
+              "number": "290",
+              "title": "Coord Pract: Mental Health/Human Service",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Principles of Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (IT Professions)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "100",
+              "title": "Introduction to Telecommunications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "120",
+              "title": "Principles of Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "296",
+              "title": "On-site Training in ITP",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Principles of Computer Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (IT Professions)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "120",
+              "title": "Principles of Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "103",
+              "title": "Administration of Networked Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime & Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security and Authentication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E-Commerce Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "276",
+              "title": "Computer Forensics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "256",
+              "title": "Advanced Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "103",
+              "title": "Administration of Networked Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "213",
+              "title": "Information Storage and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "254",
+              "title": "Virtual Infrastructure: Installation and Configuration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing: Infrastructure and Services",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "120",
+              "title": "Principles of Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "115",
+              "title": "Current Issues in Web Design",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "130",
+              "title": "Database Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHT",
+              "number": "264",
+              "title": "Digital Photography II",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITD",
+              "number": "130",
+              "title": "Database Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "120",
+              "title": "Principles of Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing: Infrastructure and Services",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Principles of Computer Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "103",
+              "title": "Administration of Networked Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime & Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "263",
+              "title": "Internet/Intranet Firewalls and E-Commerce Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (IT Professions)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/information-systems-technology/",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "120",
+              "title": "Principles of Information Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "100",
+              "title": "Software Design",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Principles of Computer Science",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "208",
+              "title": "Protocols and Communications TCP/IP",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "130",
+              "title": "Database Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "257",
+              "title": "Cloud Computing: Infrastructure and Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "296",
+              "title": "On-site Training in ITP",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITP",
+              "number": "298",
+              "title": "Seminar & Project",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (IT Professions)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Leadership — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/leadership/",
+      "total_credits": 9,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MSC",
+              "number": "111",
+              "title": "Introduction to Army ROTC",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSC",
+              "number": "196",
+              "title": "On-Site Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSC",
+              "number": "112",
+              "title": "Introduction to Leadership",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSC",
+              "number": "211",
+              "title": "Leadership Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSC",
+              "number": "296",
+              "title": "On-Site Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MSC",
+              "number": "212",
+              "title": "Foundations of the Military Profession",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts — Associate of Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/liberal-arts/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Medical Coding — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/medical-coding-hospital/",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "199",
+              "title": "Supervised Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "253",
+              "title": "Health Records Coding (Emphasizes ICD-9/10)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "255",
+              "title": "Health Data Classification Systems II: CPT",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/science-business/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction To Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to (Business Administration)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital Literacy and Computer Applications",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Business Statistics",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomicsor Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomicsor Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Science — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/science-computer-science/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Computer Organization",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Computer Systems",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "288",
+              "title": "Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Science — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/science/",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/nursing/",
+      "total_credits": 8,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Social Science — Associate of Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/social-science/",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "110",
+              "title": "Introduction to Human Communication",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Assisting — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/veterinary-assisting/",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "102",
+              "title": "Care and Maintenance of Small Domestic Animals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "103",
+              "title": "Veterinary Office Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "118",
+              "title": "Canine and Feline Behavior for Veterinary Assistants",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology (On-Campus Option) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/veterinary-technology-on-campus-program/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Veterinary Medical Terminology and Calculations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Animal Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "105",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "111",
+              "title": "Anatomy & Physiology of Domestic Animals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "115",
+              "title": "Laboratory Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "121",
+              "title": "Clinical Practices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "216",
+              "title": "Animal Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "236",
+              "title": "Companion Animal Behavior",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "205",
+              "title": "Applied Veterinary Surgical Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "215",
+              "title": "Laboratory Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "221",
+              "title": "Advanced Clinical Practices III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "230",
+              "title": "Veterinary Hospital Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "210",
+              "title": "Survey of Animal Diseases",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "217",
+              "title": "Introduction to Laboratory, Zoo and Wildlife Medicine",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "218",
+              "title": "Laboratory, Zoo, and Wildlife Medical Techniques",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Advanced Clinical Practices IV",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology (On-Campus Option) — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/veterinary-technology-on-campus-program/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "102",
+              "title": "Care and Maintenance of Small Domestic Animals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "103",
+              "title": "Veterinary Office Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "118",
+              "title": "Canine and Feline Behavior for Veterinary Assistants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology (Distance Education Option) — Associate of Applied Science",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/veterinary-technology-distance-education-program/",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "120",
+              "title": "Veterinary Medical Terminology and Calculations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "105",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "111",
+              "title": "Anatomy & Physiology of Domestic Animals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "100",
+              "title": "Introduction to Animal Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "216",
+              "title": "Animal Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "236",
+              "title": "Companion Animal Behavior",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "115",
+              "title": "Laboratory Techniques I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "121",
+              "title": "Clinical Practices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "215",
+              "title": "Laboratory Techniques II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "221",
+              "title": "Advanced Clinical Practices III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "205",
+              "title": "Applied Veterinary Surgical Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "222",
+              "title": "Advanced Clinical Practices IV",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "230",
+              "title": "Veterinary Hospital Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "210",
+              "title": "Survey of Animal Diseases",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "217",
+              "title": "Introduction to Laboratory, Zoo and Wildlife Medicine",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "218",
+              "title": "Laboratory, Zoo, and Wildlife Medical Techniques",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology (Distance Education Option) — Career Studies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://catalog.brcc.edu/programs-study/veterinary-technology-distance-education-program/",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "101",
+              "title": "Introduction to Veterinary Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "102",
+              "title": "Care and Maintenance of Small Domestic Animals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "103",
+              "title": "Veterinary Office Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VET",
+              "number": "118",
+              "title": "Canine and Feline Behavior for Veterinary Assistants",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -81,7 +81,13 @@ const vaConfig: StateConfig = {
       },
     ],
     prereqs: { source: "aggregate-from-courses" },
-    programs: [{ scripts: ["scripts/va/scrape-programs.ts"], runner: "http" }],
+    programs: [
+      { scripts: ["scripts/va/scrape-programs.ts"], runner: "http" },
+      {
+        scripts: ["scripts/va/scrape-courseleaf-programs.ts"],
+        runner: "http",
+      },
+    ],
   },
 };
 

--- a/scripts/lib/scrape-courseleaf-programs.ts
+++ b/scripts/lib/scrape-courseleaf-programs.ts
@@ -1,0 +1,422 @@
+/**
+ * scrape-courseleaf-programs.ts — shared CourseLeaf program scraper.
+ *
+ * CourseLeaf catalogs publish a `/programs-study/` index page listing all
+ * degrees/certificates offered by a college. Each program has its own
+ * detail page (e.g. `/programs-study/accounting/`) that contains one or
+ * more award sections (AAS + Career Studies Certificate, etc.) — each with
+ * a "Plan of Study Grid" table (`<table class="sc_plangrid">`) covering
+ * the recommended semester-by-semester courses.
+ *
+ * Mirrors the shape of scrape-acalog-programs.ts so it can be invoked by
+ * a per-state wrapper script with a list of college configs.
+ *
+ * Used by:
+ *   scripts/va/scrape-courseleaf-programs.ts — Blue Ridge CC (brcc), see #234
+ *   scripts/ma/scrape-courseleaf-programs.ts — Mount Wachusett CC (mwcc), see #240
+ */
+
+import * as cheerio from "cheerio";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequiredCourse,
+} from "../../lib/types.js";
+
+export interface CourseleafProgramConfig {
+  /** Stable college identifier matching `data/{state}/programs/{collegeSlug}.json`. */
+  collegeSlug: string;
+  /** Catalog root, e.g. https://catalog.brcc.edu (no trailing slash). */
+  baseUrl: string;
+  /**
+   *  Path of the program-list page, default `/programs-study/`.
+   *  Override if a college uses a different convention.
+   */
+  programIndexPath?: string;
+}
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const CONCURRENCY = 6;
+const DELAY_MS = 80;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(
+  url: string,
+  label: string,
+  attempts = 3,
+): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const u = new URL(url);
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+          Referer: `${u.protocol}//${u.host}/`,
+          "Sec-Fetch-Dest": "document",
+          "Sec-Fetch-Mode": "navigate",
+          "Sec-Fetch-Site": "same-origin",
+          "Upgrade-Insecure-Requests": "1",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) {
+        lastErr = new Error(`HTTP ${res.status}`);
+      } else {
+        return "";
+      }
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      try {
+        results[idx] = await fn(items[idx], idx);
+      } catch (e) {
+        console.error(`  pmap[${idx}] error: ${e}`);
+        results[idx] = undefined as unknown as R;
+      }
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  }
+  await Promise.all(Array.from({ length: n }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: discover all program detail page paths from the index
+// ---------------------------------------------------------------------------
+
+function discoverProgramPaths(
+  indexHtml: string,
+  programIndexPath: string,
+): string[] {
+  const $ = cheerio.load(indexHtml);
+  const paths = new Set<string>();
+  $(`a[href^="${programIndexPath}"]`).each((_, el) => {
+    const href = $(el).attr("href");
+    if (!href) return;
+    if (href === programIndexPath) return;
+    if (href === programIndexPath.replace(/\/$/, "")) return;
+    if (!href.endsWith("/")) return;
+    paths.add(href);
+  });
+  return Array.from(paths).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: classify a credential string into our enum
+// ---------------------------------------------------------------------------
+
+function parseCredential(awardText: string): ProgramCredential {
+  const t = awardText.toLowerCase();
+  if (/applied\s+science/.test(t)) return "AAS";
+  if (/associate\s+of\s+arts/.test(t)) return "AA";
+  if (/associate\s+of\s+science/.test(t)) return "AS";
+  if (/career\s+studies\s+certificate/.test(t)) return "certificate";
+  if (/diploma/.test(t)) return "diploma";
+  if (/certificate/.test(t)) return "certificate";
+  return "other";
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: parse a single sc_plangrid table into RequiredCourse[]
+// ---------------------------------------------------------------------------
+
+interface PlanGridResult {
+  courses: RequiredCourse[];
+  totalCredits: number | null;
+}
+
+function parsePlanGrid(
+  $: cheerio.CheerioAPI,
+  $table: cheerio.Cheerio<cheerio.AnyNode>,
+): PlanGridResult {
+  const courses: RequiredCourse[] = [];
+  const seen = new Set<string>();
+  let totalCredits: number | null = null;
+
+  $table.find("tr").each((_, row) => {
+    const $row = $(row);
+    const classes = $row.attr("class") || "";
+
+    // Total Credit Hours summary row — sc_plangrid uses "plangridtotal",
+    // sc_courselist uses "listsum"
+    if (classes.includes("plangridtotal") || classes.includes("listsum")) {
+      const hoursText = $row.find("td.hourscol").last().text().trim();
+      // Take the upper bound of any range like "60-62"
+      const m = hoursText.match(/(\d+)(?:\s*-\s*(\d+))?/);
+      if (m) totalCredits = parseInt(m[2] ?? m[1], 10);
+      return;
+    }
+    // Per-semester subtotals, semester/year/area headers — no course
+    if (classes.includes("plangridsum")) return;
+    if (classes.includes("plangridyear")) return;
+    if (classes.includes("areaheader")) return;
+
+    const $code = $row.find("td.codecol").first();
+    if (!$code.length) return;
+
+    // Course rows: <a class="bubblelink code">PREFIX NUM</a>
+    // Comment / placeholder rows have <span class="comment">…</span> instead
+    // of an anchor — those are "Select one of the following:" or generic
+    // electives without a concrete course; skip them.
+    const $courseLink = $code.find("a.bubblelink.code").first();
+    if (!$courseLink.length) return;
+    const codeText = $courseLink.text().trim();
+    const m = codeText.match(/^([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)/);
+    if (!m) return;
+    const [, prefix, number] = m;
+
+    // Title can be in td.titlecol (sc_plangrid) or in the second <td>
+    // (sc_courselist, where titlecol isn't always set on the td)
+    const $title = $row.find("td.titlecol").first().length
+      ? $row.find("td.titlecol").first()
+      : $code.next("td");
+    const titleText = $title
+      .clone()
+      .children("sup")
+      .remove()
+      .end()
+      .text()
+      .replace(/\s+/g, " ")
+      .trim();
+
+    const hoursText = $row.find("td.hourscol").first().text().trim();
+    const credits = hoursText && /^\d+/.test(hoursText)
+      ? parseInt(hoursText, 10)
+      : 0;
+
+    const key = `${prefix} ${number}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    courses.push({
+      prefix,
+      number,
+      title: titleText,
+      credits,
+      or_alternatives: [],
+    });
+  });
+
+  return { courses, totalCredits };
+}
+
+// ---------------------------------------------------------------------------
+// Step 4: parse a program detail page into one or more ProgramRequirements
+// ---------------------------------------------------------------------------
+
+function parseProgramPage(
+  html: string,
+  baseUrl: string,
+  programPath: string,
+): ProgramRequirement[] {
+  const $ = cheerio.load(html);
+  const programTitle = $("h1.page-title").first().text().trim();
+  if (!programTitle) return [];
+
+  const catalogUrl = new URL(programPath, baseUrl).toString();
+  const programs: ProgramRequirement[] = [];
+
+  // Each program detail page can list multiple awards (e.g. AAS + Career
+  // Studies Certificate). The structure is:
+  //   <p><strong>Award: <credential>...</strong></p>
+  //   …
+  //   <table class="sc_plangrid"> or <table class="sc_courselist">
+  // Sometimes the award strong tag lives outside the textcontainer (for the
+  // page's primary award) and sometimes inside it (for additional awards).
+  // Walk both lists in document order and pair each award with the next
+  // curriculum table that follows it.
+  const TABLE_SELECTOR = "table.sc_plangrid, table.sc_courselist";
+
+  // Collect award elements: any inline element whose visible text starts with
+  // "Award:". Limit the suffix at the next sentence boundary to avoid pulling
+  // in unrelated paragraph content.
+  type DocItem = { kind: "award"; line: string; index: number } | {
+    kind: "table";
+    el: cheerio.AnyNode;
+    index: number;
+  };
+  const items: DocItem[] = [];
+
+  $("strong").each((_, el) => {
+    // Replace <br> with a newline so the credential phrase doesn't get
+    // glued to the next sub-line ("Major: ...", "Additional Program...").
+    const html = $(el).html() ?? "";
+    const withBreaks = html.replace(/<br\s*\/?>/gi, "\n");
+    const text = cheerio
+      .load(`<x>${withBreaks}</x>`)("x")
+      .text()
+      .replace(/​/g, ""); // zero-width space
+    // Take only the first line (everything before the first \n)
+    const firstLine = text.split("\n")[0].replace(/\s+/g, " ").trim();
+    const m = firstLine.match(/^Award:\s*(.+)$/);
+    if (!m) return;
+    const line = m[1].trim().replace(/\s*Degree$/i, "");
+    // @ts-expect-error cheerio doesn't expose document positions directly,
+    // but we can use the DOM-ordered index from $('*').index(el).
+    const index = $("*").index(el);
+    items.push({ kind: "award", line, index });
+  });
+
+  $(TABLE_SELECTOR).each((_, el) => {
+    const index = $("*").index(el);
+    items.push({ kind: "table", el, index });
+  });
+
+  items.sort((a, b) => a.index - b.index);
+
+  // Pair: every table consumes the most recent award seen so far. Once an
+  // award is consumed, additional tables before the next award are sub-tables
+  // (elective lists, sample schedules per specialization, etc.) — skip them.
+  let lastAward = "";
+  for (const item of items) {
+    if (item.kind === "award") {
+      lastAward = item.line;
+      continue;
+    }
+    if (!lastAward) continue;
+    const $table = $(item.el);
+    const { courses, totalCredits } = parsePlanGrid($, $table);
+    if (courses.length === 0) continue;
+
+    const credential = parseCredential(lastAward);
+    const suffix = ` — ${lastAward}`;
+    const fullTitle = `${programTitle}${suffix}`;
+
+    programs.push({
+      title: fullTitle,
+      credential,
+      program_code: null,
+      catalog_url: catalogUrl,
+      total_credits: totalCredits,
+      gpa_minimum: 2.0,
+      description: null,
+      requirement_groups: [
+        {
+          name: "Recommended Course Sequence",
+          credits_required: totalCredits,
+          choose_n: null,
+          courses,
+        },
+      ],
+      matched_program_slug: null,
+    });
+    // After consuming an award for this table, clear it so a sibling table
+    // without its own award doesn't re-use the same credential incorrectly.
+    lastAward = "";
+  }
+
+  // Some pages have a curriculum table that's not wrapped in a textcontainer.
+  // Fall back to scanning the page for any un-claimed table.
+  if (programs.length === 0) {
+    const $tables = $(TABLE_SELECTOR);
+    if ($tables.length > 0) {
+      const $first = $tables.first();
+      const { courses, totalCredits } = parsePlanGrid($, $first);
+      if (courses.length > 0) {
+        programs.push({
+          title: programTitle,
+          credential: "other",
+          program_code: null,
+          catalog_url: catalogUrl,
+          total_credits: totalCredits,
+          gpa_minimum: 2.0,
+          description: null,
+          requirement_groups: [
+            {
+              name: "Recommended Course Sequence",
+              credits_required: totalCredits,
+              choose_n: null,
+              courses,
+            },
+          ],
+          matched_program_slug: null,
+        });
+      }
+    }
+  }
+
+  return programs;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function scrapeCourseleafPrograms(
+  config: CourseleafProgramConfig,
+): Promise<CollegePrograms> {
+  const { collegeSlug, baseUrl } = config;
+  const programIndexPath = config.programIndexPath ?? "/programs-study/";
+
+  const indexUrl = `${baseUrl}${programIndexPath}`;
+  console.log(`  [${collegeSlug}] Discovering programs at ${indexUrl}`);
+  const indexHtml = await retryFetch(indexUrl, "program-index");
+  const paths = discoverProgramPaths(indexHtml, programIndexPath);
+  console.log(`  [${collegeSlug}] Found ${paths.length} program paths`);
+
+  if (paths.length === 0) {
+    return {
+      college_slug: collegeSlug,
+      catalog_year: "",
+      catalog_url: indexUrl,
+      scraped_at: new Date().toISOString(),
+      programs: [],
+    };
+  }
+
+  console.log(`  [${collegeSlug}] Fetching program detail pages...`);
+  const all: ProgramRequirement[] = [];
+  let parsed = 0;
+  let skipped = 0;
+
+  await pmap(paths, CONCURRENCY, async (programPath) => {
+    const url = `${baseUrl}${programPath}`;
+    const html = await retryFetch(url, `program(${programPath})`);
+    if (!html) {
+      skipped++;
+      return;
+    }
+    const programs = parseProgramPage(html, baseUrl, programPath);
+    if (programs.length === 0) {
+      skipped++;
+      return;
+    }
+    all.push(...programs);
+    parsed += programs.length;
+  });
+
+  console.log(
+    `  [${collegeSlug}] Parsed ${parsed} program awards across ${paths.length} pages, skipped ${skipped}`,
+  );
+
+  return {
+    college_slug: collegeSlug,
+    catalog_year: "",
+    catalog_url: indexUrl,
+    scraped_at: new Date().toISOString(),
+    programs: all,
+  };
+}

--- a/scripts/va/scrape-courseleaf-programs.ts
+++ b/scripts/va/scrape-courseleaf-programs.ts
@@ -1,0 +1,90 @@
+/**
+ * scrape-courseleaf-programs.ts — VA CourseLeaf program scraper.
+ *
+ * Closes #234. Adds Blue Ridge Community College (brcc), the one VCCS
+ * college whose catalog is on CourseLeaf instead of Acalog (or PDF).
+ *
+ * Usage:
+ *   npx tsx scripts/va/scrape-courseleaf-programs.ts
+ *   npx tsx scripts/va/scrape-courseleaf-programs.ts --college brcc
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { scrapeCourseleafPrograms } from "../lib/scrape-courseleaf-programs.js";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type { CourseleafProgramConfig } from "../lib/scrape-courseleaf-programs.js";
+
+const COLLEGES: CourseleafProgramConfig[] = [
+  {
+    collegeSlug: "brcc",
+    baseUrl: "https://catalog.brcc.edu",
+  },
+];
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeArg =
+    args.find((a) => a.startsWith("--college="))?.split("=")[1] ||
+    (args.indexOf("--college") >= 0
+      ? args[args.indexOf("--college") + 1]
+      : null);
+
+  let colleges = COLLEGES;
+  if (collegeArg) {
+    colleges = COLLEGES.filter((c) => c.collegeSlug === collegeArg);
+    if (colleges.length === 0) {
+      console.error(
+        `Unknown college: ${collegeArg}. Available: ${COLLEGES.map((c) => c.collegeSlug).join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const outDir = path.join(process.cwd(), "data", "va", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`VA CourseLeaf program scraper — ${colleges.length} college(s)\n`);
+
+  let totalPrograms = 0;
+  for (const config of colleges) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`Scraping ${config.collegeSlug} (${config.baseUrl})`);
+    console.log("=".repeat(60));
+
+    try {
+      const data = await scrapeCourseleafPrograms(config);
+
+      if (data.programs.length === 0) {
+        console.log(
+          `  No programs found for ${config.collegeSlug}, skipping.`,
+        );
+        continue;
+      }
+
+      const { matched, unmatched } = applyProgramMatching(data.programs);
+      console.log(
+        `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+      );
+
+      const outPath = path.join(outDir, `${config.collegeSlug}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+      console.log(
+        `  ✓ Wrote ${data.programs.length} programs to ${outPath}`,
+      );
+      totalPrograms += data.programs.length;
+    } catch (e) {
+      console.error(`  ERROR scraping ${config.collegeSlug}: ${e}`);
+    }
+  }
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(
+    `Done. Total: ${totalPrograms} programs across ${colleges.length} college(s).`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #234.

## Summary

Adds a shared **CourseLeaf** program scraper library and wires up Blue Ridge Community College (brcc), the one VCCS college whose catalog runs on CourseLeaf instead of Acalog. VA program coverage goes from **20/23 → 21/23**. The remaining 2 (camp, vhcc) are PDF-only and tracked in [#235](https://github.com/rohan-c0de/cc-coursemap/issues/235) / [#236](https://github.com/rohan-c0de/cc-coursemap/issues/236).

92 programs scraped from brcc:
- 1 Associate of Arts
- 8 Associate of Science
- 20 Associate of Applied Science
- 63 Career Studies Certificate

## Approach

1. Hit `/programs-study/` (the standard CourseLeaf programs index) and discover 45 program detail pages.
2. For each detail page, walk the DOM in document order pairing each `<strong>Award: …</strong>` element with the next curriculum table (`<table class="sc_plangrid">` for AAS semester plans, or `<table class="sc_courselist">` for transfer block plans).
3. After consuming an award, subsequent tables before the next award are sub-tables (elective lists by specialization, sample tracks) and are deliberately skipped — only one program per award.
4. Course rows: `td.codecol > a.bubblelink.code` gives `PREFIX NUM`, `td.titlecol` (or the next td for sc_courselist) gives the title, `td.hourscol` gives credits.
5. Total credit hours from `plangridtotal` (sc_plangrid) or `listsum` (sc_courselist) rows, with range support ("60-62" → 62).

The library is reusable. **mwcc** ([#240](https://github.com/rohan-c0de/cc-coursemap/issues/240)) will use the same `scrapeCourseleafPrograms()` once we add an MA wrapper script — the only thing that needs to change is the per-college config.

## Known limitations (worth follow-ups)

- Transfer-style programs that describe curriculum as blocks-of-electives ("Block I — Written Communication: choose ENG 111 or ENG 112") only capture the explicitly-named required courses (4 for Liberal Arts vs ~30 for AAS programs). The "approved electives" lists exist as a second table on the same page and are correctly skipped — they're alternatives, not requirements. Acceptable trade-off; can be revisited if downstream features need the choice semantics.

## Verification

- `npx tsx scripts/va/scrape-courseleaf-programs.ts` runs end-to-end → `data/va/programs/brcc.json` (92 programs)
- `scripts/check-scraper-coverage.ts` passes — VA now declares two program scrapers (`scrape-programs.ts` for the 20 Acalog colleges + `scrape-courseleaf-programs.ts` for brcc)
- Local dev `/va/college/brcc/programs` renders "92 programs available" with credential groupings (1 AA / 8 AS / 20 AAS / 63 Certificate)

## Test plan

- [x] Output validates against `CollegePrograms` schema
- [x] Page renders with proper credential grouping
- [x] Coverage check passes
- [ ] Post-merge: confirm `https://communitycollegepath.com/va/college/brcc/programs` shows 92 programs in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)