### PR TITLE
feat: CleanCatalog program scraper + Cape Cod CC (closes #242)

### DIFF
--- a/data/ma/programs/capecod.json
+++ b/data/ma/programs/capecod.json
@@ -1,0 +1,8282 @@
+{
+  "college_slug": "capecod",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://live-capecod.cleancatalog.io/degrees",
+  "scraped_at": "2026-05-07T14:30:19.302Z",
+  "programs": [
+    {
+      "title": "Communication Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/associate-in-arts/communication-concentration",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "201",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "105",
+              "title": "Survey of Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/associate-in-arts/graphic-design-concentration",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "History of Art: Stone Age to Gothic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "171",
+              "title": "Computer Graphics I (Adobe Photoshop, Illustrator, InDesign)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "207",
+              "title": "Graphic Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "136",
+              "title": "Three-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "134",
+              "title": "Art History: Renaissance to Modern",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "219",
+              "title": "Portfolio Preparation for Artists and Graphic Designers",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "218",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "137",
+              "title": "History of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "231",
+              "title": "Computer Graphics II (Adobe Photoshop, Illustrator, InDesign)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "208",
+              "title": "Graphic Design II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Content Creation",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/certificate/media-content-creation",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "113",
+              "title": "Broadcasting and Content Creation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "114",
+              "title": "Podcasting & Radio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "131",
+              "title": "Introduction to Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "217",
+              "title": "Advanced Content Creation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Studies Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/associate-in-arts/media-studies-concentration",
+      "total_credits": 46,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "113",
+              "title": "Broadcasting and Content Creation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "105",
+              "title": "Survey of Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "120",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Performing Arts Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/associate-in-arts/performing-arts-concentration",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Arts Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/associate-in-arts/visual-arts-concentration",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "209",
+              "title": "Printmaking Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "History of Art: Stone Age to Gothic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "100",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Design I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Painting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "136",
+              "title": "Three-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "134",
+              "title": "Art History: Renaissance to Modern",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "219",
+              "title": "Portfolio Preparation for Artists and Graphic Designers",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "216",
+              "title": "Life Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "229",
+              "title": "Painting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "201",
+              "title": "Design II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radio and Podcasting",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/certificate/radio-and-podcasting",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "113",
+              "title": "Broadcasting and Content Creation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "114",
+              "title": "Podcasting & Radio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "208",
+              "title": "Broadcast Writing and Presentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "231",
+              "title": "Advanced Radio Production and Podcasting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Media & Digital Marketing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/arts-communication/certificate/social-media-digital-marketing",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "105",
+              "title": "Survey of Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "171",
+              "title": "Computer Graphics I (Adobe Photoshop, Illustrator, InDesign)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "113",
+              "title": "Broadcasting and Content Creation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "215",
+              "title": "Social Media Marketing & Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Program",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/associate-in-science/business-administration-program",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Business Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Program - Accounting Concentration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/associate-in-science/business-administration-program-accounting-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "103",
+              "title": "QuickBooks Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "225",
+              "title": "Microsoft® Excel for Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Personal and Small Business Income Taxes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Foundations of Municipal Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "202",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "220",
+              "title": "Accounting for Government and Not-for-Profit Entities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Business Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Program – Hospitality and Tourism Management Concentration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/associate-in-science/business-administration-program-hospitality-and-tourism-management",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "101",
+              "title": "Introduction to Hospitality & Tourism Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "111",
+              "title": "ServSafe Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "204",
+              "title": "Food And Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "215",
+              "title": "Lodging Operations and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Business Calculations and Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "141",
+              "title": "Blue Economy: Hospitality and Tourism Speaker Series",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "230",
+              "title": "Hospitality and Tourism Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "145",
+              "title": "Technology Solutions for the Hospitality and Tourism Industry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Technology: Administrative Assistant Concentration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/associate-in-science/business-technology-administrative-assistant-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "104",
+              "title": "Introduction to Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Business Calculations and Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "220",
+              "title": "Advanced Word Processing Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "250",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Foundations of Municipal Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "103",
+              "title": "QuickBooks Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "202",
+              "title": "Standard Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "225",
+              "title": "Microsoft® Excel for Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Program – Hospitality and Tourism Management Transfer Concentration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/associate-in-science/business-administration-program-hospitality-and-tourism-management-0",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "101",
+              "title": "Introduction to Hospitality & Tourism Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "111",
+              "title": "ServSafe Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "204",
+              "title": "Food And Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "141",
+              "title": "Blue Economy: Hospitality and Tourism Speaker Series",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "215",
+              "title": "Lodging Operations and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "230",
+              "title": "Hospitality and Tourism Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Technology: Medical Administrative Assistant Concentration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/associate-in-science/business-technology-medical-administrative-assistant-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "104",
+              "title": "Introduction to Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "210",
+              "title": "Medical Billing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "205",
+              "title": "Medical Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "220",
+              "title": "Advanced Word Processing Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Survey: Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "250",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Business Calculations and Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "203",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Administrative Assistant",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/administrative-assistant",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "104",
+              "title": "Introduction to Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Business Calculations and Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "202",
+              "title": "Standard Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "220",
+              "title": "Advanced Word Processing Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "225",
+              "title": "Microsoft® Excel for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "103",
+              "title": "QuickBooks Basics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Administrative Assistant – Medical Office",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/administrative-assistant-medical-office",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "104",
+              "title": "Introduction to Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Business Calculations and Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "203",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "220",
+              "title": "Advanced Word Processing Application",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "250",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computerized Accounting",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/computerized-accounting",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "211",
+              "title": "Personal and Small Business Income Taxes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "103",
+              "title": "QuickBooks Basics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "225",
+              "title": "Microsoft® Excel for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Culinary Arts",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/culinary-arts",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CUL",
+              "number": "150",
+              "title": "Fundamentals of Professional Cooking",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "180",
+              "title": "Baking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "210",
+              "title": "Dining Room Operations & Service",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "111",
+              "title": "ServSafe Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "101",
+              "title": "Introduction to Hospitality & Tourism Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CUL",
+              "number": "220",
+              "title": "Advanced Culinary Arts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "204",
+              "title": "Food And Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Event Planning & Meeting Management",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/event-planning-meeting-management",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "101",
+              "title": "Introduction to Hospitality & Tourism Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "141",
+              "title": "Blue Economy: Hospitality and Tourism Speaker Series",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "111",
+              "title": "ServSafe Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "216",
+              "title": "Event Planning and Meeting Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "230",
+              "title": "Hospitality and Tourism Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "145",
+              "title": "Technology Solutions for the Hospitality and Tourism Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "204",
+              "title": "Food And Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality and Tourism Management",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/hospitality-and-tourism-management",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "101",
+              "title": "Introduction to Hospitality & Tourism Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "111",
+              "title": "ServSafe Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "141",
+              "title": "Blue Economy: Hospitality and Tourism Speaker Series",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "204",
+              "title": "Food And Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "215",
+              "title": "Lodging Operations and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "230",
+              "title": "Hospitality and Tourism Marketing and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "145",
+              "title": "Technology Solutions for the Hospitality and Tourism Industry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Medical Billing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/medical-billing",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "104",
+              "title": "Introduction to Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "203",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "210",
+              "title": "Medical Billing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Survey: Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "250",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Coding and Billing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/medical-coding-and-billing",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "104",
+              "title": "Introduction to Document Processing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Survey: Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "205",
+              "title": "Medical Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "203",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "210",
+              "title": "Medical Billing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "250",
+              "title": "Database Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "206",
+              "title": "Advanced Medical Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "209",
+              "title": "Pharmacology for Medical Coding",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Municipal Finance",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/municipal-finance",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Foundations of Municipal Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Payroll Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Financial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "220",
+              "title": "Accounting for Government and Not-for-Profit Entities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "225",
+              "title": "Microsoft® Excel for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "261",
+              "title": "Accounting Cooperative Work Experience",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Professional Bar Management",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/professional-bar-management",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "101",
+              "title": "Introduction to Hospitality & Tourism Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "111",
+              "title": "ServSafe Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "160",
+              "title": "Professional Bar Management and Mixology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRM",
+              "number": "204",
+              "title": "Food And Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HRM",
+              "number": "260",
+              "title": "Hospitality and Tourism Management Cooperative Work Experience",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Small Business Development & Sustainability",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/business/certificate/small-business-development-sustainability",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Fall Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "108",
+              "title": "Introduction to Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Spring Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "109",
+              "title": "Business Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "201",
+              "title": "Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENT",
+              "number": "109",
+              "title": "Business Plan Preparation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Dental Assisting",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/dental-hygiene/certificate/dental-assisting",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAS",
+              "number": "100",
+              "title": "Dental Radiology and Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "102",
+              "title": "Dental Materials and Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "104",
+              "title": "Dental Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "106",
+              "title": "Chairside Dental Assisting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "108",
+              "title": "Dental Office Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "110",
+              "title": "OSHA Compliance - Infection Prevention and Control",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAS",
+              "number": "112",
+              "title": "Clinical Experience",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Maintenance Technology Program",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/associate-in-applied-science/aviation-maintenance",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "151",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Aviation Maintenance Technology (AMT): General Module 1",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "120",
+              "title": "Aviation Maintenance Technology (AMT): General Module 2",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "210",
+              "title": "Aviation Maintenance Technology: Airframe Module 1",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "220",
+              "title": "Aviation Maintenance Technology: Airframe Module 2",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "230",
+              "title": "Aviation Maintenance Technology: Powerplant Module 1",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "240",
+              "title": "Aviation Maintenance Technology: Powerplant Module 2",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/associate-in-arts/computer-science-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "240",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "130",
+              "title": "Computer Programming II: Java",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "230",
+              "title": "Data Structures",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "*CSC240 is recommended for students who plan to transfer to UMass-Dartmouth or UMass-Amherst.",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "250",
+              "title": "Computer Organizational & Architecture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Engineering Technology & Advanced Manufacturing",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/associate-in-science/engineering-technology-advanced",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENR",
+              "number": "106",
+              "title": "3D Design & Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "240",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENR",
+              "number": "103",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "211",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "260",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "212",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "270",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Information Technology Program",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/associate-in-science/information-technology-program",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "187",
+              "title": "Introduction to Networks (Cisco 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "IT: Windows Desktop Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "113",
+              "title": "Microcomputer Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "101",
+              "title": "Help Desk Skills and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "237",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "110",
+              "title": "Mac OS Support Essentials I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Mac OS Support Essentials II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "104",
+              "title": "Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "240",
+              "title": "Security+",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "IT: Cybersecurity Concentration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/associate-in-science/it-cybersecurity-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "187",
+              "title": "Introduction to Networks (Cisco 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "IT: Windows Desktop Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "113",
+              "title": "Microcomputer Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "116",
+              "title": "IT: Linux",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "240",
+              "title": "Security+",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "241",
+              "title": "IT: Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "248",
+              "title": "Switching, Routing & Wireless Essentials (Cisco 2)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "242",
+              "title": "IT: Advanced Ethical Hacking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "243",
+              "title": "IT: Advanced Ethical Hacking II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "104",
+              "title": "Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "254",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "245",
+              "title": "IT Security: Penetration Testing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "IT: Networking Concentration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/associate-in-science/it-networking-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "187",
+              "title": "Introduction to Networks (Cisco 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "IT: Windows Desktop Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "113",
+              "title": "Microcomputer Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "248",
+              "title": "Switching, Routing & Wireless Essentials (Cisco 2)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "249",
+              "title": "Enterprise Networking, Security, and Automation (Cisco 3)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "116",
+              "title": "IT: Linux",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "104",
+              "title": "Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "252",
+              "title": "Enterprise Routing Protocols",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "112",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "237",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Airframe Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/airframe-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Aviation Maintenance Technology (AMT): General Module 1",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "120",
+              "title": "Aviation Maintenance Technology (AMT): General Module 2",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "210",
+              "title": "Aviation Maintenance Technology: Airframe Module 1",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "220",
+              "title": "Aviation Maintenance Technology: Airframe Module 2",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architecture and Civil Technician",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/architecture-and-civil-technician",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENR",
+              "number": "108",
+              "title": "AutoCAD for Civil Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENR",
+              "number": "109",
+              "title": "AutoCAD for Architecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENR",
+              "number": "103",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Aviation Electronics Technician Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/aviation-electronics-technician-certificate",
+      "total_credits": 20,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AET",
+              "number": "101",
+              "title": "Aviation Electronics Technician (AET): Module 1",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AET",
+              "number": "102",
+              "title": "Aviation Electronics Technician (AET): Module 2",
+              "credits": 10,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/cybersecurity",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "116",
+              "title": "IT: Linux",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "248",
+              "title": "Switching, Routing & Wireless Essentials (Cisco 2)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "240",
+              "title": "Security+",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "241",
+              "title": "IT: Ethical Hacking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "242",
+              "title": "IT: Advanced Ethical Hacking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "243",
+              "title": "IT: Advanced Ethical Hacking II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "254",
+              "title": "Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "245",
+              "title": "IT Security: Penetration Testing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Engineering Design and Digital Manufacturing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/engineering-design-and-digital-manufacturing",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENR",
+              "number": "106",
+              "title": "3D Design & Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENR",
+              "number": "107",
+              "title": "3D Design & Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENR",
+              "number": "103",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "IT: Help Desk",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/it-help-desk-0",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "113",
+              "title": "Microcomputer Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "IT: Windows Desktop Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "187",
+              "title": "Introduction to Networks (Cisco 1)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "101",
+              "title": "Help Desk Skills and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "240",
+              "title": "Security+",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "110",
+              "title": "Mac OS Support Essentials I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "111",
+              "title": "Mac OS Support Essentials II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "104",
+              "title": "Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Networking",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/networking",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIT",
+              "number": "113",
+              "title": "Microcomputer Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "IT: Windows Desktop Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "187",
+              "title": "Introduction to Networks (Cisco 1)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "248",
+              "title": "Switching, Routing & Wireless Essentials (Cisco 2)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "249",
+              "title": "Enterprise Networking, Security, and Automation (Cisco 3)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "252",
+              "title": "Enterprise Routing Protocols",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "116",
+              "title": "IT: Linux",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "237",
+              "title": "Windows Server Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "PC Service Technician",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/pc-service-technician",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "113",
+              "title": "Microcomputer Hardware",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "115",
+              "title": "IT: Windows Desktop Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "187",
+              "title": "Introduction to Networks (Cisco 1)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Powerplant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/powerplant-certificate",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "110",
+              "title": "Aviation Maintenance Technology (AMT): General Module 1",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "120",
+              "title": "Aviation Maintenance Technology (AMT): General Module 2",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AMT",
+              "number": "230",
+              "title": "Aviation Maintenance Technology: Powerplant Module 1",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMT",
+              "number": "240",
+              "title": "Aviation Maintenance Technology: Powerplant Module 2",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming for Computer Science",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/programming-for-computer-science",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "120",
+              "title": "Computer Programming I: C++",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I: Java",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "130",
+              "title": "Computer Programming II: Java",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "210",
+              "title": "System Software & Assembly Language Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "230",
+              "title": "Data Structures",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Robotics and Manufacturing Automation",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/engineering-sciences-applied-technology/certificate/robotics-and-manufacturing-automation",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENR",
+              "number": "103",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENR",
+              "number": "105",
+              "title": "Circuit Theory & Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENR",
+              "number": "110",
+              "title": "Engineering and Scientific Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "175",
+              "title": "College Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "General Studies Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/general-studies-liberal-arts/associate-in-arts/general-studies-concentration",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Health Sciences Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/associate-in-arts/health-sciences-concentration",
+      "total_credits": 46,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "109",
+              "title": "Survey of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "130",
+              "title": "Standard First Aid and Basic Life Support (Cardiopulmonary Resuscitation)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "251",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "203",
+              "title": "Introduction to Allied Health Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "233",
+              "title": "Developmental Psychology: The Life Span",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/general-studies-liberal-arts/associate-in-arts/liberal-arts-concentration",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Dental Hygiene Program",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/associate-in-science/dental-hygiene-program",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEN",
+              "number": "101",
+              "title": "Oral Tissues I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "103",
+              "title": "Principles of Oral Radiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "121",
+              "title": "Dental Hygiene I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "126",
+              "title": "Clinical Dental Hygiene I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "102",
+              "title": "Oral Tissues II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "123",
+              "title": "Dental Hygiene II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "128",
+              "title": "Clinical Dental Hygiene II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "200",
+              "title": "Pharmacology for Dental Hygiene",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "206",
+              "title": "Oral Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Summer Session",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HEA",
+              "number": "201",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "281",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DEN",
+              "number": "212",
+              "title": "Periodontics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "209",
+              "title": "Dental Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "230",
+              "title": "Dental Hygiene III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "236",
+              "title": "Clinical Dental Hygiene III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "239",
+              "title": "Pain Management in Dental Hygiene Practice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "105",
+              "title": "Community Dental Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "232",
+              "title": "Dental Hygiene IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "238",
+              "title": "Clinical Dental Hygiene IV",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Funeral Service",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/associate-in-science/funeral-service",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Survey: Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "128",
+              "title": "Social Foundations of Funeral Service",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSR",
+              "number": "130",
+              "title": "Fundamentals of Embalming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "131",
+              "title": "Embalming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "135",
+              "title": "Embalming Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "129",
+              "title": "Funeral Directing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Survey of Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "232",
+              "title": "Embalming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "140",
+              "title": "Funeral Directing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "150",
+              "title": "Sanitary Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSR",
+              "number": "209",
+              "title": "Funeral Service Merchandizing & Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Grief",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "294",
+              "title": "Regulatory Compliance for Funeral Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "239",
+              "title": "Restorative Art",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "298",
+              "title": "Board Certification and Competencies Skills",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing Program",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/associate-in-science/nursing-program",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pre-admission Requirements",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "251",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "252",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "First Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "101",
+              "title": "Dosage Calculations",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "107",
+              "title": "Fundamentals of Nursing",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "233",
+              "title": "Developmental Psychology: The Life Span",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "108",
+              "title": "Nursing across the Lifespan",
+              "credits": 8,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "281",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "200",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "204",
+              "title": "Physical and Mental Health I",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "205",
+              "title": "Physical and Mental Health II",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "206",
+              "title": "Foundations of the Profession",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Bereavement Support",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/certificate/bereavement-support",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "128",
+              "title": "Social Foundations of Funeral Service",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Principles of Counseling & Crisis Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Grief",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "220",
+              "title": "Sociology Of Health And Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "201",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Diagnostic Technician",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/certificate/diagnostic-technician",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTC",
+              "number": "102",
+              "title": "EKG Technician",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTC",
+              "number": "104",
+              "title": "Fundamentals of Phlebotomy",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DTC",
+              "number": "204",
+              "title": "Phlebotomy Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Embalming",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/certificate/embalming",
+      "total_credits": 23,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Survey: Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "131",
+              "title": "Embalming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "135",
+              "title": "Embalming Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "130",
+              "title": "Fundamentals of Embalming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "232",
+              "title": "Embalming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "150",
+              "title": "Sanitary Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "239",
+              "title": "Restorative Art",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Funeral Administrant",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/certificate/funeral-administrant",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "128",
+              "title": "Social Foundations of Funeral Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "120",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Supervision",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "129",
+              "title": "Funeral Directing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "140",
+              "title": "Funeral Directing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "294",
+              "title": "Regulatory Compliance for Funeral Service",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Funeral Celebrant",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/certificate/funeral-celebrant",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "128",
+              "title": "Social Foundations of Funeral Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "203",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Grief",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSR",
+              "number": "129",
+              "title": "Funeral Directing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/certificate/health-sciences",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "109",
+              "title": "Survey of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "130",
+              "title": "Standard First Aid and Basic Life Support (Cardiopulmonary Resuscitation)",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "251",
+              "title": "Human Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "203",
+              "title": "Introduction to Allied Health Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Assisting",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/health-sciences/certificate/medical-assisting",
+      "total_credits": 19,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BST",
+              "number": "103",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BST",
+              "number": "110",
+              "title": "Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "101",
+              "title": "Fundamentals of Medical Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "204",
+              "title": "Medical Assisting Clinical Procedures and Clinical Practicum",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "205",
+              "title": "The Administrative Medical Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "English Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/language-literature/associate-in-arts/english-concentration",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "110",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Program – Career Option",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/associate-in-science/early-childhood-education-program-career-option",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "105",
+              "title": "Introduction to Young Children with Special Needs (Birth–8 years)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "201",
+              "title": "Preschool Curriculum Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "201",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "120",
+              "title": "Introduction to Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "202",
+              "title": "Advanced Curriculum Development: Creative Experiences for Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "206",
+              "title": "Field Experience in Early Childhood Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "221",
+              "title": "Classroom Management: Skills and Strategies for Early Childhood Teachers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "291",
+              "title": "Leadership and Management in Early Childhood Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "230",
+              "title": "Practicum in Early Childhood Education Preschool",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Data Science Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/mathematics/associate-in-arts/data-science-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "240",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "101",
+              "title": "Introduction to Data Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "105",
+              "title": "Computer Programming I: Python",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I: Java",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "211",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "245",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "212",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "201",
+              "title": "Data Visualization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/mathematics/associate-in-arts/mathematics-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "240",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "211",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I: Java",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "212",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "260",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "245",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "270",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Discrete Mathematics & Introduction to Proofs",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Program – Transfer",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/associate-in-science/early-childhood-education-program-transfer",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "105",
+              "title": "Introduction to Young Children with Special Needs (Birth–8 years)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "201",
+              "title": "Preschool Curriculum Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "201",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "120",
+              "title": "Introduction to Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "202",
+              "title": "Advanced Curriculum Development: Creative Experiences for Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "206",
+              "title": "Field Experience in Early Childhood Education",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "230",
+              "title": "Practicum in Early Childhood Education Preschool",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Fire Science - Emergency Medical Services Option",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/associate-in-science/fire-science-emergency-medical-services-option",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "101",
+              "title": "Emergency Medical Technician: EMT",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Survey: Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "233",
+              "title": "Developmental Psychology: The Life Span",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Paramedic I - Preparatory",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic II - Airway/Respiratory, IV, Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Paramedic I/II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic III - Trauma and Cardiology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "217",
+              "title": "Paramedic IV - Special Populations and Medical Emergencies",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "218",
+              "title": "Paramedic III/IV Lab",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fifth Semester",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Clinical Experience",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Sixth Semester",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "227",
+              "title": "Paramedic Field/Capstone Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Program – Fire Science Option",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/associate-in-science/fire-science-program-fire-science-option",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "150",
+              "title": "Principles of Emergency Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "151",
+              "title": "Fire Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "152",
+              "title": "Fire Protection Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "153",
+              "title": "Building Construction for the Fire Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "155",
+              "title": "Fire Behavior and Combustion",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FSC",
+              "number": "154",
+              "title": "Principles of Fire and Emergency Service Safety and Survival",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education Foundational Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/certificate/early-childhood-education-foundational-certificate",
+      "total_credits": 16,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Child Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "201",
+              "title": "Preschool Curriculum Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "225",
+              "title": "Foundational Practicum in Early Childhood Education",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education – Infant & Toddler",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/certificate/early-childhood-education-infant-toddler",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Child Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "105",
+              "title": "Introduction to Young Children with Special Needs (Birth–8 years)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "200",
+              "title": "Teaching Infants and Toddlers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "230",
+              "title": "Practicum in Early Childhood Education Preschool",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education – Preschool",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/certificate/early-childhood-education-preschool",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "105",
+              "title": "Introduction to Young Children with Special Needs (Birth–8 years)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Child Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "201",
+              "title": "Preschool Curriculum Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "202",
+              "title": "Advanced Curriculum Development: Creative Experiences for Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "230",
+              "title": "Practicum in Early Childhood Education Preschool",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Fire Officer Development",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/certificate/fire-officer-development",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "151",
+              "title": "Fire Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "152",
+              "title": "Fire Protection Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "103",
+              "title": "Fire Fighting Tactics and Strategy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "153",
+              "title": "Building Construction for the Fire Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "110",
+              "title": "Fire Code and Ordinances",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "120",
+              "title": "Introduction to Incident Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FSC",
+              "number": "114",
+              "title": "Fire Company Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/professional-studies/certificate/paramedic-certificate",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "206",
+              "title": "Paramedic I - Preparatory",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "207",
+              "title": "Paramedic II - Airway/Respiratory, IV, Pharmacology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "208",
+              "title": "Paramedic I/II Lab",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "216",
+              "title": "Paramedic III - Trauma and Cardiology",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "217",
+              "title": "Paramedic IV - Special Populations and Medical Emergencies",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "218",
+              "title": "Paramedic III/IV Lab",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "226",
+              "title": "Paramedic Clinical Experience",
+              "credits": 7,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "227",
+              "title": "Paramedic Field/Capstone Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biology Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/associate-in-arts/biology-concentration",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "152",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "241",
+              "title": "Cell Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Chemistry Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/associate-in-arts/chemistry-concentration",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "240",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "211",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "212",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Studies Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/associate-in-arts/environmental-studies-concentration",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "118",
+              "title": "Introduction to Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "152",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "195",
+              "title": "Precalculus with Trigonometry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Applied Economics of Coastal and Ocean Environments (Blue Economy)",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/associate-in-science/applied-economics-of-coastal-and-ocean-environments-blue-economy",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "118",
+              "title": "Introduction to Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "Introduction to Earth Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Environmental and Natural Resources Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "125",
+              "title": "Coastal Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "128",
+              "title": "Fundamentals Of Oceanography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "214",
+              "title": "Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/associate-in-arts/physics-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "211",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "240",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "212",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "250",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "260",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "270",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Technology Program",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/associate-in-science/environmental-technology-program",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "118",
+              "title": "Introduction to Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "Introduction to Earth Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "101",
+              "title": "Survey of Environmental Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "125",
+              "title": "Coastal Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "158",
+              "title": "Occupational Health and Safety (OSHA) through Hazardous Waste Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "260",
+              "title": "Environmental Technology Internship/Cooperative Experience",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/certificate/biotechnology",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "151",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Understanding Biotechnology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "206",
+              "title": "Techniques in Biotechnology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "241",
+              "title": "Cell Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "242",
+              "title": "Molecular Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Coastal Zone Management Technology",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/science/certificate/coastal-zone-management-technology",
+      "total_credits": 17,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "118",
+              "title": "Introduction to Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "128",
+              "title": "Fundamentals Of Oceanography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "125",
+              "title": "Coastal Ecology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "135",
+              "title": "Coastal Zone Management Laws and Regulations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Elementary Education Transfer Compact",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/elementary-education",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Foundation of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "201",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "U.S. History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "120",
+              "title": "Introduction to Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Mathematics for Elementary & Early Childhood Educators I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Mathematics for Elementary & Early Childhood Educators II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/education-concentration",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "History Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/history-concentration",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "U.S. History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "U.S. History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/human-services",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "101",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "109",
+              "title": "Social Work Case Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "209",
+              "title": "Group Dynamics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Principles of Counseling & Crisis Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "229",
+              "title": "Introduction to Social Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "270",
+              "title": "Social Work: Diversity, Cultural Competence & Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "209",
+              "title": "Human Services Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Philosophy Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/philosophy-concentration",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "130",
+              "title": "Introduction To Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "131",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "201",
+              "title": "Existentialism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Political Science Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/political-science",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "101",
+              "title": "Comparative Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "104",
+              "title": "Geography: Culture and Environment",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOV",
+              "number": "102",
+              "title": "International Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "103",
+              "title": "U.S. History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "U.S. History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/psychology-concentration",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Sociology/Anthropology Concentration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-arts/sociologyanthropology",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Elementary Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "107",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "215",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Marriage & Family: Sociology of Family Interaction and Organization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "209",
+              "title": "Sociology of Race & Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice Program",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/associate-in-science/criminal-justice-program",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "105",
+              "title": "Criminology, Theory and Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "116",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "103",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "125",
+              "title": "Contemporary Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "105",
+              "title": "Survey: Human Anatomy & Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "206",
+              "title": "Principles of Investigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "210",
+              "title": "Ethical Issues in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "104",
+              "title": "U.S. History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Fourth Semester",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "207",
+              "title": "Principles of Investigation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "240",
+              "title": "Selected Issues in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "261",
+              "title": "Criminal Justice Cooperative Work Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Addictions Counselor",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/certificate/addictions-counselor",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "101",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "104",
+              "title": "Introduction to Alcohol & Substance Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Principles of Counseling & Crisis Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "209",
+              "title": "Group Dynamics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "209",
+              "title": "Human Services Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Third Semester",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUS",
+              "number": "270",
+              "title": "Social Work: Diversity, Cultural Competence & Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "233",
+              "title": "Addictions Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Corrections",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/certificate/corrections",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "116",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HEA",
+              "number": "130",
+              "title": "Standard First Aid and Basic Life Support (Cardiopulmonary Resuscitation)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "104",
+              "title": "Introduction to Alcohol & Substance Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "220",
+              "title": "Crisis Intervention for Criminal Justice Professionals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "262",
+              "title": "Corrections Cooperative Work Experience",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Homeland Security Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/certificate/homeland-security-certificate",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSC",
+              "number": "101",
+              "title": "Introduction to Homeland Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "105",
+              "title": "Transportation and Infrastructure Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "103",
+              "title": "Management of Incidents",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIT",
+              "number": "104",
+              "title": "Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "135",
+              "title": "Terrorism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/certificate/human-services",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 22,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "101",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "208",
+              "title": "Principles of Counseling & Crisis Intervention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "209",
+              "title": "Group Dynamics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUS",
+              "number": "209",
+              "title": "Human Services Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/certificate/law-enforcement",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Courses",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "100",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "125",
+              "title": "Contemporary Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "103",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "105",
+              "title": "Criminology, Theory and Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "130",
+              "title": "Criminal Evidence",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Social Justice and Community Organization",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://live-capecod.cleancatalog.io/social-sciencesbehavioral-sciences-and-human-services/certificate/social-justice-and-community",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "First Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "103",
+              "title": "Human Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOV",
+              "number": "111",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Second Semester",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "209",
+              "title": "Sociology of Race & Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "206",
+              "title": "Communication in Current Settings",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -102,6 +102,10 @@ const maConfig: StateConfig = {
         scripts: ["scripts/ma/scrape-qcc-pdf-programs.ts"],
         runner: "http",
       },
+      {
+        scripts: ["scripts/ma/scrape-cleancatalog-programs.ts"],
+        runner: "http",
+      },
     ],
   },
 };

--- a/scripts/lib/scrape-cleancatalog-programs.ts
+++ b/scripts/lib/scrape-cleancatalog-programs.ts
@@ -1,0 +1,370 @@
+/**
+ * scrape-cleancatalog-programs.ts — shared CleanCatalog (Drupal) program scraper.
+ *
+ * CleanCatalog is a hosted catalog platform (cleancatalog.io). Each
+ * customer publishes at https://live-{slug}.cleancatalog.io/. Programs
+ * live under a top-level /degrees index that links to detail pages with
+ * the URL shape /{division}/{credential}/{program-slug}.
+ *
+ * Detail pages share a Drupal-rendered structure:
+ *
+ *   <title>{Program Name} | {College}</title>
+ *   <article class="node--type-degree">
+ *     <div class="paragraph--type--degree-section">
+ *       <div class="field--name-field-degree-section-description"><p><strong>Semester</strong></p></div>
+ *       <article class="node--type-class">
+ *         <div class="col-2"><a>ENL101</a></div>
+ *         <div class="col-7"><span class="field--name-field-item">English Composition I</span></div>
+ *         <div class="col-2"><span class="field--name-field-credits">3</span></div>
+ *       </article>
+ *       <article class="node--type-elective-group">…</article>   (skipped — no concrete course)
+ *       <div class="row degree-row degree-row-subtotal">
+ *         <div class="col-10">Sub-Total Credits</div>
+ *         <div class="col-2">15</div>
+ *       </div>
+ *     </div>
+ *     … repeats per semester …
+ *   </article>
+ *
+ * Each paragraph--type--degree-section becomes one RequirementGroup. The
+ * credential is derived from the URL path segment.
+ */
+
+import * as cheerio from "cheerio";
+import type { AnyNode } from "domhandler";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequiredCourse,
+  RequirementGroup,
+} from "../../lib/types.js";
+
+export interface CleanCatalogProgramConfig {
+  collegeSlug: string;
+  /** Catalog root, e.g. https://live-capecod.cleancatalog.io (no trailing slash). */
+  baseUrl: string;
+  /** Program index path. Default "/degrees". */
+  degreesPath?: string;
+  /** Catalog year for output metadata, e.g. "2025-2026". */
+  catalogYear: string;
+}
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const CONCURRENCY = 6;
+const DELAY_MS = 80;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function retryFetch(
+  url: string,
+  label: string,
+  attempts = 3,
+): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const u = new URL(url);
+      const res = await fetch(url, {
+        headers: {
+          "User-Agent": UA,
+          Accept:
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+          Referer: `${u.protocol}//${u.host}/`,
+          "Sec-Fetch-Dest": "document",
+          "Sec-Fetch-Mode": "navigate",
+          "Sec-Fetch-Site": "same-origin",
+          "Upgrade-Insecure-Requests": "1",
+        },
+      });
+      if (res.ok) return res.text();
+      if (res.status >= 500) lastErr = new Error(`HTTP ${res.status}`);
+      else return "";
+    } catch (e) {
+      lastErr = e;
+    }
+    await sleep(500 * Math.pow(2, i));
+  }
+  throw new Error(`${label} failed after ${attempts} attempts: ${lastErr}`);
+}
+
+async function pmap<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T, idx: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(n, items.length) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+      if (DELAY_MS > 0) await sleep(DELAY_MS);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Index discovery
+// ---------------------------------------------------------------------------
+
+const CREDENTIAL_SEGMENTS = new Set([
+  "associate-in-arts",
+  "associate-in-science",
+  "associate-in-applied-science",
+  "certificate",
+  "diploma",
+]);
+
+/** A program URL has shape /{division}/{credential-segment}/{program-slug}. */
+function isProgramPath(p: string): boolean {
+  if (!p.startsWith("/")) return false;
+  const parts = p.replace(/^\/+/, "").split("/");
+  if (parts.length < 3) return false;
+  return CREDENTIAL_SEGMENTS.has(parts[1]);
+}
+
+async function discoverProgramPaths(
+  baseUrl: string,
+  degreesPath: string,
+): Promise<string[]> {
+  const html = await retryFetch(`${baseUrl}${degreesPath}`, "degrees-index");
+  const $ = cheerio.load(html);
+  const found = new Set<string>();
+  $("a[href]").each((_, a) => {
+    const href = $(a).attr("href");
+    if (!href) return;
+    const clean = href.split("#")[0].split("?")[0];
+    if (isProgramPath(clean)) found.add(clean);
+  });
+  return [...found].sort();
+}
+
+// ---------------------------------------------------------------------------
+// Per-program parsing
+// ---------------------------------------------------------------------------
+
+function credentialFromPath(p: string): ProgramCredential {
+  const seg = p.replace(/^\/+/, "").split("/")[1] ?? "";
+  switch (seg) {
+    case "associate-in-arts":
+      return "AA";
+    case "associate-in-science":
+      return "AS";
+    case "associate-in-applied-science":
+      return "AAS";
+    case "certificate":
+      return "certificate";
+    case "diploma":
+      return "diploma";
+    default:
+      return "other";
+  }
+}
+
+function parseTitle($: cheerio.CheerioAPI): string {
+  // Page title is "{Program Name} | {College Name}". Take everything before
+  // the last "|" so program names containing "|" survive (rare).
+  const raw = $("title").first().text().trim();
+  const idx = raw.lastIndexOf("|");
+  const title = idx > 0 ? raw.slice(0, idx).trim() : raw;
+  return title.replace(/\s+/g, " ");
+}
+
+function parseCredits(text: string): number | null {
+  const t = text.trim();
+  if (!t) return null;
+  // Range like "15-16" → take the lower bound
+  const range = t.match(/^(\d+(?:\.\d+)?)\s*[-–]\s*\d+(?:\.\d+)?$/);
+  if (range) return Number(range[1]);
+  const num = t.match(/^(\d+(?:\.\d+)?)$/);
+  if (num) return Number(num[1]);
+  return null;
+}
+
+/** Split a CleanCatalog course code like "ENL101" into prefix + number. */
+function splitCourseCode(
+  code: string,
+): { prefix: string; number: string } | null {
+  const m = code.replace(/\s+/g, "").match(/^([A-Z]{2,5})(\d{3,4}[A-Z]?)$/);
+  if (!m) return null;
+  return { prefix: m[1], number: m[2] };
+}
+
+function parseSection(
+  $: cheerio.CheerioAPI,
+  $section: cheerio.Cheerio<AnyNode>,
+): RequirementGroup | null {
+  const descText = $section
+    .find(".field--name-field-degree-section-description")
+    .first()
+    .text()
+    .replace(/\s+/g, " ")
+    .trim();
+  const name = descText || "Required Courses";
+
+  const courses: RequiredCourse[] = [];
+
+  // Only count course rows that belong to *this* section, not ones nested
+  // inside an elective-group modal that's a descendant of this section.
+  $section.find("article.node--type-class").each((_, el) => {
+    const $el = $(el);
+    if ($el.parents(".modal").length > 0) return;
+    const codeRaw = $el.find(".col-2 a").first().text().trim();
+    if (!codeRaw) return;
+    const split = splitCourseCode(codeRaw);
+    if (!split) return;
+    const title = $el
+      .find(".field--name-field-item")
+      .first()
+      .text()
+      .replace(/\s+/g, " ")
+      .trim();
+    const creditsText = $el
+      .find(".field--name-field-credits")
+      .first()
+      .text()
+      .trim();
+    courses.push({
+      prefix: split.prefix,
+      number: split.number,
+      title,
+      credits: parseCredits(creditsText),
+      or_alternatives: [],
+    });
+  });
+
+  if (courses.length === 0) return null;
+
+  let creditsRequired: number | null = null;
+  $section.find(".degree-row-subtotal .col-2").each((_, el) => {
+    if (creditsRequired !== null) return;
+    const $el = $(el);
+    if ($el.parents(".modal").length > 0) return;
+    creditsRequired = parseCredits($el.text());
+  });
+
+  return {
+    name,
+    credits_required: creditsRequired,
+    choose_n: null,
+    courses,
+  };
+}
+
+function parseProgramPage(
+  html: string,
+  pageUrl: string,
+): ProgramRequirement | null {
+  const $ = cheerio.load(html);
+  const title = parseTitle($);
+  if (!title) return null;
+
+  const credential = credentialFromPath(new URL(pageUrl).pathname);
+
+  // Iterate only top-level sections — skip ones nested inside elective-group
+  // modals, where the same selector would otherwise pick up "choose one"
+  // option lists and corrupt the per-semester course / credit counts.
+  const groups: RequirementGroup[] = [];
+  $(".paragraph--type--degree-section").each((_, el) => {
+    const $el = $(el);
+    if ($el.parents(".modal").length > 0) return;
+    const group = parseSection($, $el);
+    if (group) groups.push(group);
+  });
+
+  if (groups.length === 0) return null;
+
+  // Total credits: prefer summing sub-totals if every group has one;
+  // otherwise sum course-level credits.
+  let total: number | null = null;
+  if (groups.every((g) => g.credits_required !== null)) {
+    total = groups.reduce((s, g) => s + (g.credits_required ?? 0), 0);
+  } else {
+    let sum = 0;
+    let any = false;
+    for (const g of groups) {
+      for (const c of g.courses) {
+        if (c.credits !== null && c.credits > 0) {
+          sum += c.credits;
+          any = true;
+        }
+      }
+    }
+    if (any) total = sum;
+  }
+
+  return {
+    title,
+    credential,
+    program_code: null,
+    catalog_url: pageUrl,
+    total_credits: total,
+    gpa_minimum: 2.0,
+    description: null,
+    requirement_groups: groups,
+    matched_program_slug: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function scrapeCleanCatalogPrograms(
+  config: CleanCatalogProgramConfig,
+): Promise<CollegePrograms> {
+  const { collegeSlug, baseUrl, catalogYear } = config;
+  const degreesPath = config.degreesPath ?? "/degrees";
+
+  console.log(
+    `  [${collegeSlug}] Discovering programs at ${baseUrl}${degreesPath}`,
+  );
+  const paths = await discoverProgramPaths(baseUrl, degreesPath);
+  console.log(`  [${collegeSlug}] Found ${paths.length} program detail pages`);
+
+  if (paths.length === 0) {
+    return {
+      college_slug: collegeSlug,
+      catalog_year: catalogYear,
+      catalog_url: `${baseUrl}${degreesPath}`,
+      scraped_at: new Date().toISOString(),
+      programs: [],
+    };
+  }
+
+  const programs: ProgramRequirement[] = [];
+  let parsed = 0;
+  let skipped = 0;
+  await pmap(paths, CONCURRENCY, async (p) => {
+    const url = `${baseUrl}${p}`;
+    const html = await retryFetch(url, `program(${p})`);
+    if (!html) {
+      skipped++;
+      return;
+    }
+    const program = parseProgramPage(html, url);
+    if (!program) {
+      skipped++;
+      return;
+    }
+    programs.push(program);
+    parsed++;
+  });
+  console.log(
+    `  [${collegeSlug}] Parsed ${parsed} programs, skipped ${skipped}`,
+  );
+
+  return {
+    college_slug: collegeSlug,
+    catalog_year: catalogYear,
+    catalog_url: `${baseUrl}${degreesPath}`,
+    scraped_at: new Date().toISOString(),
+    programs,
+  };
+}

--- a/scripts/ma/scrape-cleancatalog-programs.ts
+++ b/scripts/ma/scrape-cleancatalog-programs.ts
@@ -1,0 +1,96 @@
+/**
+ * scrape-cleancatalog-programs.ts — MA CleanCatalog program scraper.
+ *
+ * Closes #242. Adds Cape Cod Community College (capecod), the one MassCC
+ * college that publishes its catalog on the cleancatalog.io platform.
+ *
+ *   https://live-capecod.cleancatalog.io/
+ *
+ * (capecod.edu's catalog.capecod.edu still serves a frozen 2019-2020 static
+ *  HTML mirror — the live catalog is now the CleanCatalog Drupal site.)
+ *
+ * Usage:
+ *   npx tsx scripts/ma/scrape-cleancatalog-programs.ts
+ *   npx tsx scripts/ma/scrape-cleancatalog-programs.ts --college capecod
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { scrapeCleanCatalogPrograms } from "../lib/scrape-cleancatalog-programs.js";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type { CleanCatalogProgramConfig } from "../lib/scrape-cleancatalog-programs.js";
+
+const COLLEGES: CleanCatalogProgramConfig[] = [
+  {
+    collegeSlug: "capecod",
+    baseUrl: "https://live-capecod.cleancatalog.io",
+    catalogYear: "2025-2026",
+  },
+];
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeArg =
+    args.find((a) => a.startsWith("--college="))?.split("=")[1] ||
+    (args.indexOf("--college") >= 0
+      ? args[args.indexOf("--college") + 1]
+      : null);
+
+  let colleges = COLLEGES;
+  if (collegeArg) {
+    colleges = COLLEGES.filter((c) => c.collegeSlug === collegeArg);
+    if (colleges.length === 0) {
+      console.error(
+        `Unknown college: ${collegeArg}. Available: ${COLLEGES.map((c) => c.collegeSlug).join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const outDir = path.join(process.cwd(), "data", "ma", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`MA CleanCatalog program scraper — ${colleges.length} college(s)\n`);
+
+  let totalPrograms = 0;
+  for (const config of colleges) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`Scraping ${config.collegeSlug} (${config.baseUrl})`);
+    console.log("=".repeat(60));
+
+    try {
+      const data = await scrapeCleanCatalogPrograms(config);
+
+      if (data.programs.length === 0) {
+        console.log(
+          `  No programs found for ${config.collegeSlug}, skipping.`,
+        );
+        continue;
+      }
+
+      const { matched, unmatched } = applyProgramMatching(data.programs);
+      console.log(
+        `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+      );
+
+      const outPath = path.join(outDir, `${config.collegeSlug}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+      console.log(
+        `  ✓ Wrote ${data.programs.length} programs to ${outPath}`,
+      );
+      totalPrograms += data.programs.length;
+    } catch (e) {
+      console.error(`  ERROR scraping ${config.collegeSlug}: ${e}`);
+    }
+  }
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(
+    `Done. Total: ${totalPrograms} programs across ${colleges.length} college(s).`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a shared CleanCatalog (cleancatalog.io / Drupal) program scraper at [scripts/lib/scrape-cleancatalog-programs.ts](scripts/lib/scrape-cleancatalog-programs.ts), following the pattern of the existing CourseLeaf and SmartCatalogIQ libs.
- Adds an MA runner at [scripts/ma/scrape-cleancatalog-programs.ts](scripts/ma/scrape-cleancatalog-programs.ts) wired into [lib/states/ma/config.ts](lib/states/ma/config.ts).
- Scrapes Cape Cod Community College → 91 programs (24 AA, 20 AS, 1 AAS, 46 certificate), `total_credits` 15–73. 34/91 matched to registry slugs.

## Background

`catalog.capecod.edu` is a frozen 2019-2020 static-HTML mirror — the live catalog moved to https://live-capecod.cleancatalog.io. Issue [#242](https://github.com/rohan-c0de/cc-coursemap/issues/242) flagged the staleness. CleanCatalog is a different platform from anything we'd previously scraped.

## CleanCatalog quirks handled

- **Concatenated course codes** (`ENL101`, not `ENL 101`) — split into `prefix`/`number` (same fix SmartCatalogIQ needed for NECC).
- **Elective-group modals** — "Choose one of the following" rows render as a Bootstrap modal whose body contains nested `.paragraph--type--degree-section` blocks. The global selector was double-counting modal sub-totals (one AS degree showed `total_credits: 322` from summing them in) and merging modal options into semester course lists (e.g. "Fourth Semester: 37 courses"). Fix: filter out any section, course row, or subtotal whose ancestor chain includes a `.modal`.

## Coverage

MA program coverage now **11/15**. Remaining: [#230](https://github.com/rohan-c0de/cc-coursemap/issues/230) GCC (Coursedog), [#241](https://github.com/rohan-c0de/cc-coursemap/issues/241) Bristol (Drupal), [#243](https://github.com/rohan-c0de/cc-coursemap/issues/243) RCC, plus Massasoit.

## Test plan

- [x] `npx tsc --noEmit` exits 0
- [x] `npm run lint` exits 0
- [x] Scraper run produces 91 programs, sane credential mix and credit totals
- [x] Local dev: `/ma/college/capecod/programs` renders the new data (verified Business Administration, Accounting Concentration, 23 visible Certificates)
- [ ] CI green
- [ ] Post-merge: confirm Vercel ships and `communitycollegepath.com/ma/college/capecod/programs` shows the new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)