### PR TITLE
fix: import AnyNode from domhandler instead of cheerio namespace

### DIFF
--- a/scripts/lib/scrape-courseleaf-programs.ts
+++ b/scripts/lib/scrape-courseleaf-programs.ts
@@ -17,6 +17,9 @@
  */
 
 import * as cheerio from "cheerio";
+// AnyNode is exported from domhandler (cheerio's underlying DOM lib) but
+// isn't re-exported as `cheerio.AnyNode` in cheerio 1.2 — import directly.
+import type { AnyNode } from "domhandler";
 import type {
   CollegePrograms,
   ProgramCredential,
@@ -164,7 +167,7 @@ interface PlanGridResult {
 
 function parsePlanGrid(
   $: cheerio.CheerioAPI,
-  $table: cheerio.Cheerio<cheerio.AnyNode>,
+  $table: cheerio.Cheerio<AnyNode>,
 ): PlanGridResult {
   const courses: RequiredCourse[] = [];
   const seen = new Set<string>();
@@ -268,7 +271,7 @@ function parseProgramPage(
   // in unrelated paragraph content.
   type DocItem = { kind: "award"; line: string; index: number } | {
     kind: "table";
-    el: cheerio.AnyNode;
+    el: AnyNode;
     index: number;
   };
   const items: DocItem[] = [];

--- a/scripts/lib/scrape-smartcatalogiq-programs.ts
+++ b/scripts/lib/scrape-smartcatalogiq-programs.ts
@@ -28,6 +28,9 @@
  */
 
 import * as cheerio from "cheerio";
+// AnyNode is exported from domhandler (cheerio's underlying DOM lib) but
+// isn't re-exported as `cheerio.AnyNode` in cheerio 1.2 — import directly.
+import type { AnyNode } from "domhandler";
 import type {
   CollegePrograms,
   ProgramCredential,
@@ -250,7 +253,7 @@ function parseCredential(text: string): ProgramCredential {
 
 function parseProgramTable(
   $: cheerio.CheerioAPI,
-  $table: cheerio.Cheerio<cheerio.AnyNode>,
+  $table: cheerio.Cheerio<AnyNode>,
 ): { courses: RequiredCourse[]; totalCredits: number | null } {
   const courses: RequiredCourse[] = [];
   let totalCredits: number | null = null;


### PR DESCRIPTION
**Hotfix for the broken main build.** Type error showing in Vercel:

> Type error: Namespace `'"/vercel/path0/node_modules/cheerio/dist/esm/index"'` has no exported member `'AnyNode'`.
> ./scripts/lib/scrape-courseleaf-programs.ts:167:35

## Why this happened

cheerio 1.2 doesn't re-export `AnyNode` through its namespace — `AnyNode` is only available from `domhandler` (cheerio's underlying DOM library). The CourseLeaf scraper from #245 and the SmartCatalogIQ scraper from #247 both used `cheerio.AnyNode`. Local typecheck let it slide on those PRs (likely incremental compilation cache), but Vercel's clean production build started failing after #248 merged.

## Fix

Import `AnyNode` directly from `domhandler` in both lib files. No behavior change — same type, just sourced from the right module.

## Verification

- `npx tsc --noEmit` passes locally (exit 0)
- No changes to scraper logic, output JSON, or routes

## Test plan

- [x] Local `tsc --noEmit` passes
- [ ] Vercel build succeeds on this branch (will know once PR is opened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)