### PR TITLE
feat: PDF program scrapers for VHCC + Camp CC (closes #235, #236)

### DIFF
--- a/data/va/programs/camp.json
+++ b/data/va/programs/camp.json
@@ -1,0 +1,3964 @@
+{
+  "college_slug": "camp",
+  "catalog_year": "",
+  "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+  "scraped_at": "2026-05-07T13:27:28.596Z",
+  "programs": [
+    {
+      "title": "General Studies",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital & Information Literacy & Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "General Studies",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital & Information Literacy & Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Uniform Certificate of General Studies (UCGS)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Early Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "Modern Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REL",
+              "number": "100",
+              "title": "Introduction to the Study of Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital & Information Literacy & Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Introduction to Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Science",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Pre-Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "4 3 45 1 45",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "3 3 45 0 0",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "3 3 45 0 0",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "1 1 15 0 0",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "4 3 45 1 45",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "4 3 45 1 0",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "2 1 15 1 45",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "1 1 15 0 0",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "3 2 30 1 35",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "2 2 30 0 0",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "4 0 0 4 0",
+              "credits": 16,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Practical Nursing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I for Health Care Providers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "161",
+              "title": "Nursing in health Changes I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "162",
+              "title": "Nursing in Health Changes II",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "173",
+              "title": "Pharmacology for Practical Nurses",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "163",
+              "title": "Nursing in Health Changes III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "196",
+              "title": "On Site Training",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Pre-Nursing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "220",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human A & P II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nurse Aide",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "Health Care Technician I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "102",
+              "title": "Health Care Technician II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Emergency Medical Technician (EMT)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician*",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "Emergency Medical Technician - Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Administrative Assistant",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "271",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "208",
+              "title": "Medical Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "209",
+              "title": "Medical Insurance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "207",
+              "title": "Medical Law & Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "144",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "234",
+              "title": "Records and Database Mgt",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "195",
+              "title": "E-Health Records",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "195",
+              "title": "Customer Service",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "110",
+              "title": "Computerized Accounting (1st -8 weeks-online)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Coder/Reimbursement Specialist",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "208",
+              "title": "Medical Coding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "254",
+              "title": "Adv. Coding/R.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "210",
+              "title": "Medical Office Software",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "207",
+              "title": "Med. Law and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "144",
+              "title": "Med. Term II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "110",
+              "title": "Intro to Human Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "106",
+              "title": "International Classifications of Diseases",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "209",
+              "title": "Med Office Ins",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "195",
+              "title": "E-Health Records",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning or Pre-Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "U.S. Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "US History I or II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Introduction to Developmental Disabilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Literature Elective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society w/Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music and Movement to Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Qualitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science, and Social Studies for Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding Behavior of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Introduction to Teaching as a Profession",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I with Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "270",
+              "title": "Administration of Childcare Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Introduction to Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "265",
+              "title": "Adv. Obs. and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Childhood Programs, School and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music, and Movement to Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety, and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science and Social Studies for Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Childhood Programs, Schools, and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Advanced Early Childhood",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "118",
+              "title": "Language Arts for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "146",
+              "title": "Math, Science and Social Studies for Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "210",
+              "title": "Introduction to Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "216",
+              "title": "Early Childhood Programs, Schools, and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "145",
+              "title": "Teaching Art, Music and Movement to Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety and Nutrition Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Infant Toddler",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "164",
+              "title": "Working with Infants and Toddlers in Inclusive Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "235",
+              "title": "Health, Safety and Nutrition Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Student Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheet Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "Applied Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "274",
+              "title": "Intro to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Accounting Principles II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics in the Business Organization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration NEW degree plan effective Fall 2024",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Student Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "274",
+              "title": "Intro to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Accounting Principles II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "270",
+              "title": "Interpersonal Dynamics in the Business Organization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Management",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "165",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communications in Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "130",
+              "title": "Introduction to Internet Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications & Integration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "280",
+              "title": "Introduction to International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "285",
+              "title": "Current Issues in Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "220",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "271",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "215",
+              "title": "Sales and Marketing Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "276",
+              "title": "International Marketing Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "285",
+              "title": "Current Issues in Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheet Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "111",
+              "title": "Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Fundamentals of E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "150",
+              "title": "Database Software",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Bookkeeping",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 13,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "110",
+              "title": "Introduction to Computerized Accounting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Entrepreneurship in Small Business Management*",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "165",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Entrepreneurship in Small Business Management – Advanced*",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communications in Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "280",
+              "title": "Introduction to International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "220",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "General Business",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "150",
+              "title": "Economic Essentials: Theory and Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "147",
+              "title": "Introduction to Presentation Software",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "220",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Sports Management",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MKT",
+              "number": "209",
+              "title": "Sports Entertainment and Recreation Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "236",
+              "title": "Communication in Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "193",
+              "title": "Introduction to Sports Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "195",
+              "title": "Principles of Sports Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "241",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "295",
+              "title": "Fiscal Planning and Management in Sport and Recreation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Administrative Support Technology",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Keyboarding I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Fundamentals of Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "102",
+              "title": "Keyboarding II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "113",
+              "title": "Keyboarding for Speed and Accuracy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "141",
+              "title": "Word Processing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "125",
+              "title": "Applied Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "110",
+              "title": "Intro. to Computerized Accounting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "234",
+              "title": "Records and Database Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "243",
+              "title": "Office Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Adv. Computer Applications and Integration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "236",
+              "title": "Specialized Software Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "244",
+              "title": "Office Administration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "130",
+              "title": "Introduction to Internet Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "253",
+              "title": "Advanced Desktop Publishing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "207",
+              "title": "(1st -8 weeks)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "271",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "144",
+              "title": "Medical Terminology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "195",
+              "title": "E-Health Records (1st -8 weeks)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "195",
+              "title": "(2nd -8 weeks)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "208",
+              "title": "Medical Coding (1st -8 weeks)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "209",
+              "title": "Medical Insurance (2nd -8 weeks)",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Technology",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "175",
+              "title": "Schematics and Mechanical Diagrams",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Technical Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "DC and AC Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills /",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "113",
+              "title": "Materials and Processes in Manufacturing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "DC and AC Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "166",
+              "title": "Principles of Industrial Technology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "110",
+              "title": "Principles of Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "203",
+              "title": "Electronic Devices I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "204",
+              "title": "Electronic Devices II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "137",
+              "title": "Team Concepts and Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics – Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "160",
+              "title": "Power Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "133",
+              "title": "Practical Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "134",
+              "title": "Practical Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "135",
+              "title": "National Electrical Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "221",
+              "title": "Electronic Controls I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "160",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles and Applications of Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechatronics",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "AC & DC Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "160",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Introduction to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Survival Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles & Applications of Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "113",
+              "title": "Materials and Processes in Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "110",
+              "title": "Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "203",
+              "title": "Electronic Devices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "221",
+              "title": "Electronic Controls",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "216",
+              "title": "Industrial Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electricity",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "175",
+              "title": "Schematic and Mechanical Diagrams",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "133",
+              "title": "Practical Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "DC and AC Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "134",
+              "title": "Practical Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "160",
+              "title": "Power Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "AC/DC Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "135",
+              "title": "National Electric Code: Residential",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial/Residential Wiring",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "133",
+              "title": "Practical Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "AC and DC Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "134",
+              "title": "Practical Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "160",
+              "title": "Power Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "114",
+              "title": "AC and DC Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "135",
+              "title": "National Electric Code",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Electrical Technician",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "135",
+              "title": "National Electric Code: Residential",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "113",
+              "title": "DC and AC Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Fundamentals Mathematics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "126",
+              "title": "Principles of Industrial Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Energy Technology",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "175",
+              "title": "Schematic and Mechanical Diagrams",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "133",
+              "title": "Practical Electricity I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "104",
+              "title": "Energy Industry Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety, OSHA 10*",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "134",
+              "title": "Practical Electricity II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "177",
+              "title": "Photovoltaic Energy Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "135",
+              "title": "National Electric Code: Residential",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "121",
+              "title": "Electrical Circuits I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "122",
+              "title": "Electrical Circuits II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "216",
+              "title": "Industrial Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Industrial Automation and Robotics",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "AC and DC Circuit Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "160",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Introduction to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Logic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles and Application of Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "166",
+              "title": "Principles of Industrial Technology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Principles of Robotics",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IND",
+              "number": "160",
+              "title": "Introduction to Robotics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Intro to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "165",
+              "title": "Principles of Industrial Technology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "166",
+              "title": "Principles of Industrial Technology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETR",
+              "number": "286",
+              "title": "Principles & Application of Robotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "265",
+              "title": "Principles of Industrial Technology III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "266",
+              "title": "Principles of Industrial Technology IV",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Instrumentation",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "175",
+              "title": "Schematic and Mechanical Diagrams",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "AC and DC Circuit Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "216",
+              "title": "Industrial Electricity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "239",
+              "title": "Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "110",
+              "title": "Principles of Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Pre-Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Computer Organization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "208",
+              "title": "Introduction to Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Pre-Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "Pre-Calculus II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-Oriented Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Computer Organization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "208",
+              "title": "Introduction to Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Support Specialist",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "130",
+              "title": "Introduction to Internet Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheet Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "150",
+              "title": "Database Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hardware and Software Support",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheet Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "160",
+              "title": "Introduction to E-Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "215",
+              "title": "Advanced Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "111",
+              "title": "Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "150",
+              "title": "Networking Fundamentals and Introductory Routing-Cisco",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Introduction to Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime, and Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "266",
+              "title": "Network Security layers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "262",
+              "title": "Network Communication, Security, and Authentication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "267",
+              "title": "Legal Topics in Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity and Networking Foundations",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Introduction to Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Geographic Information Systems Technician",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "101",
+              "title": "Introduction to Geospatial Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "102",
+              "title": "Introduction to Geospatial Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "200",
+              "title": "Geographical Information Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administration of Justice",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://drive.google.com/file/d/11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn/view?usp=sharing",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "107",
+              "title": "Survey of Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "234",
+              "title": "Terrorism and Counter-Terrorism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "298",
+              "title": "Seminar and Project in Admin. of Justice",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "245",
+              "title": "Management of Correctional Facilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "248",
+              "title": "Probation, Parole and Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "111",
+              "title": "Law Enforcement Organization & Admin. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "231",
+              "title": "Community Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/va/programs/vhcc.json
+++ b/data/va/programs/vhcc.json
@@ -1,0 +1,8944 @@
+{
+  "college_slug": "vhcc",
+  "catalog_year": "2026-2003",
+  "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+  "scraped_at": "2026-05-07T13:27:23.064Z",
+  "programs": [
+    {
+      "title": "Science (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science – Major in Biology (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "or MTH 261 Precalculus I or Applied Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "or EEE MTH 261 or Approved Elective2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "262",
+              "title": "or EEE MTH 262 or Approved Elective2",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Science – Major in Medical Lab Science (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "241",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "245",
+              "title": "Organic Chemistry Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1855",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science with a Major in Chemistry (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "241",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "245",
+              "title": "Organic Chemistry Lab I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "242",
+              "title": "Organic Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "246",
+              "title": "Organic Chemistry Lab II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Pharmacy Science (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "261",
+              "title": "or HLT 106",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "or MTH 263 Precalculus I or Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "or MTH 264 Precalculus II or Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object-oriented Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "or MTH 265 Calculus I or Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Computer Organization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "or MTH 266 Calculus II or Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "223",
+              "title": "Data Structures and Analysis of Algorithms",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Criminal Justice (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "Survey of Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "233",
+              "title": "Multiculturalism in Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "140",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "130",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "236",
+              "title": "Principles of Investigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "Statistical Reasoning1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "133",
+              "title": "Ethics and the Criminal Justice Professional",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "171",
+              "title": "Forensic Science I2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "237",
+              "title": "Advanced Criminal Investigation2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "235",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "111",
+              "title": "Law Enforcement Organization & Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "227",
+              "title": "Constitutional Law for Justice Personnel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "229",
+              "title": "Community Policing in Modern Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "236",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "138",
+              "title": "Defensive Tactics3",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Victim Advocacy Assistant (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADJ",
+              "number": "118",
+              "title": "Crisis Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "295",
+              "title": "Topics in Victimology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "162",
+              "title": "Communication Skills for Human Services Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "100",
+              "title": "or HMS 100 Select a concentration support course",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "227",
+              "title": "The Helper as Change Agent",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADJ",
+              "number": "290",
+              "title": "or HMS 290 Coordinated Internship – determined by concentration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "230",
+              "title": "Ethics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "140",
+              "title": "Grant Proposal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "219",
+              "title": "Cross-Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education with Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Teaching in a Diverse Society with Practicum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "or MTH 161 Quantitative Reasoning or Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "111",
+              "title": "History of World Civilization Pre-1500 CE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "206",
+              "title": "or EDU 270 Classroom and Behavior Management or Introduction to Autism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "or MTH 245 Statistical Reasoning or Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "120",
+              "title": "or EEE Math for Elementary Teachers or Elective4",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "210",
+              "title": "People and the Land: Introduction to Cultural Geography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "200",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "207",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "American Sign Language (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "American Sign Language I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "102",
+              "title": "American Sign Language II1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "125",
+              "title": "History of the US Deaf Community I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "201",
+              "title": "American Sign Language III2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "202",
+              "title": "American Sign Language IV3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INT",
+              "number": "130",
+              "title": "Interpreting: An Introduction to the Profession",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Emergency Medical Services Technology – Paramedic (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "CPR for Healthcare Providers1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "111",
+              "title": "Emergency Medical Technician",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "120",
+              "title": "EMT – Basic Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Human Anatomy & Physiology for Health Sciences2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "100",
+              "title": "College Success Skills3",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "123",
+              "title": "EMS Clinical Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "180",
+              "title": "Advanced EMS Foundations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "181",
+              "title": "Advanced Airway & Shock Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "182",
+              "title": "Advanced Airway & Shock Management Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "183",
+              "title": "Advanced Medical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "184",
+              "title": "Advanced Medical Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "185",
+              "title": "Advanced Trauma Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "186",
+              "title": "Advanced Trauma Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "170",
+              "title": "ALS Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "222",
+              "title": "Paramedic Cardiovascular Care Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "223",
+              "title": "Paramedic Patient Care I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "224",
+              "title": "Paramedic Patient Care I Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "225",
+              "title": "Paramedic Patient Care I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Patient Care I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "246",
+              "title": "Paramedic Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "EMS Operations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Leadership and Professional Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "165",
+              "title": "Advanced Cardiac Life Support",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "163",
+              "title": "Prehospital Trauma Life Support",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "167",
+              "title": "Emergency Pediatric Care6",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "164",
+              "title": "Advanced Medical Life Support",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic Review",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "249",
+              "title": "Paramedic Capstone Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Social Sciences – Major in Psychology (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "or ITE 119",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Statistics for Behavioral Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Psychopathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "225",
+              "title": "Theories of Personality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "or PSY 219 Sociology Psychology or Cross-cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "211",
+              "title": "Research Methods",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Social Sciences – Major in Social Work (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "100",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "or ITE 119",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "or MTH 161 Statistical Reasoning or Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLS",
+              "number": "135",
+              "title": "United States Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "215",
+              "title": "Psychopathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "230",
+              "title": "Ethics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "106",
+              "title": "Life Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "162",
+              "title": "Communication Skills for Human Services Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "141",
+              "title": "Group Dynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "219",
+              "title": "Cross-Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "250",
+              "title": "Principles of Case Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Development, Infant and Toddler Care (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "164",
+              "title": "Working with Infants and Toddlers in Inclusive Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "165",
+              "title": "Observation and Participation in Early Childhood/Primary Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "166",
+              "title": "Infant and Toddler Programs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "135",
+              "title": "Child Health and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Development, Special Needs (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "270",
+              "title": "Introduction to Autism Spectrum Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "120",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "250",
+              "title": "Foundations of Exceptional Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "205",
+              "title": "Guiding the Behavior of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHD",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "106",
+              "title": "First Aid and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Substance Abuse Counselor-Assistant (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HMS",
+              "number": "141",
+              "title": "Group Dynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "121",
+              "title": "Basic Counseling Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "251",
+              "title": "Substance Abuse I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "145",
+              "title": "Effects of Psychoactive Drugs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "258",
+              "title": "Case Management and Substance Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "252",
+              "title": "Substance Abuse II1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "260",
+              "title": "Substance Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "198",
+              "title": "Seminar and Project",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HMS",
+              "number": "230",
+              "title": "Ethics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts (AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "or MTH 155 Quantitative Reasoning or Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "or CHM 111 General Biology I or General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "or CHM 112 General Biology II or General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts – Major in Art (AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Art History Prehistory to Gothic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "or MTH 155 Quantitative Reasoning or Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "Art History Renaissance to Modern",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "Three-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "or CHM 111 General Biology I or General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "133",
+              "title": "Time Studio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "or CHM 112 General Biology II or General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "215",
+              "title": "History of Modern Art",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Visual Art (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "Foundations of Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "180",
+              "title": "Introduction to Computer Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "History of Art: Prehistoric to Gothic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "Three-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "133",
+              "title": "Time Studio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "History of Art: Renaissance to Modern",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts – Major in Music (AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Music Theory I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Class Piano I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "or MTH 155 Quantitative Reasoning or Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Music Theory II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "or CHM 111 General Biology I or General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "142",
+              "title": "Class Piano II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "211",
+              "title": "Advanced Music Theory I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221",
+              "title": "History of Western Music pre-1750",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "or ART 102 History of Art: Prehistoric to Gothic or History of Art: Renaissance to Modern",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "History of Western Music post -1750",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "212",
+              "title": "Advanced Music Theory II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Applied Music (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "221",
+              "title": "Music History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "141",
+              "title": "Class Piano I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Music History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts – Major in Theatre (AA)",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "237",
+              "title": "Movement I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "131",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "145",
+              "title": "Technical Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "or MTH 155 Quantitative Reasoning or Statistical Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "132",
+              "title": "Acting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "160",
+              "title": "Improvisation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "or CHM 111 General Biology I or General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "136",
+              "title": "Theatre Workshop",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "149",
+              "title": "Introduction to Theatrical Makeup",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "210",
+              "title": "Dramatic Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "or CHM 112 General Biology II or General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "151",
+              "title": "Film Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "147",
+              "title": "Costume Construction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Applied Theatre (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CST",
+              "number": "131",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "136",
+              "title": "Theatre Workshop",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "130",
+              "title": "Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Foundations of Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "122",
+              "title": "Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Science – Major in Mathematics (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "263",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "264",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "266",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "241",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Principles of Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "267",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "242",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "265",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "or MTH 161 Quantitative Reasoning or Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "or MTH 245 Statistical Reasoning or Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences – Major in Sociology (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "or MTH 161 Quantitative Reasoning or Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "155",
+              "title": "or MTH 245 Statistical Reasoning or Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "211",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "236",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "United States History to 1877",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "215",
+              "title": "Sociology of the Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "266",
+              "title": "Race and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "122",
+              "title": "United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "216",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "268",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "or CHM 111 General Biology I or General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "261",
+              "title": "or BUS EEE Applied Calculus I or Approved Business Elective2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Accounting (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "or ITE 152",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "221",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Cost Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Principles of Federal Taxation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Intermediate Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Principles of Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "225",
+              "title": "Applied Business Statistics1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "106",
+              "title": "Preparation for Employment",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Management (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Principles of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "212",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "274",
+              "title": "Foundations of Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "120",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "225",
+              "title": "Applied Business Statistics1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "106",
+              "title": "Preparation for Employment",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Small Business Management (Entrepreneurship) (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "274",
+              "title": "Foundations of Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "160",
+              "title": "Marketing for Small Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Retail Management (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "or ITE 152",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "215",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "216",
+              "title": "Retail Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Industrial Supervision (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "120",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Introduction to Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "127",
+              "title": "Industrial Safety",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diesel Technology (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Track 1 (Day)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "111",
+              "title": "Introduction to Diesel",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "152",
+              "title": "Diesel Power Trains, Chassis, and Transmissions",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "143",
+              "title": "Diesel Truck Electrical Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "176",
+              "title": "Transportation Air Conditioning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "160",
+              "title": "Air Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "121",
+              "title": "Diesel Engines I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "122",
+              "title": "Diesel Engines II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Track 2 (Evening)",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DSL",
+              "number": "121",
+              "title": "Diesel Engines I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "122",
+              "title": "Diesel Engines II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "111",
+              "title": "Introduction to Diesel",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "152",
+              "title": "Diesel Power Trains, Chassis, and Transmissions",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "143",
+              "title": "Diesel Truck Electrical Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "176",
+              "title": "Transportation Air Conditioning",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DSL",
+              "number": "160",
+              "title": "Air Brakes",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "161",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "157",
+              "title": "Electricity Fundamentals",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "111",
+              "title": "Home Electric Power I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "or ENG 115 College Composition I or Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "112",
+              "title": "Home Electric Power II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "141",
+              "title": "DC & AC Machines",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "100",
+              "title": "Introduction to Information System1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "233",
+              "title": "Programmable Logic Controllers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "245",
+              "title": "Industrial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "225",
+              "title": "Electrical Control Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "234",
+              "title": "Programmable Logic Controllers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "240",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "175",
+              "title": "Industrial Solid State Devices & Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "120",
+              "title": "Human Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electric Code II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Electrical Technician (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "111",
+              "title": "Home Electric Power I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "157",
+              "title": "Electricity Fundamentals",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "112",
+              "title": "Home Electric Power II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electric Code I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "141",
+              "title": "DC and AC machines",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Practical Electrical Technician (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "233",
+              "title": "Programmable Logic Controller Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "225",
+              "title": "Electrical Control Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "245",
+              "title": "Industrial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "100",
+              "title": "Intro. Information Systems or Fundamentals of Computer Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "175",
+              "title": "Industrial Solid State Devices and Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "234",
+              "title": "Programmable Logic Controller Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "240",
+              "title": "Advanced Programmable Logic controller",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electric Code II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics-Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology – Specialization in Mechatronics (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "157",
+              "title": "Electricity Fundamentals",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Intro to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "or ENG 115 College Composition I or Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "141",
+              "title": "DC & AC Machines",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "100",
+              "title": "Introduction to Information System1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "243",
+              "title": "Principles and Applications of Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "233",
+              "title": "Programmable Logic Controllers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "245",
+              "title": "Industrial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "225",
+              "title": "Electrical Control Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "234",
+              "title": "Programmable Logic Controllers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "240",
+              "title": "Advance Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "232",
+              "title": "Systems Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "175",
+              "title": "Industrial Solid State Devices & Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electric Code II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Mechatronics (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "157",
+              "title": "Electricity Fundamentals",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "140",
+              "title": "Introduction to Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IND",
+              "number": "243",
+              "title": "Principles and Applications of Mechatronics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "141",
+              "title": "DC and AC Machines",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Mechatronics (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELE",
+              "number": "225",
+              "title": "Electrical Control Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "233",
+              "title": "Programmable Logic Controllers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "245",
+              "title": "Industrial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INS",
+              "number": "232",
+              "title": "Systems Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "175",
+              "title": "Industrial Solid State Devices and Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "234",
+              "title": "Programmable Logic Controllers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "240",
+              "title": "Advanced Programmable Logic Controllers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electric Code II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEC",
+              "number": "161",
+              "title": "Basic Fluid Mechanics - Hydraulics/Pneumatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "or 115 College Composition I or Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "or ECO 202 Principles of Macroeconomics or Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "111",
+              "title": "Home Electric Power I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "157",
+              "title": "Electricity Fundamentals",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "141",
+              "title": "DC & AC Machines",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "112",
+              "title": "Home Electric Power II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electric Code I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electrical Technology – Specialization in Energy Technology (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "or 115 College Composition I or Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "161",
+              "title": "Blueprint Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "111",
+              "title": "Home Electric Power I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "157",
+              "title": "Electricity Fundamentals",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "100",
+              "title": "Introduction to Information Systems1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "141",
+              "title": "DC & AC Machines",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "112",
+              "title": "Home Electric Power II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "131",
+              "title": "National Electrical Code I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "100",
+              "title": "Conventional and Alternate Energy Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "or REL 230 Music Appreciation I or Religions of the World2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "176",
+              "title": "Introduction to Alternative Energy Including Hybrid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "245",
+              "title": "Industrial Wiring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "177",
+              "title": "Photovoltaic Energy Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "175",
+              "title": "Industrial Solid State Devices & Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENE",
+              "number": "200",
+              "title": "Power Monitoring",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "132",
+              "title": "National Electrical Code II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "or PSY 120 Principles of Macroeconomics or Human Relations4",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Air Conditioning, Refrigeration, and Heating (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Cond. & Ref. Controls I1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "171",
+              "title": "Refrigeration I1",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "159",
+              "title": "Heating and Cooling Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "112",
+              "title": "Air Cond. & Ref. Controls II2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "276",
+              "title": "Refrigerant Usage EPA Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "172",
+              "title": "Refrigeration II2",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "122",
+              "title": "Air Conditioning and Refrigeration II2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "134",
+              "title": "Circuits and Controls I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "176",
+              "title": "Air Conditioning",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "235",
+              "title": "Heat Pumps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "154",
+              "title": "Heating Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "165",
+              "title": "Air Conditioning Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "205",
+              "title": "Hydronics and Zoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "231",
+              "title": "Circuits and Controls IV",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Refrigeration (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to college Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "111",
+              "title": "Air Conditioning and Refrigeration Controls I1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "121",
+              "title": "Air Conditioning and Refrigeration I1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "159",
+              "title": "Heating and Cooling Safety",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "171",
+              "title": "Refrigeration I1",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Refrigeration (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AIR",
+              "number": "112",
+              "title": "Air Conditioning and Refrigeration Controls II1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "122",
+              "title": "Air Conditioning and Refrigeration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "172",
+              "title": "Refrigeration II1",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AIR",
+              "number": "276",
+              "title": "Refrigerant Usage EPA Certification1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science with a Major in Natural Resources (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "161",
+              "title": "Precalculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "162",
+              "title": "or MTH 261 Precalculus II or Applied Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Principles of Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "Plant Life of Virginia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture Technology (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "100",
+              "title": "Intro. to Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "205",
+              "title": "Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "Plant Life of Virginia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "OR 115 College Composition I or Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "207",
+              "title": "Plant Pest Management*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "119",
+              "title": "Irrigation Systems for Turf & Ornamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "134",
+              "title": "Four Season Food Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "115",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "197",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "259",
+              "title": "Arboriculture*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "295",
+              "title": "Topics in Cannabis Cultivation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Applied Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "226",
+              "title": "Greenhouse Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture Technology – Specialization in Business and (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "100",
+              "title": "Intro. to Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "OR 115 College Composition I or Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "207",
+              "title": "Plant Pest Management*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "225",
+              "title": "Nursery & Garden Center Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "134",
+              "title": "Four Season Food Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "115",
+              "title": "Plant Propagation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "197",
+              "title": "Cooperative Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "Plant Life of Virginia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "259",
+              "title": "Arboriculture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Applied Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "285",
+              "title": "Management of a Horticultural Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Agriculture Management (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "141",
+              "title": "Introduction to Animal Science and Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "142",
+              "title": "Introduction to Plant Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "205",
+              "title": "Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "207",
+              "title": "Plant Pest Management*",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "143",
+              "title": "Introduction to Agribusiness & Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "231",
+              "title": "Agribusiness Marketing, Risk Management, and Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Horticulture Production (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRT",
+              "number": "100",
+              "title": "Intro. To Horticulture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "Plant Life of Virginia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "205",
+              "title": "Soils",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "207",
+              "title": "Plant Pest Management*",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality & Tourism Management (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRI",
+              "number": "154",
+              "title": "Principles of Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "103",
+              "title": "Introduction to Meeting Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "195",
+              "title": "Topics in Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "256",
+              "title": "Principles and Applications of Catering1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "136",
+              "title": "Storeroom Operations & Inventory Mgt. Laboratory1",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "153",
+              "title": "Appalachian Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital & Information Literacy & Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "235",
+              "title": "Marketing of Hospitality Services2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "255",
+              "title": "Human Res. Mgmt. and Trng. For Hospi. and Tourism2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "246",
+              "title": "Creative Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "140",
+              "title": "Fundamentals of Quality for Hospitality Industry3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "290",
+              "title": "Coordinated Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "106",
+              "title": "Principles of Culinary Arts I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "107",
+              "title": "Principles of Culinary Arts II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BAK",
+              "number": "128",
+              "title": "Principles of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRI",
+              "number": "158",
+              "title": "Sanitation and Safety",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Information Systems Technology (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "110",
+              "title": "Web Page Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "or ITE 152",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "182",
+              "title": "User Support/Help Desk Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "or MTH 155 Business Mathematics or Statistical Reasoning1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "or CST 126 Principles of Public Speaking or Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "150",
+              "title": "Desktop Database Software",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object Oriented Programming3",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "or ECO 202 Principles of Macroeconomics or Principles of Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structured Query Language4",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "113",
+              "title": "Active Directory (Windows Server)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology – Specialization in Networking (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "or ITE 152",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "182",
+              "title": "User Support/Help Desk Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "or MTH 155 Business Mathematics or Statistical Reasoning1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "PC Hardware & Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "113",
+              "title": "Active Directory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Objected Oriented Programming4",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "or 126 Principles of Public Speaking or Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Micro. Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "105",
+              "title": "Cyber Careers and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structured Query Language5",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime and Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking Fundamentals I (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "105",
+              "title": "Cyber Careers and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "106",
+              "title": "Microcomputer Operating Systems1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "107",
+              "title": "Personal Computer Hardware and Troubleshooting3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime and Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "or 119",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming4",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking Fundamentals II (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object Oriented Programming1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "182",
+              "title": "User Support/Helpdesk Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux System Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "113",
+              "title": "Active Directory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITD",
+              "number": "132",
+              "title": "Structured Query Language",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cyber Security (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "221",
+              "title": "Introduction to Problem Solving and Programming1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "105",
+              "title": "Cyber Careers and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "101",
+              "title": "Introduction to Network Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "222",
+              "title": "Object Oriented Programming2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "260",
+              "title": "Network Security Basics3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "170",
+              "title": "Linux I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITN",
+              "number": "261",
+              "title": "Network Attacks, Computer Crime, and Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Small Unmanned Aerial Systems (sUAS) (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "UMS",
+              "number": "107",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Remote Pilot Ground School1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "111",
+              "title": "Small Unmanned Aircraft Systems (sUAS) I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UMS",
+              "number": "177",
+              "title": "Small Unmanned Aircraft Systems (sUAS) Components and Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding and Billing (Pending SCHEV Approval) (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Health Information Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "176",
+              "title": "Medical Office /Unit Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "or ENG 115 College Composition I 1or Technical Writing2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "113",
+              "title": "Medical Terminology and Disease Processes3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "151",
+              "title": "Reimbursement Issues in Medical Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "260",
+              "title": "Presentation Software (PowerPoint, Zoom)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "163",
+              "title": "Anatomy and Physiology for Administrative Health Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "253",
+              "title": "Health Records Coding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "195",
+              "title": "Topics In Customer Service",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "260",
+              "title": "Pharmacology for Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "254",
+              "title": "Advanced Coding and Reimbursement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "126",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "231",
+              "title": "Health Records Applications I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "293",
+              "title": "Studies in Examination Preparation4",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "149",
+              "title": "Introduction to Medical Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding Specialist (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to Health Information Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "152",
+              "title": "Introduction to Digital and Information Literacy and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "113",
+              "title": "Medical Terminology & Disease Processes I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "151",
+              "title": "Reimbursement Issues in Medical Practice Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "226",
+              "title": "Legal Aspects of Health Record Documentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "253",
+              "title": "Health Records Coding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "176",
+              "title": "Medical Office/Unit Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "163",
+              "title": "Anatomy and Physiology for Administrative Health Professionals1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "231",
+              "title": "Health Records Applications 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "254",
+              "title": "Advanced Coding and Reimbursement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIM",
+              "number": "293",
+              "title": "Studies in Examination Preparation",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Management (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "195",
+              "title": "Topics in Customer Service Course",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "230",
+              "title": "Introduction to Office Technology1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "119",
+              "title": "or Information Literacy or",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "107",
+              "title": "Editing/Proofreading Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "205",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "238",
+              "title": "Word Processing Advanced Operations2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "132",
+              "title": "Business Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "137",
+              "title": "Records Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "260",
+              "title": "Presentation Software (PowerPoint, Zoom)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITE",
+              "number": "140",
+              "title": "Spreadsheeting for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "243",
+              "title": "Office Administration I3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "290",
+              "title": "Coordinated Internship4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "215",
+              "title": "Computerized Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Computer Numerical Control Machine Operations (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Track 1 (Day)",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "161",
+              "title": "Machine Shop Practices I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "162",
+              "title": "Machine Shop Practices II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "116",
+              "title": "Machinery’s Handbook",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "150",
+              "title": "Introduction to Computer Aided Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "163",
+              "title": "Machine Shop Practices III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "164",
+              "title": "Machine Shop Practices IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "123",
+              "title": "Numerical Control III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "126",
+              "title": "Introductory CNC Programming (MAZAK)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machine Trade Theory and Computation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "127",
+              "title": "Advanced CNC Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "134",
+              "title": "CMM Operation and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Math",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "206",
+              "title": "Production Machining Techniques",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "290",
+              "title": "Coordinated Internship or Technical Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Track 2 (Evening)",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "161",
+              "title": "Machine Shop Practices I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "162",
+              "title": "Machine Shop Practices II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "116",
+              "title": "Machinery’s Handbook",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "163",
+              "title": "Machine Shop Practices III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "150",
+              "title": "Introduction to Computer Aided Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "123",
+              "title": "Numerical Control III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "164",
+              "title": "Machine Shop Practices IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "126",
+              "title": "Introduction to CNC Programming (MAZAK)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Machine Trade Theory & Computation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "111",
+              "title": "Basic Technical Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "134",
+              "title": "CMM Operation and Programming",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "206",
+              "title": "Production Machining Techniques",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "127",
+              "title": "Advanced CNC Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "290",
+              "title": "Coordinated Internship or Technical Elective",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Precision Machining (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Track 1 (Day)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DRF",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "161",
+              "title": "Machine Shop Practices I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "162",
+              "title": "Machine Shop Practices II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "116",
+              "title": "Machinery’s Handbook",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety OSHA-10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Track 2 (Evening)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "161",
+              "title": "Machine Shop Practices I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "121",
+              "title": "Numerical Control I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety OSHA-10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DRF",
+              "number": "161",
+              "title": "Blueprint Reading I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "162",
+              "title": "Machine Shop Practices II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "116",
+              "title": "Machinery’s Handbook",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "122",
+              "title": "Numerical Control II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Advanced Precision Machining (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Track 1 (Day)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "150",
+              "title": "Introduction to Computer Aided Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "163",
+              "title": "Machine Shop Practices III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "164",
+              "title": "Machine Shop Practices IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "123",
+              "title": "Numerical Control III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "126",
+              "title": "Introductory CNC Programming (MAZAK)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Track 2 (Evening)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "163",
+              "title": "Machine Shop Practices III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "150",
+              "title": "Introduction to Computer Aided Manufacturing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "123",
+              "title": "Numerical Control III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "164",
+              "title": "Machine Shop Practices IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "126",
+              "title": "Introductory CNC Programming (MAZAK)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Welding (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Track 1 (Day)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "120",
+              "title": "Introduction to Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "150",
+              "title": "Welding Drawing & Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "161",
+              "title": "Fluxed Cored Arc Welding (FCAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "164",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Track 2 (Evening)",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WEL",
+              "number": "120",
+              "title": "Introduction to Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "123",
+              "title": "Shielded Metal Arc Welding (SMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "150",
+              "title": "Welding Drawing & Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "160",
+              "title": "Gas Metal Arc Welding (GMAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "161",
+              "title": "Fluxed Cored Arc Welding (FCAW)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "164",
+              "title": "Gas Tungsten Arc Welding (GTAW)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Advanced Welding (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Track 1 (Day)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "106",
+              "title": "First Aid and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "117",
+              "title": "Oxyfuel Welding and Cutting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "124",
+              "title": "Shielded Metal Arc Welding (SMAW II)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "130",
+              "title": "Inert Gas Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "136",
+              "title": "Welding III (Inert Gas)",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Track 2 (Evening)",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "106",
+              "title": "First Aid and Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAF",
+              "number": "130",
+              "title": "Industrial Safety – OSHA 10",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "124",
+              "title": "Shielded Metal Arc Welding (SMAW II)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "136",
+              "title": "Welding III (Inert Gas)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "130",
+              "title": "Inert Gas Welding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEL",
+              "number": "117",
+              "title": "Oxyfuel Welding and Cutting",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "welding"
+    },
+    {
+      "title": "Health Sciences (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "or CHM 111 General Biology I or General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "or SOC 200 Introduction to Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "or CHM 112 General Biology II or General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences – Major in Kinesiology (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 62,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "or MTH 263 Statistics I or Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "111",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "112",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "206",
+              "title": "Introduction to Kinesiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "or PHY 241 General Biology I or University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "Human Gross Anatomy I2",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "106",
+              "title": "First Aid and Safety2",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "or PHY 242 General Biology II or University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences – Major in Public Health (AS)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "245",
+              "title": "or MTH 263 Statistics I or Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "101",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "121",
+              "title": "or HIS 122 United States History to 1877 or United States History Since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "228",
+              "title": "Introduction to Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "230",
+              "title": "Principles of Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "or ENG 246 British Literature or American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CST",
+              "number": "100",
+              "title": "Principles of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Personal and Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "or SOC 200 Developmental Psychology or Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "100",
+              "title": "Intro. to Medical Assisting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "101",
+              "title": "Medical Assistant Science I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "107",
+              "title": "Pharmacology for Medical Assistants",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "104",
+              "title": "Medical Assistant Science IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "102",
+              "title": "Medical Assistant Science II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "209",
+              "title": "Medical Office Insurance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "203",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDA",
+              "number": "196",
+              "title": "On-Site Training",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "140",
+              "title": "Introduction to Health Related Professions",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Phlebotomy (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "140",
+              "title": "Orientation to Health Related Professions",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "105",
+              "title": "Phlebotomy1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDL",
+              "number": "196",
+              "title": "On Site Training1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Health Care Personnel",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nurse Aide (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "101",
+              "title": "Health Care Technician I1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCT",
+              "number": "102",
+              "title": "Health Care Technician II1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "145",
+              "title": "Basic Human Anatomy & Physiology1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success2",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "143",
+              "title": "Applied Nursing Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "161",
+              "title": "Nursing in Health Changes I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "173",
+              "title": "Pharmacology for Practical Nurses",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "105",
+              "title": "Cardiopulmonary Resuscitation3",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations4",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "162",
+              "title": "Nursing in Health Changes II",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "136",
+              "title": "Care of Maternal, Newborn, & Pediatric Patients",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "163",
+              "title": "Nursing In Health Changes III",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "145",
+              "title": "Trends in Practical Nursing",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNE",
+              "number": "158",
+              "title": "Mental Health & Psychiatric Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 69,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Intro to Nursing Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion & Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 58,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1151",
+              "title": "Health Care Concepts for Transition",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion and Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 69,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion & Assessment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "100",
+              "title": "Introduction to Nursing Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "106",
+              "title": "Competencies for Nursing Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "130",
+              "title": "Professional Nursing Concepts",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "170",
+              "title": "Health/Illness Concepts",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "152",
+              "title": "Health Care Participant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 58,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Microbiology for Health Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "135",
+              "title": "Drug Dosage Calculations",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SDV",
+              "number": "101",
+              "title": "Orientation to College Success",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "1151",
+              "title": "Health Care Concepts for Transition",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "200",
+              "title": "Health Promotion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "211",
+              "title": "Health Care Concepts II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "210",
+              "title": "Health Care Concepts",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "College Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "252",
+              "title": "Complex Health Care Concepts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "230",
+              "title": "Advanced Professional Nursing Concepts",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NSG",
+              "number": "270",
+              "title": "Nursing Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Radiography (AAS)",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 72,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 72,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "105",
+              "title": "Intro to Radiology Protection & Patient Care (Term II)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "College Composition I1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "154",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "141",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "110",
+              "title": "Imaging Equipment and Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "121",
+              "title": "Radiographic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "142",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "112",
+              "title": "Radiologic Science II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "221",
+              "title": "Radiographic Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "205",
+              "title": "Radiation Protection & Radiobiology (Term I)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "256",
+              "title": "Radiographic Film Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "270",
+              "title": "Digital Image Acquisition & Display",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "240",
+              "title": "Radiographic Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "215",
+              "title": "Correlated Radiographic Theory",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computerized Tomography (CSC)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "247",
+              "title": "Cross Sectional Anatomy for CT/MR",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "242",
+              "title": "CT Procedures and Instrumentation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "195",
+              "title": "Topics in Ethics, Teamwork & Professional Development",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "196",
+              "title": "On Site Training Clinical Internship in CT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "295",
+              "title": "Topics in CT Registry Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "143",
+              "title": "Medical Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "145",
+              "title": "Ethics for Healthcare Personnel",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Recommended Course Sequence",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RAD",
+              "number": "233",
+              "title": "Anatomy and Positioning of the Breast",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "234",
+              "title": "Breast Imaging/Instrumentation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "235",
+              "title": "Quality Assurance in Mammography",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "196",
+              "title": "On-Site Training Clinical Internship in Mammography",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/va/config.ts
+++ b/lib/states/va/config.ts
@@ -87,6 +87,14 @@ const vaConfig: StateConfig = {
         scripts: ["scripts/va/scrape-courseleaf-programs.ts"],
         runner: "http",
       },
+      {
+        scripts: ["scripts/va/scrape-vhcc-pdf-programs.ts"],
+        runner: "http",
+      },
+      {
+        scripts: ["scripts/va/scrape-camp-pdf-programs.ts"],
+        runner: "http",
+      },
     ],
   },
 };

--- a/scripts/lib/scrape-acalog-programs.ts
+++ b/scripts/lib/scrape-acalog-programs.ts
@@ -388,7 +388,7 @@ function parseProgramPage(
   const programCode = parseProgramCode(rawTitle);
 
   // Clean title: remove program code and trailing credential abbreviations
-  let title = rawTitle
+  const title = rawTitle
     .replace(/\s*\([A-Z0-9][-A-Z0-9]+\)\s*$/, "")
     .replace(/\s+-\s+\d{3,}\s*$/, "")
     .trim();

--- a/scripts/va/scrape-camp-pdf-programs.ts
+++ b/scripts/va/scrape-camp-pdf-programs.ts
@@ -1,0 +1,321 @@
+/**
+ * scrape-camp-pdf-programs.ts — extract program requirements for
+ * Camp Community College (formerly Paul D. Camp / PDCCC) from their
+ * Google Drive-hosted PDF catalog.
+ *
+ * Closes #235. Camp publishes their catalog as PDFs on Google Drive,
+ * linked from https://www.pdc.edu/servicesandresources/resources-and-services-for-students/college-catalog-and-student-handbook/.
+ *
+ * Each program block in the PDF has a clean fielded header:
+ *   Program:        Education
+ *   Award:          Associate of Arts and Sciences
+ *   Plan Code:      624
+ *   CIP Code:       24.0101
+ *   Length:         60 credit hours
+ *   …
+ * Then prose, then a "{Program Name} ({Plan Code})" sub-header followed
+ * by a "Required Courses and Credits / Sample Schedule" table broken
+ * into "First Semester / Second Semester / …" sections, ending with a
+ * "Total Program Credits N" or "Total Credits N" row.
+ *
+ * Requires: pdftotext (poppler) on PATH.  brew install poppler
+ *
+ * Usage:
+ *   npx tsx scripts/va/scrape-camp-pdf-programs.ts
+ *   npx tsx scripts/va/scrape-camp-pdf-programs.ts --pdf=/tmp/camp.pdf --keep-text
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequiredCourse,
+} from "../../lib/types.js";
+
+const COLLEGE_SLUG = "camp";
+const CATALOG_INDEX_URL =
+  "https://www.pdc.edu/servicesandresources/resources-and-services-for-students/college-catalog-and-student-handbook/";
+// Known-good fallback (2025-2026). Discovery scrapes the catalog page for
+// the latest Google Drive file id.
+const FALLBACK_DRIVE_ID = "11iMKYCDFeDLd-Xeay1BG5RZIhR-2oiLn";
+const FALLBACK_DRIVE_VIEW_URL =
+  `https://drive.google.com/file/d/${FALLBACK_DRIVE_ID}/view?usp=sharing`;
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function getArg(name: string): string | null {
+  const args = process.argv.slice(2);
+  const eq = args.find((a) => a.startsWith(`--${name}=`));
+  if (eq) return eq.split("=").slice(1).join("=");
+  const flat = args.indexOf(`--${name}`);
+  if (flat >= 0 && args[flat + 1] && !args[flat + 1].startsWith("--")) {
+    return args[flat + 1];
+  }
+  return null;
+}
+
+const ARG_PDF_PATH = getArg("pdf");
+const ARG_KEEP = process.argv.includes("--keep-text");
+
+// ---------------------------------------------------------------------------
+// Discovery + download
+// ---------------------------------------------------------------------------
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": UA, Accept: "text/html,*/*" },
+    redirect: "follow",
+  });
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return res.text();
+}
+
+/**
+ * Camp's catalog page links to Google Drive PDFs. Discover the file id from
+ * the most recent "Camp Catalog & Student Handbook" link. Fall back to the
+ * known-good 2025-2026 file id if discovery fails.
+ */
+async function discoverDriveFileId(): Promise<{ fileId: string; viewUrl: string }> {
+  try {
+    const html = await fetchText(CATALOG_INDEX_URL);
+    // Look for the prominent "Camp Catalog & Student Handbook" link first
+    // (it's the current year). If not labelled, fall back to the first
+    // drive.google.com/file/d/{id}/view link on the page.
+    const re = /href="(https:\/\/drive\.google\.com\/file\/d\/([^/"]+)\/[^"]+)"/g;
+    const matches: { url: string; id: string }[] = [];
+    let m;
+    while ((m = re.exec(html)) !== null) {
+      matches.push({ url: m[1], id: m[2] });
+    }
+    if (matches.length > 0) {
+      // The first match is typically the current/featured catalog
+      return { fileId: matches[0].id, viewUrl: matches[0].url };
+    }
+  } catch (e) {
+    console.warn(`  discovery failed (${e}); falling back to known URL`);
+  }
+  return { fileId: FALLBACK_DRIVE_ID, viewUrl: FALLBACK_DRIVE_VIEW_URL };
+}
+
+async function downloadDrivePdf(fileId: string, dest: string): Promise<void> {
+  // Google Drive direct-download endpoint
+  const url = `https://drive.google.com/uc?export=download&id=${fileId}`;
+  const res = await fetch(url, { headers: { "User-Agent": UA }, redirect: "follow" });
+  if (!res.ok) throw new Error(`download ${url} -> HTTP ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  fs.writeFileSync(dest, buf);
+}
+
+function pdfToText(pdfPath: string, txtPath: string): void {
+  execFileSync("pdftotext", ["-layout", pdfPath, txtPath], {
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+interface ProgramHeader {
+  /** Line index of the "Program:" line */
+  startLine: number;
+  programName: string;
+  awardText: string;
+}
+
+function findProgramHeaders(lines: string[]): ProgramHeader[] {
+  const out: ProgramHeader[] = [];
+  for (let i = 0; i < lines.length - 1; i++) {
+    const a = lines[i].trim();
+    const b = lines[i + 1].trim();
+    const programMatch = a.match(/^Program:\s+(.+?)\s*$/);
+    const awardMatch = b.match(/^Award:\s+(.+?)\s*$/);
+    if (programMatch && awardMatch) {
+      out.push({
+        startLine: i,
+        programName: programMatch[1].trim(),
+        awardText: awardMatch[1].trim(),
+      });
+    }
+  }
+  return out;
+}
+
+function parseCredential(awardText: string): ProgramCredential {
+  const t = awardText.toLowerCase();
+  if (/applied science/.test(t)) return "AAS";
+  if (/associate of arts and sciences|associate of arts/.test(t)) return "AA";
+  if (/associate of science|associate of sciences/.test(t)) return "AS";
+  if (/career studies certificate/.test(t)) return "certificate";
+  if (/diploma/.test(t)) return "diploma";
+  if (/certificate/.test(t)) return "certificate";
+  return "other";
+}
+
+// Course rows in camp's tables have the form:
+//   "        ENG 111            College Composition I1                                  3"
+// Multi-column with credits at the end. Some rows have a credit range.
+const COURSE_ROW_RE =
+  /^\s*([A-Z]{2,5})\s+(\d{2,4}[A-Z]?)(?:\s+or\s+\d{2,4})?\s{2,}(.+?)\s{2,}(\d+(?:-\d+)?)\s*$/;
+
+const TOTAL_RE =
+  /\bTotal\s+(?:Program\s+|Credits\s+Required:?\s*|Required:?\s*)?Credits?(?:\s+Required)?\s*([0-9]+(?:-[0-9]+)?)\s*$/i;
+
+function parseProgramBlock(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+): { courses: RequiredCourse[]; totalCredits: number | null } {
+  const courses: RequiredCourse[] = [];
+  const seen = new Set<string>();
+  let totalCredits: number | null = null;
+
+  for (let i = startLine + 1; i < endLine; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const totalMatch = trimmed.match(TOTAL_RE);
+    if (totalMatch) {
+      const v = totalMatch[1];
+      const upper = v.includes("-") ? parseInt(v.split("-")[1], 10) : parseInt(v, 10);
+      // Stop at the FIRST "Total Program Credits" row — that's the program total.
+      // Per-semester "Total Semester Credits N" rows match the regex too; we
+      // need to differentiate. The Program total appears AFTER the last semester
+      // total; looking at the actual structure, the program total typically
+      // says "Total Program Credits" (or just "Total Credits") and is the last
+      // one before the next program block.
+      if (/Total\s+Program\s+Credits/i.test(trimmed)) {
+        totalCredits = upper;
+        // Don't break — there might be additional notes following
+      } else if (/Total\s+Semester\s+Credits/i.test(trimmed)) {
+        // Per-semester subtotal — ignore
+      } else if (/^Total\s+Credits/i.test(trimmed)) {
+        // Generic total — only adopt if we haven't seen a more specific one
+        if (totalCredits === null) totalCredits = upper;
+      }
+      continue;
+    }
+
+    const m = line.match(COURSE_ROW_RE);
+    if (!m) continue;
+    const [, prefix, number, rawTitle, creditsStr] = m;
+    const title = rawTitle.replace(/\s+/g, " ").replace(/\d+$/, "").trim();
+    if (!title) continue;
+    if (/^(Course Title|Course Number|Sample|First|Second|Third|Fourth|Fifth)/i.test(title)) {
+      continue;
+    }
+    const upper = creditsStr.includes("-")
+      ? parseInt(creditsStr.split("-")[1], 10)
+      : parseInt(creditsStr, 10);
+    const key = `${prefix} ${number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    courses.push({
+      prefix,
+      number,
+      title,
+      credits: upper,
+      or_alternatives: [],
+    });
+  }
+
+  return { courses, totalCredits };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const tmp = os.tmpdir();
+  const pdfPath = ARG_PDF_PATH ?? path.join(tmp, "camp-catalog.pdf");
+  const txtPath = path.join(tmp, "camp-catalog.txt");
+
+  let catalogUrl: string;
+  if (ARG_PDF_PATH) {
+    catalogUrl = CATALOG_INDEX_URL;
+    console.log(`Using local PDF: ${pdfPath}`);
+  } else {
+    console.log("Discovering latest Camp catalog PDF on Google Drive...");
+    const { fileId, viewUrl } = await discoverDriveFileId();
+    catalogUrl = viewUrl;
+    console.log(`  Drive file id: ${fileId}`);
+    console.log(`  Downloading -> ${pdfPath}`);
+    await downloadDrivePdf(fileId, pdfPath);
+  }
+
+  console.log(`Running pdftotext -layout -> ${txtPath}`);
+  pdfToText(pdfPath, txtPath);
+  const lines = fs.readFileSync(txtPath, "utf8").split(/\r?\n/);
+  console.log(`  Loaded ${lines.length} lines of text`);
+
+  const headers = findProgramHeaders(lines);
+  console.log(`  Found ${headers.length} program-block headers`);
+
+  const programs: ProgramRequirement[] = [];
+  for (let i = 0; i < headers.length; i++) {
+    const h = headers[i];
+    const nextStart = i + 1 < headers.length ? headers[i + 1].startLine : lines.length;
+    const { courses, totalCredits } = parseProgramBlock(lines, h.startLine, nextStart);
+    if (courses.length === 0) continue;
+
+    programs.push({
+      title: h.programName,
+      credential: parseCredential(h.awardText),
+      program_code: null,
+      catalog_url: catalogUrl,
+      total_credits: totalCredits,
+      gpa_minimum: 2.0,
+      description: null,
+      requirement_groups: [
+        {
+          name: "Recommended Course Sequence",
+          credits_required: totalCredits,
+          choose_n: null,
+          courses,
+        },
+      ],
+      matched_program_slug: null,
+    });
+  }
+
+  console.log(`  Parsed ${programs.length} programs`);
+
+  const { matched, unmatched } = applyProgramMatching(programs);
+  console.log(
+    `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+  );
+
+  const data: CollegePrograms = {
+    college_slug: COLLEGE_SLUG,
+    catalog_year: "",
+    catalog_url: catalogUrl,
+    scraped_at: new Date().toISOString(),
+    programs,
+  };
+
+  const outDir = path.join(process.cwd(), "data", "va", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${COLLEGE_SLUG}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+  console.log(`\n✓ Wrote ${programs.length} programs to ${outPath}`);
+
+  if (!ARG_KEEP) fs.unlinkSync(txtPath);
+  else console.log(`  text kept at ${txtPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/va/scrape-vhcc-pdf-programs.ts
+++ b/scripts/va/scrape-vhcc-pdf-programs.ts
@@ -1,0 +1,350 @@
+/**
+ * scrape-vhcc-pdf-programs.ts — extract program requirements for
+ * Virginia Highlands Community College (VCCS) from their PDF-only
+ * catalog.
+ *
+ * Closes #236. VHCC publishes a single combined catalog PDF on
+ * https://www.vhcc.edu/catalog rather than an Acalog/CourseLeaf
+ * instance.
+ *
+ * Each program block in the PDF starts with a heading line like:
+ *   "Associate of Applied Science (AAS) in Criminal Justice"
+ *   "Career Studies Certificate (CSC) in Welding"
+ *   "Associate of Science (AS) in Computer Science"
+ * Followed by a duration line ("Two/Four semesters"), a description
+ * paragraph, and one or more curriculum tables of the form:
+ *
+ *   Course Number    Course Title                                          Credits
+ *   ENG 111          College Composition I                                    3
+ *   …
+ *   Total Minimum Credits                                                    16
+ *
+ * Some programs have multiple "Tracks" (Day / Evening / etc.); we
+ * collapse these into a single requirement_groups array, one group
+ * per track, retaining the per-track Total Minimum Credits.
+ *
+ * Requires: pdftotext (poppler) on PATH.  brew install poppler
+ *
+ * Usage:
+ *   npx tsx scripts/va/scrape-vhcc-pdf-programs.ts
+ *   npx tsx scripts/va/scrape-vhcc-pdf-programs.ts --pdf=/tmp/vhcc.pdf --keep-text
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequiredCourse,
+  RequirementGroup,
+} from "../../lib/types.js";
+
+const COLLEGE_SLUG = "vhcc";
+const CATALOG_INDEX_URL = "https://www.vhcc.edu/catalog";
+// Known-good fallback (2026-2027). Discovery scrapes the catalog page
+// to pick up newer publications automatically.
+const FALLBACK_PDF_URL =
+  "https://www.vhcc.edu/sites/default/files/2026-03/2026-27%20VHCC%20Catalog%20-%20v1_1%20-%2020260312.pdf";
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function getArg(name: string): string | null {
+  const args = process.argv.slice(2);
+  const eq = args.find((a) => a.startsWith(`--${name}=`));
+  if (eq) return eq.split("=").slice(1).join("=");
+  const flat = args.indexOf(`--${name}`);
+  if (flat >= 0 && args[flat + 1] && !args[flat + 1].startsWith("--")) {
+    return args[flat + 1];
+  }
+  return null;
+}
+
+const ARG_PDF_PATH = getArg("pdf");
+const ARG_KEEP = process.argv.includes("--keep-text");
+
+// ---------------------------------------------------------------------------
+// Discovery + download + pdftotext
+// ---------------------------------------------------------------------------
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": UA, Accept: "text/html,*/*" },
+    redirect: "follow",
+  });
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return res.text();
+}
+
+async function discoverPdfUrl(): Promise<string> {
+  try {
+    const html = await fetchText(CATALOG_INDEX_URL);
+    // VHCC links to PDFs via href="https://www.vhcc.edu/sites/default/files/.../<...>VHCC%20Catalog<...>.pdf"
+    const re = /href="(https:\/\/www\.vhcc\.edu\/sites\/default\/files\/[^"]+VHCC[^"]+\.pdf)"/gi;
+    const matches: string[] = [];
+    let m;
+    while ((m = re.exec(html)) !== null) matches.push(m[1]);
+    if (matches.length > 0) return matches[0];
+  } catch (e) {
+    console.warn(`  discovery failed (${e}); falling back to known URL`);
+  }
+  return FALLBACK_PDF_URL;
+}
+
+async function downloadPdf(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, { headers: { "User-Agent": UA } });
+  if (!res.ok) throw new Error(`download ${url} -> HTTP ${res.status}`);
+  const buf = Buffer.from(await res.arrayBuffer());
+  fs.writeFileSync(dest, buf);
+}
+
+function pdfToText(pdfPath: string, txtPath: string): void {
+  execFileSync("pdftotext", ["-layout", pdfPath, txtPath], {
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+const HEADING_RE =
+  /^(Associate of Applied Science \(AAS\)|Associate of Arts \(AA\)|Associate of Science \(AS\)|Career Studies Certificate \(CSC\)|Certificate \(CERT\)|Diploma)\s+in\s+(.+?)\s*$/;
+
+function parseCredential(prefix: string): ProgramCredential {
+  if (/AAS/.test(prefix)) return "AAS";
+  if (/AA\b/.test(prefix)) return "AA";
+  if (/AS\b/.test(prefix)) return "AS";
+  if (/Diploma/i.test(prefix)) return "diploma";
+  return "certificate";
+}
+
+interface ProgramHeader {
+  startLine: number;
+  prefix: string;
+  programName: string;
+}
+
+function findProgramHeaders(lines: string[]): ProgramHeader[] {
+  const out: ProgramHeader[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].replace(/\s+$/, "");
+    const m = trimmed.match(HEADING_RE);
+    if (!m) continue;
+    out.push({ startLine: i, prefix: m[1], programName: m[2].trim() });
+  }
+  return out;
+}
+
+// Course rows look like:
+//   " ENG 111                    College Composition I                              3"
+// Sometimes the credit value is a range "3-6", sometimes a single integer.
+const COURSE_ROW_RE =
+  /^\s+([A-Z]{2,5})\s+(\d{2,4}[A-Z]?)\s+(.+?)\s{2,}(\d+(?:-\d+)?)\s*$/;
+
+const TOTAL_RE =
+  /\bTotal\s+(?:Minimum\s+)?Credits(?:\s+Required)?\s*([0-9]+(?:-[0-9]+)?)\s*$/i;
+
+interface ParsedTrack {
+  name: string;
+  courses: RequiredCourse[];
+  totalCredits: number | null;
+}
+
+function parseProgramBlock(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+): { tracks: ParsedTrack[]; totalCredits: number | null } {
+  const tracks: ParsedTrack[] = [];
+  let currentTrack: ParsedTrack = {
+    name: "Recommended Course Sequence",
+    courses: [],
+    totalCredits: null,
+  };
+  const seenInTrack = new Set<string>();
+  let blockTotal: number | null = null;
+
+  // Some VHCC programs name their tracks as "Track 1 (Day)" / "Track 2 (Evening)"
+  // or split by a "<Foo> Sequence" sub-header. Detect via headings followed by
+  // a "Course Number ... Course Title ... Credits" table-header line.
+  const TRACK_HEADING_RE = /^(?:\s*)(Track\s+\d+\s*\(.+?\)|.+?Sequence|.+?Schedule)\s*$/i;
+
+  for (let i = startLine + 1; i < endLine; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // "Total Credits Required" / "Total Minimum Credits"
+    const totalMatch = trimmed.match(TOTAL_RE);
+    if (totalMatch) {
+      const v = totalMatch[1];
+      const upper = v.includes("-") ? parseInt(v.split("-")[1], 10) : parseInt(v, 10);
+      currentTrack.totalCredits = upper;
+      // If this is the first total we see in the block, also use it as
+      // the program's overall total. Multiple tracks → keep the largest.
+      if (blockTotal === null || upper > blockTotal) blockTotal = upper;
+      // Push the current track and prepare a new one (in case another track follows).
+      if (currentTrack.courses.length > 0) {
+        tracks.push(currentTrack);
+      }
+      currentTrack = {
+        name: "Recommended Course Sequence",
+        courses: [],
+        totalCredits: null,
+      };
+      seenInTrack.clear();
+      continue;
+    }
+
+    // Track heading (e.g. "Track 1 (Day)")
+    const trackMatch = trimmed.match(TRACK_HEADING_RE);
+    if (
+      trackMatch &&
+      // Not the column-header row
+      !/Course\s+Number\s+Course\s+Title/i.test(trimmed) &&
+      // Not the start of a paragraph
+      trimmed.length < 60 &&
+      /Track\s+\d+/i.test(trimmed)
+    ) {
+      // If we have queued courses without a total yet, push the partial track
+      if (currentTrack.courses.length > 0) tracks.push(currentTrack);
+      currentTrack = {
+        name: trackMatch[1].trim(),
+        courses: [],
+        totalCredits: null,
+      };
+      seenInTrack.clear();
+      continue;
+    }
+
+    const m = line.match(COURSE_ROW_RE);
+    if (!m) continue;
+    const [, prefix, number, rawTitle, creditsStr] = m;
+    // Skip artifacts: a "row" with Title="Course Title" is the column header
+    if (/^Course\s+Title/i.test(rawTitle.trim())) continue;
+    const title = rawTitle.replace(/\s+/g, " ").trim();
+    const creditsUpper = creditsStr.includes("-")
+      ? parseInt(creditsStr.split("-")[1], 10)
+      : parseInt(creditsStr, 10);
+    const key = `${prefix} ${number}`;
+    if (seenInTrack.has(key)) continue;
+    seenInTrack.add(key);
+    currentTrack.courses.push({
+      prefix,
+      number,
+      title,
+      credits: creditsUpper,
+      or_alternatives: [],
+    });
+  }
+
+  // Push the last open track if it has courses
+  if (currentTrack.courses.length > 0) tracks.push(currentTrack);
+
+  return { tracks, totalCredits: blockTotal };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const tmp = os.tmpdir();
+  const pdfPath = ARG_PDF_PATH ?? path.join(tmp, "vhcc-catalog.pdf");
+  const txtPath = path.join(tmp, "vhcc-catalog.txt");
+
+  let catalogUrl: string;
+  if (ARG_PDF_PATH) {
+    catalogUrl = CATALOG_INDEX_URL;
+    console.log(`Using local PDF: ${pdfPath}`);
+  } else {
+    console.log("Discovering latest VHCC catalog PDF...");
+    catalogUrl = await discoverPdfUrl();
+    console.log(`  PDF URL: ${catalogUrl}`);
+    console.log(`  Downloading -> ${pdfPath}`);
+    await downloadPdf(catalogUrl, pdfPath);
+  }
+
+  console.log(`Running pdftotext -layout -> ${txtPath}`);
+  pdfToText(pdfPath, txtPath);
+  const lines = fs.readFileSync(txtPath, "utf8").split(/\r?\n/);
+  console.log(`  Loaded ${lines.length} lines of text`);
+
+  const headers = findProgramHeaders(lines);
+  console.log(`  Found ${headers.length} program-block headers`);
+
+  const programs: ProgramRequirement[] = [];
+  for (let i = 0; i < headers.length; i++) {
+    const h = headers[i];
+    const nextStart = i + 1 < headers.length ? headers[i + 1].startLine : lines.length;
+    const { tracks, totalCredits } = parseProgramBlock(lines, h.startLine, nextStart);
+    if (tracks.length === 0 || tracks.every((t) => t.courses.length === 0)) continue;
+
+    const requirementGroups: RequirementGroup[] = tracks
+      .filter((t) => t.courses.length > 0)
+      .map((t) => ({
+        name: t.name,
+        credits_required: t.totalCredits,
+        choose_n: null,
+        courses: t.courses,
+      }));
+
+    programs.push({
+      title: `${h.programName} (${h.prefix.match(/\(([A-Z]+)\)/)?.[1] ?? ""})`.replace(
+        /\s\(\)$/,
+        "",
+      ),
+      credential: parseCredential(h.prefix),
+      program_code: null,
+      catalog_url: catalogUrl,
+      total_credits: totalCredits,
+      gpa_minimum: 2.0,
+      description: null,
+      requirement_groups: requirementGroups,
+      matched_program_slug: null,
+    });
+  }
+
+  console.log(`  Parsed ${programs.length} programs`);
+
+  const { matched, unmatched } = applyProgramMatching(programs);
+  console.log(
+    `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+  );
+
+  const yearMatch = catalogUrl.match(/(\d{4})-(\d{2,4})/);
+  const catalogYear = yearMatch
+    ? `${yearMatch[1]}-${yearMatch[2].length === 2 ? `20${yearMatch[2]}` : yearMatch[2]}`
+    : "";
+
+  const data: CollegePrograms = {
+    college_slug: COLLEGE_SLUG,
+    catalog_year: catalogYear,
+    catalog_url: catalogUrl,
+    scraped_at: new Date().toISOString(),
+    programs,
+  };
+
+  const outDir = path.join(process.cwd(), "data", "va", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${COLLEGE_SLUG}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+  console.log(`\n✓ Wrote ${programs.length} programs to ${outPath}`);
+
+  if (!ARG_KEEP) fs.unlinkSync(txtPath);
+  else console.log(`  text kept at ${txtPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes [#235](https://github.com/rohan-c0de/cc-coursemap/issues/235) and [#236](https://github.com/rohan-c0de/cc-coursemap/issues/236).

## Summary

The last two VCCS gaps from #228. After this lands, **VA program coverage is 23/23**.

| College | Programs | Breakdown |
|---|---|---|
| vhcc | 75 | 4 AA / 18 AAS / 18 AS / 35 cert |
| camp | 45 | 5 AA / 7 AAS / 4 AS / 29 cert |

Both PDFs have unique structures that don't share parsing logic with JSCC ([#233](https://github.com/rohan-c0de/cc-coursemap/pull/233)) or QCC ([#248](https://github.com/rohan-c0de/cc-coursemap/pull/248)), so they're separate per-college scrapers.

## VHCC parsing

Heading lines like `Associate of Applied Science (AAS) in <name>` or `Career Studies Certificate (CSC) in <name>` demarcate program blocks. Each block has one or more curriculum tables with format:

```
Course Number    Course Title              Credits
 ENG 111         College Composition I       3
```

Programs may have multiple `Track 1 (Day)` / `Track 2 (Evening)` tables; each track becomes its own `RequirementGroup`. The last `Total Minimum Credits N` or `Total Credits Required N-M` row in the block sets the program's `total_credits` (upper bound of any range).

## Camp parsing (PDCCC, Google Drive)

Camp's catalog lives on **Google Drive**. Discovery scrapes the PDC catalog index page for the most recent `/file/d/{id}/view` link, then fetches via `/uc?export=download&id={id}`.

Each program has a fielded header:

```
Program:  <name>
Award:    <credential>
Plan Code, CIP Code, Length, …
```

Followed by a "Required Courses and Credits / Sample Schedule" table broken into First/Second/Third/Fourth Semester sub-sections. The program's total comes from a `Total Program Credits N` row at the end (with `Total Credits N` fallback when the specific label is absent).

## Verification

- `npx tsx scripts/va/scrape-vhcc-pdf-programs.ts` (live download from vhcc.edu) → 75 programs
- `npx tsx scripts/va/scrape-camp-pdf-programs.ts` (live Google Drive download via discovered file id) → 45 programs
- `scripts/check-scraper-coverage.ts` passes with both new scripts declared in `lib/states/va/config.ts`
- Local dev:
  - `/va/college/vhcc/programs` → "75 programs available"
  - `/va/college/camp/programs` → "45 programs available"

## Known limitations

- **Camp**: 8 of 53 program-block headers parse to zero courses (mostly short certificate/career-studies pages whose curriculum is laid out as bullet text rather than a credit-aligned table). 45 valid programs > 0.
- **VHCC's "Technical Studies" AAS** is intentionally a flexible degree with a "Content Skills & Knowledge" placeholder section rather than a fixed course list — only its General Education courses get captured. Reflects the actual catalog structure.
- Both scrapers collapse semester sequencing into a single "Recommended Course Sequence" group (or per-track group for VHCC). Same simplification accepted for JSCC and QCC.

## Test plan

- [x] Output validates against `CollegePrograms` schema
- [x] Live download path works for both (no `--pdf=` cache)
- [x] Both pages render with credential groupings
- [x] Coverage check passes
- [ ] Post-merge: confirm `https://communitycollegepath.com/va/college/vhcc/programs` and `/camp/programs` show their programs in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)