### PR TITLE
feat: PDF program scraper for Massasoit CC

### DIFF
--- a/data/ma/programs/massasoit.json
+++ b/data/ma/programs/massasoit.json
@@ -1,0 +1,5507 @@
+{
+  "college_slug": "massasoit",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://massasoit.edu/academics/academic-programs/",
+  "scraped_at": "2026-05-07T15:00:33.843Z",
+  "programs": [
+    {
+      "title": "Corrections",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/corrections-certificate.html",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "200",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "105",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "302",
+              "title": "Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "340",
+              "title": "Community Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "345",
+              "title": "Corrections Law & Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "203",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice - Career",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/criminal-justice-career.html",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "105",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "200",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "302",
+              "title": "Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "305",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "306",
+              "title": "Criminal Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "203",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "316",
+              "title": "Police, Community, and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Criminal Justice - Transfer",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/criminal-justice-transfer.html",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "105",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "200",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "302",
+              "title": "Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "305",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "306",
+              "title": "Criminal Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "203",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "316",
+              "title": "Police, Community, and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "403",
+              "title": "Criminal Justice Capstone",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "DDS Direct Support in Human Services Certificate (DDS Employees Only)",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/direct-support-in-human-services-certificate.html",
+      "total_credits": 22,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "101",
+              "title": "Introduction to Social Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "103",
+              "title": "Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "221",
+              "title": "Special Topics in Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "222",
+              "title": "Developmental Disabilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "405",
+              "title": "Field Experience and Seminar",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education & Administration - Transfer",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/early-childhood-education-administration-transfer.html",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "102",
+              "title": "Development in Early Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Intro to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "107",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "101",
+              "title": "Positive Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "111",
+              "title": "Early Childhood Curriculum:",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "Environmental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "121",
+              "title": "Biological Principles I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "217",
+              "title": "The Young Child with Special Needs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "280",
+              "title": "Practicum I in Child Care Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "285",
+              "title": "Seminar I in Child Care Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "127",
+              "title": "Math for Elementary Teachers I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "121",
+              "title": "Children’s Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Math for Elementary Teachers II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Early Childhood Education & Administration",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/early-childhood-education-administration.html",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "102",
+              "title": "Development in Early Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "105",
+              "title": "Intro to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "112",
+              "title": "Health, Nutrition, and Safety Needs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "107",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "101",
+              "title": "Positive Guidance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "111",
+              "title": "Early Childhood Curriculum:",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "217",
+              "title": "The Young Child with Special Needs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "231",
+              "title": "Infant/Toddler Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "280",
+              "title": "Practicum I in Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "285",
+              "title": "Seminar I in Early Childhood Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "208",
+              "title": "Family and Community",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECED",
+              "number": "201",
+              "title": "Administration, Supervision, and",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "211",
+              "title": "Child Care Policies and Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "290",
+              "title": "Practicum II in Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECED",
+              "number": "295",
+              "title": "Seminar II in Early Childhood Education",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Elementary Education",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/elementary-education.html",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "143",
+              "title": "Environmental Science",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "121",
+              "title": "Biological Principles I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "103",
+              "title": "US History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "127",
+              "title": "Math for Elementary Teachers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "108",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "128",
+              "title": "Math for Elementary Teachers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "111",
+              "title": "Intro to Elementary Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "201",
+              "title": "MTEL Prep for CSLT",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "213",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "105",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "202",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Economics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "205",
+              "title": "Language and Literacy Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "210",
+              "title": "Critical and Anti-Racist Approaches to Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "214",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEOG",
+              "number": "201",
+              "title": "Human Geography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/fire-science-technology.html",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "101",
+              "title": "Principles of Emergency Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "103",
+              "title": "Fundamentals of Fire Prevention",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131",
+              "title": "Survey of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "107",
+              "title": "Legal Aspects of Emergency Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHYS",
+              "number": "120",
+              "title": "Science of Fire and Combustion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "211",
+              "title": "Hazardous Material Incident Response",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "213",
+              "title": "Building Construction, Blueprint, and Plan Review 3o",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "301",
+              "title": "Fire Company Officership - Tactics and Strategy 3o",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "105",
+              "title": "American National Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "200",
+              "title": "State and Local Government",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FIRE",
+              "number": "111",
+              "title": "Fire Investigation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "205",
+              "title": "Fire Service Safety and Survival",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "206",
+              "title": "Fire Protection Systems and Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIRE",
+              "number": "208",
+              "title": "Fire Hydraulics and Water Distribution Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human & Social Services - Career",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/human-services-career.html",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "101",
+              "title": "Introduction to Social Work/Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "103",
+              "title": "Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "102",
+              "title": "Counseling Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "105",
+              "title": "Human/Social Services Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "405",
+              "title": "Field Experience and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "200",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "107",
+              "title": "Fostering Equality and Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "406",
+              "title": "Field Experience and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human & Social Services - Transfer",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/human-services-transfer.html",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "101",
+              "title": "Introduction to Social Work/Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "103",
+              "title": "Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "158",
+              "title": "Introduction to Statistics or higher",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "105",
+              "title": "Human/Social Services Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "405",
+              "title": "Field Experience and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSRV",
+              "number": "406",
+              "title": "Field Experience and Seminar",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Human Growth and Development",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "160",
+              "title": "Human Genetics, Reproduction, and Society",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSRV",
+              "number": "107",
+              "title": "Fostering Equality and Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Juvenile Justice",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/juvenile-justice-certificate.html",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYCH",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "231",
+              "title": "Juvenile Justice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "323",
+              "title": "Juvenile Delinquency",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPSYC",
+              "number": "293",
+              "title": "Adolescent Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Law Enforcement Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/law-enforcement-certificate.html",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJUS",
+              "number": "305",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "306",
+              "title": "Criminal Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "316",
+              "title": "Police, Community, and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "203",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Private Security - Basic Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/private-security-certificate.html",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SECI",
+              "number": "101",
+              "title": "Introduction to Private Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJUS",
+              "number": "223",
+              "title": "Intro to Investigative and Forensic Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "180",
+              "title": "Computer and Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/behavioral-science-public-service-education/psychology.html",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "202",
+              "title": "Child Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "203",
+              "title": "Adolescence Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Developmental Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "121",
+              "title": "Biological Principles I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Abnormal Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "208",
+              "title": "Psychology of Personality",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "209",
+              "title": "Social Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "206",
+              "title": "Psychology of Learning",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "207",
+              "title": "Biological Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Statistics for Psychology and Social Sciences",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "201",
+              "title": "Ethical Dilemmas",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Business Administration Careers - Accounting",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/business-administration-careers-accounting.html",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Principles of Financial Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "108",
+              "title": "Computerized Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "106",
+              "title": "Principles of Financial Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Principles of Managerial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "170",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Economics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "211",
+              "title": "Taxation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "201",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "115",
+              "title": "Small Business Financial Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "201",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "225",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Hospitality Management",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/business-administration-careers-hospitality-management.html",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "108",
+              "title": "Computerized Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "103",
+              "title": "Introduction to Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "133",
+              "title": "Introduction to Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "104",
+              "title": "Fundamentals of Financial Reporting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "106",
+              "title": "Conference and Event Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "134",
+              "title": "Hospitality Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Economics I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Economics II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Principles of Managerial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "101",
+              "title": "Food/Beverage Service Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "107",
+              "title": "Hospitality Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRGE",
+              "number": "101",
+              "title": "Destination Geography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRGE",
+              "number": "102",
+              "title": "Destination Geography II",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "113",
+              "title": "Managerial Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "131",
+              "title": "Hotel Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "135",
+              "title": "Hospitality Human Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "136",
+              "title": "ServSafe Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRGE",
+              "number": "101",
+              "title": "Destination Geography I",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRGE",
+              "number": "102",
+              "title": "Destination Geography II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Careers - Management",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/business-administration-careers-management.html",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "108",
+              "title": "Computerized Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Economics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "104",
+              "title": "Fundamentals of Financial Reporting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "112",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "170",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Principles of Managerial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "125",
+              "title": "Small Business Management",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "127",
+              "title": "Human Resources Management",
+              "credits": 15,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "201",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "260",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Careers - Marketing",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/business-administration-careers-marketing.html",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "108",
+              "title": "Computerized Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Economics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "104",
+              "title": "Fundamentals of Financial Reporting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "170",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Principles of Managerial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "112",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "123",
+              "title": "Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "201",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "122",
+              "title": "Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "124",
+              "title": "Principles of Retailing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Transfer",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/business-administration-transfer.html",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "108",
+              "title": "Computerized Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Principles of Economics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Principles of Financial Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "201",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "202",
+              "title": "Principles of Economics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "106",
+              "title": "Principles of Financial Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "112",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "158",
+              "title": "Introduction to Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "107",
+              "title": "Principles of Managerial Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "120",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Community Banking Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/community-banking-certificate.html",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Compostion I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "108",
+              "title": "Computerized Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "111",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "201",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "170",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "117",
+              "title": "Critical Issues in Community Banking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems - Integrated User Support",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/computer-user-support.html",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTIM",
+              "number": "101",
+              "title": "Beginning Windows",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "102",
+              "title": "Beginning Word",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "103",
+              "title": "Beginning Excel",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "114",
+              "title": "Beginning PowerPoint",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "171",
+              "title": "Computer Hardware and Software Configuration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSN",
+              "number": "112",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "112",
+              "title": "Word Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "115",
+              "title": "Intermediate PowerPoint",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "266",
+              "title": "Professional Development for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "225",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "170",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "131",
+              "title": "Introduction to Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "225",
+              "title": "Introduction to Networking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTIM",
+              "number": "117",
+              "title": "Beginning Access",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "178",
+              "title": "Help Desk Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "180",
+              "title": "Computer and Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "221",
+              "title": "Desktop Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "230",
+              "title": "Ethics in Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computerized Accounting Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/computerized-accounting-certificate.html",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "105",
+              "title": "Principles of Financial Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "108",
+              "title": "Computerized Business Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "211",
+              "title": "Taxation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "110",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "106",
+              "title": "Principles of Financial Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "115",
+              "title": "Small Business Financial Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "225",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "111",
+              "title": "Personal Finance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Culinary Arts",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/culinary-arts.html",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "123",
+              "title": "Table Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "139",
+              "title": "Culinary Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "140",
+              "title": "Culinary Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "143",
+              "title": "Foundations of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "128",
+              "title": "The Art of Bread",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "146",
+              "title": "American Regional Cuisine",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "151",
+              "title": "International Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "152",
+              "title": "Classical Cuisine",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "161",
+              "title": "Advanced Pastries",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "162",
+              "title": "Classical Desserts",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "295",
+              "title": "Field Work Experience in Culinary Arts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "107",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Food Production Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/food-production-certificate.html",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "139",
+              "title": "Culinary Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "140",
+              "title": "Culinary Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "143",
+              "title": "Foundations of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "156",
+              "title": "Nutrition and Food Trends",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "123",
+              "title": "Table Service",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "135",
+              "title": "Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "146",
+              "title": "American Regional Cuisine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "157",
+              "title": "Meat Fabrication and Charcuterie",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality Management Certificatre",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/hospitality-management-certificate.html",
+      "total_credits": 25,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "103",
+              "title": "Introduction to Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "106",
+              "title": "Conference and Event Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "133",
+              "title": "Introduction to Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "134",
+              "title": "Hospitality Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HOSP",
+              "number": "101",
+              "title": "Food and Beverage Service Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "107",
+              "title": "Hospitality Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "131",
+              "title": "Hotel Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "135",
+              "title": "Hospitality Human Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HOSP",
+              "number": "136",
+              "title": "ServSafe Certification",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Microsoft Office Specialist Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/microsoft-office-specialist-certificate.html",
+      "total_credits": 12,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTIM",
+              "number": "100",
+              "title": "Computer Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "101",
+              "title": "Beginning Windows",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "102",
+              "title": "Beginning Word",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "103",
+              "title": "Beginning Excel",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "114",
+              "title": "Beginning PowerPoint",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "115",
+              "title": "Intermediate PowerPoint",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "117",
+              "title": "Beginning Access",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "266",
+              "title": "Prof. Development for Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Office Technologies Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/office-technologies-certificate.html",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CTIM",
+              "number": "100",
+              "title": "Computer Keyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "101",
+              "title": "Beginning Windows",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "102",
+              "title": "Beginning Word",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "103",
+              "title": "Beginning Excel",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "114",
+              "title": "Beginning PowerPoint",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "115",
+              "title": "Intermediate PowerPoint",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "117",
+              "title": "Beginning Access",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "180",
+              "title": "Computer Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "266",
+              "title": "Professional Development for Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "225",
+              "title": "Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "112",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSN",
+              "number": "170",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "112",
+              "title": "Word Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CTIM",
+              "number": "171",
+              "title": "Computer Hardware and",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pastry Certificaate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/business-entrepreneurial-leadership/pastry-certificate.html",
+      "total_credits": 26,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "139",
+              "title": "Culinary Certification",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "140",
+              "title": "Culinary Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "143",
+              "title": "Foundations of Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "159",
+              "title": "Cake Decorating",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CULA",
+              "number": "128",
+              "title": "The Art of Bread",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "160",
+              "title": "Chocolate Artistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "161",
+              "title": "Advanced Pastries",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CULA",
+              "number": "162",
+              "title": "Classical Desserts",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Assistant Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/dental-assistant-certificate.html",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENT",
+              "number": "102",
+              "title": "Dental Materials I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "103",
+              "title": "Dental Radiography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "105",
+              "title": "Dental Office Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "106",
+              "title": "Dental Science I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENT",
+              "number": "107",
+              "title": "Chairside Assisting",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DENT",
+              "number": "111",
+              "title": "Dental Science II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "112",
+              "title": "Clinical Externship",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "113",
+              "title": "Dental Materials II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DENT",
+              "number": "114",
+              "title": "Dental Radiography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts Studies - Health Sciences",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/liberal-arts-studies-health-sciences.html",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "121",
+              "title": "Biologic Principles I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Anatomy & Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "107",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "LPN to Associate Degree Advanced Placement Nurse Education – Full Time",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/lpn-to-associate-degree-advanced-placement-nurse-education-full-time.html",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "101",
+              "title": "Nursing I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "301",
+              "title": "Nursing IV",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "231",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "LPN to Associate Degree Advanced Placement Nurse Education - Part Time",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/lpn-to-associate-degree-advanced-placement-nurse-education-part-time.html",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "212",
+              "title": "Nursing I-E",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "214",
+              "title": "Nursing III-E",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "213",
+              "title": "Nursing II-E",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "304",
+              "title": "Nursing A",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "305",
+              "title": "Nursing B",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "231",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "306",
+              "title": "Nursing C",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "307",
+              "title": "Nursing Trends",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Medical Assistant Cetificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/medical-assistant-certificate.html",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEDA",
+              "number": "104",
+              "title": "Basic Laboratory Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "107",
+              "title": "Medical Assisting Techniques I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "108",
+              "title": "Anatomy, Physiology, and Terminology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "109",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "229",
+              "title": "Medical Office Management I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "111",
+              "title": "Medical Law and Ethics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEDA",
+              "number": "116",
+              "title": "Clinical Externship",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "119",
+              "title": "Anatomy, Physiology, and Terminology II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "120",
+              "title": "Medical Assisting Techniques II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "121",
+              "title": "Basic Laboratory Procedures II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDA",
+              "number": "230",
+              "title": "Medical Office Management II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nurse Education - Full Time",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/nurse-education-full-time.html",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "101",
+              "title": "Nursing I",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "203",
+              "title": "Nursing II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "204",
+              "title": "Nursing III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "301",
+              "title": "Nursing IV",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "231",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "302",
+              "title": "Nursing V",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "303",
+              "title": "Nursing Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nurse Education - Part Time",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/nurse-education-part-time.html",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "212",
+              "title": "Nursing I-E",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "214",
+              "title": "Nursing III-E",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "213",
+              "title": "Nursing II-E",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "304",
+              "title": "Nursing A",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "205",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 5",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "305",
+              "title": "Nursing B",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "231",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 6",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NURS",
+              "number": "306",
+              "title": "Nursing C",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NURS",
+              "number": "307",
+              "title": "Nursing Trends",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Radiologic Technology",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/radiologic-technology.html",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RADT",
+              "number": "102",
+              "title": "Image Production and Evaluation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "112",
+              "title": "RADT Anatomy/Positioning Lab II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "120",
+              "title": "RADT Principles of Digital Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "134",
+              "title": "RADT Anatomy/Positioning Lecture II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RADT",
+              "number": "142",
+              "title": "RADT Clinical Experience II A",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Respiratory Care",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/health-sciences/respiratory-care.html",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RESP",
+              "number": "101",
+              "title": "Fundamentals of Respiratory Care I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "113",
+              "title": "Respiratory Care Seminar I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "115",
+              "title": "Respiratory Care Equipment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "201",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "131",
+              "title": "Survey of Chemistry",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RESP",
+              "number": "102",
+              "title": "Fundamentals of Respiratory Care II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "112",
+              "title": "Introduction to Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "202",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RESP",
+              "number": "103",
+              "title": "Fundamentals of Respiratory Care III",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "111",
+              "title": "Introduction to Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "121",
+              "title": "Respiratory Care - Clinical Cardio",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RESP",
+              "number": "104",
+              "title": "Fundamentals of Respiratory Care IV",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "116",
+              "title": "Seminar II in Respiratory Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RESP",
+              "number": "117",
+              "title": "Cardiopulmonary Diagnostics and Evaluation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "231",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Black Studies",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/black-studies.html",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLST",
+              "number": "150",
+              "title": "Introduction to Black Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "232",
+              "title": "Sociology of Race and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTG",
+              "number": "204",
+              "title": "The Black Arts Movement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLST",
+              "number": "220",
+              "title": "The Civil Rights and Black Power Movement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLST",
+              "number": "230",
+              "title": "Contemporary Issues in the Black Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "215",
+              "title": "African-American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUSC",
+              "number": "220",
+              "title": "The Black Experience through Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLST",
+              "number": "240",
+              "title": "The Caribbean: History, People, and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "216",
+              "title": "African-American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "201",
+              "title": "Black Images in Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "215",
+              "title": "Urban Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts Studies",
+      "credential": "AS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/liberal-arts-studies.html",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOVT",
+              "number": "105",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "107",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts Transfer",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/liberal-arts-transfer-programs.html",
+      "total_credits": 62,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "107",
+              "title": "Oral Interpretation",
+              "credits": null,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Media Arts - Radio and Podcasting Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/media-arts-radio-certificate.html",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "108",
+              "title": "Radio Broadcasting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "110",
+              "title": "Broadcast Writing and Presentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "111",
+              "title": "Intro to Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "113",
+              "title": "Radio Production and Podcasting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "213",
+              "title": "Advanced Radio Production and Podcasting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "401",
+              "title": "Practicum in Radio",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Arts - Video Production Certificate",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/media-arts-video-production-certificate.html",
+      "total_credits": 21,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "110",
+              "title": "Broadcast Writing and Presentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "111",
+              "title": "Intro to Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "112",
+              "title": "Television Studio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "116",
+              "title": "Digital Video Editing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "200",
+              "title": "Film Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "114",
+              "title": "Advanced Television Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "401",
+              "title": "Practicum in Television",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/media-arts.html",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "111",
+              "title": "Introduction to Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "112",
+              "title": "Television Studio Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "113",
+              "title": "Radio Production and Podcasting CHOOSE ONE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "105",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FILM",
+              "number": "200",
+              "title": "Film Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "116",
+              "title": "Digital Video Editing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "108",
+              "title": "Radio Broadcasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "108",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "JOUR",
+              "number": "120",
+              "title": "Journalism Basics for the Digital Age",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "110",
+              "title": "Broadcast Writing and Presentation CHOOSE ONE",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "114",
+              "title": "Advanced Television Production",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MDIA",
+              "number": "213",
+              "title": "Advanced Radio Production and Podcasting",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MDIA",
+              "number": "401",
+              "title": "Practicum in Television or Radio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre Arts",
+      "credential": "AA",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/theatre-arts.html",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THET",
+              "number": "101",
+              "title": "Introduction to the Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THET",
+              "number": "204",
+              "title": "Movement for Acting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THET",
+              "number": "102",
+              "title": "Voice Improvement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THET",
+              "number": "205",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPCH",
+              "number": "107",
+              "title": "Oral Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 3",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THET",
+              "number": "110",
+              "title": "Stagecraft I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "119",
+              "title": "Creative Writing",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "217",
+              "title": "Dramatic Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "104",
+              "title": "Principles of Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THET",
+              "number": "230",
+              "title": "Design for the Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "218",
+              "title": "Dramatic Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Arts - Fine Arts",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/visual-arts-fine-arts.html",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTG",
+              "number": "107",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "113",
+              "title": "Color and Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "263",
+              "title": "Sculpture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTG",
+              "number": "108",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "114",
+              "title": "Color and Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "221",
+              "title": "Painting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTG",
+              "number": "102",
+              "title": "History of Art II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Arts - Art & Graphic Design",
+      "credential": "AAS",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/liberal-studies-and-the-arts/visual-arts-graphic-design.html",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTG",
+              "number": "100",
+              "title": "Art History of the Western World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "107",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "113",
+              "title": "Color and Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "281",
+              "title": "Computer-Aided Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTG",
+              "number": "108",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "112",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "114",
+              "title": "Color and Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "115",
+              "title": "Intro to Graphic Design & Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 4",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTG",
+              "number": "106",
+              "title": "Graphic Design II",
+              "credits": null,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTG",
+              "number": "212",
+              "title": "Illustration II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Alternative Fuels & Emissions",
+      "credential": "certificate",
+      "program_code": null,
+      "catalog_url": "https://massasoit.edu/academics/academic-programs/science-technology-engineering-math/alternative-fuels-emissions-certificate.html",
+      "total_credits": 24,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Semester 1",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIES",
+              "number": "107",
+              "title": "Engine Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIES",
+              "number": "108",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIES",
+              "number": "123",
+              "title": "Truck Components I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIES",
+              "number": "223",
+              "title": "Compressed Natural Gas Engines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Semester 2",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DIES",
+              "number": "122",
+              "title": "Fuel Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIES",
+              "number": "124",
+              "title": "Truck Components II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIES",
+              "number": "222",
+              "title": "Electronic Engine Diagnostics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DIES",
+              "number": "226",
+              "title": "Hydraulics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -110,6 +110,10 @@ const maConfig: StateConfig = {
         scripts: ["scripts/ma/scrape-rcc-programs.ts"],
         runner: "http",
       },
+      {
+        scripts: ["scripts/ma/scrape-massasoit-programs.ts"],
+        runner: "http",
+      },
     ],
   },
 };

