### PR TITLE
fix: clear remaining typecheck errors in program scraper libs

### DIFF
--- a/scripts/lib/scrape-courseleaf-programs.ts
+++ b/scripts/lib/scrape-courseleaf-programs.ts
@@ -290,8 +290,6 @@ function parseProgramPage(
     const m = firstLine.match(/^Award:\s*(.+)$/);
     if (!m) return;
     const line = m[1].trim().replace(/\s*Degree$/i, "");
-    // @ts-expect-error cheerio doesn't expose document positions directly,
-    // but we can use the DOM-ordered index from $('*').index(el).
     const index = $("*").index(el);
     items.push({ kind: "award", line, index });
   });

--- a/scripts/lib/scrape-smartcatalogiq-programs.ts
+++ b/scripts/lib/scrape-smartcatalogiq-programs.ts
@@ -426,7 +426,7 @@ function parseProgramPage(
     let hasAny = false;
     for (const g of groups) {
       for (const c of g.courses) {
-        if (c.credits > 0) {
+        if (c.credits !== null && c.credits > 0) {
           sum += c.credits;
           hasAny = true;
         }
@@ -442,7 +442,8 @@ function parseProgramPage(
   if (
     finalTotalCredits !== null &&
     finalTotalCredits >= 50 &&
-    (credential === "certificate" || credential === "other")
+    ((credential as ProgramCredential) === "certificate" ||
+      (credential as ProgramCredential) === "other")
   ) {
     credential = "AS";
   }


### PR DESCRIPTION
## Summary

Three pre-existing typecheck errors that survived #250's cheerio `AnyNode` hotfix. Local `tsc --noEmit` was incremental-cached on previous runs, so they only surfaced on a clean CI build (and are now blocking #249's CI).

- [scripts/lib/scrape-courseleaf-programs.ts](scripts/lib/scrape-courseleaf-programs.ts): drop unused `@ts-expect-error` (TS2578)
- [scripts/lib/scrape-smartcatalogiq-programs.ts](scripts/lib/scrape-smartcatalogiq-programs.ts): null-guard `c.credits` before `> 0` (TS18047 — `RequiredCourse.credits` is `number | null`)
- [scripts/lib/scrape-smartcatalogiq-programs.ts](scripts/lib/scrape-smartcatalogiq-programs.ts): widen `credential` via `as ProgramCredential` at the credit-hour sanity override (TS2367 — flow analysis narrowed it to `"other"` because the earlier reassignments happened inside cheerio `.each()` closures that TS can't track precisely)

No behavior change — all three are pure type-system fixes.

## Test plan

- [x] `npx tsc --noEmit` exits 0 locally
- [ ] CI `test` workflow passes
- [ ] CI `Vercel` build passes
- [ ] Rebase #249 (VA PDFs) onto this once merged; its CI should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)