### PR TITLE
feat: program scraper for Roxbury CC (closes #243)

### DIFF
--- a/data/ma/programs/rcc.json
+++ b/data/ma/programs/rcc.json
@@ -1,0 +1,2978 @@
+{
+  "college_slug": "rcc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/",
+  "scraped_at": "2026-05-07T14:40:11.660Z",
+  "programs": [
+    {
+      "title": "Arts and Humanities",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/arts-and-humanities.html",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Intro to Speech",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Arts and Humanities: Musical Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/musical-arts.html",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "103",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Arts and Humanities: Theatre Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/theatre-arts.html",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "MAT 100 or higher",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Intro to Speech",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Arts and Humanities: Visual Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/visual-arts.html",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biological Science",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/biological-science.html",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "103",
+              "title": "Biology I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "104",
+              "title": "Biology II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "123",
+              "title": "Prin. of Chem I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "124",
+              "title": "Prin. of Chem II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Biological Science - Laboratory Animal Care",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/biological-science-laboratory-animal-care.html",
+      "total_credits": 43,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "103",
+              "title": "Biology I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Pre-Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "104",
+              "title": "Biology II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "123",
+              "title": "Prin. of Chem I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "201",
+              "title": "Anat/Phys I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "124",
+              "title": "Prin. of Chem II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "202",
+              "title": "Anat/Phys II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "299",
+              "title": "Science Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Broadcast Media Technology",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/broadcast-media-technology.html",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "100",
+              "title": "Intro to Prod/Directing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "120",
+              "title": "Video Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BMT",
+              "number": "110",
+              "title": "Television Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BMT",
+              "number": "101",
+              "title": "Intro to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "298",
+              "title": "BMT Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "Journalism I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BMT",
+              "number": "210",
+              "title": "Adv Tel. Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "230",
+              "title": "Intro. To Video Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "299",
+              "title": "BMT Internship II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/business-administration.html",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Prin of Acct I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "221",
+              "title": "Economics I: Micro",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Prin of Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "222",
+              "title": "Economics II: Macro",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "131",
+              "title": "Management I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Business Law 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "122",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "141",
+              "title": "Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Intro to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "English",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/english.html",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Intro to Speech",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "British Literature 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "101",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "220",
+              "title": "World Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "226",
+              "title": "Literature in Amer. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "102",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Careers",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/health-careers.html",
+      "total_credits": 46,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Intro to Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "103",
+              "title": "Biology I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "122",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "104",
+              "title": "Biology II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Survey of Chem I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "122",
+              "title": "Survey of Chem II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "201",
+              "title": "Anat/Phys I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "209",
+              "title": "Human Growth & Dev.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "202",
+              "title": "Anat/Phys II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "204",
+              "title": "Microbiology w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/liberal-arts.html",
+      "total_credits": 15,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Mathematics",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/mathematics.html",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "120",
+              "title": "Engineering Computatns I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Pre-Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "143",
+              "title": "Prin. of Phys I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "225",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four - Spring 2025",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "244",
+              "title": "Ord. Dif. Equations",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Science",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/physical-science.html",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Pre-Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "123",
+              "title": "Prin. of Chem I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "124",
+              "title": "Prin. of Chem II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "143",
+              "title": "Prin. of Phys I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "144",
+              "title": "Prin. of Phys II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Social Sciences",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-arts/social-sciences.html",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Intro to Speech",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Intro to Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "101",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "102",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "122",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SSI",
+              "number": "123",
+              "title": "Intro to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "221",
+              "title": "Economics I: Micro",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/accounting.html",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Prin of Acct I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Intro to Bus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Prin of Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Income Taxes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Business Law 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "221",
+              "title": "Economics I: Micro",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Computerized Acct.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Interm. Acct. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "222",
+              "title": "Economics II: Macro",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "202",
+              "title": "Interm. Acct. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "203",
+              "title": "Managerial Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Intro to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/biotechnology.html",
+      "total_credits": 47,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Pre-Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "103",
+              "title": "Biology I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "123",
+              "title": "Prin. of Chem I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "104",
+              "title": "Biology II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "124",
+              "title": "Prin. of Chem II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "111",
+              "title": "MATH for Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "204",
+              "title": "Microbiology w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "206",
+              "title": "Intro to Biomanufac I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "207",
+              "title": "Intro to Biomanufac II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business Management",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/business-management.html",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "130",
+              "title": "Intro to Bus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "MAT 100 or higher",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Prin of Acct I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Business Law 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "122",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "221",
+              "title": "Economics I: Micro",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Prin of Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "131",
+              "title": "Management I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "222",
+              "title": "Economics II: Macro",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "141",
+              "title": "Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "206",
+              "title": "Intro to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/criminal-justice.html",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJP",
+              "number": "100",
+              "title": "Intro to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "MAT 100 or higher",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "123",
+              "title": "Intro to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJP",
+              "number": "120",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJP",
+              "number": "130",
+              "title": "Law Enforcement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "119",
+              "title": "Intro to US Gov't",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "122",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJP",
+              "number": "110",
+              "title": "Intro to Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJP",
+              "number": "140",
+              "title": "Criminal Court Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJP",
+              "number": "210",
+              "title": "Correctional Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJP",
+              "number": "200",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/early-childhood-education.html",
+      "total_credits": 45,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "100",
+              "title": "Foundations Early Childh",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "101",
+              "title": "Child Growth & Dev",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "MAT 100 or higher",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "102",
+              "title": "Obs/Recording Chldhd Beh",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "105",
+              "title": "Health, Safety, and Nutri",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "106",
+              "title": "Guidance and Discipline",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "206",
+              "title": "ECE Curriculum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "298",
+              "title": "ECE Internship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "122",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "203",
+              "title": "Special Needs in Chld Ed",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "207",
+              "title": "ECE Curriculum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "299",
+              "title": "ECE Internship II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Information Systems Technology",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/information-systems-technology.html",
+      "total_credits": 47,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "110",
+              "title": "or CIS102: Intro to Progr",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "or CIS122: Visual Basic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Pre-Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "130",
+              "title": "Linux Oper. Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "170",
+              "title": "or CIS255: Java I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "230",
+              "title": "or CIS281: Relational DB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "270",
+              "title": "or CIS271: Java II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "142",
+              "title": "Network Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "150",
+              "title": "or CIS155: Web Dsgn Fluen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "210",
+              "title": "Soc Issues & Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "298",
+              "title": "or CIS298: Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Technologies",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/web-technologies.html",
+      "total_credits": 51,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "110",
+              "title": "or CIS102: Intro to Progr",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "or CIS122: Visual Basic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Pre-Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "130",
+              "title": "Linux Oper. Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "142",
+              "title": "Network Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "150",
+              "title": "or CIS155: Web Dsgn Fluen",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "LAN Switching & Wireless",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "151",
+              "title": "or CIS257 or IST151",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "210",
+              "title": "Soc Issues & Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "250",
+              "title": "or CIS159: Web Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "251",
+              "title": "or CIS257: Internet Prog",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "298",
+              "title": "or CIS298: Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering - Smart Building Technology Conc",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/associate-in-science/engineering/smart-building-technology-concentration.html",
+      "total_credits": 50,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "120",
+              "title": "Engineering Computatns I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "150",
+              "title": "Building Automation Syste",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Pre-Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "131",
+              "title": "DC Circuits with Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "160",
+              "title": "BAS Control Device 1",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "132",
+              "title": "AC Circuits with Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "133",
+              "title": "Intro to Digital Logic",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "260",
+              "title": "BAS Control Device 2",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Four",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "121",
+              "title": "Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "142",
+              "title": "Network Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "299",
+              "title": "Science Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Accounting Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/certificate-programs/accounting.html",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Prin of Acct I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "221",
+              "title": "Business Law 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Prin of Acct II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "103",
+              "title": "Income Taxes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Computerized Acct.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "English Comp. II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Biotechnology/Biomanufacturing",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/certificate-programs/biotechnology-biomanufacturing.html",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "104",
+              "title": "Biology II w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "123",
+              "title": "Prin. of Chem I w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "204",
+              "title": "Microbiology w/LAB",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "206",
+              "title": "Intro to Biomanufac I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "207",
+              "title": "Intro to Biomanufac II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "298",
+              "title": "Biotechnology Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Broadcast Media Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/certificate-programs/broadcast-media-technology.html",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "100",
+              "title": "Intro to Prod/Directing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "120",
+              "title": "Video Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Comp. I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "103",
+              "title": "Math 103 or above",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BMT",
+              "number": "110",
+              "title": "Television Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BMT",
+              "number": "230",
+              "title": "Intro. To Video Editing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Systems Technology Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/certificate-programs/information-systems-technology.html",
+      "total_credits": 31,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "110",
+              "title": "or CIS102: Intro to Progr",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "120",
+              "title": "or CIS141: Microcomp Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "145",
+              "title": "or CIS122: Visual Basic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "130",
+              "title": "Linux Oper. Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "142",
+              "title": "Network Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "170",
+              "title": "or CIS255: Java I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Three",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "150",
+              "title": "or CIS155: Web Dsgn Fluen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "210",
+              "title": "Soc Issues & Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "270",
+              "title": "or CIS271: Java II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Network Administration Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://www.rcc.mass.edu/learn/find-your-program/certificate-programs/network-administration.html",
+      "total_credits": 18,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester One",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "102",
+              "title": "The College Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "110",
+              "title": "or CIS102: Intro to Progr",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "117",
+              "title": "IT Essent-PC Hard-Softwar",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IST",
+              "number": "142",
+              "title": "Network Fundamentals",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester Two",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IST",
+              "number": "144",
+              "title": "LAN Switching & Wireless",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -106,6 +106,10 @@ const maConfig: StateConfig = {
         scripts: ["scripts/ma/scrape-cleancatalog-programs.ts"],
         runner: "http",
       },
+      {
+        scripts: ["scripts/ma/scrape-rcc-programs.ts"],
+        runner: "http",
+      },
     ],
   },
 };

--- a/scripts/ma/scrape-rcc-programs.ts
+++ b/scripts/ma/scrape-rcc-programs.ts
@@ -1,0 +1,282 @@
+/**
+ * scrape-rcc-programs.ts — MA program scraper for Roxbury Community College.
+ *
+ * Closes #243. RCC publishes degree and certificate programs as plain
+ * static HTML pages on their main marketing site:
+ *
+ *   https://www.rcc.mass.edu/learn/find-your-program/
+ *     associate-in-arts/{slug}.html
+ *     associate-in-science/{slug}.html
+ *     associate-in-science/engineering/{slug}.html
+ *     certificate-programs/{slug}.html
+ *
+ * Each program page has:
+ *   <h1 class="hero-inner__title">Accounting</h1>
+ *   <table class="simple-tables__item">
+ *     <tr><th colspan="2">Semester One</th><th>Credits</th></tr>
+ *     <tr><td>BUS101</td><td>Prin of Acct I</td><td>3.00</td></tr>
+ *     ...
+ *   </table>
+ *   <table class="simple-tables__item">…</table>  // one per semester
+ *
+ * No CMS, no API — bespoke enough that this scraper stays in scripts/ma/
+ * rather than going into the shared lib (no other college uses this layout).
+ *
+ * Usage:
+ *   npx tsx scripts/ma/scrape-rcc-programs.ts
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as cheerio from "cheerio";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequiredCourse,
+  RequirementGroup,
+} from "../../lib/types.js";
+
+const BASE_URL = "https://www.rcc.mass.edu";
+const COLLEGE_SLUG = "rcc";
+const STATE = "ma";
+const CATALOG_YEAR = "2025-2026";
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const INDEX_PATHS = [
+  { path: "/learn/find-your-program/associate-in-arts/", credential: "AA" as const },
+  { path: "/learn/find-your-program/associate-in-science/", credential: "AS" as const },
+  { path: "/learn/find-your-program/certificate-programs/", credential: "certificate" as const },
+];
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function fetchHtml(url: string): Promise<string> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const res = await fetch(url, {
+      headers: {
+        "User-Agent": UA,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+      },
+    });
+    if (res.ok) return res.text();
+    if (res.status >= 500) {
+      await sleep(500 * Math.pow(2, attempt));
+      continue;
+    }
+    return "";
+  }
+  return "";
+}
+
+/**
+ * Walk a credential's index page and any subdirectory indexes to collect
+ * all candidate program-page URLs (anything ending in .html under that
+ * path). Returns a unique list of absolute URLs to try.
+ */
+async function collectCandidates(indexPath: string): Promise<string[]> {
+  const seen = new Set<string>();
+  const queue = [indexPath];
+  const candidates = new Set<string>();
+
+  while (queue.length) {
+    const current = queue.shift()!;
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    const html = await fetchHtml(`${BASE_URL}${current}`);
+    if (!html) continue;
+    const $ = cheerio.load(html);
+    $("a[href]").each((_, a) => {
+      const href = $(a).attr("href");
+      if (!href) return;
+      const clean = href.split("#")[0].split("?")[0];
+      // Only follow paths under this credential subtree
+      if (!clean.startsWith(indexPath)) return;
+      if (clean === indexPath) return;
+      // index.html in a sub-folder → enqueue the folder for further crawl
+      if (clean.endsWith("/index.html")) {
+        const subdir = clean.replace(/index\.html$/, "");
+        queue.push(subdir);
+        return;
+      }
+      // Trailing slash → another index
+      if (clean.endsWith("/")) {
+        queue.push(clean);
+        return;
+      }
+      if (clean.endsWith(".html")) candidates.add(clean);
+    });
+  }
+
+  return [...candidates];
+}
+
+// Filenames seen in subdirectories (nursing/, radiologic-technology/) that
+// are *not* program pages — FAQs, faculty bios, clinical obligations, etc.
+// Compared against the final URL segment so paths like
+// /find-your-program/associate-in-science/nursing/faqs.html match while
+// regular program pages don't.
+const SKIP_FILENAMES = new Set([
+  "general-education-requirements.html",
+  "apply-to-nursing-programs.html",
+  "rt-course-descriptions.html",
+  "rt-mission-and-goals.html",
+  "rt-technical-standards.html",
+  "rt-program-requirements.html",
+  "program-effectiveness-data.html",
+  "clinical-obligations.html",
+  "faculty-staff.html",
+  "faqs.html",
+]);
+
+function looksLikeProgramSubpage(url: string): boolean {
+  const last = url.split("/").pop()?.toLowerCase() ?? "";
+  return SKIP_FILENAMES.has(last);
+}
+
+function splitCourseCode(
+  raw: string,
+): { prefix: string; number: string } | null {
+  const code = raw.trim().replace(/\+$/, ""); // MAT103+ → MAT103
+  const m = code.match(/^([A-Z]{2,5})(\d{3,4}[A-Z]?)$/);
+  if (!m) return null;
+  return { prefix: m[1], number: m[2] };
+}
+
+function parseCredits(text: string): number | null {
+  const m = text.trim().match(/^(\d+(?:\.\d+)?)/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseProgram(
+  html: string,
+  url: string,
+  credential: ProgramCredential,
+): ProgramRequirement | null {
+  const $ = cheerio.load(html);
+  const title = $(".hero-inner__title").first().text().replace(/\s+/g, " ").trim();
+  if (!title) return null;
+
+  const groups: RequirementGroup[] = [];
+  $("table.simple-tables__item").each((_, table) => {
+    const $table = $(table);
+    // Group name from the first <th colspan="2">
+    const headerCell = $table.find("tr").first().find("th").first();
+    const groupName =
+      headerCell.text().replace(/\s+/g, " ").trim() || "Required Courses";
+    const courses: RequiredCourse[] = [];
+
+    $table.find("tr").each((idx, tr) => {
+      if (idx === 0) return; // header
+      const tds = $(tr).find("td");
+      if (tds.length < 3) return;
+      const codeRaw = $(tds[0]).text().trim();
+      const split = splitCourseCode(codeRaw);
+      if (!split) return; // skip placeholder codes (DEVEDG, HUMELECT, etc.)
+      const titleText = $(tds[1]).text().replace(/\s+/g, " ").trim();
+      const credits = parseCredits($(tds[2]).text());
+      // Drop zero-credit dev-ed / placeholder rows even when the code parses
+      if (credits === 0) return;
+      courses.push({
+        prefix: split.prefix,
+        number: split.number,
+        title: titleText,
+        credits,
+        or_alternatives: [],
+      });
+    });
+
+    if (courses.length > 0) {
+      groups.push({
+        name: groupName,
+        credits_required: null,
+        choose_n: null,
+        courses,
+      });
+    }
+  });
+
+  if (groups.length === 0) return null;
+
+  let total = 0;
+  let any = false;
+  for (const g of groups) {
+    for (const c of g.courses) {
+      if (c.credits !== null && c.credits > 0) {
+        total += c.credits;
+        any = true;
+      }
+    }
+  }
+
+  return {
+    title,
+    credential,
+    program_code: null,
+    catalog_url: url,
+    total_credits: any ? total : null,
+    gpa_minimum: 2.0,
+    description: null,
+    requirement_groups: groups,
+    matched_program_slug: null,
+  };
+}
+
+async function main() {
+  const programs: ProgramRequirement[] = [];
+
+  for (const { path: indexPath, credential } of INDEX_PATHS) {
+    console.log(`Walking ${indexPath} (${credential})`);
+    const urls = await collectCandidates(indexPath);
+    console.log(`  Found ${urls.length} candidate page(s)`);
+    let parsed = 0;
+    for (const u of urls) {
+      if (looksLikeProgramSubpage(u)) continue;
+      const html = await fetchHtml(`${BASE_URL}${u}`);
+      if (!html) continue;
+      const program = parseProgram(html, `${BASE_URL}${u}`, credential);
+      if (!program) continue;
+      programs.push(program);
+      parsed++;
+      await sleep(80);
+    }
+    console.log(`  Parsed ${parsed} program(s)`);
+  }
+
+  // Dedupe by catalog_url (a program slug might appear under more than one
+  // credential index if the site cross-links).
+  const byUrl = new Map<string, ProgramRequirement>();
+  for (const p of programs) byUrl.set(p.catalog_url, p);
+  const unique = [...byUrl.values()];
+
+  const { matched, unmatched } = applyProgramMatching(unique);
+  console.log(
+    `\nMatcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+  );
+
+  const out: CollegePrograms = {
+    college_slug: COLLEGE_SLUG,
+    catalog_year: CATALOG_YEAR,
+    catalog_url: `${BASE_URL}/learn/find-your-program/`,
+    scraped_at: new Date().toISOString(),
+    programs: unique,
+  };
+
+  const outDir = path.join(process.cwd(), "data", STATE, "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${COLLEGE_SLUG}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(out, null, 2));
+  console.log(`✓ Wrote ${unique.length} programs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a standalone scraper at [scripts/ma/scrape-rcc-programs.ts](scripts/ma/scrape-rcc-programs.ts) for Roxbury Community College.
- Wires it into [lib/states/ma/config.ts](lib/states/ma/config.ts).
- Output: **27 programs** (14 AA, 8 AS, 5 certificate); 10/27 matched to registry slugs.

## Background

RCC publishes its catalog as plain static HTML on the main marketing site under `/learn/find-your-program/{credential}/{slug}.html`. No Acalog / CourseLeaf / SmartCatalogIQ / CleanCatalog / Coursedog — just hand-edited HTML with a stable `<table class="simple-tables__item">` per semester. The original investigation in #243 missed these pages because they're not linked from the obvious "college-catalog" landing.

Bespoke enough that the scraper stays in `scripts/ma/` rather than going into the shared lib — no other MA college uses this layout.

## Discovery quirks

- Three credential index pages walked: `/associate-in-arts/`, `/associate-in-science/`, `/certificate-programs/`.
- The AS index points into sub-folders (`engineering/`, `nursing/`, `radiologic-technology/`) where the program tables live alongside FAQ/faculty/clinical-obligations pages. Filtered the noise out by filename, not by URL substring (a first pass had `"find-your-program"` in the skip list, which matched every URL on the site → 0 programs parsed).
- Engineering's `smart-building-technology-concentration.html` is correctly picked up.

## Known limitations

- `total_credits` runs light (15–51 range) because RCC's tables include rows like `HUMELECT`, `SCIELECT`, `BUSELECT` — generic elective placeholders without a real course code. The schema (`prefix` + `number`) can't represent those, so they're skipped along with 0-credit dev-ed rows. Same limitation the existing CourseLeaf scraper documents at line 200.
- Nursing and Radiologic Technology programs likely don't have the same table shape on their `index.html` pages, so they didn't parse — left out rather than emitting half-data.

## Coverage

MA program coverage now **12/15**. Remaining: [#241](https://github.com/rohan-c0de/coursemap/issues/241) Bristol (Drupal) + Massasoit + [#230](https://github.com/rohan-c0de/cc-coursemap/issues/230) GCC (Coursedog, deferred).

## Test plan

- [x] `npx tsc --noEmit` exits 0
- [x] `npm run lint` exits 0
- [x] Scraper run produces 27 programs across 3 credentials
- [x] Local dev: `/ma/college/rcc/programs` renders the new data (Accounting, Biotechnology, Liberal Arts, etc.)
- [ ] CI green
- [ ] Post-merge: confirm Vercel ships and `communitycollegepath.com/ma/college/rcc/programs` shows the new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)