--- a/scripts/ma/scrape-massasoit-programs.ts
+++ b/scripts/ma/scrape-massasoit-programs.ts
@@ -1,0 +1,288 @@
+/**
+ * scrape-massasoit-programs.ts — MA program scraper for Massasoit CC.
+ *
+ * Massasoit publishes per-program "Academic Map" PDFs at
+ *   https://massasoit.edu/academics/maps/{Program-Name}-25-26.pdf
+ * Each program's marketing page on the static HTML site links to its map.
+ * The maps render the curriculum as a tabular layout that pdftotext --layout
+ * extracts as multi-column text, where the right column carries
+ * instructional prose that bleeds onto the same lines as left-column
+ * course rows. We split each line at runs of ≥5 spaces to isolate the
+ * course-row chunk from the prose.
+ *
+ * Discovery: walk the 6 academic-pathway index pages, collect program
+ * page URLs, scrape the map PDF link from each, parse the PDF.
+ *
+ * Custom one-off — no other MA college uses this layout.
+ *
+ * Usage:
+ *   npx tsx scripts/ma/scrape-massasoit-programs.ts
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import * as cheerio from "cheerio";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequirementGroup,
+} from "../../lib/types.js";
+
+const BASE_URL = "https://massasoit.edu";
+const COLLEGE_SLUG = "massasoit";
+const STATE = "ma";
+const CATALOG_YEAR = "2025-2026";
+
+const UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const PATHWAYS = [
+  "/academics/academic-programs/behavioral-science-public-service-education/",
+  "/academics/academic-programs/business-entrepreneurial-leadership/",
+  "/academics/academic-programs/health-sciences/",
+  "/academics/academic-programs/liberal-studies-and-the-arts/",
+  "/academics/academic-programs/science-technology-engineering-math/",
+  "/academics/academic-programs/future-work-institute/",
+];
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": UA, Accept: "text/html,*/*" },
+  });
+  return res.ok ? res.text() : "";
+}
+
+async function fetchBuffer(url: string): Promise<Buffer | null> {
+  const res = await fetch(url, { headers: { "User-Agent": UA } });
+  if (!res.ok) return null;
+  const ab = await res.arrayBuffer();
+  return Buffer.from(ab);
+}
+
+function pdfToText(pdfBuf: Buffer): string {
+  const tmpPdf = path.join(os.tmpdir(), `massasoit-${process.pid}-${Date.now()}.pdf`);
+  const tmpTxt = `${tmpPdf}.txt`;
+  fs.writeFileSync(tmpPdf, pdfBuf);
+  try {
+    execFileSync("pdftotext", ["-layout", tmpPdf, tmpTxt]);
+    return fs.readFileSync(tmpTxt, "utf-8");
+  } finally {
+    try { fs.unlinkSync(tmpPdf); } catch { /* ignore */ }
+    try { fs.unlinkSync(tmpTxt); } catch { /* ignore */ }
+  }
+}
+
+function classifyCredential(label: string): ProgramCredential {
+  const t = label.toLowerCase();
+  if (t.includes("associate in applied science") || t.includes("a.a.s")) return "AAS";
+  if (t.includes("associate in arts")) return "AA";
+  if (t.includes("associate in science")) return "AS";
+  if (t.includes("certificate")) return "certificate";
+  return "other";
+}
+
+// Course-code + title pattern. Applied to the *first* whitespace-split
+// chunk of a line so we don't pick up right-column instructional text that
+// bleeds into the same line in the PDF's multi-column layout.
+const COURSE_HEADER_RE = /^([A-Z]{2,5})\s+(\d{3,4}[A-Z]?)\s+(.+)$/;
+const CREDITS_CHUNK_RE = /^(\d+(?:\.\d+)?)[a-zA-Z*+^]?$/;
+
+// Semester section header. The PDF renders these with decorative second
+// digits ("Semester 21", "Semester 41") that confuse a digit-anchored
+// regex, so we just detect "Semester " and number the groups
+// sequentially in the parse loop — semesters in academic maps are
+// always presented in order.
+const SEMESTER_RE = /^\s*Semester\b/i;
+
+function parseMap(text: string): {
+  groups: RequirementGroup[];
+  totalCredits: number | null;
+} {
+  const lines = text.split("\n");
+  const groups: RequirementGroup[] = [];
+  let currentGroup: RequirementGroup | null = null;
+  let semesterNumber = 0;
+
+  for (const raw of lines) {
+    const line = raw.replace(/ /g, " ");
+    // Stop parsing past the "congratulations / You've Arrived!" footer.
+    if (/c\s*o\s*n\s*g\s*r\s*a\s*t\s*u\s*l\s*a\s*t\s*i\s*o\s*n\s*s/i.test(line)) break;
+
+    if (SEMESTER_RE.test(line)) {
+      if (currentGroup && currentGroup.courses.length > 0) groups.push(currentGroup);
+      semesterNumber += 1;
+      currentGroup = {
+        name: `Semester ${semesterNumber}`,
+        credits_required: null,
+        choose_n: null,
+        courses: [],
+      };
+      continue;
+    }
+    if (!currentGroup) continue;
+
+    // Split at ≥5 consecutive spaces to isolate the left-hand column from
+    // right-column prose that pdftotext glued onto the same line.
+    const chunks = line.split(/\s{5,}/).map((s) => s.trim()).filter(Boolean);
+    if (chunks.length === 0) continue;
+    const m = chunks[0].match(COURSE_HEADER_RE);
+    if (!m) continue;
+    const [, prefix, number, titleRaw] = m;
+    const title = titleRaw.replace(/\s+/g, " ").trim();
+    if (/^[A-Za-z ]+ Elective$/.test(title)) continue;
+
+    let credits: number | null = null;
+    for (let i = 1; i < chunks.length; i++) {
+      const cm = chunks[i].match(CREDITS_CHUNK_RE);
+      if (cm) {
+        credits = Number(cm[1]);
+        break;
+      }
+    }
+    currentGroup.courses.push({
+      prefix,
+      number,
+      title,
+      credits,
+      or_alternatives: [],
+    });
+  }
+  if (currentGroup && currentGroup.courses.length > 0) groups.push(currentGroup);
+
+  // Total credits: prefer the prose statement ("A minimum of 63 credits …");
+  // fall back to summing course-level credits.
+  let total: number | null = null;
+  const totalProse = text.match(/minimum of\s+(\d{2,3})\s+credits/i);
+  if (totalProse) total = Number(totalProse[1]);
+  if (total === null && groups.length > 0) {
+    const sum = groups.reduce(
+      (s, g) => s + g.courses.reduce((cs, c) => cs + (c.credits ?? 0), 0),
+      0,
+    );
+    if (sum > 0) total = sum;
+  }
+
+  return { groups, totalCredits: total };
+}
+
+async function discoverProgramPages(): Promise<string[]> {
+  const seen = new Set<string>();
+  const programs = new Set<string>();
+  for (const pathway of PATHWAYS) {
+    const html = await fetchText(`${BASE_URL}${pathway}`);
+    if (!html) continue;
+    const $ = cheerio.load(html);
+    $("a[href]").each((_, a) => {
+      const href = $(a).attr("href");
+      if (!href) return;
+      const clean = href.split("#")[0].split("?")[0];
+      if (!clean.startsWith(pathway)) return;
+      if (clean === pathway) return;
+      if (clean.includes("/departments/")) return;
+      if (clean.endsWith("/index.html")) return;
+      if (!clean.endsWith(".html")) return;
+      if (seen.has(clean)) return;
+      seen.add(clean);
+      programs.add(clean);
+    });
+  }
+  return [...programs].sort();
+}
+
+async function scrapeProgram(
+  programPath: string,
+): Promise<ProgramRequirement | null> {
+  const html = await fetchText(`${BASE_URL}${programPath}`);
+  if (!html) return null;
+  const $ = cheerio.load(html);
+  const title = $("h1").first().text().replace(/\s+/g, " ").trim();
+  if (!title) return null;
+  const cleanTitle = title.replace(/\s+Program$/i, "");
+
+  const credentialLabel = $("h2").first().text().replace(/\s+/g, " ").trim();
+  let credential = classifyCredential(credentialLabel);
+
+  const mapLink = $("a[href*='/academics/maps/']")
+    .filter((_, a) => ($(a).attr("href") ?? "").endsWith(".pdf"))
+    .first();
+  if (mapLink.length === 0) return null;
+  const mapHref = mapLink.attr("href")!;
+  const mapUrl = mapHref.startsWith("http") ? mapHref : `${BASE_URL}${mapHref}`;
+
+  const pdfBuf = await fetchBuffer(mapUrl);
+  if (!pdfBuf) return null;
+  const pdfText = pdfToText(pdfBuf);
+
+  if (credential === "other") {
+    const headerLine = pdfText.split("\n").slice(0, 10).join(" ");
+    credential = classifyCredential(headerLine);
+  }
+
+  const { groups, totalCredits } = parseMap(pdfText);
+  if (groups.length === 0) return null;
+
+  return {
+    title: cleanTitle,
+    credential,
+    program_code: null,
+    catalog_url: `${BASE_URL}${programPath}`,
+    total_credits: totalCredits,
+    gpa_minimum: 2.0,
+    description: null,
+    requirement_groups: groups,
+    matched_program_slug: null,
+  };
+}
+
+async function main() {
+  const programs: ProgramRequirement[] = [];
+  const programPaths = await discoverProgramPages();
+  console.log(`Discovered ${programPaths.length} program page(s)`);
+
+  let parsed = 0;
+  let skipped = 0;
+  for (const p of programPaths) {
+    try {
+      const program = await scrapeProgram(p);
+      if (program) {
+        programs.push(program);
+        parsed++;
+      } else {
+        skipped++;
+      }
+    } catch (e) {
+      console.warn(`  ! ${p}: ${e instanceof Error ? e.message : e}`);
+      skipped++;
+    }
+    await sleep(80);
+  }
+  console.log(`Parsed ${parsed} programs; skipped ${skipped}`);
+
+  const { matched, unmatched } = applyProgramMatching(programs);
+  console.log(`Matcher: ${matched} matched, ${unmatched} unmatched`);
+
+  const out: CollegePrograms = {
+    college_slug: COLLEGE_SLUG,
+    catalog_year: CATALOG_YEAR,
+    catalog_url: `${BASE_URL}/academics/academic-programs/`,
+    scraped_at: new Date().toISOString(),
+    programs,
+  };
+
+  const outDir = path.join(process.cwd(), "data", STATE, "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${COLLEGE_SLUG}.json`);
+  fs.writeFileSync(outPath, JSON.stringify(out, null, 2));
+  console.log(`✓ Wrote ${programs.length} programs to ${outPath}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Standalone scraper at [scripts/ma/scrape-massasoit-programs.ts](scripts/ma/scrape-massasoit-programs.ts) for Massasoit Community College.
- Wired into [lib/states/ma/config.ts](lib/states/ma/config.ts).
- Output: **47 programs** (4 AAS, 6 AA, 20 AS, 17 certificate); 21/47 matched to registry slugs; `total_credits` range 12–73.

## Background

Massasoit publishes per-program "Academic Map" PDFs at `/academics/maps/{Program-Name}-25-26.pdf`, each linked from its program page under `massasoit.edu/academics/academic-programs/{pathway}/{slug}.html`. The full catalog PDF is **not** the right source — its program-description section is prose only, with no course-by-course requirements. The academic maps are.

So this scraper walks the 6 pathway index pages → fetches each program page → scrapes the map PDF link → downloads and parses with `pdftotext --layout`.

## PDF parsing quirks handled

- **Multi-column layout.** pdftotext glues right-column instructional prose onto the same line as left-column course rows. Split at runs of ≥5 spaces to isolate the course-row chunk — same trick the QCC and VHCC scrapers use.
- **Decorative semester numbering.** Later headers render as "Semester 21" / "Semester 41" (an inline decorative digit in the source PDF). A digit-anchored regex misses them. Parser now detects "Semester " (no digit) and counts groups sequentially — academic maps always present semesters in order.
- **Footer stop boundary.** Trailing "congratulations / You've Arrived!" page contains program-notes prose with stray course-code-like text — parser bails at that marker.
- **Total credits.** Prefer the prose ("A minimum of 63 credits and 20 courses is required for completion") over summing course credits, because rows for generic electives (Math Elective, Liberal Arts Elective) without concrete `prefix`+`number` get filtered out and would undercount.

## Coverage

MA program coverage now **14/15**. Only [#230](https://github.com/rohan-c0de/cc-coursemap/issues/230) GCC (Coursedog, deferred) remains.

19 of 66 discovered Massasoit pages were skipped (no map link found or parser produced 0 groups) — typically nursing / health-careers pages with non-standard layouts.

## Test plan

- [x] `npx tsc --noEmit` exits 0
- [x] `npm run lint` exits 0
- [x] Scraper produces 47 programs with sane credentials and credit totals
- [x] Spot-check Accounting AS: 4 semesters, 14 courses, total 63 cr — matches the catalog
- [x] Local dev: `/ma/college/massasoit/programs` renders the new data
- [ ] CI green
- [ ] Post-merge: confirm Vercel ships and prod URL shows the new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)