### PR TITLE
feat: Coursedog program scraper + 7 CUNY community colleges (closes #230)

### DIFF
--- a/data/ny/programs/bmcc.json
+++ b/data/ny/programs/bmcc.json
@@ -1,0 +1,13350 @@
+{
+  "college_slug": "bmcc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://bmcc.catalog.cuny.edu/programs",
+  "scraped_at": "2026-05-07T15:25:23.355Z",
+  "programs": [
+    {
+      "title": "Accounting",
+      "credential": "AAS",
+      "program_code": "ACC-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ACC-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Introduction to Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "206.5",
+              "title": "Intermediate Algebra & Precalculus (Same as MAT 206)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "206H",
+              "title": "Precalculus (Honors)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "209",
+              "title": "Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "214",
+              "title": "Mathematics for Elementary Education I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "110",
+              "title": "General Astronomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Fundamentals of Public Speaking for Non-Native Speakers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "Survey of Art History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102H",
+              "title": "Survey of Art Hist I (Honors)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Survey of Art History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104H",
+              "title": "Survey of Art History II (Honors)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Modern and Contemporary Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "113",
+              "title": "History of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Latin American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "126",
+              "title": "Introduction to African Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "251",
+              "title": "Asian Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "251H",
+              "title": "Asian Art History (Honors)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Music Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102H",
+              "title": "Understanding Music (Honors)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Music and Western Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "104",
+              "title": "The World of Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "107",
+              "title": "Introduction of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Accounting Principles II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "231",
+              "title": "Accounting Applications on Microcomputers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Taxation: Federal",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "330",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "350",
+              "title": "Cost Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "430",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CED",
+              "number": "201",
+              "title": "Career Planning (Classroom Course)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CED",
+              "number": "301",
+              "title": "Accounting Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "200",
+              "title": "Introduction Systems and Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Personal Accounting and Financial Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "242",
+              "title": "Taxation of Business Entities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "331",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "360",
+              "title": "Government and Not-For-Profit Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "370",
+              "title": "Forensic Accounting & Fraud Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACL",
+              "number": "205",
+              "title": "Health Literacies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting",
+      "credential": "certificate",
+      "program_code": "ACC-CERT",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ACC-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Non-Degree",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Accounting Principles II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Taxation: Federal",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "330",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "331",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "350",
+              "title": "Cost Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "360",
+              "title": "Government and Not-For-Profit Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "430",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Art Foundations Art History",
+      "credential": "AA",
+      "program_code": "AFH-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/AFH-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Survey of Art History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Modern and Contemporary Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "450",
+              "title": "Final Thesis Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Latin American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "126",
+              "title": "Introduction to African Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Pre-Columbian Art of Mesoamerica and the Andes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "251",
+              "title": "Asian Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "295",
+              "title": "African-American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "290",
+              "title": "Medieval Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "292",
+              "title": "Renaissance & Baroque Art: The Age of Discovery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "293",
+              "title": "Ancient Greece and Rome: Classical Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "294",
+              "title": "18th & 19th Century Art: The Age of Enlightenment and Industry",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art Foundations Studio Art",
+      "credential": "AS",
+      "program_code": "AFS-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/AFS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "101",
+              "title": "Digital Imaging Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Survey of Art History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107",
+              "title": "Color and Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "143",
+              "title": "3D Design: Materials and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "166",
+              "title": "Drawing Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "174",
+              "title": "Painting Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "133",
+              "title": "Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "183",
+              "title": "Sculpture Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "176",
+              "title": "Comic Art 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "266",
+              "title": "Drawing Studio II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "269",
+              "title": "Life Drawing Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "270",
+              "title": "Portrait Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "276",
+              "title": "Comic Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "366",
+              "title": "Drawing Studio III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "369",
+              "title": "Life Drawing Studio II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "133",
+              "title": "Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "233",
+              "title": "Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "315",
+              "title": "Print Process and Portfolio Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "215",
+              "title": "Typography and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "235",
+              "title": "Visual Communication and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "174",
+              "title": "Painting Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "274",
+              "title": "Painting Studio II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "374",
+              "title": "Painting Studio III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "122",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "237",
+              "title": "Photographic Studio & Light I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "238",
+              "title": "Photography Experiments & Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "300",
+              "title": "Documentary and Narrative Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "335",
+              "title": "Commercial Photography and Career Strategies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "183",
+              "title": "Sculpture Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "283",
+              "title": "Sculpture Studio II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "383",
+              "title": "Sculpture Studio III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "285",
+              "title": "Figure Sculpture I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Animation and Motion Graphics",
+      "credential": "AS",
+      "program_code": "ANI-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ANI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Educations Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "400",
+              "title": "The Physics of Music",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "100",
+              "title": "Introduction to Multimedia",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMA",
+              "number": "100",
+              "title": "Foundations of Digital Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "166",
+              "title": "Drawing Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "301",
+              "title": "Introduction to Motion Graphics and Visual Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "260",
+              "title": "Introduction to 2D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "401",
+              "title": "Introduction to 3D Animations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "402",
+              "title": "3D Animation Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "360",
+              "title": "2D Animation Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "201",
+              "title": "Career Planning and Professional Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "371",
+              "title": "Media Arts and Technology Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MES",
+              "number": "153",
+              "title": "Script Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "269",
+              "title": "Life Drawing Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "176",
+              "title": "Comic Art 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "215",
+              "title": "Typography and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "225",
+              "title": "Digital Imaging for Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "235",
+              "title": "Visual Communication and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "210",
+              "title": "Multimedia Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "250",
+              "title": "Digital Film Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "270",
+              "title": "Introduction to Video Game Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "240",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "245",
+              "title": "The Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "211",
+              "title": "Makerspace Design Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "300",
+              "title": "Topics in Media Arts and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "250",
+              "title": "Stress: Awareness, Understanding and Mangement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": "BAN-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/BAN-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "200",
+              "title": "Introduction Systems and Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "100",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "209",
+              "title": "Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "320",
+              "title": "Predictive Analytics & Decision Modeling",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNB",
+              "number": "100",
+              "title": "Introduction to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SBE",
+              "number": "100",
+              "title": "Entrepreneurship: Product & Service Creation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "225",
+              "title": "Operations Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Accounting Principles II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Management",
+      "credential": "AAS",
+      "program_code": "BEC-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/BEC-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Introduction to Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "110",
+              "title": "General Astronomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CED",
+              "number": "361",
+              "title": "Business Management Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RMI",
+              "number": "110",
+              "title": "Principles of Risk Management and Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "200",
+              "title": "Introduction Systems and Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "100",
+              "title": "Introduction to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "100",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Managerial Decision Making",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "140",
+              "title": "Introduction to Spreadsheet Applications",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Finance and Banking Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FNB",
+              "number": "230",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "250",
+              "title": "Money and Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "250",
+              "title": "Money & Banking (Same as FNB 250)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "300",
+              "title": "Investments",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - General Management Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "311",
+              "title": "Human Resources Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SBE",
+              "number": "100",
+              "title": "Entrepreneurship: Product & Service Creation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Marketing Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAR",
+              "number": "210",
+              "title": "Consumer Motivation & Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "220",
+              "title": "Essentials of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "300",
+              "title": "Sales Principles and Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Risk Management and Insurance Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RMI",
+              "number": "220",
+              "title": "Property and Liability Insurance Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RMI",
+              "number": "230",
+              "title": "Commercial Insurance Principles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RMI",
+              "number": "240",
+              "title": "Insurance Operations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Hotels, Travel and Tourism Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HTT",
+              "number": "200",
+              "title": "Introduction to Hotels, Travel and Tourism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTT",
+              "number": "201",
+              "title": "Hotels, Travel and Tourism Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "AS",
+      "program_code": "BTE-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/BTE-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTE",
+              "number": "201",
+              "title": "Introduction to Biotechnology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "240",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Computer Information Systems",
+      "credential": "AAS",
+      "program_code": "CIS-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/CIS-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "110",
+              "title": "General Astronomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "101",
+              "title": "Principles in Information Technology and Computation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "111",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "210",
+              "title": "Computer Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "345",
+              "title": "Telecommunication Networks I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "440",
+              "title": "Unix",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "395",
+              "title": "Database Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "495",
+              "title": "Database Systems Il",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "385",
+              "title": "Web Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "485",
+              "title": "Web Programming Il",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "101",
+              "title": "Digital Earth",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Introduction to Geographic Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "316",
+              "title": "Introduction to Digital Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "359",
+              "title": "Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "362",
+              "title": "Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "364",
+              "title": "Mobile Device Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "459",
+              "title": "Ethical Hacking and System Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "490",
+              "title": "Introduction Data Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "272",
+              "title": "Introduction to Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "285",
+              "title": "Mobile Device Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Network Technology",
+      "credential": "AAS",
+      "program_code": "CNT-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/CNT-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Applied Sciences",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "206.5",
+              "title": "Intermediate Algebra & Precalculus (Same as MAT 206)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "101",
+              "title": "Principles in Information Technology and Computation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "111",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "165",
+              "title": "Introduction to Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "255",
+              "title": "Computer Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "345",
+              "title": "Telecommunication Networks I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "440",
+              "title": "Unix",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "445",
+              "title": "Telecommunications Networks II / LAN",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "455",
+              "title": "Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GIS",
+              "number": "101",
+              "title": "Digital Earth",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Introduction to Geographic Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "103",
+              "title": "Introduction to Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "115",
+              "title": "Introduction to Computer and Information Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "316",
+              "title": "Introduction to Digital Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "359",
+              "title": "Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "362",
+              "title": "Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "364",
+              "title": "Mobile Device Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "459",
+              "title": "Ethical Hacking and System Defense",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "490",
+              "title": "Introduction Data Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Community Health Education",
+      "credential": "AS",
+      "program_code": "COH-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/COH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSD",
+              "number": "110",
+              "title": "Comprehensive Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "211",
+              "title": "Critical Health Topics & Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "301",
+              "title": "Introduction of Community Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "302",
+              "title": "Health Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSD",
+              "number": "202",
+              "title": "Drug Use in American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "220",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "235",
+              "title": "Nutrition for Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "250",
+              "title": "Stress: Awareness, Understanding and Mangement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "230",
+              "title": "Consumer Health Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "340",
+              "title": "Global Nutrition and Disease",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "341",
+              "title": "Nutrition Across the Lifespan",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "201",
+              "title": "Health Education and Exercise",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "240",
+              "title": "First Aid, Stafety and Cardio Pulmonary Resuscitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "260",
+              "title": "Wellness Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "255",
+              "title": "Communication Strategies in Health Literacy, Promotion & Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "240",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "255",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "260",
+              "title": "Small Group Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Accounting Principles II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "121",
+              "title": "Fundamentals General, Organic, Biological Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "100",
+              "title": "Introduction to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "190",
+              "title": "Human Sexuality and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "195",
+              "title": "Food, Culture and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "225",
+              "title": "Health Concerns of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "270",
+              "title": "Health Perspectives of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "476",
+              "title": "Cross Cultural Health Education in Peru and the U.S.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Studies",
+      "credential": "AA",
+      "program_code": "COM-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/COM-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COM",
+              "number": "240",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "245",
+              "title": "The Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "255",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AA",
+      "program_code": "CRJ-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/CRJ-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirement - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirement - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirement - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "102",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "200",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "201",
+              "title": "Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Justice and the Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirement - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIN",
+              "number": "250",
+              "title": "Forensic Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "CSC-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/CSC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "215",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "101",
+              "title": "Principles in Information Technology and Computation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "111",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "211",
+              "title": "Adv. Programming Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Fundamentals of Computer Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "231",
+              "title": "Discrete Structures and Applications to Computer Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "331",
+              "title": "Data Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "350",
+              "title": "Software Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "302",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "272",
+              "title": "Introduction to Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "285",
+              "title": "Mobile Device Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "316",
+              "title": "Introduction to Digital Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "317",
+              "title": "Introduction to Cryptography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "345",
+              "title": "Telecommunication Networks I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "359",
+              "title": "Information Assurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "362",
+              "title": "Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "364",
+              "title": "Mobile Device Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "385",
+              "title": "Web Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "395",
+              "title": "Database Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "103",
+              "title": "Introduction to Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "203",
+              "title": "Python Programming for Data Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Introduction to Geographic Methods",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Critical Thinking and Justice",
+      "credential": "AA",
+      "program_code": "CTJ-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/CTJ-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACL",
+              "number": "110",
+              "title": "Literacy for the Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "120",
+              "title": "Reading for Justice and Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "195",
+              "title": "Literacy, Development, and Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "150",
+              "title": "Critical Thinking and Scientific Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "100",
+              "title": "Critical Thinking (Same as PHI 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "120",
+              "title": "Critical Thinking and Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRT",
+              "number": "196",
+              "title": "Queer Theories",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "200",
+              "title": "Introduction to Semiotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "210",
+              "title": "Community Building and Education in Theory and Action",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "220",
+              "title": "Critical Thinking through Virtue Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "245",
+              "title": "Critical Thinking and Media Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "250",
+              "title": "Critical Data Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "295",
+              "title": "Critical Thinking Approaches to Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "310",
+              "title": "Critical Thinking through Legal Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "350",
+              "title": "Conceptualizing Violence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "240",
+              "title": "Language and Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "111",
+              "title": "Cultural and Ethical Issues in Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "120",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "260",
+              "title": "Political Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "265",
+              "title": "Gender and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "120",
+              "title": "Critical Thinking and Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "300",
+              "title": "Being Bodied: The Discourses and Rhetorics of (Dis)ability, Illness, Violence, Trauma, & Healing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Gender & Women's Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "125",
+              "title": "Language and Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "150",
+              "title": "Language, Race, and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "300",
+              "title": "Language, Gender, and Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "154",
+              "title": "Sociology of the Black Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "154",
+              "title": "Sociology of the Black Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "150",
+              "title": "The Latino Experience in the U.S.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "150",
+              "title": "The Latino Experience in the U.S. (Same as SOC 150)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Gender and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "321",
+              "title": "African-American Writing From 18th Century to 1940",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "322",
+              "title": "Contemporary Black Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "338",
+              "title": "Black Literature of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "116",
+              "title": "Creative Writing Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "300",
+              "title": "Fundamentals of Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "311",
+              "title": "Creative Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "314",
+              "title": "Creative Nonfiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "336",
+              "title": "Postcolonial Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "338",
+              "title": "Latino/a Literature in the U.S. (Same as LAT 338)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "338",
+              "title": "Latino/a Literature in the U.S. (Same as ENG 338)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "339",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "340",
+              "title": "Middle Eastern Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "346",
+              "title": "Queer Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "353",
+              "title": "Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "123",
+              "title": "African American History: 17th Century to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "123",
+              "title": "African-American History, 17th Century to 1865 (Same as HIS 123)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "124",
+              "title": "African-American History: 1865 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "124",
+              "title": "African-American History, 1865 to Present (Same as HIS 124)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "126",
+              "title": "Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "126",
+              "title": "Caribbean History (Same as HIS 126)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "130",
+              "title": "History of Latin America (Same as HIS 130)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "150",
+              "title": "Literacy in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "250",
+              "title": "Literacy & Language Disabilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "201",
+              "title": "Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "202",
+              "title": "Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "111",
+              "title": "Economics of Urban Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Human Services and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Human Services Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "201",
+              "title": "Language in the Helping Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "250",
+              "title": "Forensic Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "230",
+              "title": "Power in American Politics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Children and Youth Studies",
+      "credential": "AA",
+      "program_code": "CYS-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/CYS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirement - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirement - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirement - Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "334",
+              "title": "Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "213",
+              "title": "Child Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "250",
+              "title": "The Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "200",
+              "title": "Literacy Practices: Birth through Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Psychological Foundations of Early Development and Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Art in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Music and Movement in Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "116",
+              "title": "Music and Movement in Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDS",
+              "number": "201",
+              "title": "Adolescent Learning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDS",
+              "number": "202",
+              "title": "Special Topics in Secondary School Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "110",
+              "title": "Comprehensive Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "190",
+              "title": "Human Sexuality and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "202",
+              "title": "Drug Use in American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "220",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "270",
+              "title": "Health Perspectives of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "411",
+              "title": "Social Welfare Programs and Policies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "161",
+              "title": "Health Problems in Urban Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "256",
+              "title": "The Contemporary Black Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "256",
+              "title": "The Contemporary Black Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "111",
+              "title": "Chinese Culture and Heritage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "111",
+              "title": "Chinese Culture and History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "115",
+              "title": "Language and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "100",
+              "title": "Language and Culture (Same as ANT 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "125",
+              "title": "Puerto Rican Culture and Folklore",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "127",
+              "title": "Haitian History and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "200",
+              "title": "Peoples & Cultures of Latin America and the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "200",
+              "title": "Peoples & Cultures of Latin America and the Caribbean (Same as ANT 200)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "301",
+              "title": "Selected Topics in Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Gender & Women's Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "234",
+              "title": "The Puerto Rican Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "234",
+              "title": "The Puerto Rican Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Psychology of Personality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Urban Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "127",
+              "title": "Haitian History and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Marketing",
+      "credential": "AS",
+      "program_code": "DMA-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/DMA-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110.5",
+              "title": "Business Law for Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "100",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "330",
+              "title": "Marketing Research and Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "340",
+              "title": "Digital Marketing and Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAR",
+              "number": "210",
+              "title": "Consumer Motivation & Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "220",
+              "title": "Essentials of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "230",
+              "title": "Essentials of Public Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "200",
+              "title": "Introduction Systems and Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "245",
+              "title": "The Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "240",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Data Science",
+      "credential": "AS",
+      "program_code": "DSM-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/DSM-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "302",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "409",
+              "title": "Probability and Statistics for Data Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "415",
+              "title": "Linear Algebra for Data Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "420",
+              "title": "An Introduction to Machine Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "203",
+              "title": "Python Programming for Data Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "211",
+              "title": "Adv. Programming Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "395",
+              "title": "Database Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "490",
+              "title": "Introduction Data Science",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "AS",
+      "program_code": "ECE-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ECE-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Psychological Foundations of Early Development and Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "210",
+              "title": "Social Foundations of Early Care and Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECE",
+              "number": "209",
+              "title": "Infant Care and Curriculum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "308",
+              "title": "Infants and Toddlers Practicum I: Observing and Recording",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "309",
+              "title": "Toddler Care and Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "409",
+              "title": "Infants and Toddlers Practicum II: Pedagogy for Infants and Toddlers",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "410",
+              "title": "Educational Foundations and Pedagogy for The Exceptional Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "211",
+              "title": "Curriculum for Young Children I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "311",
+              "title": "Early Childhood Practicum I: Observing and Recording",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "312",
+              "title": "Curriculum for Young Children II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "411",
+              "title": "Early Childhood Practicum II: Pedagogy for Young Children",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Economics",
+      "credential": "AA",
+      "program_code": "ECO-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ECO-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "209",
+              "title": "Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "215",
+              "title": "Environmental Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "221",
+              "title": "International Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "223",
+              "title": "Economic History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "225",
+              "title": "Public Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "226",
+              "title": "Development Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "229",
+              "title": "Economics of Antitrust and Regulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "230",
+              "title": "Feminist Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "235",
+              "title": "Labor Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "240",
+              "title": "Behavioral Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "245",
+              "title": "Competition and Strategy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "250",
+              "title": "Money & Banking (Same as FNB 250)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Bilingual Childhood Education",
+      "credential": "AA",
+      "program_code": "EDB-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/EDB-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Art in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Music and Movement in Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Teaching Literacy in the Classroom (1-6 Grades)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "391",
+              "title": "World Literature from Antiquity to the Early Modern Era",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "392",
+              "title": "World Literature from the Early Modern Era to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDB",
+              "number": "202",
+              "title": "Schools in a Linguistically diverse American Society: Bilingual Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "Mathematics for Elementary Education II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "General Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Childhood Education",
+      "credential": "AA",
+      "program_code": "EDU-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/EDU-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Art in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Music and Movement in Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Teaching Literacy in the Classroom (1-6 Grades)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "216",
+              "title": "Mathematics for Elementary Education II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "391",
+              "title": "World Literature from Antiquity to the Early Modern Era",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "392",
+              "title": "World Literature from the Early Modern Era to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "General Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic",
+      "credential": "AAS",
+      "program_code": "EMT-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/EMT-AAS",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "104",
+              "title": "Mathematics for Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "118",
+              "title": "Fundamentals of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "121",
+              "title": "Fundamentals General, Organic, Biological Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Fundamentals of Public Speaking for Non-Native Speakers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "425",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMC",
+              "number": "101",
+              "title": "Emergency Medical Care Paramedic I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMC",
+              "number": "102",
+              "title": "Emergency Medical Care/Paramedic II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMC",
+              "number": "201",
+              "title": "Emergency Medical Care/Paramedic III",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMC",
+              "number": "202",
+              "title": "Emergency Medical Care/Paramedic IV",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMC",
+              "number": "301",
+              "title": "Emergency Medical Care/Paramedic Clinical Internship I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMC",
+              "number": "302",
+              "title": "Emergency Medical Care/Paramedic Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMC",
+              "number": "303",
+              "title": "Emergency Medical Care/Paramedic Internship III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "426",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMC",
+              "number": "100",
+              "title": "Emergency Medical Care",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Writing and Literature",
+      "credential": "AA",
+      "program_code": "ENG-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ENG-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Introduction to Literary Studies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements- Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Writing and Literature: General Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "300",
+              "title": "Fundamentals of Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "303",
+              "title": "Journalism: News Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "304",
+              "title": "Journalism: Feature Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "311",
+              "title": "Creative Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "314",
+              "title": "Creative Nonfiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "315",
+              "title": "Playwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "317",
+              "title": "Poetry Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "318",
+              "title": "Fiction Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "338",
+              "title": "Latino/a Literature in the U.S. (Same as LAT 338)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "339",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "358",
+              "title": "Contemporary Urban Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "360",
+              "title": "Italian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "381",
+              "title": "American Literature from the Colonial Era to the Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "382",
+              "title": "American Literature from the Reconstruction Era to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "383",
+              "title": "The American Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "384",
+              "title": "Modern American Drama",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "321",
+              "title": "African-American Writing From 18th Century to 1940",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "322",
+              "title": "Contemporary Black Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "335",
+              "title": "History of Black Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "371",
+              "title": "British Literature from the Medieval Era to the Eighteenth Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "372",
+              "title": "British Literature from the Romantic Era to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "373",
+              "title": "Introduction to Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "320",
+              "title": "Environmental Literature and Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "329",
+              "title": "Native American/Indigenous Literatures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "336",
+              "title": "Postcolonial Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "340",
+              "title": "Middle Eastern Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "391",
+              "title": "World Literature from Antiquity to the Early Modern Era",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "392",
+              "title": "World Literature from the Early Modern Era to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "394",
+              "title": "Modern European Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "393",
+              "title": "Jewish Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "338",
+              "title": "Black Literature of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Writing and Literature: Journalism Concentration",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "300",
+              "title": "Fundamentals of Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "303",
+              "title": "Journalism: News Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "304",
+              "title": "Journalism: Feature Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "314",
+              "title": "Creative Nonfiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "335",
+              "title": "Autobiography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "395",
+              "title": "Literary Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Science",
+      "credential": "AS",
+      "program_code": "ESC-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ESC-AS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "120",
+              "title": "Computer Methods in Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "121",
+              "title": "Computer Methods in Science (Pascal)",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ESC",
+              "number": "111",
+              "title": "Elements of Engineering Design",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "113",
+              "title": "Computer Aided Analysis for Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "302",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "303",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "501",
+              "title": "Ordinary Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "215",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "225",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "230",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "240",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "130",
+              "title": "Engineering Graphics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "131",
+              "title": "Engineering Graphics - AutoCAD",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "201",
+              "title": "Engineering Mechanics I (Statics and Particle Kinematics)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "202",
+              "title": "Engineering Mechanics II (Kinematics and Dynamics of Rigid Bodies)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "211",
+              "title": "Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "221",
+              "title": "Circuits and Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESC",
+              "number": "223",
+              "title": "Switching Systems and Logic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "210",
+              "title": "Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "315",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "240",
+              "title": "Modern Physics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Ethnic Studies",
+      "credential": "AA",
+      "program_code": "ETH-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/ETH-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associates in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETH",
+              "number": "100",
+              "title": "Introduction to Ethnic Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "300",
+              "title": "Research and Writing Methods",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ETH",
+              "number": "125",
+              "title": "Comparative Ethnic Studies (Same as SOC 125)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "124",
+              "title": "African-American History, 1865 to Present (Same as HIS 124)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "114",
+              "title": "Asian American History (Same as HIS 114)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "150",
+              "title": "The Latino Experience in the U.S. (Same as SOC 150)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "111",
+              "title": "Chinese Culture and History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "339",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "122",
+              "title": "Africa 1500 to Present (Same as HIS 122)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "123",
+              "title": "African-American History, 17th Century to 1865 (Same as HIS 123)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "111",
+              "title": "Economics of Urban Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "130",
+              "title": "History of Latin America (Same as HIS 130)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "200",
+              "title": "Peoples & Cultures of Latin America and the Caribbean (Same as ANT 200)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting for Forensics",
+      "credential": "AS",
+      "program_code": "FAC-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/FAC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "222",
+              "title": "Accounting Principles II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "241",
+              "title": "Taxation: Federal",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "330",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "360",
+              "title": "Government and Not-For-Profit Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "370",
+              "title": "Forensic Accounting & Fraud Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "430",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "110",
+              "title": "Comprehensive Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Financial Management",
+      "credential": "AS",
+      "program_code": "FIN-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/FIN-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "100",
+              "title": "Introduction to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "230",
+              "title": "Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "250",
+              "title": "Money and Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "250",
+              "title": "Money & Banking (Same as FNB 250)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "300",
+              "title": "Investments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Science for Forensics",
+      "credential": "AS",
+      "program_code": "FSC-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/FSC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "230",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "205",
+              "title": "Quantitative Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "240",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "215",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "225",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Gerontology",
+      "credential": "AS",
+      "program_code": "GER-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/GER-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Human Services and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "211",
+              "title": "Introduction to Gerontology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "110",
+              "title": "Comprehensive Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "310",
+              "title": "Aging, Health and Culture: Global Perspectives",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "302",
+              "title": "Health Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "301",
+              "title": "Field Experience in Human Services I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "411",
+              "title": "Social Welfare Programs and Policies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "270",
+              "title": "Health Perspectives of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "202",
+              "title": "Drug Use in American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "220",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "225",
+              "title": "Health Concerns of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "230",
+              "title": "Consumer Health Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "235",
+              "title": "Nutrition for Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "240",
+              "title": "First Aid, Stafety and Cardio Pulmonary Resuscitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "250",
+              "title": "Stress: Awareness, Understanding and Mangement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "212",
+              "title": "Introduction to Disabilities and Behavior Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "401",
+              "title": "Field Experience in Human Services II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Geographic Information Science",
+      "credential": "AS",
+      "program_code": "GIS-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/GIS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GLY",
+              "number": "210",
+              "title": "Geology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CIS",
+              "number": "395",
+              "title": "Database Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "201",
+              "title": "Introduction to Geographic Methods",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "261",
+              "title": "Introduction to Geographic Information Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "361",
+              "title": "Advances Geographic Information Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "209",
+              "title": "Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "226",
+              "title": "Environmental Conservation: Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CED",
+              "number": "201",
+              "title": "Career Planning (Classroom Course)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GIS",
+              "number": "325",
+              "title": "Geographic Information Science Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "241",
+              "title": "Population Geography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Gender and Women's Studies",
+      "credential": "AA",
+      "program_code": "GWS-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/GWS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Gender & Women's Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "300",
+              "title": "Gender & Women's Studies Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "265",
+              "title": "Gender and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "Gender and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFN",
+              "number": "128",
+              "title": "Black Women in the Americas and the Caribbean (Same as ANT 128)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "129",
+              "title": "The Black Man in Contemporary Society (Same as SOC 129)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "210",
+              "title": "The Roles of Women in a Changing World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "245",
+              "title": "The Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "255",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "196",
+              "title": "Queer Theories",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "230",
+              "title": "Feminist Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "346",
+              "title": "Queer Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "353",
+              "title": "Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "225",
+              "title": "Health Concerns of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "225",
+              "title": "History of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "120",
+              "title": "Gender and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "400",
+              "title": "Latin American Women Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "305",
+              "title": "Women in American Theater",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Informatics",
+      "credential": "certificate",
+      "program_code": "HIC-CERT",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/HIC-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Non-Degree",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "111",
+              "title": "Introduction to Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "209",
+              "title": "ICD-CM PCS Coding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "HIM Medical Legal Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "101",
+              "title": "Principles in Information Technology and Computation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "165",
+              "title": "Introduction to Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "345",
+              "title": "Telecommunication Networks I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "395",
+              "title": "Database Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "325",
+              "title": "Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "385",
+              "title": "Web Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "History",
+      "credential": "AA",
+      "program_code": "HIS-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/HIS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "275",
+              "title": "History Research and Writing Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization: From Ancient to Early Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization: The Emergence of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "115",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "116",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "120",
+              "title": "Early American History: Colonial Period to Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "125",
+              "title": "Modern American History: Civil War to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Information Technology",
+      "credential": "AAS",
+      "program_code": "HIT-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/HIT-AAS",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Introduction to Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "425",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "426",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIT",
+              "number": "110",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "111",
+              "title": "Introduction to Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "112",
+              "title": "Principles of Health Care Reimbursement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "206",
+              "title": "Pathology and Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "209",
+              "title": "ICD-CM PCS Coding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "210",
+              "title": "Professional Practice Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "215",
+              "title": "HIM Medical Legal Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "332",
+              "title": "Performance Improvement and Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "334",
+              "title": "CPT/HCPCS Coding",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "423",
+              "title": "Management in the HIM Department",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIT",
+              "number": "430",
+              "title": "Medical Record Clinical Practicum",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "207",
+              "title": "Healthcare Information Technologies and Management Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Human Services",
+      "credential": "AS",
+      "program_code": "HUM-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/HUM-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Human Services and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "Human Services Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "211",
+              "title": "Introduction to Gerontology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "212",
+              "title": "Introduction to Disabilities and Behavior Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "213",
+              "title": "Child Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "301",
+              "title": "Field Experience in Human Services I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "401",
+              "title": "Field Experience in Human Services II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "411",
+              "title": "Social Welfare Programs and Policies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "100",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "230",
+              "title": "Race and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "250",
+              "title": "The Family",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts",
+      "credential": "AA",
+      "program_code": "LIB-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/LIB-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Linguistics",
+      "credential": "AA",
+      "program_code": "LIN-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/LIN-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements -  Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIN",
+              "number": "100",
+              "title": "Language and Culture (Same as ANT 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "101",
+              "title": "Introduction to Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - General Concentration",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIN",
+              "number": "110",
+              "title": "The Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "130",
+              "title": "Phonetics and Phonology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "140",
+              "title": "World/Global Englishes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "150",
+              "title": "Language, Race, and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "200",
+              "title": "Literacy Practices: Birth through Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "250",
+              "title": "Literacy & Language Disabilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "200",
+              "title": "Language Acquisition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "210",
+              "title": "Foundations of Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "220",
+              "title": "Language Teaching Practices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "240",
+              "title": "Language and Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "250",
+              "title": "Forensic Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "300",
+              "title": "Language, Gender, and Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "321",
+              "title": "African-American Writing From 18th Century to 1940",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "322",
+              "title": "Contemporary Black Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "338",
+              "title": "Black Literature of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "339",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "334",
+              "title": "Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "336",
+              "title": "Postcolonial Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "340",
+              "title": "Middle Eastern Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "346",
+              "title": "Queer Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "353",
+              "title": "Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "360",
+              "title": "Italian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "393",
+              "title": "Jewish Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "338",
+              "title": "Latino/a Literature in the U.S. (Same as ENG 338)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "255",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "265",
+              "title": "Gender and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "100",
+              "title": "Critical Thinking (Same as PHI 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDB",
+              "number": "202",
+              "title": "Schools in a Linguistically diverse American Society: Bilingual Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "103",
+              "title": "Voice and Articulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Oral Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - TESOL/Applied Linguistics Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "110",
+              "title": "The Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "130",
+              "title": "Phonetics and Phonology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "200",
+              "title": "Language Acquisition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "210",
+              "title": "Foundations of Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "220",
+              "title": "Language Teaching Practices",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Literacy Studies",
+      "credential": "AA",
+      "program_code": "LTS-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/LTS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements- Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACL",
+              "number": "125",
+              "title": "Introduction to the Study of Literacy: Interdisciplinary Perspectives",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "195",
+              "title": "Literacy, Development, and Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "300",
+              "title": "Critical Local Literacies: Literacy Inquiry in the New York City Region",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "300",
+              "title": "Being Bodied: The Discourses and Rhetorics of (Dis)ability, Illness, Violence, Trauma, & Healing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "240",
+              "title": "Language and Power",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACL",
+              "number": "150",
+              "title": "Literacy in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "175",
+              "title": "The Literacy & Language Practices of Activism & Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "200",
+              "title": "Literacy Practices: Birth through Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "201",
+              "title": "Libraries, Archives, & Literacies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "205",
+              "title": "Health Literacies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "215",
+              "title": "Literacies & Incarceration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "250",
+              "title": "Literacy & Language Disabilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "275",
+              "title": "Selected Topics in Literacy & Language Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "101",
+              "title": "Introduction to Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "150",
+              "title": "Critical Thinking and Scientific Inquiry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "100",
+              "title": "Creative Literacies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "101",
+              "title": "African Art (Same as ART 801)",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "102",
+              "title": "African-American Art",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "411",
+              "title": "Modern Chinese Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "245",
+              "title": "The Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "203",
+              "title": "Art in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "204",
+              "title": "Music and Movement in Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "116",
+              "title": "Creative Writing Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "311",
+              "title": "Creative Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "315",
+              "title": "Playwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "321",
+              "title": "Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "322",
+              "title": "Fiction into Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "204",
+              "title": "French Film and Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "462",
+              "title": "History of French Drama and Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITL",
+              "number": "204",
+              "title": "Italian Film and Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITL",
+              "number": "205E",
+              "title": "Italian Cinema in Context",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITL",
+              "number": "312E",
+              "title": "Modern Italian Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "125",
+              "title": "Puerto Rican Culture and Folklore",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "141",
+              "title": "Puerto Rican Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "235",
+              "title": "Puerto Rican Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "210",
+              "title": "Oral Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "204",
+              "title": "Spanish Film and Conversation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "410",
+              "title": "Latin American Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "420",
+              "title": "Introduction to Spanish Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "426",
+              "title": "Creative Writing in Spanish",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "480",
+              "title": "Spanish and Latin American Texts Into Films",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "321",
+              "title": "African-American Writing From 18th Century to 1940",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "322",
+              "title": "Contemporary Black Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "338",
+              "title": "Black Literature of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "339",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "440",
+              "title": "Twentieth Century Chinese literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "265",
+              "title": "Gender and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "200",
+              "title": "Introduction to Semiotics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "300",
+              "title": "Being Bodied: The Discourses and Rhetorics of (Dis)ability, Illness, Violence, Trauma, & Healing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "205",
+              "title": "Teaching Literacy in the Classroom (1-6 Grades)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "Introduction to Literary Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "265",
+              "title": "Children and Young Adult Literature in French",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "400",
+              "title": "Francophone Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "430",
+              "title": "French Literature from the Middle Ages to the 17th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "435",
+              "title": "French Literature from the 18th and 19th Centuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "440",
+              "title": "French Literature from the 20th and 21st Centuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "446",
+              "title": "Literature and Cinema from West Africa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "460",
+              "title": "Existentialism in French Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "461",
+              "title": "The Individual and Society in 19th Century French Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "233",
+              "title": "Modern Languages and Literature Representative Puerto Rican Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "237",
+              "title": "Puerto Rican Literature: Early Colonial through 19th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "238",
+              "title": "Contemporary Puerto Rican Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "239",
+              "title": "The Short Story in the Spanish Speaking Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "338",
+              "title": "Latino/a Literature in the U.S. (Same as ENG 338)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITL",
+              "number": "260",
+              "title": "The Modern Italian Short Story",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITL",
+              "number": "265",
+              "title": "Children and Young Adult Literature in Italian",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITL",
+              "number": "330",
+              "title": "Survey of Italian Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "200",
+              "title": "Language Acquisition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "201",
+              "title": "Language in the Helping Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "210",
+              "title": "Foundations of Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "240",
+              "title": "Language and Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "250",
+              "title": "Forensic Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "300",
+              "title": "Language, Gender, and Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "370",
+              "title": "Literature and Civilization of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "371",
+              "title": "Literature and Civilization of Spain",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "400",
+              "title": "Latin American Women Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "425",
+              "title": "Introduction to Spanish Poetry of the 20th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "430",
+              "title": "Medieval and Golden Age Spanish Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "435",
+              "title": "Spanish VI: Survey of Spanish Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "440",
+              "title": "Spanish Literature of the 20th and 21st Centuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "445",
+              "title": "Colonial and 19th Century Latin American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "450",
+              "title": "Latin American Literature of the 20th and 21st Centuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "460",
+              "title": "Masculinities in Latin American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "461",
+              "title": "LGBTQ+ Literature in Spanish",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "472",
+              "title": "Literature, Culture and Civilization of the Greater Antilles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "485",
+              "title": "New York Literature in Spanish",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "110",
+              "title": "Literacy for the Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "120",
+              "title": "Reading for Justice and Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "135",
+              "title": "Critical Literacies & Empowerment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "111",
+              "title": "Economics of Urban Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "112",
+              "title": "Economic Development of the Dominican Republic in the 20th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "113",
+              "title": "African Development in the 20th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "151",
+              "title": "Political Economy of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "210",
+              "title": "The Roles of Women in a Changing World (Same as ANT 210)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "121",
+              "title": "History of African Civilizations (Same as HIS 121)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "122",
+              "title": "Africa 1500 to Present (Same as HIS 122)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "124",
+              "title": "African-American History, 1865 to Present (Same as HIS 124)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "126",
+              "title": "Caribbean History (Same as HIS 126)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "128",
+              "title": "Black Women in the Americas and the Caribbean (Same as ANT 128)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "129",
+              "title": "The Black Man in Contemporary Society (Same as SOC 129)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "130",
+              "title": "The History of Haiti",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "152",
+              "title": "The Black Radical Tradition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "154",
+              "title": "Sociology of the Black Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "253",
+              "title": "The Black Experience in Africa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "256",
+              "title": "The Contemporary Black Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "111",
+              "title": "Chinese Culture and History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "114",
+              "title": "Asian American History (Same as HIS 114)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "129",
+              "title": "An Introduction to the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASN",
+              "number": "211",
+              "title": "Asian Communities in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "170E",
+              "title": "Literature, Culture, and Civilization of China",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHI",
+              "number": "203",
+              "title": "Chinese Culture and Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "100",
+              "title": "Introduction to Communication Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "150",
+              "title": "Introduction to Digital Communication and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Justice and the Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "100",
+              "title": "Critical Thinking (Same as PHI 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "120",
+              "title": "Critical Thinking and Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "125",
+              "title": "Critical Thinking & Popular Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "196",
+              "title": "Queer Theories",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "210",
+              "title": "Community Building and Education in Theory and Action",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "245",
+              "title": "Critical Thinking and Media Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "275",
+              "title": "Critical Thinking: Conspiracy Theories",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "295",
+              "title": "Critical Thinking Approaches to Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRT",
+              "number": "350",
+              "title": "Conceptualizing Violence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "110",
+              "title": "Psychological Foundations of Early Development and Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "226",
+              "title": "Development Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "230",
+              "title": "Feminist Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDS",
+              "number": "201",
+              "title": "Adolescent Learning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "100",
+              "title": "Introduction to Ethnic Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ETH",
+              "number": "125",
+              "title": "Comparative Ethnic Studies (Same as SOC 125)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "100",
+              "title": "Introduction to Human Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GWS",
+              "number": "100",
+              "title": "Introduction to Gender & Women's Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "190",
+              "title": "Human Sexuality and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "195",
+              "title": "Food, Culture and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "220",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "225",
+              "title": "Health Concerns of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "275",
+              "title": "HIV/AIDS: Public Health Implications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "285",
+              "title": "Social and Behavioral Determinants of Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "225",
+              "title": "History of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "226",
+              "title": "Conflict in the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ITL",
+              "number": "170E",
+              "title": "Literature, Culture and Civilization of Italy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "127",
+              "title": "History of Puerto Rico: Discovery through 19th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "128",
+              "title": "History of Puerto Rico: 1900 to Present (Same as HIS 128)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "130",
+              "title": "History of Latin America (Same as HIS 130)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "131",
+              "title": "History of the Dominican Republic (Same as HIS 131)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "140",
+              "title": "Introduction to Mexican-American Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "150",
+              "title": "The Latino Experience in the U.S. (Same as SOC 150)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "151",
+              "title": "Politics of Puerto Rican Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "152",
+              "title": "Puerto Rican Experience in Urban U.S. Settings (Same as SOC 152)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "200",
+              "title": "Peoples & Cultures of Latin America and the Caribbean (Same as ANT 200)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "234",
+              "title": "The Puerto Rican Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "236",
+              "title": "Puerto Rican Economic Development since 1898",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "100",
+              "title": "Language and Culture (Same as ANT 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "125",
+              "title": "Language and Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "140",
+              "title": "World/Global Englishes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "150",
+              "title": "Language, Race, and Ethnicity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "100",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "120",
+              "title": "Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "220",
+              "title": "Urban Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "260",
+              "title": "Political Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "URB",
+              "number": "100",
+              "title": "Introduction to Urban Studies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics",
+      "credential": "AS",
+      "program_code": "MAT-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/MAT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "215",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "111",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "225",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "302",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "303",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "315",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "210",
+              "title": "Computer Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "211",
+              "title": "Adv. Programming Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "209",
+              "title": "Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "300",
+              "title": "Introduction to Geometry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "310",
+              "title": "Bridge to Advanced Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "320",
+              "title": "Abstract Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "501",
+              "title": "Ordinary Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "505",
+              "title": "History of Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "601",
+              "title": "Advanced Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Modern Languages",
+      "credential": "AA",
+      "program_code": "MLA-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/MLA-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Art",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - French Specialization",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AFN",
+              "number": "122",
+              "title": "Africa 1500 to Present (Same as HIS 122)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "127",
+              "title": "Haitian History and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "128",
+              "title": "Black Women in the Americas and the Caribbean (Same as ANT 128)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "338",
+              "title": "Black Literature of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "290",
+              "title": "Medieval Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "292",
+              "title": "Renaissance & Baroque Art: The Age of Discovery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "394",
+              "title": "Modern European Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "280E",
+              "title": "French Caribbean Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "281E",
+              "title": "French-Speaking Women Writers in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "110",
+              "title": "The Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "210",
+              "title": "Foundations of Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "126",
+              "title": "Caribbean History (Same as HIS 126)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "152",
+              "title": "The Black Radical Tradition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "113",
+              "title": "African Development in the 20th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "126",
+              "title": "Introduction to African Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "294",
+              "title": "18th & 19th Century Art: The Age of Enlightenment and Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "100",
+              "title": "Language and Culture (Same as ANT 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Music and Western Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "113",
+              "title": "African Development in the 20th Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "300",
+              "title": "History of Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Italian Specialization",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Introduction to the History of Western Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "290",
+              "title": "Medieval Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "292",
+              "title": "Renaissance & Baroque Art: The Age of Discovery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "360",
+              "title": "Italian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "391",
+              "title": "World Literature from Antiquity to the Early Modern Era",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "110",
+              "title": "The Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "210",
+              "title": "Foundations of Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "115",
+              "title": "World History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "116",
+              "title": "World History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSC",
+              "number": "150",
+              "title": "Field Experience in Italy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "294",
+              "title": "18th & 19th Century Art: The Age of Enlightenment and Industry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "100",
+              "title": "Language and Culture (Same as ANT 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Music and Western Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "300",
+              "title": "History of Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Spanish Specialization",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "221",
+              "title": "Pre-Columbian Art of Mesoamerica and the Andes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "338",
+              "title": "Latino/a Literature in the U.S. (Same as LAT 338)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "476",
+              "title": "Cross Cultural Health Education in Peru and the U.S.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "130",
+              "title": "History of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "110",
+              "title": "The Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "210",
+              "title": "Foundations of Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "485",
+              "title": "New York Literature in Spanish",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "125",
+              "title": "Introduction to Latin American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "100",
+              "title": "Language and Culture (Same as ANT 115)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "881",
+              "title": "Puerto Rican Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Spanish Translation and Interpretation",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRS",
+              "number": "345",
+              "title": "Capstone Project - Translation/Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "110",
+              "title": "Comprehensive Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Multimedia Programming and Design",
+      "credential": "AS",
+      "program_code": "MMD-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/MMD-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMP",
+              "number": "100",
+              "title": "Introduction to Multimedia",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMA",
+              "number": "100",
+              "title": "Foundations of Digital Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "200",
+              "title": "Multimedia Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "460",
+              "title": "Multimedia Project Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "201",
+              "title": "Career Planning and Professional Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "371",
+              "title": "Media Arts and Technology Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Sequences",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMP",
+              "number": "210",
+              "title": "Multimedia Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "270",
+              "title": "Introduction to Video Game Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "271",
+              "title": "3D Game Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "240",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "350",
+              "title": "Advanced Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "202",
+              "title": "Introduction to User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "215",
+              "title": "Typography and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "235",
+              "title": "Visual Communication and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "225",
+              "title": "Digital Imaging for Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MMP",
+              "number": "202",
+              "title": "Introduction to User Experience Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "210",
+              "title": "Multimedia Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "240",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "270",
+              "title": "Introduction to Video Game Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "271",
+              "title": "3D Game Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "310",
+              "title": "Multimedia Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "350",
+              "title": "Advanced Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "215",
+              "title": "Typography and Layout",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "225",
+              "title": "Digital Imaging for Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "235",
+              "title": "Visual Communication and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "211",
+              "title": "Makerspace Design Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "300",
+              "title": "Topics in Media Arts and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "260",
+              "title": "Introduction to 2D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "401",
+              "title": "Introduction to 3D Animations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "111",
+              "title": "Animated Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "102",
+              "title": "Survey of Art History I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "104",
+              "title": "Survey of Art History II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "106",
+              "title": "Modern and Contemporary Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "107",
+              "title": "Color and Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "133",
+              "title": "Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "233",
+              "title": "Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "166",
+              "title": "Drawing Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "174",
+              "title": "Painting Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "176",
+              "title": "Comic Art 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "183",
+              "title": "Sculpture Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "123",
+              "title": "Basics of Digital Music Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110.5",
+              "title": "Business Law for Digital Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "165",
+              "title": "Introduction to Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "101",
+              "title": "Principles in Information Technology and Computation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "110",
+              "title": "Computer Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "111",
+              "title": "Introduction to Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "240",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "245",
+              "title": "The Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SBE",
+              "number": "100",
+              "title": "Entrepreneurship: Product & Service Creation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music",
+      "credential": "AS",
+      "program_code": "MUS-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/MUS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "117",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "217",
+              "title": "Music Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "317",
+              "title": "Music Theory III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "118",
+              "title": "Aural Skills I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "218",
+              "title": "Aural Skills II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "318",
+              "title": "Aural Skills III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "418",
+              "title": "Aural Skills IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "119",
+              "title": "Keyboard Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "219",
+              "title": "Keyboard Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "319",
+              "title": "Keyboard Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "419",
+              "title": "Keyboard Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Music Studies Specialization",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "651",
+              "title": "Applied Studies: Strings I- Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "652",
+              "title": "Applied Studies: Strings II-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "653",
+              "title": "Applied Studies: Strings III-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "654",
+              "title": "Applied Studies: Strings IV-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "656",
+              "title": "Applied Studies: Piano I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "657",
+              "title": "Applied Studies: Piano II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "658",
+              "title": "Applied Studies: Piano III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "659",
+              "title": "Applied Studies: Piano IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "661",
+              "title": "Applied Studies: Woodwinds I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "662",
+              "title": "Applied Studies: Woodwinds II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "663",
+              "title": "Applied Studies: Woodwinds III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "664",
+              "title": "Applied Studies: Woodwinds IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "666",
+              "title": "Applied Studies: Brass I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "667",
+              "title": "Applied Studies: Brass II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "668",
+              "title": "Applied Studies: Brass III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "669",
+              "title": "Applied Studies: Brass IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "671",
+              "title": "Applied Studies: Voice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "672",
+              "title": "Applied Studies: Voice II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "673",
+              "title": "Applied Studies: Voice III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "674",
+              "title": "Applied Studies: Voice IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "676",
+              "title": "Applied Studies: Guitar I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "677",
+              "title": "Applied Studies: Guitar II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "678",
+              "title": "Applied Studies: Guitar III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "679",
+              "title": "Applied Studies: Guitar IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "686",
+              "title": "Applied Studies: Percussion I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "687",
+              "title": "Applied Studies: Percussion II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "688",
+              "title": "Applied Studies: Percussion III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "689",
+              "title": "Applied Studies: Percussion IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "234",
+              "title": "Music Notation Software",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Musical Theatre: Acting the Song, Level I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "222",
+              "title": "Musical Theatre: Acting the Song, Level I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Music and Western Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "104",
+              "title": "The World of Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "107",
+              "title": "Introduction of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "351",
+              "title": "Arranging I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "352",
+              "title": "Arranging II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "501",
+              "title": "Wind Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "502",
+              "title": "Wind Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "503",
+              "title": "Wind Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "504",
+              "title": "Wind Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "301",
+              "title": "Jazz Performance Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "302",
+              "title": "Jazz Performance Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "303",
+              "title": "Jazz Performance Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "304",
+              "title": "Jazz Performance Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "305",
+              "title": "Orchestral Performance I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "306",
+              "title": "Orchestral Performance II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "307",
+              "title": "Orchestral Performance III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "308",
+              "title": "Orchestral Performance IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "265",
+              "title": "Concert Choir I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "266",
+              "title": "Concert Choir II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "267",
+              "title": "Concert Choir III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "268",
+              "title": "Concert Choir IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "510",
+              "title": "Instrumental Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "520",
+              "title": "Instrumental Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "530",
+              "title": "Instrumental Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "540",
+              "title": "Instrumental Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "701",
+              "title": "String Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "702",
+              "title": "String Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "703",
+              "title": "String Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "704",
+              "title": "String Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "705",
+              "title": "Guitar Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "706",
+              "title": "Guitar Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "707",
+              "title": "Guitar Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "708",
+              "title": "Guitar Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "165",
+              "title": "College Chorus I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "166",
+              "title": "College Chorus II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "167",
+              "title": "College Chorus III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "168",
+              "title": "College Chorus IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "114",
+              "title": "Music Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "123",
+              "title": "Basics of Digital Music Production I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Music Education Specialization",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "651",
+              "title": "Applied Studies: Strings I- Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "652",
+              "title": "Applied Studies: Strings II-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "653",
+              "title": "Applied Studies: Strings III-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "654",
+              "title": "Applied Studies: Strings IV-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "656",
+              "title": "Applied Studies: Piano I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "657",
+              "title": "Applied Studies: Piano II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "658",
+              "title": "Applied Studies: Piano III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "659",
+              "title": "Applied Studies: Piano IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "661",
+              "title": "Applied Studies: Woodwinds I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "662",
+              "title": "Applied Studies: Woodwinds II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "663",
+              "title": "Applied Studies: Woodwinds III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "664",
+              "title": "Applied Studies: Woodwinds IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "666",
+              "title": "Applied Studies: Brass I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "667",
+              "title": "Applied Studies: Brass II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "668",
+              "title": "Applied Studies: Brass III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "669",
+              "title": "Applied Studies: Brass IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "671",
+              "title": "Applied Studies: Voice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "672",
+              "title": "Applied Studies: Voice II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "673",
+              "title": "Applied Studies: Voice III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "674",
+              "title": "Applied Studies: Voice IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "676",
+              "title": "Applied Studies: Guitar I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "677",
+              "title": "Applied Studies: Guitar II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "678",
+              "title": "Applied Studies: Guitar III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "679",
+              "title": "Applied Studies: Guitar IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "686",
+              "title": "Applied Studies: Percussion I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "687",
+              "title": "Applied Studies: Percussion II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "688",
+              "title": "Applied Studies: Percussion III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "689",
+              "title": "Applied Studies: Percussion IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "501",
+              "title": "Wind Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "502",
+              "title": "Wind Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "503",
+              "title": "Wind Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "504",
+              "title": "Wind Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "301",
+              "title": "Jazz Performance Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "302",
+              "title": "Jazz Performance Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "303",
+              "title": "Jazz Performance Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "304",
+              "title": "Jazz Performance Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "305",
+              "title": "Orchestral Performance I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "306",
+              "title": "Orchestral Performance II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "307",
+              "title": "Orchestral Performance III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "308",
+              "title": "Orchestral Performance IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "265",
+              "title": "Concert Choir I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "266",
+              "title": "Concert Choir II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "267",
+              "title": "Concert Choir III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "268",
+              "title": "Concert Choir IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "510",
+              "title": "Instrumental Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "520",
+              "title": "Instrumental Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "530",
+              "title": "Instrumental Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "540",
+              "title": "Instrumental Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "701",
+              "title": "String Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "702",
+              "title": "String Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "703",
+              "title": "String Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "704",
+              "title": "String Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "705",
+              "title": "Guitar Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "706",
+              "title": "Guitar Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "707",
+              "title": "Guitar Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "708",
+              "title": "Guitar Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "165",
+              "title": "College Chorus I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "166",
+              "title": "College Chorus II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "167",
+              "title": "College Chorus III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "168",
+              "title": "College Chorus IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Methods: Woodwinds",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "126",
+              "title": "Methods: Upper Strings - Violin and Viola",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "127",
+              "title": "Methods: Lower Strings - Cello & String Bass",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "131",
+              "title": "Methods: Brass",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "136",
+              "title": "Methods: Percussion",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "161",
+              "title": "Methods: Voice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "181",
+              "title": "Methods: Guitar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDS",
+              "number": "201",
+              "title": "Adolescent Learning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Music Performance Specialization",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "651",
+              "title": "Applied Studies: Strings I- Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "652",
+              "title": "Applied Studies: Strings II-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "653",
+              "title": "Applied Studies: Strings III-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "654",
+              "title": "Applied Studies: Strings IV-Violin, Viola, Cello & Double Bass",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "656",
+              "title": "Applied Studies: Piano I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "657",
+              "title": "Applied Studies: Piano II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "658",
+              "title": "Applied Studies: Piano III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "659",
+              "title": "Applied Studies: Piano IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "661",
+              "title": "Applied Studies: Woodwinds I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "662",
+              "title": "Applied Studies: Woodwinds II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "663",
+              "title": "Applied Studies: Woodwinds III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "664",
+              "title": "Applied Studies: Woodwinds IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "666",
+              "title": "Applied Studies: Brass I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "667",
+              "title": "Applied Studies: Brass II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "668",
+              "title": "Applied Studies: Brass III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "669",
+              "title": "Applied Studies: Brass IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "671",
+              "title": "Applied Studies: Voice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "672",
+              "title": "Applied Studies: Voice II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "673",
+              "title": "Applied Studies: Voice III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "674",
+              "title": "Applied Studies: Voice IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "676",
+              "title": "Applied Studies: Guitar I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "677",
+              "title": "Applied Studies: Guitar II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "678",
+              "title": "Applied Studies: Guitar III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "679",
+              "title": "Applied Studies: Guitar IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "686",
+              "title": "Applied Studies: Percussion I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "687",
+              "title": "Applied Studies: Percussion II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "688",
+              "title": "Applied Studies: Percussion III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "689",
+              "title": "Applied Studies: Percussion IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "501",
+              "title": "Wind Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "502",
+              "title": "Wind Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "503",
+              "title": "Wind Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "504",
+              "title": "Wind Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "301",
+              "title": "Jazz Performance Workshop I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "302",
+              "title": "Jazz Performance Workshop II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "303",
+              "title": "Jazz Performance Workshop III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "304",
+              "title": "Jazz Performance Workshop IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "305",
+              "title": "Orchestral Performance I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "306",
+              "title": "Orchestral Performance II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "307",
+              "title": "Orchestral Performance III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "308",
+              "title": "Orchestral Performance IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "265",
+              "title": "Concert Choir I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "266",
+              "title": "Concert Choir II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "267",
+              "title": "Concert Choir III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "268",
+              "title": "Concert Choir IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "510",
+              "title": "Instrumental Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "520",
+              "title": "Instrumental Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "530",
+              "title": "Instrumental Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "540",
+              "title": "Instrumental Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "701",
+              "title": "String Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "702",
+              "title": "String Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "703",
+              "title": "String Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "704",
+              "title": "String Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "705",
+              "title": "Guitar Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "706",
+              "title": "Guitar Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "707",
+              "title": "Guitar Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "708",
+              "title": "Guitar Ensemble IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "165",
+              "title": "College Chorus I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "166",
+              "title": "College Chorus II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "167",
+              "title": "College Chorus III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "168",
+              "title": "College Chorus IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Jazz and Popular Music Specialization",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "180",
+              "title": "Guitar Class I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "190",
+              "title": "Guitar Class II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "160",
+              "title": "Voice Class I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "170",
+              "title": "Voice Class II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "114",
+              "title": "Music Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "123",
+              "title": "Basics of Digital Music Production I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NUR-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/NUR-AAS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "104",
+              "title": "Mathematics for Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "425",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "121",
+              "title": "Fundamentals General, Organic, Biological Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "420",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "426",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Nursing Process I: Fundamentals of Patient Care",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "211",
+              "title": "Nursing Process II: Obstetrical and Psychiatric Nursing Care",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "313",
+              "title": "Nursing Process III: Pediatric and Basic Medical-Surgical Nursing Care",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "411",
+              "title": "Nursing Process IV: Medical-Surgical Nursing",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "415",
+              "title": "Professional Issues in Contemporary Nursing Practice",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Public and Non-Profit Administration",
+      "credential": "AS",
+      "program_code": "PAN-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/PAN-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associates in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAN",
+              "number": "100",
+              "title": "Introduction to Public Affairs and Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAN",
+              "number": "230",
+              "title": "Policy Development and Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "225",
+              "title": "Public Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "100",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAN",
+              "number": "240",
+              "title": "Research Methods in Nonprofit and Public Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PAN",
+              "number": "250",
+              "title": "Performance Measurement: Collecting and Interpreting Data",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public Health",
+      "credential": "AS",
+      "program_code": "PHE-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/PHE-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSD",
+              "number": "110",
+              "title": "Comprehensive Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "275",
+              "title": "HIV/AIDS: Public Health Implications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "276",
+              "title": "Environmental and Occupational Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "280",
+              "title": "History and Principles of Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "285",
+              "title": "Social and Behavioral Determinants of Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "290",
+              "title": "Principles and Practice of Behavior Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "295",
+              "title": "Epidemiology for Public Health Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "296",
+              "title": "Biostatistics in Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "201",
+              "title": "Health Education and Exercise",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "202",
+              "title": "Drug Use in American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "210",
+              "title": "Contemporary Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "211",
+              "title": "Critical Health Topics & Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "220",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "225",
+              "title": "Health Concerns of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "230",
+              "title": "Consumer Health Survey",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "235",
+              "title": "Nutrition for Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "240",
+              "title": "First Aid, Stafety and Cardio Pulmonary Resuscitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "250",
+              "title": "Stress: Awareness, Understanding and Mangement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "255",
+              "title": "Communication Strategies in Health Literacy, Promotion & Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "260",
+              "title": "Wellness Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "270",
+              "title": "Health Perspectives of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "476",
+              "title": "Cross Cultural Health Education in Peru and the U.S.",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Philosophy",
+      "credential": "AA",
+      "program_code": "PHI-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/PHI-AA",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Common  Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Flexible Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Curriculum Requirements",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "105",
+              "title": "Introduction to World Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "110",
+              "title": "Logic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Political Science",
+      "credential": "AA",
+      "program_code": "POL-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/POL-AA",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Flexible Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Curriculum Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "100",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "110",
+              "title": "Introduction to Politics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology",
+      "credential": "AA",
+      "program_code": "PSY-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/PSY-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "265",
+              "title": "Research in Psychology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements- Psychology: General Concentration",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Psychology of Personality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Behavioral Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "225",
+              "title": "Brain and Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "255",
+              "title": "Cognitive Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "271",
+              "title": "Foundations of Black Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "280",
+              "title": "Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "290",
+              "title": "Industrial-Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "295",
+              "title": "Special Topics in Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements- Psychology: STEM Concentration",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "220",
+              "title": "Behavioral Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "225",
+              "title": "Brain and Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "255",
+              "title": "Cognitive Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "200",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "230",
+              "title": "Psychology of Personality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "240",
+              "title": "Developmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "210",
+              "title": "Psychology of Death and Dying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "245",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "260",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "271",
+              "title": "Foundations of Black Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "280",
+              "title": "Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "290",
+              "title": "Industrial-Organizational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "295",
+              "title": "Special Topics in Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Respiratory Therapy",
+      "credential": "AAS",
+      "program_code": "RTT-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/RTT-AAS",
+      "total_credits": 73,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Applied Science",
+          "credits_required": 73,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "109",
+              "title": "Mathematics for Respiratory Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "118",
+              "title": "Fundamentals of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "121",
+              "title": "Fundamentals General, Organic, Biological Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "425",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 53,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RTT",
+              "number": "100",
+              "title": "Fundamentals of Respiratory Therapy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "101",
+              "title": "Introduction to Respiratory Therapy Equipment",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "201",
+              "title": "Respiratory Therapy I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "202",
+              "title": "Respiratory Therapy Clinical Practicum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "210",
+              "title": "Respiratory Therapy Summer Clinical Practicum",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "301",
+              "title": "Respiratory Therapy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "302",
+              "title": "Respiratory Therapy Clinical Practicum II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "310",
+              "title": "Cardio-Respiratory Physiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "320",
+              "title": "Pulmonary Function Testing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "401",
+              "title": "Respiratory Therapy III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "403",
+              "title": "Respiratory Therapy Clinical Practicum III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RTT",
+              "number": "410",
+              "title": "Fundamentals of Clinical Medicine",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "420",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "426",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "530",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Small Business Entrepreneurship",
+      "credential": "AAS",
+      "program_code": "SBE-AAS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/SBE-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "201",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "Introduction to Statistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "110",
+              "title": "General Astronomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "102",
+              "title": "Fundamentals of Public Speaking for Non-Native Speakers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "104",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "150",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Business Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "122",
+              "title": "Accounting Principles I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CED",
+              "number": "365",
+              "title": "Small Business Entrepreneurship Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "202",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FNB",
+              "number": "100",
+              "title": "Introduction to Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "100",
+              "title": "Introduction to Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAR",
+              "number": "320",
+              "title": "Retail Organization, Operation and Buying",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SBE",
+              "number": "100",
+              "title": "Entrepreneurship: Product & Service Creation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SBE",
+              "number": "201",
+              "title": "International Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SBE",
+              "number": "400",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "100",
+              "title": "Introduction to Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Science",
+      "credential": "AS",
+      "program_code": "SCI-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/SCI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "206",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "215",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "225",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Fundamentals of Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "260",
+              "title": "Cell Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "270",
+              "title": "Plant Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "120",
+              "title": "Fundamentals of Organic Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "205",
+              "title": "Quantitative Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "230",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "240",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "250",
+              "title": "Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "302",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "240",
+              "title": "Modern Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "120",
+              "title": "Computer Methods in Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "140",
+              "title": "Introduction to Microprocessors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "430",
+              "title": "Scientific Instrumentation",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - General Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mathematics and Science for Secondary Education",
+      "credential": "AS",
+      "program_code": "SED-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/SED-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Specialization",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDS",
+              "number": "202",
+              "title": "Special Topics in Secondary School Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDS",
+              "number": "201",
+              "title": "Adolescent Learning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "391",
+              "title": "World Literature from Antiquity to the Early Modern Era",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "392",
+              "title": "World Literature from the Early Modern Era to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "100",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "215",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "120",
+              "title": "Early American History: Colonial Period to Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "125",
+              "title": "Modern American History: Civil War to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "103",
+              "title": "Introduction to the History of Western Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Music and Western Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "302",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "303",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "315",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization: From Ancient to Early Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "225",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "240",
+              "title": "Modern Physics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Secondary Education for Social Studies",
+      "credential": "AA",
+      "program_code": "SES-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/SES-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "100",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDS",
+              "number": "201",
+              "title": "Adolescent Learning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "100",
+              "title": "Introduction to Human Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "241",
+              "title": "Population Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "120",
+              "title": "Early American History: Colonial Period to Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "125",
+              "title": "Modern American History: Civil War to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "School Health Education",
+      "credential": "AS",
+      "program_code": "SHE-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/SHE-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements- Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDS",
+              "number": "201",
+              "title": "Adolescent Learning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "Observing Children and their Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "201",
+              "title": "Health Education and Exercise",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "210",
+              "title": "Contemporary Health Issues",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "211",
+              "title": "Critical Health Topics & Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "240",
+              "title": "First Aid, Stafety and Cardio Pulmonary Resuscitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "250",
+              "title": "Stress: Awareness, Understanding and Mangement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "260",
+              "title": "Wellness Cardiovascular Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACL",
+              "number": "205",
+              "title": "Health Literacies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECE",
+              "number": "410",
+              "title": "Educational Foundations and Pedagogy for The Exceptional Child",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science for Health",
+      "credential": "AS",
+      "program_code": "SHP-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/SHP-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "121",
+              "title": "Fundamentals General, Organic, Biological Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "425",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "426",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "122",
+              "title": "Fundamentals General, Organic, Biological Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "420",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "125",
+              "title": "Fundamentals of Biochemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "150",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "235",
+              "title": "Nutrition for Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "151",
+              "title": "The Science of Food",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "510",
+              "title": "Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "530",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - General Electives",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Sociology",
+      "credential": "AA",
+      "program_code": "SOC-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/SOC-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "350",
+              "title": "Sociology Capstone",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spanish Translation for the Health, Legal and Business Professions",
+      "credential": "certificate",
+      "program_code": "STR-CERT",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/STR-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Non-Degree",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TRS",
+              "number": "201",
+              "title": "Introduction to Translation and Interpretation Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRS",
+              "number": "206",
+              "title": "The Structure of the Spanish Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "110",
+              "title": "The Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TRS",
+              "number": "345",
+              "title": "Capstone Project - Translation/Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Theatre",
+      "credential": "AS",
+      "program_code": "THE-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/THE-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THE",
+              "number": "100",
+              "title": "Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "110",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "115",
+              "title": "Voice and Movement for the Actor",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "121",
+              "title": "Elements of Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "140",
+              "title": "Stage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "141",
+              "title": "Theatre Management: Exploring Theaters of New York City and Beyond",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "220",
+              "title": "Page-to-Stage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "300",
+              "title": "History of Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "125",
+              "title": "Scenic Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "126",
+              "title": "Costume Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "127",
+              "title": "Performance Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "128",
+              "title": "Special Topics Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "373",
+              "title": "Introduction to Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "103",
+              "title": "Voice and Articulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "210",
+              "title": "Acting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "328",
+              "title": "Acting: Solo Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "258",
+              "title": "Theatre Externship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "280",
+              "title": "Acting for the Camera",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "310",
+              "title": "Advanced Theatre Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "315",
+              "title": "Playwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "324",
+              "title": "Latin American Theatre and Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "305",
+              "title": "Women in American Theater",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Urban Studies",
+      "credential": "AA",
+      "program_code": "URB-AA",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/URB-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements- Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "URB",
+              "number": "100",
+              "title": "Introduction to Urban Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "100",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "URB",
+              "number": "300",
+              "title": "Special Topics in Urban Studies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements- Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "102",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "204",
+              "title": "Criminal Justice and the Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "111",
+              "title": "Economics of Urban Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "111",
+              "title": "Economics of Urban Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "202",
+              "title": "Urban Schools in a Diverse American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GEO",
+              "number": "241",
+              "title": "Population Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Human Services and Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "411",
+              "title": "Social Welfare Programs and Policies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "110",
+              "title": "Introduction to Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "220",
+              "title": "Urban Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "110",
+              "title": "Sociology of Urban Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "111",
+              "title": "Understanding Technological Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAT",
+              "number": "152",
+              "title": "Puerto Rican Experience in Urban U.S. Settings (Same as SOC 152)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "152",
+              "title": "Puerto Rican Experience in Urban U.S. Settings",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "154",
+              "title": "Sociology of the Black Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFN",
+              "number": "154",
+              "title": "Sociology of the Black Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AFL",
+              "number": "161",
+              "title": "Health Problems in Urban Communities (Same as SOC 161)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "161",
+              "title": "Health Problems in Urban Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "200",
+              "title": "Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "240",
+              "title": "Urban Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Video Arts and Technology",
+      "credential": "AS",
+      "program_code": "VAT-AS",
+      "catalog_url": "https://bmcc.catalog.cuny.edu/programs/VAT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "400",
+              "title": "The Physics of Music",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "100",
+              "title": "Introduction to Multimedia",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VAT",
+              "number": "100",
+              "title": "Introduction to Video Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MES",
+              "number": "152",
+              "title": "Introduction to Contemporary Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "201",
+              "title": "Career Planning and Professional Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "371",
+              "title": "Media Arts and Technology Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "161",
+              "title": "TV Studio Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "165",
+              "title": "Sound for Performance/Digital Media I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "261",
+              "title": "TV Studio Production II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "265",
+              "title": "Sound for Performance/Digital Media II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "171",
+              "title": "Remote Production/Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "271",
+              "title": "Remote Production/Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANI",
+              "number": "301",
+              "title": "Introduction to Motion Graphics and Visual Effects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "300",
+              "title": "Budgeting for Television",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "302",
+              "title": "Lighting for Television",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "303",
+              "title": "Cinematography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VAT",
+              "number": "306",
+              "title": "Teleconferencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MES",
+              "number": "251",
+              "title": "Television Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANI",
+              "number": "401",
+              "title": "Introduction to 3D Animations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "200",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "245",
+              "title": "The Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSD",
+              "number": "250",
+              "title": "Stress: Awareness, Understanding and Mangement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "211",
+              "title": "Makerspace Design Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEA",
+              "number": "300",
+              "title": "Topics in Media Arts and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMA",
+              "number": "100",
+              "title": "Foundations of Digital Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MMP",
+              "number": "270",
+              "title": "Introduction to Video Game Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "225",
+              "title": "Introduction to Digital Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "110",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ny/programs/bronx-cc.json
+++ b/data/ny/programs/bronx-cc.json
@@ -1,0 +1,10111 @@
+{
+  "college_slug": "bronx-cc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://bcc.catalog.cuny.edu/programs",
+  "scraped_at": "2026-05-07T15:25:55.358Z",
+  "programs": [
+    {
+      "title": "Accounting",
+      "credential": "AS",
+      "program_code": "ACC-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/ACC-AS",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "113",
+              "title": "Principles of Intermediate Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "41",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "51",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWE",
+              "number": "31",
+              "title": "Cooperative Work Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "31",
+              "title": "Principles of Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "41",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Animal Care and Management",
+      "credential": "certificate",
+      "program_code": "ANIML-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/ANIML-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACM",
+              "number": "90",
+              "title": "Animal Care and Management Internship",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "15",
+              "title": "Zoology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "47",
+              "title": "Clinical Techniques For Medical Personnel II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "33",
+              "title": "Microcomputer Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21",
+              "title": "A Mathematical World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21.5",
+              "title": "A Mathematical World with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Automotive Technology",
+      "credential": "AAS",
+      "program_code": "AUTO-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/AUTO-AAS",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "112",
+              "title": "English Composition II: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "113",
+              "title": "English Composition II: Writing about Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "114",
+              "title": "English Composition II: Writing about Fiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "115",
+              "title": "English Composition II: Writing about Drama",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "116",
+              "title": "English Composition II: Writing about Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "11",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "10",
+              "title": "Introduction To Automotive Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "11",
+              "title": "Engine Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "12",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "21",
+              "title": "Steering and Suspension Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "23",
+              "title": "Heating and Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "24",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "36",
+              "title": "Hybrid/Electric Vehicles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "10",
+              "title": "Art Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "10",
+              "title": "Music Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "50",
+              "title": "Automotive Technology Internship",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "15",
+              "title": "Computer Applications in Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WFA",
+              "number": "10",
+              "title": "Workplace First Aid Training",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Options",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "13",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "25",
+              "title": "Automatic/Manual Transmission and Drivetrains",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "38",
+              "title": "Advanced Vehicle Diagnostics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "45",
+              "title": "Diesel Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "55",
+              "title": "Intro to Electric Vehicles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "56",
+              "title": "Autonomous Vehicle systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "57",
+              "title": "EV Performance and Diagosis",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Automotive Technician",
+      "credential": "certificate",
+      "program_code": "AUTO-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/AUTO-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACS",
+              "number": "10",
+              "title": "Introduction To Automotive Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "11",
+              "title": "Engine Repair",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "12",
+              "title": "Brake Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "13",
+              "title": "Engine Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "21",
+              "title": "Steering and Suspension Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "25",
+              "title": "Automatic/Manual Transmission and Drivetrains",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "38",
+              "title": "Advanced Vehicle Diagnostics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "23",
+              "title": "Heating and Air Conditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "24",
+              "title": "Electrical Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "35",
+              "title": "Alternative Fuel Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "36",
+              "title": "Hybrid/Electric Vehicles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACS",
+              "number": "45",
+              "title": "Diesel Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "automotive-technology"
+    },
+    {
+      "title": "Bilingual Early Childhood Assistant",
+      "credential": "certificate",
+      "program_code": "BILNG-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/BILNG-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "10",
+              "title": "Child Study - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "15",
+              "title": "Reading and Other Language Arts for the Early Childhood and Elementary Years",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "16",
+              "title": "Literacy in Early Childhood Education - Birth to Grade 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "17",
+              "title": "Literacy in Childhood Education - Grades 1 - 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "41",
+              "title": "Psychology of Infancy and Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "18",
+              "title": "Literacy in a Bilingual/Dual Language Early Childhood Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "30",
+              "title": "Introduction to Special Needs, Schools and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "40",
+              "title": "Field Work Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "AS",
+      "program_code": "BIOTECH-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/BIOTECH-AS",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Biology I: Molecules, Cells, and Genes",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Biology II: Organisms, Biodiversity, and Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "254",
+              "title": "Genetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "256",
+              "title": "Cell and Molecular Biology with an Introduction to Biotechnology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "11",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "12",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "37",
+              "title": "Elements of Calculus and Statistics for Biology Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "31",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": "BUSADM-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/BUSADM-AS",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Required Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "41",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "51",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "30",
+              "title": "Introduction to Computer Fundamentals and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "41",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Options",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "113",
+              "title": "Principles of Intermediate Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "31",
+              "title": "Principles of Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "13",
+              "title": "Website Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "47",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "49",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "51",
+              "title": "Web Programming with Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "11",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "21",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "52",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "53",
+              "title": "International Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "54",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "18",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "43",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "48",
+              "title": "Marketing Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Options",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "113",
+              "title": "Principles of Intermediate Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "115",
+              "title": "Accounting Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FIN",
+              "number": "31",
+              "title": "Principles of Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "13",
+              "title": "Website Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "47",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "49",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "51",
+              "title": "Web Programming with Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "11",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "21",
+              "title": "Small Business Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "52",
+              "title": "Organizational Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "53",
+              "title": "International Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "54",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "18",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "36",
+              "title": "Digital Marketing & Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "43",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "48",
+              "title": "Marketing Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Assistant of Children with Special Needs",
+      "credential": "certificate",
+      "program_code": "CHISN-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/CHISN-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "10",
+              "title": "Child Study - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "30",
+              "title": "Introduction to Special Needs, Schools and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "41",
+              "title": "Psychology of Infancy and Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "26",
+              "title": "Human Relations in Urban Schools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "31",
+              "title": "Introduction to Learning Disabilities and Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "40",
+              "title": "Field Work Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "COMPSCI-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/COMPSCI-AS",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General  Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "11",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Biology I: Molecules, Cells, and Genes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "11",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "31",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSI",
+              "number": "30",
+              "title": "Discrete Mathematics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "12",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Biology II: Organisms, Biodiversity, and Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "12",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "12",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "32",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "33",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "31",
+              "title": "Introduction to Computer Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "32",
+              "title": "Introduction to Computer Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "33",
+              "title": "Data Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "35",
+              "title": "Discrete Mathematics II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Information Systems",
+      "credential": "AAS",
+      "program_code": "COMSYS-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/COMSYS-AAS",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "21",
+              "title": "A Mathematical World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21.5",
+              "title": "A Mathematical World with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "12",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "11",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "13",
+              "title": "Website Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "23",
+              "title": "Client-Side Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "31",
+              "title": "Server-Side Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "12",
+              "title": "Voice and Diction:Business and Professional Speech",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWE",
+              "number": "31",
+              "title": "Cooperative Work Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "30",
+              "title": "Introduction to Computer Fundamentals and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "33",
+              "title": "Microcomputer Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "36",
+              "title": "Microcomputer Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "47",
+              "title": "Java Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "49",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "51",
+              "title": "Web Programming with Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KEY",
+              "number": "10",
+              "title": "Keyboarding For Computers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AA",
+      "program_code": "CRIMJUS-AA",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/CRIMJUS-AA",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "20",
+              "title": "Public Speaking and Critical Listening",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "20",
+              "title": "The American Nation: The Political and Social Development of a People",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "11",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "31",
+              "title": "Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "37",
+              "title": "Social Inequality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Criminal Justice Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "11",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "21",
+              "title": "Introduction to Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "22",
+              "title": "Introduction to Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "23",
+              "title": "Introduction to Corrections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "65",
+              "title": "Criminal Law and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Cybersecurity and Networking",
+      "credential": "AAS",
+      "program_code": "CYBNET-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/CYBNET-AAS",
+      "total_credits": 36,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "12",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "10",
+              "title": "Art Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "10",
+              "title": "Music Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Networking/Cybersecurity Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSN",
+              "number": "100",
+              "title": "Introduction to Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "105",
+              "title": "Computer Hardware and Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "110",
+              "title": "Network Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "120",
+              "title": "Network Switching and Routing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "130",
+              "title": "Network Operating Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "132",
+              "title": "Network Operating Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "140",
+              "title": "Network Scripting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "150",
+              "title": "Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "160",
+              "title": "Ethical Hacking and Network Penetration Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "170",
+              "title": "Internet and Cloud Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "190",
+              "title": "Cybersecurity Project",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity and Networking",
+      "credential": "certificate",
+      "program_code": "CYBNT-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/CYBNT-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "100",
+              "title": "Introduction to Cybersecurity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "105",
+              "title": "Computer Hardware and Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "110",
+              "title": "Network Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "130",
+              "title": "Network Operating Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "132",
+              "title": "Network Operating Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "140",
+              "title": "Network Scripting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "150",
+              "title": "Cybersecurity",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSN",
+              "number": "190",
+              "title": "Cybersecurity Project",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Dietetics and Nutrition Science",
+      "credential": "AS",
+      "program_code": "DIETNUT-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/DIETNUT-AS",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General  Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WFA",
+              "number": "10",
+              "title": "Workplace First Aid Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "94",
+              "title": "Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "101",
+              "title": "Introduction to Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "11",
+              "title": "The U.S. Health Care Delivery System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "51",
+              "title": "Stress Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Design",
+      "credential": "AAS",
+      "program_code": "DIGDES-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/DIGDES-AAS",
+      "total_credits": 35,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "21",
+              "title": "A Mathematical World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21.5",
+              "title": "A Mathematical World with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "15",
+              "title": "Design Basics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "21",
+              "title": "Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "22",
+              "title": "Painting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "55",
+              "title": "Modern Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "56",
+              "title": "Graphic and Digital Design History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "79",
+              "title": "Typographic Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "81",
+              "title": "Typography and Layout",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "82",
+              "title": "Illustration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "84",
+              "title": "Digital Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "86",
+              "title": "Digital Illustration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "87",
+              "title": "User Interface Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "88",
+              "title": "Web Interactivity",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "90",
+              "title": "Graphic Design Project",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "91",
+              "title": "Design Portfolio",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "32",
+              "title": "Printmaking",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "72",
+              "title": "Digital Photography and Motion Graphics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "89",
+              "title": "Publication Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "95",
+              "title": "Introduction to 3D Graphics and Animation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Assistant",
+      "credential": "certificate",
+      "program_code": "EARLY-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/EARLY-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "10",
+              "title": "Child Study - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "24",
+              "title": "Pre-School Seminar I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "41",
+              "title": "Psychology of Infancy and Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "25",
+              "title": "Pre-School Seminar II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "30",
+              "title": "Introduction to Special Needs, Schools and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "40",
+              "title": "Field Work Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Education",
+      "credential": "AS",
+      "program_code": "EDUC-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/EDUC-AS",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "10",
+              "title": "Child Study - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "12",
+              "title": "Contemporary Urban Education - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "26",
+              "title": "Human Relations in Urban Schools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "30",
+              "title": "Introduction to Special Needs, Schools and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "40",
+              "title": "Field Work Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "50",
+              "title": "Creativity and the Arts for Early Childhood and Childhood Years",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "16",
+              "title": "Literacy in Early Childhood Education - Birth to Grade 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "24",
+              "title": "Pre-School Seminar I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "25",
+              "title": "Pre-School Seminar II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "17",
+              "title": "Literacy in Childhood Education - Grades 1 - 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "18",
+              "title": "Literacy in a Bilingual/Dual Language Early Childhood Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "31",
+              "title": "Introduction to Learning Disabilities and Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "41",
+              "title": "Psychology of Infancy and Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronic Engineering Technology",
+      "credential": "AAS",
+      "program_code": "ELC-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/ELC-AAS",
+      "total_credits": 43,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "12",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ELC",
+              "number": "11",
+              "title": "DC Circuit Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "15",
+              "title": "Computer Applications in Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "18",
+              "title": "Computer Programming for Engineering Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "21",
+              "title": "AC Circuit Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "25",
+              "title": "Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "35",
+              "title": "Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "51",
+              "title": "Electronic Controls",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "81",
+              "title": "Electronic Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "94",
+              "title": "Laser and Fiber Optic Communications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "96",
+              "title": "Digital Systems I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "English",
+      "credential": "AA",
+      "program_code": "ENG-AA",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/ENG-AA",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Additional Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - English Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "155",
+              "title": "Introduction to Literary Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "121",
+              "title": "Introduction to Creative Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "124",
+              "title": "Great Writers of English Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "125",
+              "title": "Great Writers of English Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "133",
+              "title": "Modern American Short Story",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "140",
+              "title": "Folklore",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "141",
+              "title": "History of the English Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "147",
+              "title": "Latino Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "148",
+              "title": "Afro-Caribbean Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "150",
+              "title": "U.S. Literature and Thought I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "151",
+              "title": "U.S. Literature and Thought II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "153",
+              "title": "The Black Writer in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "154",
+              "title": "Black Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "156",
+              "title": "Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "157",
+              "title": "Introduction to Woman's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "161",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "172",
+              "title": "The Bible as Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Science",
+      "credential": "AS",
+      "program_code": "ENGRSCI-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/ENGRSCI-AS",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "31",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "32",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "11",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "11",
+              "title": "Introduction to Engineering Design",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "21",
+              "title": "Analysis Tools for Engineers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "31",
+              "title": "Circuit Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "33",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "34",
+              "title": "Differential Equations and Selected Topics in Advanced Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "33",
+              "title": "University Physics III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Exercise Science and Kinesiology",
+      "credential": "AS",
+      "program_code": "EXERSCI-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/EXERSCI-AS",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "20",
+              "title": "Public Speaking and Critical Listening",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WFA",
+              "number": "10",
+              "title": "Workplace First Aid Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "100",
+              "title": "Introduction to Exercise Science and Kinesiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "102",
+              "title": "Behavioral Aspects of Physical Activity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "94",
+              "title": "Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "12",
+              "title": "Elementary Hatha Yoga",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "16",
+              "title": "Strength and Flexibility Training Through Pilates",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "11",
+              "title": "Fitness for Life",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "51",
+              "title": "Stress Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "101",
+              "title": "Introduction to Personal Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "35",
+              "title": "Dynamics of Human Motivation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science for Forensics",
+      "credential": "AS",
+      "program_code": "FORSCI-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/FORSCI-AS",
+      "total_credits": 32,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "11",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "12",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "31",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 32,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "11",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "12",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "31",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "32",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "33",
+              "title": "Quantitative Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Health Sciences",
+      "credential": "AS",
+      "program_code": "HLTHSCI-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/HLTHSCI-AS",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HCM",
+              "number": "11",
+              "title": "The U.S. Health Care Delivery System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "94",
+              "title": "Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "101",
+              "title": "Introduction to Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "45",
+              "title": "Medical Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Healthcare Careers Preparation Option",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "22",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "28",
+              "title": "Microbiology and Infection Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "18",
+              "title": "Fundamentals of Organic Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "20",
+              "title": "Aspects of Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "20",
+              "title": "Aspects of Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "24",
+              "title": "Principles of General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "40",
+              "title": "Life Span Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "10",
+              "title": "Dosage Calculations for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Health Administration Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "51",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "11",
+              "title": "Medical Billing and Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "22",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Care Coordination Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "88",
+              "title": "Fundamentals of Community Health Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "12",
+              "title": "Human Services Skills and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "35",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "20",
+              "title": "Aspects of Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "20",
+              "title": "Aspects of Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "89",
+              "title": "HIV/AIDS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "90",
+              "title": "Health and Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "92",
+              "title": "Drugs, Society and Human Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "94",
+              "title": "Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "96",
+              "title": "Health Education For Parenting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services",
+      "credential": "AAS",
+      "program_code": "HUMSER-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/HUMSER-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overview of Requirements",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "10",
+              "title": "Human Services and Social Welfare Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "12",
+              "title": "Human Services Skills and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "91",
+              "title": "Field Work and Seminar in Human Services I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "92",
+              "title": "Field Work And Seminar In Human Services II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "40",
+              "title": "Life Span Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "35",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "11",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "11",
+              "title": "Case Management for Specialized Populations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "37",
+              "title": "Social Inequality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "31",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "41",
+              "title": "Psychology of Infancy and Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services",
+      "credential": "AS",
+      "program_code": "HUMSER-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/HUMSER-AS",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "10",
+              "title": "Human Services and Social Welfare Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "12",
+              "title": "Human Services Skills and Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "91",
+              "title": "Field Work and Seminar in Human Services I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "92",
+              "title": "Field Work And Seminar In Human Services II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "40",
+              "title": "Life Span Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "35",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "11",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "11",
+              "title": "Case Management for Specialized Populations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "37",
+              "title": "Social Inequality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "31",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "41",
+              "title": "Psychology of Infancy and Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts and Sciences",
+      "credential": "AA",
+      "program_code": "LIBARTS-AA",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/LIBARTS-AA",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / General Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Black and Latinx Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "147",
+              "title": "Latino Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "148",
+              "title": "Afro-Caribbean Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "153",
+              "title": "The Black Writer in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "154",
+              "title": "Black Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "31",
+              "title": "Latin American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "35",
+              "title": "History of Africa",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "37",
+              "title": "African - American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "39",
+              "title": "History of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "51",
+              "title": "History of New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANT",
+              "number": "11",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "11",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "41",
+              "title": "Civil Rights in America since 1954",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "51",
+              "title": "Urban Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "61",
+              "title": "Solving Social Problems Through the Political Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "71",
+              "title": "Politics of Developing Areas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "72",
+              "title": "International Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "22",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "40",
+              "title": "Life Span Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "44",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "31",
+              "title": "Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "32",
+              "title": "Urban Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "37",
+              "title": "Social Inequality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "28",
+              "title": "African American and Caribbean Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "34",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "12",
+              "title": "Contemporary Urban Education - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRN",
+              "number": "123",
+              "title": "Francophone Caribbean Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "20",
+              "title": "The American Nation: The Political and Social Development of a People",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "18",
+              "title": "History of Jazz",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POR",
+              "number": "111",
+              "title": "Introduction to Portuguese I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "130",
+              "title": "Literature and Culture of Puerto Rico",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "131",
+              "title": "Literature and Culture of the Spanish Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "122",
+              "title": "Latin American Language And Culture",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Early Childhood and Childhood Education Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "20",
+              "title": "Public Speaking and Critical Listening",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "10",
+              "title": "Child Study - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "12",
+              "title": "Contemporary Urban Education - Birth to Grade 6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "40",
+              "title": "Field Work Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "26",
+              "title": "Human Relations in Urban Schools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "30",
+              "title": "Introduction to Special Needs, Schools and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / History Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "20",
+              "title": "The American Nation: The Political and Social Development of a People",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Human Services Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSC",
+              "number": "10",
+              "title": "Human Services and Social Welfare Institutions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "35",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Media Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEST",
+              "number": "60",
+              "title": "Introduction to Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEST",
+              "number": "64",
+              "title": "Social Media Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEST",
+              "number": "96",
+              "title": "Television, Society and the Individual",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "61",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "91",
+              "title": "World Cinema",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Performing Arts Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "70",
+              "title": "Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "75",
+              "title": "Introduction to Acting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "140",
+              "title": "Folklore",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "161",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "121",
+              "title": "Introduction to Creative Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "154",
+              "title": "Black Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "26",
+              "title": "Oral Interpretation of Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FILM",
+              "number": "61",
+              "title": "Introduction to Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "21",
+              "title": "Choral Performance I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "22",
+              "title": "Choral Performance II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "23",
+              "title": "Choral Performance III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "65",
+              "title": "Beginning Guitar Class",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "66",
+              "title": "Guitar Class II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "70",
+              "title": "Piano Class for Beginners",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "71",
+              "title": "Secondary Piano I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "72",
+              "title": "Secondary Piano II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "12",
+              "title": "Elementary Hatha Yoga",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "14",
+              "title": "Aerobic Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "41",
+              "title": "Techniques of Jazz Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "46",
+              "title": "African, Caribbean and Black Dance Forms",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "47",
+              "title": "Beginning Salsa",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "82",
+              "title": "Introduction to Tai Chi Chuan",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THEA",
+              "number": "71",
+              "title": "Theatre Production",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Political Science Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "11",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "21",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "31",
+              "title": "Comparative Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "41",
+              "title": "Civil Rights in America since 1954",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "42",
+              "title": "Civil Rights Throughout the World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "51",
+              "title": "Urban Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "61",
+              "title": "Solving Social Problems Through the Political Process",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "69",
+              "title": "Introduction to Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "71",
+              "title": "Politics of Developing Areas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "72",
+              "title": "International Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "81",
+              "title": "Independent Study and Internships In Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Psychology Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "22",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "23",
+              "title": "Environmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "27",
+              "title": "Introduction to Behavioral Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "31",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "35",
+              "title": "Dynamics of Human Motivation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "40",
+              "title": "Life Span Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "41",
+              "title": "Psychology of Infancy and Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "42",
+              "title": "Psychology of Adolescence and Adulthood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "43",
+              "title": "Psychological Development During Maturity and Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "44",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "51",
+              "title": "Principles of Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "71",
+              "title": "Clinical Techniques of Assessment: The Interview",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Secondary Education Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "20",
+              "title": "Public Speaking and Critical Listening",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "70",
+              "title": "Educational Foundations of Middle and High School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "71",
+              "title": "Multicultural Perspectives of Middle and High School",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "30",
+              "title": "Introduction to Special Needs, Schools and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "40",
+              "title": "Field Work Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Sociology Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Spanish Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "110",
+              "title": "Introductory Spanish for Heritage Speakers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "111",
+              "title": "Beginning Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "112",
+              "title": "Beginning Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "113",
+              "title": "Intermediate Spanish Language and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "124",
+              "title": "Don Quijote and Other Cervantes Masterpieces",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "126",
+              "title": "Spanish for Global Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "117",
+              "title": "Advanced Spanish Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "120",
+              "title": "Advanced Spanish Grammar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "121",
+              "title": "Spanish Language and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "122",
+              "title": "Latin American Language And Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "125",
+              "title": "Generation of 1898",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "130",
+              "title": "Literature and Culture of Puerto Rico",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "131",
+              "title": "Literature and Culture of the Spanish Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Speech Pathology Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "21",
+              "title": "The Human Body",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "20",
+              "title": "Public Speaking and Critical Listening",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "41",
+              "title": "The Theory of Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "42",
+              "title": "The Anatomy and Physiology of the Speech Mechanism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Studio Art Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "12",
+              "title": "Introduction to Art History: Africa, the Americas, Asia, and the Middle East",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "12",
+              "title": "Introduction to Music: A Multi-Cultural Survey of World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "15",
+              "title": "Design Basics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "21",
+              "title": "Drawing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "22",
+              "title": "Painting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "24",
+              "title": "Drawing II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "26",
+              "title": "Painting II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "32",
+              "title": "Printmaking",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "41",
+              "title": "Ceramics: Handbuilding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "42",
+              "title": "Ceramics: Wheel Throwing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "72",
+              "title": "Digital Photography and Motion Graphics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "82",
+              "title": "Illustration",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "84",
+              "title": "Digital Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Licensed Practical Nurse",
+      "credential": "certificate",
+      "program_code": "LPN-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/LPN-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Special Requirements for Admission",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Pre-Clinical Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "10",
+              "title": "Dosage Calculations for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PNR",
+              "number": "101",
+              "title": "Fundamental Concepts of Practical Nursing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "201",
+              "title": "Concepts of Family-Centered Care for the Practical Nurse",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "301",
+              "title": "Concepts of Adult Health for the Practical Nurse I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "401",
+              "title": "Concepts of Adult Health for the Practical Nurse II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PNR",
+              "number": "501",
+              "title": "Transition to Practical Nursing Practice",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Mathematics",
+      "credential": "AS",
+      "program_code": "MATH-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/MATH-AS",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "11",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Biology I: Molecules, Cells, and Genes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "11",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "31",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "12",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Biology II: Organisms, Biodiversity, and Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "12",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "12",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "32",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "33",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "42",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "34",
+              "title": "Differential Equations and Selected Topics in Advanced Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "35",
+              "title": "Selected Topics in Advanced Calculus and Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "44",
+              "title": "Vector Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "46",
+              "title": "Abstract Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "48",
+              "title": "Advanced Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSI",
+              "number": "35",
+              "title": "Discrete Mathematics II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Laboratory Technician",
+      "credential": "AAS",
+      "program_code": "MEDLAB-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/MEDLAB-AAS",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "11",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "12",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "10",
+              "title": "Art Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "10",
+              "title": "Music Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "22",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "18",
+              "title": "Fundamentals of Organic Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "81",
+              "title": "Introduction to Medical Laboratory Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "82",
+              "title": "Clinical Hematology and Coagulation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "83",
+              "title": "Clinical Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "85",
+              "title": "Immunology/Serology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "86",
+              "title": "Immunohematology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "87",
+              "title": "Urinalysis and Body Fluids",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "88",
+              "title": "Intro to Clinical Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "89",
+              "title": "Diagnostic Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MLT",
+              "number": "90",
+              "title": "Clinical Internship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Assistant",
+      "credential": "AAS",
+      "program_code": "MEDOFF-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/MEDOFF-AAS",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21",
+              "title": "A Mathematical World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21.5",
+              "title": "A Mathematical World with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "108",
+              "title": "Spanish for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "22",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "46",
+              "title": "Clinical Techniques for Medical Personnel I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "47",
+              "title": "Clinical Techniques For Medical Personnel II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "31",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWE",
+              "number": "31",
+              "title": "Cooperative Work Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "33",
+              "title": "Microcomputer Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KEY",
+              "number": "10",
+              "title": "Keyboarding For Computers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "45",
+              "title": "Medical Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "11",
+              "title": "Medical Billing and Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "12",
+              "title": "Health Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MED",
+              "number": "13",
+              "title": "Principles of Patient Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EKG",
+              "number": "78",
+              "title": "Electrocardiogram",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLB",
+              "number": "79",
+              "title": "Phlebotomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "35",
+              "title": "Medical Office Procedures and Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPR",
+              "number": "21",
+              "title": "Word Processing Applications",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media and Digital Film Production",
+      "credential": "AS",
+      "program_code": "MEDP-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/MEDP-AS",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MEDP",
+              "number": "10",
+              "title": "Introduction to Media and Digital Film Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "12",
+              "title": "Digital Studio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "14",
+              "title": "Digital Animation and VFX",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "31",
+              "title": "Digital Audio Production and Post Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "18",
+              "title": "Introduction to Visual Storytelling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "23",
+              "title": "Digital Video Field Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "33",
+              "title": "Digital Video Editing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "35",
+              "title": "Digital Video Editing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "36",
+              "title": "Media and Digital Film Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEDP",
+              "number": "51",
+              "title": "Media and Digital Film Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MEST",
+              "number": "60",
+              "title": "Introduction to Mass Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marketing",
+      "credential": "AAS",
+      "program_code": "MKTG-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/MKTG-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overview of Requirements",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "41",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "51",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWE",
+              "number": "31",
+              "title": "Cooperative Work Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "11",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "18",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "36",
+              "title": "Digital Marketing & Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "43",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "48",
+              "title": "Marketing Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Marketing",
+      "credential": "AS",
+      "program_code": "MKTG-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/MKTG-AS",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "41",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "51",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWE",
+              "number": "31",
+              "title": "Cooperative Work Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "11",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "18",
+              "title": "Consumer Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "36",
+              "title": "Digital Marketing & Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "43",
+              "title": "Principles of Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MKT",
+              "number": "48",
+              "title": "Marketing Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Nuclear Medicine Technology",
+      "credential": "AAS",
+      "program_code": "NUCMED-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/NUCMED-AAS",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "108",
+              "title": "Spanish for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "10",
+              "title": "Art Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "10",
+              "title": "Music Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "22",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "45",
+              "title": "Medical Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "71",
+              "title": "Nuclear Physics Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "78",
+              "title": "EKG-Interpretation and Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "79",
+              "title": "Phlebotomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "81",
+              "title": "Orientation in Clinical Nuclear Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "82",
+              "title": "Radio-Pharmaceutical Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "83",
+              "title": "Radiation Physics and Dosimetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "84",
+              "title": "Radiation Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "85",
+              "title": "Nuclear Medicine Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "86",
+              "title": "Didactic Nuclear Medicine",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "87",
+              "title": "Clinical Nuclear Medicine I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "88",
+              "title": "Senior NMT Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "90",
+              "title": "Clinical Nuclear Medicine II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "24",
+              "title": "Principles of General Physics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nuclear Medicine Technology",
+      "credential": "certificate",
+      "program_code": "NUMED-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/NUMED-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NMT",
+              "number": "71",
+              "title": "Nuclear Physics Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "78",
+              "title": "EKG-Interpretation and Techniques",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "79",
+              "title": "Phlebotomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "81",
+              "title": "Orientation in Clinical Nuclear Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "82",
+              "title": "Radio-Pharmaceutical Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "83",
+              "title": "Radiation Physics and Dosimetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "84",
+              "title": "Radiation Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "85",
+              "title": "Nuclear Medicine Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "86",
+              "title": "Didactic Nuclear Medicine",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "87",
+              "title": "Clinical Nuclear Medicine I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "88",
+              "title": "Senior NMT Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NMT",
+              "number": "90",
+              "title": "Clinical Nuclear Medicine II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NUR-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/NUR-AAS",
+      "total_credits": 40,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "108",
+              "title": "Spanish for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "11",
+              "title": "Introduction to Art History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "11",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "28",
+              "title": "Microbiology and Infection Control",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "100",
+              "title": "Gerontological Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "101",
+              "title": "Nursing Care Across the Life Span Level I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "201",
+              "title": "Nursing Care Across the Life Span Level II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "301",
+              "title": "Nursing Care Across the Life Span Level III",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "401",
+              "title": "Nursing Care Across the Life Span Level IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "402",
+              "title": "Transition Into Nursing Practice",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHM",
+              "number": "10",
+              "title": "Dosage Calculations for Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Office Administration and Technology",
+      "credential": "AAS",
+      "program_code": "OFFADM-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/OFFADM-AAS",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21",
+              "title": "A Mathematical World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21.5",
+              "title": "A Mathematical World with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "111",
+              "title": "Stellar Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "11",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "110",
+              "title": "Contemporary Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "11",
+              "title": "Introduction to Environmental Health",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "11",
+              "title": "Earth Systems Science: The Earth",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "12",
+              "title": "Earth Systems Science: The Atmosphere",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "13",
+              "title": "Earth Systems Science: The Ocean",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "110",
+              "title": "Concepts of Physics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Introduction to Business Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Application of Mathematics for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "51",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIS",
+              "number": "13",
+              "title": "Website Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "31",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWE",
+              "number": "31",
+              "title": "Cooperative Work Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "36",
+              "title": "Microcomputer Spreadsheet Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KEY",
+              "number": "10",
+              "title": "Keyboarding For Computers",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "KEY",
+              "number": "11",
+              "title": "Document Formatting and Speed Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SEC",
+              "number": "35",
+              "title": "Medical Office Procedures and Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPR",
+              "number": "11",
+              "title": "Transcription for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPR",
+              "number": "21",
+              "title": "Word Processing Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WPR",
+              "number": "24",
+              "title": "Presentation for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AST",
+              "number": "101",
+              "title": "Laboratory Exercises In Stellar Astronomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "101",
+              "title": "Contemporary Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "Laboratory Exercises in Physics",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Horticulture",
+      "credential": "AAS",
+      "program_code": "ORNHRT-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/ORNHRT-AAS",
+      "total_credits": 39,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "11",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "12",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "17",
+              "title": "Fundamentals of General Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "10",
+              "title": "Art Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "10",
+              "title": "Music Survey",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Application of Mathematics for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "51",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BOT",
+              "number": "11",
+              "title": "Basic Botany",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "12",
+              "title": "Plant Form and Function",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "13",
+              "title": "Plant Kingdom",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "41",
+              "title": "Entomology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "11",
+              "title": "Horticultural Techniques I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "12",
+              "title": "Horticultural Techniques II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "13",
+              "title": "Pruning",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "21",
+              "title": "Soil Science I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "24",
+              "title": "Soil Science II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "31",
+              "title": "Preparation for Pesticide Applicator Certification",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "32",
+              "title": "Diseases of Ornamental Plants",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "61",
+              "title": "Woody Plant Identification; Fall Trees and Shurbs",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BOT",
+              "number": "64",
+              "title": "Woody Plant Identification; Spring Trees and Shrubs",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "41",
+              "title": "Plant Propagation I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "51",
+              "title": "Turf and Ground Maintenance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GAR",
+              "number": "81",
+              "title": "Plants for Landscaping",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "13",
+              "title": "Turf and Ground Maintenance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "14",
+              "title": "Arboriculture 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "15",
+              "title": "Perennials and Flower Borders I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "16",
+              "title": "Greenhouse Operation I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LND",
+              "number": "11",
+              "title": "Landscape Design Theory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LND",
+              "number": "12",
+              "title": "Graphics",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "22",
+              "title": "Nursery Operations I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "33",
+              "title": "Turf And Ground Management II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "34",
+              "title": "Arboriculture II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "35",
+              "title": "Perennials II and Flower Borders",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HRT",
+              "number": "36",
+              "title": "Greenhouse Operation I",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal and Legal Studies",
+      "credential": "AAS",
+      "program_code": "PALGST-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/PALGST-AAS",
+      "total_credits": 38,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "21",
+              "title": "A Mathematical World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "21.5",
+              "title": "A Mathematical World with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "23.5",
+              "title": "Probability and Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements- Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "11",
+              "title": "American National Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "35",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAT",
+              "number": "33",
+              "title": "Microcomputer Applications",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "17",
+              "title": "Introduction to Paralegal Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "19",
+              "title": "Introduction to Law Office Management and Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "41",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "47",
+              "title": "Civil Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "95",
+              "title": "Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "96",
+              "title": "Advanced Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CWE",
+              "number": "31",
+              "title": "Cooperative Work Experience",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Specialization",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Application of Mathematics for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAX",
+              "number": "11",
+              "title": "Introduction to Taxation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "52",
+              "title": "Business Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "62",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "64",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "65",
+              "title": "Criminal Law and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "72",
+              "title": "Real Property",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "77",
+              "title": "Immigration Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "82",
+              "title": "Insurance and Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "91",
+              "title": "Landlord/Tenant Advocacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "92",
+              "title": "Estates, Trust and Wills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "97",
+              "title": "Field Work in Community Health Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "89",
+              "title": "Legal Advocacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal and Legal Studies",
+      "credential": "certificate",
+      "program_code": "PLGST-CERT",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/PLGST-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAT",
+              "number": "10",
+              "title": "Computer Fundamentals and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "17",
+              "title": "Introduction to Paralegal Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "19",
+              "title": "Introduction to Law Office Management and Computers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "41",
+              "title": "Business Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "47",
+              "title": "Civil Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "95",
+              "title": "Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "96",
+              "title": "Advanced Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "52",
+              "title": "Business Organizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "62",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "65",
+              "title": "Criminal Law and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "72",
+              "title": "Real Property",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "77",
+              "title": "Immigration Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "82",
+              "title": "Insurance and Torts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "91",
+              "title": "Landlord/Tenant Advocacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "92",
+              "title": "Estates, Trust and Wills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "Application of Mathematics for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAX",
+              "number": "11",
+              "title": "Introduction to Taxation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public Health",
+      "credential": "AS",
+      "program_code": "PUBHLTH-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/PUBHLTH-AS",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "21",
+              "title": "The Human Body",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENV",
+              "number": "11",
+              "title": "Introduction to Environmental Health",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WFA",
+              "number": "10",
+              "title": "Workplace First Aid Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "101",
+              "title": "Introduction to Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "12",
+              "title": "Elementary Hatha Yoga",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "82",
+              "title": "Introduction to Tai Chi Chuan",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "11",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "88",
+              "title": "Fundamentals of Community Health Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "20",
+              "title": "Aspects of Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "93",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "89",
+              "title": "HIV/AIDS",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "90",
+              "title": "Health and Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "92",
+              "title": "Drugs, Society and Human Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "94",
+              "title": "Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "96",
+              "title": "Health Education For Parenting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "97",
+              "title": "Field Work in Community Health Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "20",
+              "title": "Public Speaking and Critical Listening",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "35",
+              "title": "Dynamics of Human Motivation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology",
+      "credential": "AAS",
+      "program_code": "RADTEC-AAS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/RADTEC-AAS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "English Composition I: Integrated Reading and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Composition I: Fundamentals of Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "English Composition I: Writing and Rhetoric",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "10",
+              "title": "History of the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "11",
+              "title": "Introduction to the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPN",
+              "number": "108",
+              "title": "Spanish for Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "11",
+              "title": "Fundamentals of Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CLE",
+              "number": "11",
+              "title": "Clinical Radiography Fundamentals",
+              "credits": 0.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLE",
+              "number": "15",
+              "title": "Clinical Radiography I",
+              "credits": 0.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLE",
+              "number": "21",
+              "title": "Clinical Radiography II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLE",
+              "number": "31",
+              "title": "Clinical Radiography III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLE",
+              "number": "41",
+              "title": "Clinical Radiography IV",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLE",
+              "number": "45",
+              "title": "Clinical Radiography V",
+              "credits": 0.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLE",
+              "number": "51",
+              "title": "Clinical Radiography VI",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CLE",
+              "number": "61",
+              "title": "Clinical Radiography VII / Senior Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "11",
+              "title": "Fundamentals of Radiologic Sciences and Health Care",
+              "credits": 3.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "12",
+              "title": "Radiographic Exposure I",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "13",
+              "title": "Radiographic Procedures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "15",
+              "title": "Radiographic Anatomy I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "16",
+              "title": "Patient Care and Pharmacology in Radiological Sciences",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "22",
+              "title": "Radiographic Exposure II",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "23",
+              "title": "Radiographics Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "24",
+              "title": "Radiation Protection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "25",
+              "title": "Radiograpic Anatomy II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "32",
+              "title": "Imaging Modalities",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "33",
+              "title": "Radiographic Procedures III and Cross Sectional Anatomy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "34",
+              "title": "Radiographic Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "42",
+              "title": "Radiation Biology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "43",
+              "title": "Quality Assessment/Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "71",
+              "title": "Radiation Physics",
+              "credits": 2.5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science",
+      "credential": "AS",
+      "program_code": "SCIENCE-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/SCIENCE-AS",
+      "total_credits": 27,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "28",
+              "title": "College Algebra and Elementary Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "28.5",
+              "title": "College Algebra and Elementary Trigonometry (Corequisite)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "11",
+              "title": "General College Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "12",
+              "title": "General College Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "30",
+              "title": "Precalculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Options",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Biology I: Molecules, Cells, and Genes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Biology II: Organisms, Biodiversity, and Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "31",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "32",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "34",
+              "title": "Biofuels and Bioproducts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "34",
+              "title": "Biofuels and Bioproducts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "21",
+              "title": "Introduction to Chemical Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "33",
+              "title": "Quantitative Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "31",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "27",
+              "title": "Principles of Laboratory Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "21",
+              "title": "Earth Systems Science: The Environment",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "11",
+              "title": "Earth Systems Science: The Earth",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "12",
+              "title": "Earth Systems Science: The Atmosphere",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "13",
+              "title": "Earth Systems Science: The Ocean",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "33",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "32",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "33",
+              "title": "University Physics III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Biology Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Biology I: Molecules, Cells, and Genes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Biology II: Organisms, Biodiversity, and Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "31",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "32",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Chemistry Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "31",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "32",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Biology I: Molecules, Cells, and Genes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "34",
+              "title": "Biofuels and Bioproducts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "34",
+              "title": "Biofuels and Bioproducts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "21",
+              "title": "Introduction to Chemical Processes",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "33",
+              "title": "Quantitative Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "11",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "31",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Earth Systems and Environmental Science Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "27",
+              "title": "Principles of Laboratory Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "33",
+              "title": "Quantitative Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "21",
+              "title": "Earth Systems Science: The Environment",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "11",
+              "title": "Earth Systems Science: The Earth",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "12",
+              "title": "Earth Systems Science: The Atmosphere",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ESE",
+              "number": "13",
+              "title": "Earth Systems Science: The Ocean",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements / Physics Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FYS",
+              "number": "11",
+              "title": "First-Year Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "31",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "32",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MTH",
+              "number": "33",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "31",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "32",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "33",
+              "title": "University Physics III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Therapeutic Recreation",
+      "credential": "AS",
+      "program_code": "THERREC-AS",
+      "catalog_url": "https://bcc.catalog.cuny.edu/programs/THERREC-AS",
+      "total_credits": 28,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Pathways Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "23",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Pathways Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "24",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Total Credits",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CPR",
+              "number": "10",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WFA",
+              "number": "10",
+              "title": "Workplace First Aid Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "91",
+              "title": "Critical Issues in Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "101",
+              "title": "Introduction to Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HCM",
+              "number": "11",
+              "title": "The U.S. Health Care Delivery System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEA",
+              "number": "51",
+              "title": "Stress Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "11",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REC",
+              "number": "93",
+              "title": "Introduction to Therapeutic Recreation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REC",
+              "number": "94",
+              "title": "Recreation: Historical and Philosophical Perspective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REC",
+              "number": "95",
+              "title": "Recreation Leadership",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "REC",
+              "number": "96",
+              "title": "Introduction to Alternative Therapies in Therapeutic Recreation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ny/programs/guttman-cc.json
+++ b/data/ny/programs/guttman-cc.json
@@ -1,0 +1,2942 @@
+{
+  "college_slug": "guttman-cc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://guttman.catalog.cuny.edu/programs",
+  "scraped_at": "2026-05-07T15:26:05.069Z",
+  "programs": [
+    {
+      "title": "Business Administration",
+      "credential": "AA",
+      "program_code": "BUSAD-AA",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/BUSAD-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACCT",
+              "number": "121",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACCT",
+              "number": "223",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSI",
+              "number": "102",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSI",
+              "number": "201",
+              "title": "Business Law & Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "201",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "204",
+              "title": "Contemporary Economic Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "203",
+              "title": "Introduction to Management Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOVT",
+              "number": "201",
+              "title": "Urban Politics: New York City Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "202",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "295",
+              "title": "Issues in Global Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "102",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSI",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "certificate",
+      "program_code": "CYBER-CERT",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/CYBER-CERT",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Certificate",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INFT",
+              "number": "102",
+              "title": "Hardware & Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "202",
+              "title": "Database Management & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "203",
+              "title": "Introduction to Management Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "217",
+              "title": "Networking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "215",
+              "title": "Operating Systems I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "216",
+              "title": "Network Security I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "225",
+              "title": "Operating Systems II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "226",
+              "title": "Network Security II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "236",
+              "title": "Penetration Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "239",
+              "title": "Introduction to Computer Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "256",
+              "title": "Cybersecurity Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Health Information Technology",
+      "credential": "AAS",
+      "program_code": "HIT-AAS",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/HIT-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HITE",
+              "number": "100",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "101",
+              "title": "Introduction to Health Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "120",
+              "title": "Introduction to Legal & Ethical Aspects of Health Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "150",
+              "title": "Quality Assessment & Healthcare Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "160",
+              "title": "Computer Applications in Healthcare & Data Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "200",
+              "title": "Pathophysiology & Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "210",
+              "title": "Clinical Classification Systems: ICD-10-CM/PCS Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "215",
+              "title": "Introduction to CPT/HCPCS Coding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "220",
+              "title": "Organizational Resources & Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "230",
+              "title": "Organizational Resources & Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HITE",
+              "number": "254",
+              "title": "Professional Practice Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "202",
+              "title": "Database Management & Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Human Services",
+      "credential": "AA",
+      "program_code": "HUMSV-AA",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/HUMSV-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOVT",
+              "number": "202",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSVC",
+              "number": "103",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSVC",
+              "number": "113",
+              "title": "Methods of Intervention for Human Services",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSVC",
+              "number": "201",
+              "title": "Fieldwork and Integrative Seminar I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSVC",
+              "number": "203",
+              "title": "Fieldwork and Integrative Seminar II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSVC",
+              "number": "213",
+              "title": "Health and Human Services Policy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "102",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "201",
+              "title": "Urban Anthropology: Poverty & Affluence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "227",
+              "title": "Sexuality and Gender in Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSVC",
+              "number": "204",
+              "title": "Special Topics in Fields of Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSVC",
+              "number": "223",
+              "title": "Introduction to Disability Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSVC",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "203",
+              "title": "Introduction to Management Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "295",
+              "title": "Issues in Global Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "201",
+              "title": "Crime & Justice in Urban Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "203",
+              "title": "Community Organizing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "214",
+              "title": "Social Determinants of Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Information Technology",
+      "credential": "AAS",
+      "program_code": "IT-AAS",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/IT-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "INFT",
+              "number": "102",
+              "title": "Hardware & Software",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "217",
+              "title": "Networking I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "202",
+              "title": "Database Management & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "203",
+              "title": "Introduction to Management Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "211",
+              "title": "Programming I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "221",
+              "title": "Web Technologies & Multimedia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "223",
+              "title": "Programming II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "233",
+              "title": "Systems Analysis & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "204",
+              "title": "Internship in Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "298",
+              "title": "Information Technology Independent Project",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "213",
+              "title": "Special Topics in Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUSI",
+              "number": "102",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUSI",
+              "number": "204",
+              "title": "Fundamentals of Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INFT",
+              "number": "213",
+              "title": "Special Topics in Information Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Liberal Arts",
+      "credential": "AA",
+      "program_code": "LAS-AA",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/LAS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Specialization",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Introduction to Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "102",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "202",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "223",
+              "title": "Economics of Social Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "214",
+              "title": "Women's Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "215",
+              "title": "Topics in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "201",
+              "title": "Who Built New York? New York City History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "221",
+              "title": "History of Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "103",
+              "title": "Introduction to Philosophical and Humanistic Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "254",
+              "title": "Capstone Seminar in the Liberal Arts & Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "210",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "201",
+              "title": "Urban Politics: New York City Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "202",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "223",
+              "title": "Economics of Social Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "201",
+              "title": "Urban Anthropology: Poverty & Affluence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "227",
+              "title": "Sexuality and Gender in Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "101",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "214",
+              "title": "Women's Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "215",
+              "title": "Topics in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "201",
+              "title": "Who Built New York? New York City History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "221",
+              "title": "History of Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "201",
+              "title": "Environmental Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "243",
+              "title": "Internship Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Secondary Education Social Studies",
+      "credential": "AA",
+      "program_code": "LASESS-AA",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/LASESS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOVT",
+              "number": "202",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "The United States from the Colonial Era to the Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "127",
+              "title": "The United States from the Civil War to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "225",
+              "title": "Latin American History:19th and 20th Centuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "222",
+              "title": "Social Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "224",
+              "title": "Literacy in the Content Areas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "226",
+              "title": "Adolescent Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "210",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Child Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "201",
+              "title": "Urban Politics: New York City Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "201",
+              "title": "Urban Anthropology: Poverty & Affluence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "227",
+              "title": "Sexuality and Gender in Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "203",
+              "title": "Race, Ethnicity & Community Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "223",
+              "title": "Economics of Social Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "201",
+              "title": "Who Built New York? New York City History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "243",
+              "title": "Internship Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Introduction to Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Science",
+      "credential": "AS",
+      "program_code": "SCI-AS",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/SCI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "221",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "221",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "260",
+              "title": "Cell Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "231",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "241",
+              "title": "Analytical Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIOL",
+              "number": "251",
+              "title": "Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "231",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "260",
+              "title": "Cell Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "241",
+              "title": "Analytical Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "210",
+              "title": "Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Urban Studies",
+      "credential": "AA",
+      "program_code": "URBST-AA",
+      "catalog_url": "https://guttman.catalog.cuny.edu/programs/URBST-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Overall",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Degree Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "103",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "203",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103A",
+              "title": "Statistics A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "103B",
+              "title": "Statistics B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "122",
+              "title": "Introduction to Biology: Earth & Environmental Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "120",
+              "title": "Introduction to Biological Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "211",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIOL",
+              "number": "212",
+              "title": "Human Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "103",
+              "title": "Introduction to Social Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AMST",
+              "number": "203",
+              "title": "Civic Engagement in a Global Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "206",
+              "title": "International Political Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "120",
+              "title": "Perspectives in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "200",
+              "title": "The Arts in New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "211",
+              "title": "Literature, Film, Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COMM",
+              "number": "102",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "111",
+              "title": "Ethnographic Methods at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOSC",
+              "number": "213",
+              "title": "Social Theory at Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "203",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHEM",
+              "number": "211",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "215",
+              "title": "Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GOVT",
+              "number": "201",
+              "title": "Urban Politics: New York City Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "202",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GOVT",
+              "number": "203",
+              "title": "Introduction to Urban Planning and Policy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "221",
+              "title": "History of Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "102",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "201",
+              "title": "Crime & Justice in Urban Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "227",
+              "title": "Sexuality and Gender in Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "102",
+              "title": "Introduction to Urban Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "203",
+              "title": "Race, Ethnicity & Community Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "225",
+              "title": "Urbanisms Global",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "253",
+              "title": "Urban Research Seminar Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECON",
+              "number": "223",
+              "title": "Economics of Social Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LASC",
+              "number": "295",
+              "title": "Issues in Global Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120",
+              "title": "College Algebra & Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "120.5",
+              "title": "College Algebra and Trigonometry with LAB",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MATH",
+              "number": "201",
+              "title": "Precalculus",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "201",
+              "title": "Environmental Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "201",
+              "title": "Crime & Justice in Urban Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "227",
+              "title": "Sexuality and Gender in Urban Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCI",
+              "number": "231",
+              "title": "Introduction to Urban Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "204",
+              "title": "Special Topics in Urban Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ny/programs/hostos-cc.json
+++ b/data/ny/programs/hostos-cc.json
@@ -1,0 +1,7345 @@
+{
+  "college_slug": "hostos-cc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://hostos.catalog.cuny.edu/programs",
+  "scraped_at": "2026-05-07T15:26:29.918Z",
+  "programs": [
+    {
+      "title": "Accounting",
+      "credential": "AAS",
+      "program_code": "ACCT-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/ACCT-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 41,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Introduction to Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "102",
+              "title": "Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "199",
+              "title": "Accounting Internship Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "250",
+              "title": "Personal Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Business Fundamentals: The Contemporary Business Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "105",
+              "title": "Personal Financial Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Applications Using Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "222",
+              "title": "Principles of Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "103",
+              "title": "Introduction to Computer Software Packages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "106",
+              "title": "Federal Business Income Taxes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "212",
+              "title": "Business Law II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "220",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "230",
+              "title": "Electronic Commerce",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting",
+      "credential": "AS",
+      "program_code": "ACCT-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/ACCT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "110",
+              "title": "College Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "College Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "210",
+              "title": "Cost Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Business Fundamentals: The Contemporary Business Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Accounting for Forensic Accounting",
+      "credential": "AS",
+      "program_code": "ACCTFOR-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/ACCTFOR-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "110",
+              "title": "College Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "111",
+              "title": "College Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "150",
+              "title": "Computerized Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "201",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "250",
+              "title": "Personal Income Tax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Business Fundamentals: The Contemporary Business Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "150",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Aging and Health Studies",
+      "credential": "AAS",
+      "program_code": "AGING-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/AGING-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Plants and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GERO",
+              "number": "101",
+              "title": "Introduction to Gerontology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERO",
+              "number": "102",
+              "title": "Therapeutic Recreation in Long Term Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERO",
+              "number": "103",
+              "title": "Health and Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERO",
+              "number": "299",
+              "title": "Fieldwork with an Older Population",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "103",
+              "title": "Interpersonal Relations and Teamwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "215",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "118",
+              "title": "Caribbean Society and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "150",
+              "title": "Ethnicity, Health, and Illness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "180",
+              "title": "Psychology of Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "101",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "121",
+              "title": "Social Services Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Management",
+      "credential": "AS",
+      "program_code": "BUSMGT-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/BUSMGT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "100",
+              "title": "Introduction to Accounting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "101",
+              "title": "Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "102",
+              "title": "Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Business Fundamentals: The Contemporary Business Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Applications Using Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Chemical Engineering Science",
+      "credential": "AS",
+      "program_code": "CHEENGR-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/CHEENGR-AS",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "210",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "220",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "310",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "202",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "310",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "228",
+              "title": "Introduction to Chemical Engineering Principals & Practice",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "312",
+              "title": "Organic Chemistry I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "320",
+              "title": "Organic Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "320",
+              "title": "Linear Algebra with Vector Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "360",
+              "title": "Ordinary Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Civil Engineering Science",
+      "credential": "AS",
+      "program_code": "CIVENGR-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/CIVENGR-AS",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "210",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "220",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Modern Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "202",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "310",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "320",
+              "title": "Linear Algebra with Vector Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "360",
+              "title": "Ordinary Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Tracks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CE",
+              "number": "209",
+              "title": "Structural and Site Plans",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CE",
+              "number": "214",
+              "title": "Civil Engineering Data Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "204",
+              "title": "Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "103",
+              "title": "Computer-Aided Analysis Tools for Engineers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "106",
+              "title": "Introduction to Earth and Atmospheric Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Community Health",
+      "credential": "AS",
+      "program_code": "COMHLTH-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/COMHLTH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Introduction to Community Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "212",
+              "title": "Bilingual Issues in Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "214",
+              "title": "Substance Use and Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "215",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "220",
+              "title": "Contemporary Health Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "299",
+              "title": "Field Experience in Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AA",
+      "program_code": "CRIMJUS-AA",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/CRIMJUS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "World History to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Modern World History",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "150",
+              "title": "The Role of the Police in the Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "201",
+              "title": "Issues in Law Enforcements",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "202",
+              "title": "Corrections and Sentencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "150",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "150",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "203",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "CSCI-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/CSCI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "210",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "220",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Mathematics Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "217",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Computer Science Sequence",
+          "credits_required": 13,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "205",
+              "title": "Discrete Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Modern Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "275",
+              "title": "Object Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "300",
+              "title": "Data Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "320",
+              "title": "Computer Algorithms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "375",
+              "title": "Computer Networking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "395",
+              "title": "Web & Mobile App Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "301",
+              "title": "Probability and Mathematical Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Digital Design and Animation",
+      "credential": "AAS",
+      "program_code": "DD-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/DD-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DD",
+              "number": "100",
+              "title": "Foundation Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "101",
+              "title": "Introduction to the Digital Toolbox",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "102",
+              "title": "Media Design in the Digital Age",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "105",
+              "title": "2D Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Sequences",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DD",
+              "number": "112",
+              "title": "Web Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "114",
+              "title": "Digital Illustration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "201",
+              "title": "Communication Design",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "120",
+              "title": "Typography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "215",
+              "title": "Portfolio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "220",
+              "title": "Typography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business for the Digital Entrepreneur",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "104",
+              "title": "Color Theory & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "106",
+              "title": "Introduction to Usable Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "107",
+              "title": "Concepts in Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "108",
+              "title": "Visual Narrative",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "111",
+              "title": "Introduction to Sound Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "113",
+              "title": "Motion Graphics and Animation Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "202",
+              "title": "Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "205",
+              "title": "3D Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "207",
+              "title": "3D Computer Animation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "299",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "301",
+              "title": "Digital Illustration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "302",
+              "title": "Web Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "307",
+              "title": "3D Computer Animation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "101",
+              "title": "Introduction to Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "105",
+              "title": "Code for Art & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "110",
+              "title": "Visual Design for Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "133",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "134",
+              "title": "Digital Photography 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "250",
+              "title": "2D Computer Animation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "290",
+              "title": "Special Topics in Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "102",
+              "title": "Beyond Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "121",
+              "title": "Painting and Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "122",
+              "title": "Painting and Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dental Hygiene",
+      "credential": "AAS",
+      "program_code": "DENHYG-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/DENHYG-AAS",
+      "total_credits": 70,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 70,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 47,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "120",
+              "title": "Principles of Organic Chemistry",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "110",
+              "title": "Oral Anatomy and Physiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "111",
+              "title": "Head and Neck Anatomy",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "112",
+              "title": "Clinical Dental Hygiene Practice I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "120",
+              "title": "Clinical Dental Hygiene Practice II",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "121",
+              "title": "Dental Radiology I: Basic Concepts",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "122",
+              "title": "Oral Microbiology",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "123",
+              "title": "Oral Embryology & Histology",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "129",
+              "title": "Clinic I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "130",
+              "title": "Nutrition",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "131",
+              "title": "Dental Radiology II: Technique & Interpretation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "132",
+              "title": "Dental Materials",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "210",
+              "title": "General & Oral Pathology",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "211",
+              "title": "Periodontology",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "212",
+              "title": "Dental Health Education",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "213",
+              "title": "Advanced Clinical Dental Hygiene Practice",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "219",
+              "title": "Clinic II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "220",
+              "title": "Community Dental Health",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "221",
+              "title": "Pharmacology",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "222",
+              "title": "Dental Specialties",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "223",
+              "title": "Ethics/Jurisprudence/ Practice Management",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "224",
+              "title": "Senior Seminar",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DEN",
+              "number": "229",
+              "title": "Clinic III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Digital Music",
+      "credential": "AAS",
+      "program_code": "DM-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/DM-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "101",
+              "title": "Fundamentals of Music Theory at the Keyboard",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "Music Theory & Ear Training I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "118",
+              "title": "History of Western Musical Styles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "103",
+              "title": "Popular Music Since 1900",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "106",
+              "title": "Introduction to Recording Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "201",
+              "title": "Synthesizers, Sampling, & MIDI Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "202",
+              "title": "Mix Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "205",
+              "title": "Sound Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "206",
+              "title": "Production 1",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLS",
+              "number": "161",
+              "title": "Hip-Hop Worldview",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "262",
+              "title": "History of Latin American and Caribbean Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "114",
+              "title": "History of the Film Score",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "116",
+              "title": "World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business for the Digital Entrepreneur",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "101",
+              "title": "Introduction to the Digital Toolbox",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "102",
+              "title": "Media Design in the Digital Age",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "107",
+              "title": "Concepts in Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "202",
+              "title": "Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "298",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "299",
+              "title": "Independent Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "310",
+              "title": "Sound As Story",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "315",
+              "title": "Sound Design In Context",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "316",
+              "title": "Production 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "207",
+              "title": "Theory & Ear Training II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "141",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "AAS",
+      "program_code": "ECE-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/ECE-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "Introduction to College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "150",
+              "title": "College Algebra with Trigonometric Functions",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "310",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "210",
+              "title": "United States History: Through the Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "United States History: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 42,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "103",
+              "title": "Interpersonal Relations and Teamwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "111",
+              "title": "Health and the Young Child",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "107",
+              "title": "Creative Art Activities for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "109",
+              "title": "Music and Movement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "111",
+              "title": "Science and Mathematics for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "113",
+              "title": "Field Experience in Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "116",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "130",
+              "title": "Teaching in the Multicultural/Multi-lingual Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "150",
+              "title": "Introduction to Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Concentrations",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "104",
+              "title": "Language Arts for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "105",
+              "title": "Social Studies for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Language Arts in a Bilingual Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "132",
+              "title": "Social Studies in a Bilingual Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Electrical Engineering Science",
+      "credential": "AS",
+      "program_code": "ELEENGR-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/ELEENGR-AS",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "210",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "220",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "202",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Modern Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "310",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "320",
+              "title": "Linear Algebra with Vector Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "360",
+              "title": "Ordinary Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "103",
+              "title": "Computer-Aided Analysis Tools for Engineers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "204",
+              "title": "Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Food Studies",
+      "credential": "AS",
+      "program_code": "FOOD-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/FOOD-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "110",
+              "title": "Principles of Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "Principles in Biology (Laboratory)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "Environmental Science I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "111",
+              "title": "Environmental Science I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FS",
+              "number": "101",
+              "title": "Food Studies I: Introduction to Food Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FS",
+              "number": "120",
+              "title": "Food Studies II: Food, Environment and Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FS",
+              "number": "200",
+              "title": "Food, Policy and Advocacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FS",
+              "number": "220",
+              "title": "Food, Health, and Environment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FS",
+              "number": "225",
+              "title": "Food Studies Career Practices and Field Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FS",
+              "number": "230",
+              "title": "Food Studies Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Tracks",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLS",
+              "number": "119",
+              "title": "Diversity and Pluralism in America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "101",
+              "title": "The Latino Experience in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "132",
+              "title": "Hispanics Migrations to the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "101",
+              "title": "Fundamentals of Public Administration and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "110",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "120",
+              "title": "Unions and Labor",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "122",
+              "title": "Health and Welfare Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSC",
+              "number": "101",
+              "title": "Introduction to Social Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "120",
+              "title": "Social Problems of the Minority Communities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "150",
+              "title": "Ethnicity, Health, and Illness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "105",
+              "title": "Sociology of Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Introduction to Community Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "215",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "220",
+              "title": "Contemporary Health Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "130",
+              "title": "Plants and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "131",
+              "title": "Plants and Society (Laboratory)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "250",
+              "title": "Botany of Food",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "260",
+              "title": "Introduction to Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "270",
+              "title": "Food Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "110",
+              "title": "Environmental Science I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "111",
+              "title": "Environmental Science I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "120",
+              "title": "Environmental Science II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "121",
+              "title": "Environmental Science II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Organismic Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Organismic Biology (Laboratory)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FS",
+              "number": "140",
+              "title": "Urban Agricultural Systems",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science for Forensic Science",
+      "credential": "AS",
+      "program_code": "FORSCI-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/FORSCI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "160",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "World History to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Modern World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "101",
+              "title": "The Latino Experience in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "114",
+              "title": "The African-American Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "210",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 45,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "220",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "230",
+              "title": "Quantitative Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "310",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "312",
+              "title": "Organic Chemistry I Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "320",
+              "title": "Organic Chemistry II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "322",
+              "title": "Organic Chemistry II Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Game Design",
+      "credential": "AAS",
+      "program_code": "GAME-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/GAME-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DD",
+              "number": "101",
+              "title": "Introduction to the Digital Toolbox",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "102",
+              "title": "Media Design in the Digital Age",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "113",
+              "title": "Motion Graphics and Animation Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "207",
+              "title": "3D Computer Animation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "101",
+              "title": "Introduction to Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "102",
+              "title": "Beyond Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "105",
+              "title": "Code for Art & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "110",
+              "title": "Visual Design for Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "201",
+              "title": "Digital Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "210",
+              "title": "Game Studio",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Modern Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "112",
+              "title": "Web Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "302",
+              "title": "Web Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "205",
+              "title": "Code for Games",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "101",
+              "title": "Introduction to Business for the Digital Entrepreneur",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Modern Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "100",
+              "title": "Foundation Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "107",
+              "title": "Concepts in Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "108",
+              "title": "Visual Narrative",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "111",
+              "title": "Introduction to Sound Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "112",
+              "title": "Web Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "202",
+              "title": "Video Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "302",
+              "title": "Web Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DD",
+              "number": "307",
+              "title": "3D Computer Animation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "205",
+              "title": "Code for Games",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "290",
+              "title": "Special Topics in Game Art & Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "298",
+              "title": "Independent Study I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GD",
+              "number": "299",
+              "title": "Independent Study II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts and Science",
+      "credential": "AA",
+      "program_code": "LIBARTS-AA",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/LIBARTS-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "111",
+              "title": "Principles in Biology (Laboratory)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENV",
+              "number": "111",
+              "title": "Environmental Science I Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "121",
+              "title": "Organismic Biology (Laboratory)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "131",
+              "title": "Plants and Society (Laboratory)",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FYS",
+              "number": "101",
+              "title": "A New York State of Mind: What Makes a City Great",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Historical Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "World History to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Modern World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "210",
+              "title": "United States History: Through the Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "United States History: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "114",
+              "title": "The African-American Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "214",
+              "title": "Modern African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "110",
+              "title": "African Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "112",
+              "title": "African Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "109",
+              "title": "History of Latin America I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "110",
+              "title": "History of Latin America II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "108",
+              "title": "History of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "106",
+              "title": "History of Dominican Republic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Interdisciplinary Studies in Human Behavior and Social Institutions Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "105",
+              "title": "Sociology of Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "150",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "Life-Span Development of Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "115",
+              "title": "Educational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "120",
+              "title": "Developmental Psychology I (Childhood)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "170",
+              "title": "Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "182",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "140",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "144",
+              "title": "Personality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "146",
+              "title": "Small Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Psychology Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "142",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "Life-Span Development of Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "115",
+              "title": "Educational Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "120",
+              "title": "Developmental Psychology I (Childhood)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "121",
+              "title": "Developmental Psychology II (Adolescence and Adulthood)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "140",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "144",
+              "title": "Personality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "146",
+              "title": "Small Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "170",
+              "title": "Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "180",
+              "title": "Psychology of Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "182",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Introduction to Research Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Psychology - Research Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "250",
+              "title": "Introduction to Research Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "202",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Social Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "210",
+              "title": "United States History: Through the Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "United States History: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "214",
+              "title": "Modern African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "100",
+              "title": "Women's and Gender Studies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Social Work Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "101",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "150",
+              "title": "Social Work Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "105",
+              "title": "Sociology of Social Problems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "146",
+              "title": "Small Group Dynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "103",
+              "title": "Interpersonal Relations and Teamwork",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - United States Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "210",
+              "title": "United States History: Through the Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "United States History: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "214",
+              "title": "Modern African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "161",
+              "title": "Hip-Hop Worldview",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "132",
+              "title": "Hispanics Migrations to the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "246",
+              "title": "Latina/Latino Literature in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "211",
+              "title": "The Modern American Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Literature of the Black American",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "114",
+              "title": "Modern Art in the City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "200",
+              "title": "Gender and Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Community Health Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Introduction to Community Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "214",
+              "title": "Substance Use and Abuse",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "215",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "220",
+              "title": "Contemporary Health Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Health Care Management Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "110",
+              "title": "Introduction to Community Health Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "103",
+              "title": "Interpersonal Relations and Teamwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "101",
+              "title": "Fundamentals of Public Administration and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Business Fundamentals: The Contemporary Business Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Physical Education Teacher Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PED",
+              "number": "201",
+              "title": "Principles and Foundations of Physical Education, Exercise Science, & Sport",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "202",
+              "title": "Motor Learning and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "100",
+              "title": "Personal Physical Fitness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "105",
+              "title": "Beginner's Volleyball",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "122",
+              "title": "Beginning Swimming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "139",
+              "title": "Beginning Yoga",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "145",
+              "title": "Black and Puerto Rican Dance",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Physical Education Science Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PED",
+              "number": "201",
+              "title": "Principles and Foundations of Physical Education, Exercise Science, & Sport",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "202",
+              "title": "Motor Learning and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "150",
+              "title": "Human Biology II Lecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "100",
+              "title": "Personal Physical Fitness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "105",
+              "title": "Advanced Athletics - Women's Volleyball",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "122",
+              "title": "Beginning Swimming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "139",
+              "title": "Beginning Yoga",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PED",
+              "number": "145",
+              "title": "Black and Puerto Rican Dance",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Teacher Education Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "116",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "130",
+              "title": "Teaching in the Multicultural/Multi-lingual Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "150",
+              "title": "Introduction to Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "104",
+              "title": "Language Arts for Young Children",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Style, Story and Expression Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Creative Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Creative Non Fiction: Autobiography and Memoir",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Studies in Fiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "212",
+              "title": "Studies in Drama",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "214",
+              "title": "Readings in Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "213",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "The Bible and Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "211",
+              "title": "The Modern American Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "221",
+              "title": "Introduction to Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "226",
+              "title": "Science Fiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "237",
+              "title": "Reading Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "240",
+              "title": "The Graphic Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "Writing About Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "Female Detective Novel",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Writing Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DD",
+              "number": "102",
+              "title": "Media Design in the Digital Age",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "202",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "203",
+              "title": "Creative Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Creative Non Fiction: Autobiography and Memoir",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "203",
+              "title": "Fundamentals of Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "238",
+              "title": "Tutoring Writing English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "Writing About Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Literature and the Human Experience Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLS",
+              "number": "125",
+              "title": "The Harlem Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "213",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "215",
+              "title": "The Bible and Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "216",
+              "title": "The Holocaust in Literature and Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "221",
+              "title": "Introduction to Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "222",
+              "title": "Latin American Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "223",
+              "title": "Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "224",
+              "title": "Literature and Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Literature of the Black American",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "227",
+              "title": "Literature and Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "228",
+              "title": "Literature and Illness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "230",
+              "title": "Language Culture and Identity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "239",
+              "title": "The Nation in Global Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "246",
+              "title": "Latina/Latino Literature in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "201",
+              "title": "Women and Religious Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Women's and Gender Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "WGS",
+              "number": "100",
+              "title": "Women's and Gender Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "200",
+              "title": "Gender and Work",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "201",
+              "title": "Women and Religious Experiences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "270",
+              "title": "Topics in Women's and Gender Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "140",
+              "title": "Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "223",
+              "title": "Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "223",
+              "title": "Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "Introduction to LGBTQ Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "251",
+              "title": "Female Detective Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "260",
+              "title": "US Latina Women’s Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WGS",
+              "number": "260",
+              "title": "US Latina Women’s Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Black Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLS",
+              "number": "101",
+              "title": "Introduction to Black Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "110",
+              "title": "African Civilization I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "112",
+              "title": "African Civilization II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "114",
+              "title": "The African-American Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "123",
+              "title": "African-American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "125",
+              "title": "The Harlem Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "201",
+              "title": "Black Rebellion and Resistance in the Americas",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "202",
+              "title": "African Spirituality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "150",
+              "title": "Ethnicity, Health, and Illness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "161",
+              "title": "Hip-Hop Worldview",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "105",
+              "title": "Language and Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "121",
+              "title": "Painting and Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Theater Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VPA",
+              "number": "171",
+              "title": "Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "172",
+              "title": "Play & Performance Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "181",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "182",
+              "title": "Movement for the Actor I: Theory and Practice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "193",
+              "title": "Voice and Diction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "281",
+              "title": "Acting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "282",
+              "title": "Movement for the Actor II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Art History Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Introduction to Global Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "111",
+              "title": "Arts and Civilization I: Prehistory to 1400",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "112",
+              "title": "Arts and Civilization II: 1400 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "113",
+              "title": "Introduction to Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "114",
+              "title": "Modern Art in the City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "131",
+              "title": "Black-American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "240",
+              "title": "The Graphic Novel",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Studio Art Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Introduction to Global Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "111",
+              "title": "Arts and Civilization I: Prehistory to 1400",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "112",
+              "title": "Arts and Civilization II: 1400 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "113",
+              "title": "Introduction to Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "114",
+              "title": "Modern Art in the City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "121",
+              "title": "Painting and Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "133",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "133H",
+              "title": "Digital Photography I (HONORS)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "122",
+              "title": "Painting and Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "134",
+              "title": "Digital Photography 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "124",
+              "title": "Still Life Oil Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "240",
+              "title": "The Graphic Novel",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Latina/o, Latin-American, and Caribbean Studies Option",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAC",
+              "number": "101",
+              "title": "The Latino Experience in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "106",
+              "title": "History of Dominican Republic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "108",
+              "title": "History of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "132",
+              "title": "Hispanics Migrations to the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "207",
+              "title": "Political Systems of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "118",
+              "title": "Caribbean Society and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "202",
+              "title": "Latin American Film and Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "246",
+              "title": "Latina/Latino Literature in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "122",
+              "title": "Negritude",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "141",
+              "title": "The African-American and Latino Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "131",
+              "title": "Language Arts in a Bilingual Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "132",
+              "title": "Social Studies in a Bilingual Classroom",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Introduction to Global Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "125",
+              "title": "Immigration Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Music Option",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "VPA",
+              "number": "141",
+              "title": "Music Appreciation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "151",
+              "title": "Fundamentals of Music Theory at the Keyboard",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "152",
+              "title": "Fundamentals of Music Theory at the Piano II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "153",
+              "title": "Music Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "103",
+              "title": "Popular Music Since 1900",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DM",
+              "number": "106",
+              "title": "Introduction to Recording Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "VPA",
+              "number": "161",
+              "title": "Chorus",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "161",
+              "title": "Hip-Hop Worldview",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "242",
+              "title": "Writing About Music",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Language, Society and Culture Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIN",
+              "number": "100",
+              "title": "Introduction to Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "102",
+              "title": "Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "103",
+              "title": "Language Acquisition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "230",
+              "title": "Language Culture and Identity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "105",
+              "title": "Language and Power",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "140",
+              "title": "Sociology of Race and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "120",
+              "title": "Developmental Psychology I (Childhood)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "212",
+              "title": "Bilingual Issues in Community Health",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements- Interdisciplinary Studies in Aging and Health Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "GERO",
+              "number": "101",
+              "title": "Introduction to Gerontology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERO",
+              "number": "102",
+              "title": "Therapeutic Recreation in Long Term Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GERO",
+              "number": "103",
+              "title": "Health and Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "180",
+              "title": "Psychology of Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SW",
+              "number": "101",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Practical Nursing",
+      "credential": "certificate",
+      "program_code": "LPN-CERT",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/LPN-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - PreClinical Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "Life-Span Development of Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Certificate Requirements - LPN Clinical Sequence",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "110",
+              "title": "LPN Clinical Nursing I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "111",
+              "title": "Pharmacology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "112",
+              "title": "Maternal/Child",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "120",
+              "title": "Clinical Nursing II",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "310",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Certificate Requirements - Overall",
+          "credits_required": 45.5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Certificate Requirements - Transition from LPN to A.A.S. RN Program",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NUR",
+              "number": "200",
+              "title": "Transition into Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "227",
+              "title": "Nursing Care of the Childbearing Family I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "228",
+              "title": "Nursing Care of the Childrearing Family II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "220",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "316",
+              "title": "Nursing Care of the Client with Mental Illness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "317",
+              "title": "Nursing Care of the Adult I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "215",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "326",
+              "title": "Nursing Care of the Adult II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "320",
+              "title": "Nursing Trends and Issues",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Mathematics",
+      "credential": "AS",
+      "program_code": "MATH-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/MATH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "210",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "210",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "220",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "217",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "310",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "215",
+              "title": "Modern Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "360",
+              "title": "Ordinary Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Engineering Science",
+      "credential": "AS",
+      "program_code": "MECENGR-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/MECENGR-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "210",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "220",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "310",
+              "title": "Organic Chemistry I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "202",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "220",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "310",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "320",
+              "title": "Linear Algebra with Vector Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "360",
+              "title": "Ordinary Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "210",
+              "title": "University Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "220",
+              "title": "University Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGR",
+              "number": "204",
+              "title": "Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "145",
+              "title": "Computer Aided Drafting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ME",
+              "number": "246",
+              "title": "Engineering Mechanics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NURS-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/NURS-AAS",
+      "total_credits": 71,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 71,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "310",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "110",
+              "title": "Introduction to Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "215",
+              "title": "Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "216",
+              "title": "Fundamentals of Nursing Practice",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "220",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "227",
+              "title": "Nursing Care of the Childbearing Family I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "228",
+              "title": "Nursing Care of the Childrearing Family II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "316",
+              "title": "Nursing Care of the Client with Mental Illness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "317",
+              "title": "Nursing Care of the Adult I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "320",
+              "title": "Nursing Trends and Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "326",
+              "title": "Nursing Care of the Adult II",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "110",
+              "title": "Life-Span Development of Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Office Technology",
+      "credential": "AAS",
+      "program_code": "OFFTEC-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/OFFTEC-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "Introduction to College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "100",
+              "title": "Business Fundamentals: The Contemporary Business Landscape",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "201",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "203",
+              "title": "Fundamentals of Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "101",
+              "title": "Keyboarding and Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "103",
+              "title": "Introduction to Computer Software Packages",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "104",
+              "title": "Office Systems and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COOP",
+              "number": "101",
+              "title": "Introduction to Career Practices",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COOP",
+              "number": "102",
+              "title": "Work Experience",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements -  Options",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "124",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "105",
+              "title": "Electronic Health Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "209",
+              "title": "Medical Office Procedures with Lab",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "206",
+              "title": "Medical Billing and Insurance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OT",
+              "number": "210",
+              "title": "Medical Coding/Billing and Insurance II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "WEB",
+              "number": "101",
+              "title": "Fundamentals of Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "110",
+              "title": "Business Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "210",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "215",
+              "title": "Business Applications Using Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "240",
+              "title": "Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public Interest Paralegal Studies",
+      "credential": "AAS",
+      "program_code": "PLEGAL-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/PLEGAL-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "Introduction to College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "Quantitative Reasoning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "World History to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Modern World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "210",
+              "title": "United States History: Through the Civil War",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "United States History: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BLS",
+              "number": "114",
+              "title": "The African-American Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "101",
+              "title": "The Latino Experience in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "100",
+              "title": "Introduction to Global Humanities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "100",
+              "title": "Introduction to World Philosophies: A Comparative Approach",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "COM",
+              "number": "110",
+              "title": "Fundamentals of Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "202",
+              "title": "Law and Evidence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEG",
+              "number": "101",
+              "title": "Introduction to the Legal Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEG",
+              "number": "102",
+              "title": "Law Office Organization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEG",
+              "number": "130",
+              "title": "Legal Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEG",
+              "number": "131",
+              "title": "Legal Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEG",
+              "number": "240",
+              "title": "Legal Practicum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEG",
+              "number": "241",
+              "title": "Legal Practicum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LEG",
+              "number": "250",
+              "title": "Hearing and Trial Advocacy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "120",
+              "title": "Penal Law of New York State",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "125",
+              "title": "Immigration Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "126",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "127",
+              "title": "Public and Employee Benefit Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "150",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Police Science",
+      "credential": "AS",
+      "program_code": "POLICE-AS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/POLICE-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJ",
+              "number": "150",
+              "title": "The Role of the Police in the Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "201",
+              "title": "Issues in Law Enforcements",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "202",
+              "title": "Corrections and Sentencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "120",
+              "title": "Penal Law of New York State",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "150",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "202",
+              "title": "Law and Evidence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "203",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PS",
+              "number": "101",
+              "title": "Introduction to Police Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PS",
+              "number": "201",
+              "title": "Police Organization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public Policy and Administration",
+      "credential": "AAS",
+      "program_code": "PUBADM-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/PUBADM-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "100",
+              "title": "Integrated Reading and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "100",
+              "title": "Introduction to College Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Introduction to Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BLS",
+              "number": "114",
+              "title": "The African-American Experience I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAC",
+              "number": "101",
+              "title": "The Latino Experience in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "211",
+              "title": "United States History: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "214",
+              "title": "Modern African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "American Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "201",
+              "title": "World History to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "202",
+              "title": "Modern World History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PPA",
+              "number": "101",
+              "title": "Fundamentals of Public Administration and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "110",
+              "title": "State and Local Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "120",
+              "title": "Unions and Labor",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "123",
+              "title": "Administration of Personnel Resources",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "101",
+              "title": "Law and Social Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "125",
+              "title": "Immigration Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice Administration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PPA",
+              "number": "111",
+              "title": "Federal Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "121",
+              "title": "Social Services Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "122",
+              "title": "Health and Welfare Administration I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "128",
+              "title": "Field Practicum/Organization Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "251",
+              "title": "Women in Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "126",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "150",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LAW",
+              "number": "203",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "201",
+              "title": "Issues in Law Enforcements",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CJ",
+              "number": "250",
+              "title": "Criminal Justice Policy and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "125",
+              "title": "Health and Welfare Administration II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "127",
+              "title": "Health Care Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PPA",
+              "number": "130",
+              "title": "Health Care Human Resource Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology",
+      "credential": "AAS",
+      "program_code": "XRAY-AAS",
+      "catalog_url": "https://hostos.catalog.cuny.edu/programs/XRAY-AAS",
+      "total_credits": 64.5,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 64.5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "111",
+              "title": "Literature and Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "105",
+              "title": "Mathematics for Allied Health Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "230",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "240",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 47.5,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HLT",
+              "number": "103",
+              "title": "Interpersonal Relations and Teamwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HLT",
+              "number": "124",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "110",
+              "title": "Radiography I & Lab",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "111",
+              "title": "Radiologic Science I & Lab",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "112",
+              "title": "Radiologic Physics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "113",
+              "title": "Radiographic Anatomy I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "114",
+              "title": "Professional Practice Issues in Diagnostic Imaging",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "120",
+              "title": "Radiography II & Lab",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "121",
+              "title": "Radiologic Science II & Lab",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "122",
+              "title": "Radiation Protection",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "123",
+              "title": "Radiographic Anatomy II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "124",
+              "title": "Contrast Media",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "129",
+              "title": "Clinical Radiography I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "139",
+              "title": "Clinical Radiography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "210",
+              "title": "Radiation Biology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "211",
+              "title": "Advanced Procedures I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "219",
+              "title": "Clinical Radiography III",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "220",
+              "title": "Pathology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "221",
+              "title": "Advanced Procedures II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "222",
+              "title": "Applied Quality Assurance",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "229",
+              "title": "Clincial Radiography IV",
+              "credits": 2.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "230",
+              "title": "Senior Seminar",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "XRA",
+              "number": "239",
+              "title": "Clinical Radiography V",
+              "credits": 2.5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ny/programs/kingsborough-cc.json
+++ b/data/ny/programs/kingsborough-cc.json
@@ -1,0 +1,7104 @@
+{
+  "college_slug": "kingsborough-cc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://kbcc.catalog.cuny.edu/programs",
+  "scraped_at": "2026-05-07T15:27:02.483Z",
+  "programs": [
+    {
+      "title": "Accounting",
+      "credential": "AS",
+      "program_code": "ACC-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/ACC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Fundamentals of Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1200",
+              "title": "Fundamentals of Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2100",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "2200",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1100",
+              "title": "Fundamentals of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1200",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1200",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1300",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BA",
+              "number": "1300",
+              "title": "Business Law II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6100",
+              "title": "Spreadsheet Applications in Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1400",
+              "title": "Money and Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2200",
+              "title": "Principles of Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "3100",
+              "title": "Cost Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "6000",
+              "title": "Microcomputer Accounting Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Addiction Studies",
+      "credential": "certificate",
+      "program_code": "ASAC-CERT",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/ASAC-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Certificate Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "2000",
+              "title": "Introduction to Alcoholism and Substace Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2200",
+              "title": "Basic Techniques in Substance Abuse Counseling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2400",
+              "title": "Basic Techniques in Substance Abuse Counseling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2600",
+              "title": "Ethics, Confidentiality and the Counselor-Client Relationship in Substance Abuse Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2800",
+              "title": "Behavioral Health Care Treatment Approaches",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "3000",
+              "title": "Compulsive Gambling: Treatment and Prevention for Substance Abuse Counselors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "3200",
+              "title": "Addiction and the Family",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "91A0",
+              "title": "Substance Abuse Counseling Program - Field Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "91B0",
+              "title": "Substance Abuse Counseling Program - Field Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": "BA-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/BA-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Fundamentals of Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1200",
+              "title": "Fundamentals of Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1100",
+              "title": "Fundamentals of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1200",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1400",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "3100",
+              "title": "Organizational Behavior and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1200",
+              "title": "Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1300",
+              "title": "Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BA",
+              "number": "1300",
+              "title": "Business Law II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6100",
+              "title": "Spreadsheet Applications in Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "1400",
+              "title": "Money and Banking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "2200",
+              "title": "Principles of Financial Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "The Business of Fashion",
+      "credential": "AAS",
+      "program_code": "BFSH-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/BFSH-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BA",
+              "number": "1100",
+              "title": "Fundamentals of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1200",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1400",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "1900",
+              "title": "Fashion Forecasting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "3100",
+              "title": "Elements of Retail Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "3200",
+              "title": "Product Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "3300",
+              "title": "Salesmanship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "3400",
+              "title": "Merchandising Planning and Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "3500",
+              "title": "Textiles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "3900",
+              "title": "Fashion Sales Promotion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "9229",
+              "title": "Field Experience in Business of Fashion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "1300",
+              "title": "Computerized Fashion Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Biology",
+      "credential": "AS",
+      "program_code": "BIO-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/BIO-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9010",
+              "title": "Introduction to Mathematics with College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1300",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 19,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1200",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CP",
+              "number": "1100",
+              "title": "Introduction to Computers and Computer Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "6000",
+              "title": "Computer Applications in Bioinformatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1200",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2100",
+              "title": "Comparative Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "2200",
+              "title": "Developmental Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5000",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5200",
+              "title": "Marine Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5300",
+              "title": "Ecology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5800",
+              "title": "Recombinant DNA Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5900",
+              "title": "Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "6500",
+              "title": "Molecular and Cellular Biology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "AS",
+      "program_code": "BIOTECH-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/BIOTECH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9010",
+              "title": "Introduction to Mathematics with College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1300",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "9100",
+              "title": "Biostatistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9100",
+              "title": "Biostatistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 23,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1200",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "6500",
+              "title": "Molecular and Cellular Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5000",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5900",
+              "title": "Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5800",
+              "title": "Recombinant DNA Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5700",
+              "title": "Biotechnology: Cell Culture and Cloning",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "6000",
+              "title": "Computer Applications in Bioinformatics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Culinary Arts",
+      "credential": "AAS",
+      "program_code": "CA-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CA-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CA",
+              "number": "990",
+              "title": "Culinary Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "100",
+              "title": "Culinary Arts I: Fundamental Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "1100",
+              "title": "Baking I: Baking and Pastry Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "2100",
+              "title": "Food Safety and Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "5000",
+              "title": "Menu Planning and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "7000",
+              "title": "Industry Exploration and Entrepreneurship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "9200",
+              "title": "Internship in Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "7100",
+              "title": "Introduction to Food Service Operations and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "6000",
+              "title": "Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "4300",
+              "title": "Catering and Quantity Food Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentrations",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CA",
+              "number": "1200",
+              "title": "Baking II: Techniques and Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "1300",
+              "title": "Contemporary Dessert Plating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "1400",
+              "title": "Artisan Bread Baking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "1500",
+              "title": "Professional Cake Decorating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "1600",
+              "title": "Chocolate and Sugar Confections",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "200",
+              "title": "Culinary Arts II: Techniques and Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "300",
+              "title": "Culinary Arts III: Breakfast, Pantry, and Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "7200",
+              "title": "Restaurant Kitchen Operations and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "7400",
+              "title": "Restaurant Management and Dining Room Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "9000",
+              "title": "Global Cuisines",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts",
+      "credential": "certificate",
+      "program_code": "CA-CERT",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CA-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Overall",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Certificate Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TAH",
+              "number": "7100",
+              "title": "Introduction to Food Service Operations and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "990",
+              "title": "Culinary Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "100",
+              "title": "Culinary Arts I: Fundamental Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "200",
+              "title": "Culinary Arts II: Techniques and Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "1100",
+              "title": "Baking I: Baking and Pastry Fundamentals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "2100",
+              "title": "Food Safety and Sanitation Certification",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "9000",
+              "title": "Global Cuisines",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "9200",
+              "title": "Internship in Culinary Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "300",
+              "title": "Culinary Arts III: Breakfast, Pantry, and Garde Manger",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "1200",
+              "title": "Baking II: Techniques and Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "7200",
+              "title": "Restaurant Kitchen Operations and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "7400",
+              "title": "Restaurant Management and Dining Room Operations",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Culinary Arts and Food Management",
+      "credential": "certificate",
+      "program_code": "CAFM-CERT",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CAFM-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Certificate Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SAC",
+              "number": "2000",
+              "title": "Introduction to Alcoholism and Substace Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2200",
+              "title": "Basic Techniques in Substance Abuse Counseling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2400",
+              "title": "Basic Techniques in Substance Abuse Counseling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2600",
+              "title": "Ethics, Confidentiality and the Counselor-Client Relationship in Substance Abuse Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2800",
+              "title": "Behavioral Health Care Treatment Approaches",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "3000",
+              "title": "Compulsive Gambling: Treatment and Prevention for Substance Abuse Counselors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "3200",
+              "title": "Addiction and the Family",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "91A0",
+              "title": "Substance Abuse Counseling Program - Field Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "91B0",
+              "title": "Substance Abuse Counseling Program - Field Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Addiction Studies",
+      "credential": "AS",
+      "program_code": "CDC-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CDC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "3600",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2000",
+              "title": "Introduction to Alcoholism and Substace Abuse Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2200",
+              "title": "Basic Techniques in Substance Abuse Counseling I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2400",
+              "title": "Basic Techniques in Substance Abuse Counseling II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2600",
+              "title": "Ethics, Confidentiality and the Counselor-Client Relationship in Substance Abuse Treatment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "2800",
+              "title": "Behavioral Health Care Treatment Approaches",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "3000",
+              "title": "Compulsive Gambling: Treatment and Prevention for Substance Abuse Counselors",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "3200",
+              "title": "Addiction and the Family",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "91A0",
+              "title": "Substance Abuse Counseling Program - Field Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SAC",
+              "number": "91B0",
+              "title": "Substance Abuse Counseling Program - Field Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Chemistry",
+      "credential": "AS",
+      "program_code": "CHM-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CHM-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9010",
+              "title": "Introduction to Mathematics with College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1200",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1300",
+              "title": "Advanced General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "3100",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "3200",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1400",
+              "title": "Advanced General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1000",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2100",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5500",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5600",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems",
+      "credential": "AAS",
+      "program_code": "CIS-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CIS-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "100",
+              "title": "Digital Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CP",
+              "number": "500",
+              "title": "Introduction to Computer Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CP",
+              "number": "2100",
+              "title": "C++ Programming I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CP",
+              "number": "2200",
+              "title": "C++ Programming II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "1200",
+              "title": "Introduction to Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "1500",
+              "title": "Applied Computer Architecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "3100",
+              "title": "Introduction to Database",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "1100",
+              "title": "Fundamentals of Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1100",
+              "title": "Fundamentals of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1200",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "1400",
+              "title": "Critical Issues in Per Health",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CP",
+              "number": "6200",
+              "title": "Java Programming II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2100",
+              "title": "Introduction to Web Page Development",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2200",
+              "title": "HTML Authoring and JavaScript",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "3200",
+              "title": "Advanced Database Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "4500",
+              "title": "Network Server Administration",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AA",
+      "program_code": "CJ-AA",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CJ-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRJ",
+              "number": "6300",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "POL",
+              "number": "5100",
+              "title": "Introduction to U.S. Government",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "6400",
+              "title": "Crime and Punishment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "6600",
+              "title": "Constitutional Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "6700",
+              "title": "The United States Judiciary",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "6900",
+              "title": "Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "7000",
+              "title": "Corrections and Sentencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "7200",
+              "title": "Minorities and the Criminal Justice System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "3100",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Requirements - Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SOC",
+              "number": "6500",
+              "title": "Introduction to Law and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRJ",
+              "number": "7500",
+              "title": "Fieldwork in Public Service",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "CS-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/CS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1200",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "13A0",
+              "title": "Advanced Programming Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1400",
+              "title": "Computers and Assembly Language Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "3500",
+              "title": "Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "3700",
+              "title": "Data Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5600",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9100",
+              "title": "Biostatistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "9100",
+              "title": "Biostatistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2200",
+              "title": "Statistics for Business with Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "2200",
+              "title": "Statistics for Business with Computer Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Math Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "1000",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2100",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Education Studies",
+      "credential": "AS",
+      "program_code": "EDUST-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/EDUST-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements -Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 29,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "200",
+              "title": "Social Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "2200",
+              "title": "Art Workshop in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "2400",
+              "title": "Teaching Emergent Bilinguals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "2500",
+              "title": "Psychological Foundations of Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "2100",
+              "title": "Social Science in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "2800",
+              "title": "Techniques in Math, Science and Technology Teaching for Early Childhood Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "3200",
+              "title": "Infant/Toddler Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "4000",
+              "title": "Educational Practice for Early Language and Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "9200",
+              "title": "Seminar and Practicum in Early Childhood Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "1600",
+              "title": "Survey of Speech, Language and Hearing Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "2900",
+              "title": "Elementary Science, Technology and Mathematics Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "3100",
+              "title": "Social Science in Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "4200",
+              "title": "Children’s Literature and Language Arts in Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "5000",
+              "title": "Foundations of Disability and Inclusive Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "90A4",
+              "title": "Seminar and Practicum in Teacher Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "5100",
+              "title": "Pedagogical Approaches for Students With Disabilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "5200",
+              "title": "Partnering with Families, Professionals and Community",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Requirements - Elective",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDC",
+              "number": "2300",
+              "title": "Music and Movement Workshop in Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "3000",
+              "title": "Seminar and Practicum in Early Childhood Education Curriculum",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "6001",
+              "title": "Social Emotional Learning through Puppetry and Play",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDC",
+              "number": "6002",
+              "title": "Creating Classroom Culture Through Successful Management",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Science",
+      "credential": "AS",
+      "program_code": "EGRSCI-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/EGRSCI-AS",
+      "total_credits": 61,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 61,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9010",
+              "title": "Introduction to Mathematics with College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1200",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1300",
+              "title": "Advanced General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "1400",
+              "title": "Advanced General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2100",
+              "title": "Engineering Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2200",
+              "title": "Introduction to Electrical Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2300",
+              "title": "Introduction to Engineering Thermodynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1200",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1000",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2100",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5500",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5600",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Emergency Medical Services",
+      "credential": "AAS",
+      "program_code": "EMS-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/EMS-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1200",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 40,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "100",
+              "title": "Emergency Medical Technician - Basic",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "101",
+              "title": "Emergency Medical Technician - Clinical",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "Paramedic I",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Paramedic Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "220",
+              "title": "Paramedic II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "221",
+              "title": "Paramedic Clinical II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "230",
+              "title": "Paramedic III",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "231",
+              "title": "Paramedic Clinical III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "240",
+              "title": "Paramedic IV",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "241",
+              "title": "Paramedic Clinical IV",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Earth and Planetary Sciences",
+      "credential": "AS",
+      "program_code": "EPS-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/EPS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3100",
+              "title": "Meteorology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3800",
+              "title": "Introduction to Earth Science",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EPS",
+              "number": "3200",
+              "title": "Physical Oceanography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3300",
+              "title": "Physical Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3500",
+              "title": "Introduction to Astronomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3600",
+              "title": "Planetology: A Trip Through the Solar System",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1100",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1000",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2100",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5500",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5600",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Exercise Science",
+      "credential": "AS",
+      "program_code": "EXSCI-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/EXSCI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1200",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 28,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EXS",
+              "number": "500",
+              "title": "Introduction to Exercise Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "1300",
+              "title": "Fitness Assessment and Program Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "1500",
+              "title": "Lifetime Strength and Flexibility Training",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EXS",
+              "number": "2000",
+              "title": "Exercise, Energy Balance, and Weight Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "3500",
+              "title": "First Aid and Personal Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "4200",
+              "title": "Health and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "1200",
+              "title": "Concepts of Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PEC",
+              "number": "200",
+              "title": "Walk Jog Run",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "1900",
+              "title": "Aerobic Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "7100",
+              "title": "High Intensity Fitness Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "3000",
+              "title": "Swimming for Non-Swimmers and Beginners",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "3300",
+              "title": "Advanced Swimming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "6500",
+              "title": "Aqua Exercise",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "800",
+              "title": "Body Weight Resistance Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "2500",
+              "title": "Tai Chi Ch'uan",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "2700",
+              "title": "Beginning Karate and Self-Defense",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "2900",
+              "title": "Introduction to Hatha Yoga",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "5600",
+              "title": "Pilates System of Exercise",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEW",
+              "number": "2100",
+              "title": "Personal Self Defense for Women",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fashion Design",
+      "credential": "AAS",
+      "program_code": "FD-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/FD-AAS",
+      "total_credits": 30,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associates in Applied Science",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 37,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FD",
+              "number": "1100",
+              "title": "Fashion Sketching for Fashion Designers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "1200",
+              "title": "Fashion Sketching for Fashion Designers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "1300",
+              "title": "Computerized Fashion Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "1400",
+              "title": "Garment Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "2000",
+              "title": "Flat Patternmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "2100",
+              "title": "Fashion Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "2200",
+              "title": "Fashion Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "2300",
+              "title": "Design Trends and Aesthetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "2500",
+              "title": "Advanced CAD for Fashion Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BF",
+              "number": "3500",
+              "title": "Textiles",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "1400",
+              "title": "Critical Issues in Per Health",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "9200",
+              "title": "Field Experience in Fashion Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "8192",
+              "title": "Independent Study: Fashion Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FD",
+              "number": "8122",
+              "title": "Independent Study of Fashion Design II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fine Arts",
+      "credential": "AS",
+      "program_code": "FINART-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/FINART-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associates in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "3300",
+              "title": "Survey of Art History: From Ancient To Renaissance Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "3400",
+              "title": "Survey of Art History: From Renaissance To 19th Century Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "5500",
+              "title": "Design Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "5700",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "3500",
+              "title": "Nineteenth-Century Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "3600",
+              "title": "Twentieth-Century Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "3700",
+              "title": "Survey of Non-Western Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "3800",
+              "title": "Renaissance Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "6300",
+              "title": "Ceramics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "6400",
+              "title": "Ceramics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "8072",
+              "title": "Ceramic Sculpture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "5800",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "5900",
+              "title": "Painting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "6000",
+              "title": "Painting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "5100",
+              "title": "Darkroom Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "5200",
+              "title": "Darkroom Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "9400",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "6100",
+              "title": "Sculpture I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "6200",
+              "title": "Sculpture II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "5600",
+              "title": "3-Dimenstional Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Graphic Design and Illustration",
+      "credential": "AS",
+      "program_code": "GRDSGN-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/GRDSGN-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "5500",
+              "title": "Design Foundations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "6800",
+              "title": "Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "7400",
+              "title": "Typography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "4300",
+              "title": "Digital Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "4600",
+              "title": "Photoshop as a Design Tool",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "7500",
+              "title": "Graphic Design and Advertising",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "5700",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "9600",
+              "title": "The Art of Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "4800",
+              "title": "The Art of 3D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "4900",
+              "title": "The Art of Storyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "6900",
+              "title": "Illustration Style",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "7300",
+              "title": "Digital Publication Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2500",
+              "title": "Human Centered Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2600",
+              "title": "UX Visual Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "2700",
+              "title": "Coding for Designers",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality and Meeting Planning",
+      "credential": "certificate",
+      "program_code": "HMP-CERT",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/HMP-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Overall",
+          "credits_required": 16,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Certificate Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TAH",
+              "number": "1200",
+              "title": "Tourism Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "2200",
+              "title": "Front Office Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "4100",
+              "title": "Meeting and Convention Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "9096",
+              "title": "The Virtual Enterprise",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "9160",
+              "title": "Professional Portfolio",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "9250",
+              "title": "Field Experience in Tourism and Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts",
+      "credential": "AA",
+      "program_code": "LIBARTS-AA",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/LIBARTS-AA",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Required Core",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Flexible Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Literary Studies Concentration",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "3000",
+              "title": "Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "3100",
+              "title": "Classical and Biblical Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "3200",
+              "title": "World Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "3300",
+              "title": "Introduction to Literary Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "3500",
+              "title": "Modern European Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "4000",
+              "title": "Short Fiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "4200",
+              "title": "Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "4300",
+              "title": "Drama",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "4800",
+              "title": "American Environmental Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "6300",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "6600",
+              "title": "Literature and Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "6700",
+              "title": "Women Writers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "6800",
+              "title": "Gothic and Horror Fiction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "6900",
+              "title": "Caribbean Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "7000",
+              "title": "Queer Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "7300",
+              "title": "Themes in American Literature I: Beginnings to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "7400",
+              "title": "Themes in American Literature II: 1865 to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "7700",
+              "title": "African-American Literature: Beginnings to the Harlem Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "7800",
+              "title": "African-American Literature: Great Depression to Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Mathematics",
+      "credential": "AS",
+      "program_code": "MATH-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/MATH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9010",
+              "title": "Introduction to Mathematics with College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "1200",
+              "title": "Introduction to Computing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "3500",
+              "title": "Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2100",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5500",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5600",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2200",
+              "title": "Statistics for Business with Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "2200",
+              "title": "Statistics for Business with Computer Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9100",
+              "title": "Biostatistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "9100",
+              "title": "Biostatistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Math Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "1000",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "13A0",
+              "title": "Advanced Programming Techniques",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1100",
+              "title": "Finite Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "3200",
+              "title": "Introduction to Set Theory",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "7100",
+              "title": "Applications of Linear Algebra & Vector Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Media Arts",
+      "credential": "AS",
+      "program_code": "MEDART-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/MEDART-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MCB",
+              "number": "3900",
+              "title": "Radio Studio Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "4100",
+              "title": "Television Studio Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "4600",
+              "title": "Media Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "4900",
+              "title": "Media Production and Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "5000",
+              "title": "Writing for Electronic Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "5200",
+              "title": "Video Editing with Media Composer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCM",
+              "number": "3000",
+              "title": "Mass Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCF",
+              "number": "4000",
+              "title": "Film: The Creative Medium",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MCB",
+              "number": "4000",
+              "title": "Introduction to Pro Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "5100",
+              "title": "Advanced Media Production and Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8145",
+              "title": "Independent Study - Internship: Broadcasting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8147",
+              "title": "Independent Study: Broadcasting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8148",
+              "title": "Independent Study: Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8149",
+              "title": "Independent Study: Media Production and Editing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8159",
+              "title": "Independent Study: Radio Station Ops",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8198",
+              "title": "Independent Study: Broadcasting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8211",
+              "title": "Television News and Intermediate Talk",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "8252",
+              "title": "Producing for a Television Series",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCB",
+              "number": "9201",
+              "title": "Internship in Broadcasting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCF",
+              "number": "4300",
+              "title": "Film Genre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MCF",
+              "number": "4400",
+              "title": "Film and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4700",
+              "title": "Stage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5500",
+              "title": "Introduction to Theatre Design & Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5600",
+              "title": "Fundamentals of Theatrical Lighting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6000",
+              "title": "Introduction to Costume and Make-Up",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6300",
+              "title": "Basic Sound Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JRL",
+              "number": "3100",
+              "title": "News Literacy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "4900",
+              "title": "The Art of Storyboarding",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "6500",
+              "title": "Literature and Film",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Marine Mechanic",
+      "credential": "certificate",
+      "program_code": "MMECH-CERT",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/MMECH-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Overall",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Certificate Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MT",
+              "number": "4300",
+              "title": "Marina Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5000",
+              "title": "Introduction to Outboard Motors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5100",
+              "title": "Introduction to Diesel Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5200",
+              "title": "Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5300",
+              "title": "Fiberglass, Refrigeration and Hydraulic Repairs",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5400",
+              "title": "Low Voltage Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5500",
+              "title": "Marine Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5600",
+              "title": "Advanced Outboards",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5700",
+              "title": "Vessel Systems, Theory, Maintenance and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5800",
+              "title": "Advanced Welding",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Maritime Technology: Deck Specialty",
+      "credential": "certificate",
+      "program_code": "MTDS-CERT",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/MTDS-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Certificate Requirements - Overall",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Cerificate Requirements- Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MT",
+              "number": "3300",
+              "title": "Vessel Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "3400",
+              "title": "Vessel Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "4600",
+              "title": "Coastal Piloting and Seamanship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5400",
+              "title": "Low Voltage Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5500",
+              "title": "Marine Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Maritime Technology",
+      "credential": "AAS",
+      "program_code": "MTECH-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/MTECH-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirement - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirement – Overall",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirement – Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "3500",
+              "title": "First Aid and Personal Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "3300",
+              "title": "Vessel Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "3400",
+              "title": "Vessel Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "4300",
+              "title": "Marina Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "4600",
+              "title": "Coastal Piloting and Seamanship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5000",
+              "title": "Introduction to Outboard Motors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5100",
+              "title": "Introduction to Diesel Engines",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5200",
+              "title": "Welding",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5300",
+              "title": "Fiberglass, Refrigeration and Hydraulic Repairs",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5400",
+              "title": "Low Voltage Electrical Systems",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5500",
+              "title": "Marine Electronics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5600",
+              "title": "Advanced Outboards",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5700",
+              "title": "Vessel Systems, Theory, Maintenance and Troubleshooting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "5800",
+              "title": "Advanced Welding",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NUR-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/NUR-AAS",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "3200",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "3100",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1200",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 43,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCI",
+              "number": "2500",
+              "title": "Applied Physical Sciences for Allied Health Careers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "5100",
+              "title": "Microbiology in Health and Disease",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "1700",
+              "title": "Calculations for Medication Administration",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "1800",
+              "title": "Fundamentals of Nursing",
+              "credits": 7,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "1900",
+              "title": "Family Centered Maternity Nursing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "2000",
+              "title": "Nursing the Emotionally Ill",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "2100",
+              "title": "Nursing the Ill Adult I",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "2200",
+              "title": "Nursing the Ill Adult II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "2300",
+              "title": "Nursing of Children",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "2400",
+              "title": "Issues in Nursing",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Office Administration and Technology",
+      "credential": "AAS",
+      "program_code": "OFFADM-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/OFFADM-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TEC",
+              "number": "1100",
+              "title": "Computer Keyboarding I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "1200",
+              "title": "Computer Keyboarding II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "1300",
+              "title": "Computer Keyboarding III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "4100",
+              "title": "Intensive Computer Keyboarding II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "4200",
+              "title": "Intensive Computer Keyboarding III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2400",
+              "title": "Organizing The Electronic Office For The Administrative Assistant",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2500",
+              "title": "Office Computer Applications I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "3400",
+              "title": "Office Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "3700",
+              "title": "Office Communication Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "9229",
+              "title": "Field Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "1400",
+              "title": "Critical Issues in Per Health",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Stenographic Executive Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "1500",
+              "title": "Gregg Shorthand (Elementary)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "1700",
+              "title": "Gregg Shorthand (Intermediate)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "3000",
+              "title": "Advanced Stenography and Transcription",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2500",
+              "title": "Office Computer Applications I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CP",
+              "number": "1100",
+              "title": "Introduction to Computers and Computer Applications",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Word/Information Processing Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "2400",
+              "title": "Office Systems and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2100",
+              "title": "Word/Information Processing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2300",
+              "title": "Electronic Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2600",
+              "title": "Office Computer Applications II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Stenographic/Legal Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "1500",
+              "title": "Gregg Shorthand (Elementary)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "1700",
+              "title": "Gregg Shorthand (Intermediate)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "3000",
+              "title": "Advanced Stenography and Transcription",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5000",
+              "title": "Legal Terminology and Law Office Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CP",
+              "number": "1100",
+              "title": "Introduction to Computers and Computer Applications",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2500",
+              "title": "Office Computer Applications I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Medical Information Processing Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "2400",
+              "title": "Office Systems and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2100",
+              "title": "Word/Information Processing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2300",
+              "title": "Electronic Transcription",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "6100",
+              "title": "Medical Terminology and Electronic Transcription",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "6200",
+              "title": "Medical Office Computer Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements -Stenographic/School Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "1500",
+              "title": "Gregg Shorthand (Elementary)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "1700",
+              "title": "Gregg Shorthand (Intermediate)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "8117",
+              "title": "Independent Study Intmdt Sten Gregg",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "3000",
+              "title": "Advanced Stenography and Transcription",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "8130",
+              "title": "Independent Study - Adv Steno & Trans",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "5300",
+              "title": "The School Secretary I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "8153",
+              "title": "I.S. The School Secretary 1",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "5400",
+              "title": "The School Secretary II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "8154",
+              "title": "I.S. School Sec II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "5500",
+              "title": "School Records Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "8155",
+              "title": "Independent Study of School Records Management",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Education, Recreation, and Recreation Therapy",
+      "credential": "AS",
+      "program_code": "PERRT-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/PERRT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HPE",
+              "number": "1200",
+              "title": "Concepts of Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "1100",
+              "title": "Introduction to Recreation and Physical Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "1200",
+              "title": "Leadership in Recreation, Physical Education, and Sport Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "3200",
+              "title": "Organization and Administration of Recreation, Physical Education, and Sport Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "9152",
+              "title": "Field Experience in Physical Education, Recreation, and Recreation Therap",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "RPE",
+              "number": "1300",
+              "title": "Social Recreation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "3100",
+              "title": "Therapeutic Recreation for Individuals with Disabilities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "3400",
+              "title": "Methods and Materials in Arts and Crafts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "3500",
+              "title": "Therapeutic Recreation for Individuals with Disabilities II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "3600",
+              "title": "The Assessment Process in Therapeutic Recreation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HPE",
+              "number": "1500",
+              "title": "Fitness Assessment and Prescription",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "3500",
+              "title": "First Aid and Personal Safety",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "1400",
+              "title": "Camping and Outdoor Recreation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "4000",
+              "title": "Sport and American Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "7000",
+              "title": "Introduction to Teaching Methods in Physical Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "700",
+              "title": "Introduction to Sports Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RPE",
+              "number": "4600",
+              "title": "Facilities Planning in Sports",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1100",
+              "title": "Fundamentals of Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1400",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physics",
+      "credential": "AS",
+      "program_code": "PHY-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/PHY-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9010",
+              "title": "Introduction to Mathematics with College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1200",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1300",
+              "title": "Advanced General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 26,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements Core",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "1400",
+              "title": "Advanced General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2200",
+              "title": "Introduction to Electrical Engineering",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "2300",
+              "title": "Introduction to Engineering Thermodynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3100",
+              "title": "Meteorology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3200",
+              "title": "Physical Oceanography",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3300",
+              "title": "Physical Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3500",
+              "title": "Introduction to Astronomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3600",
+              "title": "Planetology: A Trip Through the Solar System",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EPS",
+              "number": "3800",
+              "title": "Introduction to Earth Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1000",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2100",
+              "title": "Calculus III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5500",
+              "title": "Differential Equations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "5600",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Polysomnographic Technology",
+      "credential": "AAS",
+      "program_code": "PSG-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/PSG-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2000",
+              "title": "Elements of Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "20B0",
+              "title": "Statistics with Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "7600",
+              "title": "Ethics and Morality in the Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1200",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 34,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSG",
+              "number": "100",
+              "title": "The Science of Sleep and Circadian Rhythms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "101",
+              "title": "Neuroscience and Pharmacology in Sleep",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "102",
+              "title": "Foundations of Polysomnography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "103",
+              "title": "Clinical Practicum in Sleep Medicine I",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "104",
+              "title": "Foundations of Polysomnography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "105",
+              "title": "Clinical Polysomnographic Scoring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "106",
+              "title": "Classification of Sleep Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "107",
+              "title": "Cardiopulmonary Physiology in Sleep",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSG",
+              "number": "108",
+              "title": "Clinical Practicum in Sleep Medicine II",
+              "credits": 6,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Therapist Assistant",
+      "credential": "AAS",
+      "program_code": "PTA-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/PTA-AAS",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "2000",
+              "title": "Elements of Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "2100",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1200",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 44,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PTA",
+              "number": "100",
+              "title": "Foundations of Physical Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "200",
+              "title": "Kinesiology and Applied Anatomy",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "300",
+              "title": "Foundations of Physical Therapy II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "400",
+              "title": "Modalities and Procedures I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "500",
+              "title": "Therapeutic Exercise",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "600",
+              "title": "Clinical Practicum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "700",
+              "title": "Modalities and Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "800",
+              "title": "Selected Topics in Physical Therapy",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "900",
+              "title": "Clinical Practicum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "1000",
+              "title": "Introduction to Physical Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2000",
+              "title": "Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PTA",
+              "number": "2500",
+              "title": "Interactions in the Clinic",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science for Forensics",
+      "credential": "AS",
+      "program_code": "SCIFOR-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/SCIFOR-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9010",
+              "title": "Introduction to Mathematics with College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "900",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "9B0",
+              "title": "College Algebra for STEM Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1300",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1400",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "1100",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 25,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHM",
+              "number": "1200",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "3100",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHM",
+              "number": "3200",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1300",
+              "title": "Advanced General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "1400",
+              "title": "Advanced General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1000",
+              "title": "College Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1400",
+              "title": "Analytic Geometry and Pre-Calculus Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1500",
+              "title": "Calculus I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "1600",
+              "title": "Calculus II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Speech Communication",
+      "credential": "AS",
+      "program_code": "SPECOM-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/SPECOM-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPE",
+              "number": "2400",
+              "title": "Career Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "2500",
+              "title": "Small Group Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "2700",
+              "title": "Oral Interpretation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentrations",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPE",
+              "number": "1200",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "1800",
+              "title": "Health Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "1900",
+              "title": "Family Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "2100",
+              "title": "Effective Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "2600",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "1700",
+              "title": "Introduction to Linguistics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "2900",
+              "title": "Voice and Articulation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "4000",
+              "title": "Phonetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPE",
+              "number": "4100",
+              "title": "Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Surgical Technology",
+      "credential": "AAS",
+      "program_code": "STECH-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/STECH-AAS",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1100",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "7600",
+              "title": "Ethics and Morality in the Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "3100",
+              "title": "Introduction to Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "1200",
+              "title": "Human Anatomy & Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "1100",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 36,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "5100",
+              "title": "Microbiology in Health and Disease",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "7600",
+              "title": "Ethics and Morality in the Health Professions",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "100",
+              "title": "Surgical Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "200",
+              "title": "Surgical Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "300",
+              "title": "Surgical Technology III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "3P00",
+              "title": "Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "400",
+              "title": "Surgical Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "4P00",
+              "title": "Practicum II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "500",
+              "title": "Advanced Surgical Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "5P00",
+              "title": "Practicum III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "600",
+              "title": "Professional Strategies for the Surgical Technologist",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "6P00",
+              "title": "Practicum IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ST",
+              "number": "4500",
+              "title": "Surgical Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Tourism and Hospitality",
+      "credential": "AAS",
+      "program_code": "TAH-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/TAH-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 39,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TAH",
+              "number": "100",
+              "title": "Introduction to Tourism and Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "400",
+              "title": "Tourism and Hospitality Customer Service",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "500",
+              "title": "Human Resources and Labor Relations in Tourism and Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "1200",
+              "title": "Tourism Entrepreneurship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "2500",
+              "title": "Tourism and Hospitality Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "3000",
+              "title": "Financial Decision Making",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "9096",
+              "title": "The Virtual Enterprise",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "9250",
+              "title": "Field Experience in Tourism and Hospitality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "6000",
+              "title": "Introduction to Computer Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentrations",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CA",
+              "number": "990",
+              "title": "Culinary Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "7100",
+              "title": "Introduction to Food Service Operations and Sanitation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "5000",
+              "title": "Menu Planning and Cost Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CA",
+              "number": "6000",
+              "title": "Beverage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "2200",
+              "title": "Front Office Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "4100",
+              "title": "Meeting and Convention Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "5200",
+              "title": "Hotel Property Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "5500",
+              "title": "Housekeeping Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "200",
+              "title": "Destination Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "1500",
+              "title": "Cruises and Specialty Markets",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "1700",
+              "title": "Tourism Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TAH",
+              "number": "6500",
+              "title": "Airport and Aviation Security and Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre Arts",
+      "credential": "AS",
+      "program_code": "THA-AS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/THA-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements – Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Overall",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THA",
+              "number": "5000",
+              "title": "Introduction to Theatre Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5100",
+              "title": "Script Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5200",
+              "title": "Acting I: Fundamentals of Acting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6800",
+              "title": "History of Theatre: From Sophocles to Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5500",
+              "title": "Introduction to Theatre Design & Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THA",
+              "number": "4000",
+              "title": "Performance Practicum Series",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4100",
+              "title": "Production Practicum Series",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4200",
+              "title": "Advanced Theatrical Practicum",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4300",
+              "title": "Playwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4400",
+              "title": "Voice and Diction for the Actor",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4600",
+              "title": "Musical Theatre Vocal Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4700",
+              "title": "Stage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5050",
+              "title": "Theater Arts-Integrative Seminar",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5300",
+              "title": "Acting II: Scene Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5600",
+              "title": "Fundamentals of Theatrical Lighting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5800",
+              "title": "Musical Theatre Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6000",
+              "title": "Introduction to Costume and Make-Up",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6300",
+              "title": "Basic Sound Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6500",
+              "title": "Scenic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6700",
+              "title": "History of Musical Theatre in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "2000",
+              "title": "Beginner's Ballet",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "3800",
+              "title": "Modern Dance Techniques",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PEC",
+              "number": "3900",
+              "title": "Modern Dance Composition",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THA",
+              "number": "4400",
+              "title": "Voice and Diction for the Actor",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4600",
+              "title": "Musical Theatre Vocal Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5300",
+              "title": "Acting II: Scene Study",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5800",
+              "title": "Musical Theatre Performance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4100",
+              "title": "Production Practicum Series",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4000",
+              "title": "Performance Practicum Series",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "4700",
+              "title": "Stage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "5600",
+              "title": "Fundamentals of Theatrical Lighting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6000",
+              "title": "Introduction to Costume and Make-Up",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6300",
+              "title": "Basic Sound Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THA",
+              "number": "6500",
+              "title": "Scenic Design",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Website Development",
+      "credential": "AAS",
+      "program_code": "WEBDEV-AAS",
+      "catalog_url": "https://kbcc.catalog.cuny.edu/programs/WEBDEV-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "1200",
+              "title": "Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "2400",
+              "title": "Composition II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Overall",
+          "credits_required": 38,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ADM",
+              "number": "2500",
+              "title": "Ebusiness Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "1200",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BA",
+              "number": "3300",
+              "title": "Business Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ADM",
+              "number": "3700",
+              "title": "Office Communication Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "2200",
+              "title": "HTML Authoring and JavaScript",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "1400",
+              "title": "Critical Issues in Per Health",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "2500",
+              "title": "Office Computer Applications I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5100",
+              "title": "Adobe Flash for Website Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5300",
+              "title": "Website Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5400",
+              "title": "Website Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5500",
+              "title": "Website Technology III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5700",
+              "title": "The Computer as a Design Tool",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5800",
+              "title": "Basic Desktop Publishing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TEC",
+              "number": "5900",
+              "title": "Photodigital Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ny/programs/laguardia-cc.json
+++ b/data/ny/programs/laguardia-cc.json
@@ -1,0 +1,13560 @@
+{
+  "college_slug": "laguardia-cc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://laguardia.catalog.cuny.edu/programs",
+  "scraped_at": "2026-05-07T15:27:39.743Z",
+  "programs": [
+    {
+      "title": "Accounting",
+      "credential": "AS",
+      "program_code": "ACCT-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/ACCT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTF",
+              "number": "101",
+              "title": "First Year Seminar for Business",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "201",
+              "title": "Intermediate Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "202",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTC",
+              "number": "200",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "106",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "110",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTI",
+              "number": "201",
+              "title": "Business Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "105",
+              "title": "Financial Planning and Individual Investing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Unrestricted Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Biology",
+      "credential": "AS",
+      "program_code": "BIO-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/BIO-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core 13 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core: 27 credits",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSF",
+              "number": "101",
+              "title": "First Year Seminar for Natural Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "252",
+              "title": "Fundamentals of Biotechniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "255",
+              "title": "Cell Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "207",
+              "title": "Genomics and Bioinformatics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "257",
+              "title": "Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "204",
+              "title": "Research in Natural Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": "BUSAD-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/BUSAD-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTF",
+              "number": "101",
+              "title": "First Year Seminar for Business",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "112",
+              "title": "Principles of Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTC",
+              "number": "200",
+              "title": "Introduction to Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "103",
+              "title": "Principles of Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "106",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "110",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTI",
+              "number": "201",
+              "title": "Business Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "105",
+              "title": "Financial Planning and Individual Investing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "113",
+              "title": "Introduction to Facilities Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "206",
+              "title": "Building Systems: Anatomy of a Building",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "208",
+              "title": "Project Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTO",
+              "number": "125",
+              "title": "Medical Terminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTO",
+              "number": "170",
+              "title": "Electronic Health Records",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTO",
+              "number": "270",
+              "title": "Health Insurance: Billing and Reimbursement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTO",
+              "number": "280",
+              "title": "U.S. Healthcare Administration and Delivery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Unrestricted Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Photography",
+      "credential": "AAS",
+      "program_code": "CMPHT-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/CMPHT-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements -  Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAF",
+              "number": "90",
+              "title": "First Year Seminar Theater, Photo",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "130",
+              "title": "Beginning Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "131",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "145",
+              "title": "Studio Lighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "202",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "230",
+              "title": "Intermediate Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "231",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "234",
+              "title": "Color Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "245",
+              "title": "Studio Lighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "275",
+              "title": "Commercial Photography Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "280",
+              "title": "Commercial Photography Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "191",
+              "title": "Photojournalism: An Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "155",
+              "title": "The View Camera, Large Format Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "238",
+              "title": "Alternative Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "291",
+              "title": "Experiential Learning in Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "240",
+              "title": "Video Production Workshop I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Fine Art Photography Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAF",
+              "number": "90",
+              "title": "First Year Seminar Theater, Photo",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "103",
+              "title": "Beginning Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "125",
+              "title": "Introduction to Computer Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "130",
+              "title": "Beginning Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "155",
+              "title": "The View Camera, Large Format Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "202",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "230",
+              "title": "Intermediate Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "234",
+              "title": "Color Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "238",
+              "title": "Alternative Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "240",
+              "title": "Video Production Workshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "104",
+              "title": "Introduction to Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "115",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "126",
+              "title": "Computer Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "191",
+              "title": "Photojournalism: An Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "192",
+              "title": "Art and Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Commercial Photography Certificate",
+      "credential": "certificate",
+      "program_code": "CMPHT-CERT",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/CMPHT-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Certificate Requirements",
+          "credits_required": 24,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUA",
+              "number": "130",
+              "title": "Beginning Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "131",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "145",
+              "title": "Studio Lighting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "230",
+              "title": "Intermediate Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "231",
+              "title": "Digital Photography II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "234",
+              "title": "Color Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "245",
+              "title": "Studio Lighting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "155",
+              "title": "The View Camera, Large Format Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "238",
+              "title": "Alternative Photography",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "CMPSC-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/CMPSC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 30,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSF",
+              "number": "101",
+              "title": "First Year Seminar for Computer Science",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "101",
+              "title": "Introduction to Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "125",
+              "title": "Advanced C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "190",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "281",
+              "title": "Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "283",
+              "title": "Computer Organization and Assembly Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "286",
+              "title": "Data Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Technology",
+      "credential": "AAS",
+      "program_code": "CMPTH-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/CMPTH-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSF",
+              "number": "101",
+              "title": "First Year Seminar for Computer Science",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "241",
+              "title": "Computer Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "242",
+              "title": "Computer Electronics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "265",
+              "title": "Hardware and Software Interfacing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "289",
+              "title": "Computer Technology Project Lab",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "291",
+              "title": "Computer Logic, Design and Implementation I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "292",
+              "title": "Computer Logic, Design and Implementation II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "293",
+              "title": "Computer Repair and Network Maintenance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "295",
+              "title": "Computer Architecture",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Unrestricted Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Communication Studies",
+      "credential": "AA",
+      "program_code": "COMSTD-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/COMSTD-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CMF",
+              "number": "90",
+              "title": "First Year Seminar for Communication Studies",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "101",
+              "title": "Introduction to Communication Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "106",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "111",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "205",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration Areas",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUC",
+              "number": "230",
+              "title": "Communication Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "112",
+              "title": "Small Group Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "117",
+              "title": "Communication and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "118",
+              "title": "Gender and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "120",
+              "title": "Introduction to Media Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "136",
+              "title": "Persuasion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "141",
+              "title": "Public Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "142",
+              "title": "Public Relations Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "192",
+              "title": "Health Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "204",
+              "title": "Race and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "212",
+              "title": "Organizational Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "220",
+              "title": "Experiential Learning in Communication Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "101",
+              "title": "Introduction to Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "120",
+              "title": "Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "114",
+              "title": "Normal Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "114",
+              "title": "Normal Language Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "115",
+              "title": "Phonetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "116",
+              "title": "Survey of Speech, Language & Hearing Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "104",
+              "title": "Voice and Diction",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AS",
+      "program_code": "CRMJS-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/CRMJS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CJF",
+              "number": "101",
+              "title": "First Year Seminar for Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSJ",
+              "number": "101",
+              "title": "Introduction to Criminal Justice",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSJ",
+              "number": "201",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSJ",
+              "number": "202",
+              "title": "Corrections and Sentencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSJ",
+              "number": "203",
+              "title": "Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "204",
+              "title": "Crime and Justice in Urban Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "101",
+              "title": "Themes in American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "110",
+              "title": "East Asian Civilization and Societies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "231",
+              "title": "African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "AAS",
+      "program_code": "CYBER-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/CYBER-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTM",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "290",
+              "title": "Internship for Computer Majors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSF",
+              "number": "101",
+              "title": "First Year Seminar for Computer Science",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "108",
+              "title": "Introduction to Programming with Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "232",
+              "title": "Unix Network Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "233",
+              "title": "Windows NT Network Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "245",
+              "title": "Data Communication and Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "246",
+              "title": "Advanced Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "254",
+              "title": "Advanced Windows & UNIX System Administration",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "250",
+              "title": "Database Concepts and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "227",
+              "title": "Introduction to Cryptography and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "237",
+              "title": "Computer Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "247",
+              "title": "Advanced Systems Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "257",
+              "title": "Digital Forensics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "certificate",
+      "program_code": "CYBER-CERT",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/CYBER-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Curriculum Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "232",
+              "title": "Unix Network Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "233",
+              "title": "Windows NT Network Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "245",
+              "title": "Data Communication and Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "246",
+              "title": "Advanced Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "227",
+              "title": "Introduction to Cryptography and Applications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "237",
+              "title": "Computer Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "247",
+              "title": "Advanced Systems Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Digital Media Arts Certificate",
+      "credential": "certificate",
+      "program_code": "DGMD-CERT",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/DGMD-CERT",
+      "total_credits": 33,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Certificate",
+          "credits_required": 33,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUW",
+              "number": "112",
+              "title": "Introduction to New Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "161",
+              "title": "Principles of Multimedia and Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "162",
+              "title": "3D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "163",
+              "title": "Visual Effects in Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "125",
+              "title": "Introduction to Computer Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "240",
+              "title": "Video Production Workshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "241",
+              "title": "Video Production Workshop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "270",
+              "title": "American Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTC",
+              "number": "100",
+              "title": "Computers Applications and Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUW",
+              "number": "166",
+              "title": "Introduction to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "146",
+              "title": "Music Audio Recording I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education Associate: Bilingual Child",
+      "credential": "AA",
+      "program_code": "EDASC-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/EDASC-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDF",
+              "number": "101",
+              "title": "First Year Seminar for Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Arts in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "203",
+              "title": "Language and Literacy in Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "123",
+              "title": "Foundations of Bilingual Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "101",
+              "title": "Introduction to Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "220",
+              "title": "Introduction to Sociolinguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "204",
+              "title": "Latin American Civilizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "210",
+              "title": "Advanced Spanish Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "105",
+              "title": "Learning & Education: Childhood to Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Education",
+      "credential": "AA",
+      "program_code": "EDUC-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/EDUC-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Early Childhood Education Program Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDF",
+              "number": "101",
+              "title": "First Year Seminar for Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Arts in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "200",
+              "title": "Foundations of Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "205",
+              "title": "Language and Literacy in Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "121",
+              "title": "Foundations of Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "206",
+              "title": "Family, School & Community in Early Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "105",
+              "title": "Learning & Education: Childhood to Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "240",
+              "title": "Developmental Psychology I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements- Childhood Education Program Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDF",
+              "number": "101",
+              "title": "First Year Seminar for Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Arts in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "150",
+              "title": "Introduction to Education Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "200",
+              "title": "Foundations of Special Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "203",
+              "title": "Language and Literacy in Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "101",
+              "title": "Introduction to Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "120",
+              "title": "Foundations of American Education: Grades 1-6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "105",
+              "title": "Learning & Education: Childhood to Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "104",
+              "title": "Mathematics in Elementary Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Secondary Education Program Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDF",
+              "number": "101",
+              "title": "First Year Seminar for Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "204",
+              "title": "Language and Literacy in Secondary Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "122",
+              "title": "Foundations of American Education: Grades 7-12",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "101",
+              "title": "Introduction to Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "105",
+              "title": "Learning & Education: Childhood to Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "290",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "291",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "292",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "293",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Afro-American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "247",
+              "title": "The Woman Writer: Her Vision & Her Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "248",
+              "title": "Latino/Latina Writing of the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "270",
+              "title": "Introduction to Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "280",
+              "title": "Children's Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "230",
+              "title": "Introduction to Discrete Mathematical Structures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "101",
+              "title": "Themes in American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "106",
+              "title": "Anthropology of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "280",
+              "title": "Sociology of the Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "204",
+              "title": "Latin American Civilizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "210",
+              "title": "Advanced Spanish Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "200",
+              "title": "Latin American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "201",
+              "title": "Latin American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Science: Civil Engineering",
+      "credential": "AS",
+      "program_code": "ENGN-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/ENGN-AS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "259",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "231",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "232",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Linear Algebra and Vector Analysis for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "101",
+              "title": "Engineering Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "108",
+              "title": "Introduction to Programming with Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "209",
+              "title": "Structural and Site Plans",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "202",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Electrical Engineering",
+      "credential": "AS",
+      "program_code": "ENGNELE-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/ENGNELE-AS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "259",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "231",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "232",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Introduction to Probability",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Linear Algebra and Vector Analysis for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "101",
+              "title": "Engineering Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "108",
+              "title": "Introduction to Programming with Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "213",
+              "title": "Electrical Circuits I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "219",
+              "title": "Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mechanical Engineering",
+      "credential": "AS",
+      "program_code": "ENGNMCH-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/ENGNMCH-AS",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "259",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "231",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "232",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAE",
+              "number": "101",
+              "title": "Engineering Lab I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "108",
+              "title": "Introduction to Programming with Python",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Linear Algebra and Vector Analysis for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "211",
+              "title": "Engineering Mechanics: Statics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "213",
+              "title": "Electrical Circuits I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "219",
+              "title": "Thermodynamics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "202",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "106",
+              "title": "Earth System Science & Engineering",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "217",
+              "title": "Systems Analysis of the Earth",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Energy Technician",
+      "credential": "AAS",
+      "program_code": "ENRGTC-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/ENRGTC-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "259",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "100",
+              "title": "Computer-Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "107",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "109",
+              "title": "Introduction to Engineering",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "110",
+              "title": "Circuit Analysis I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "111",
+              "title": "Circuit Analysis II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "121",
+              "title": "Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "190",
+              "title": "Material Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "191",
+              "title": "Statics and Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "201",
+              "title": "Heating/Ventilating /Air Conditioning System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "207",
+              "title": "Introduction to Thermodynamics for Technicians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "208",
+              "title": "Electromechanical Devices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "230",
+              "title": "Senior Design Project",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "241",
+              "title": "Computer Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "242",
+              "title": "Computer Electronics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "291",
+              "title": "Computer Logic, Design and Implementation I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "292",
+              "title": "Computer Logic, Design and Implementation II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "102",
+              "title": "Electrical Drafting and Blue Print Reading",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAE",
+              "number": "122",
+              "title": "Electrical Measurements and Instrumentation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Environmental Science",
+      "credential": "AS",
+      "program_code": "ENVSC-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/ENVSC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCB",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "110",
+              "title": "Foundations of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSF",
+              "number": "101",
+              "title": "First Year Seminar for Natural Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "265",
+              "title": "Ecology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCG",
+              "number": "250",
+              "title": "Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "260",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "202",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCG",
+              "number": "150",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "200",
+              "title": "Principles of Botany",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCG",
+              "number": "220",
+              "title": "Soil Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCG",
+              "number": "230",
+              "title": "Introduction to Sustainable Vegetable Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "257",
+              "title": "Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCG",
+              "number": "252",
+              "title": "Animal Behavior and Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "212",
+              "title": "Integrative Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Film and Television",
+      "credential": "AA",
+      "program_code": "FILMTV-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/FILMTV-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "238",
+              "title": "Screenwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "240",
+              "title": "Video Production Workshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "270",
+              "title": "American Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "151",
+              "title": "Television Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "241",
+              "title": "Video Production Workshop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "242",
+              "title": "Postproduction: Effects, Color, Audio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "243",
+              "title": "Television Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "244",
+              "title": "Experiential Learning in Film & TV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "196",
+              "title": "Film and New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "103",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "104",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "250",
+              "title": "Political Ideas and Ideologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "101",
+              "title": "Themes in American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "110",
+              "title": "East Asian Civilization and Societies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "231",
+              "title": "African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "220",
+              "title": "Politics of Latin America and the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fine Arts",
+      "credential": "AS",
+      "program_code": "FINART-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/FINART-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FAF",
+              "number": "101",
+              "title": "First Year Seminar for Fine Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "103",
+              "title": "Beginning Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "104",
+              "title": "Introduction to Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "165",
+              "title": "Art History: Prehistoric through Gothic",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "166",
+              "title": "Art History: Renaissance through Modern",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "180",
+              "title": "Life Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "289",
+              "title": "Art and Design Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "106",
+              "title": "Three Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "110",
+              "title": "Beginning Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "115",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "120",
+              "title": "Beginning Sculpture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "130",
+              "title": "Beginning Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "150",
+              "title": "Beginning Printmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "185",
+              "title": "Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "203",
+              "title": "Intermediate Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "210",
+              "title": "Intermediate Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "220",
+              "title": "Intermediate Sculpture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "285",
+              "title": "Graphic Narrative",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "196",
+              "title": "Latin American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "200",
+              "title": "Art of the Twentieth Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "195",
+              "title": "Art in New York: A Museum/Gallery Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "202",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "215",
+              "title": "Art of the Renaissance in Italy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "216",
+              "title": "Afr,Oceania,&Pre Col",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "107",
+              "title": "Philosophy of Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "294",
+              "title": "Experiential Learning in the Fine Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "212",
+              "title": "History of Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "107",
+              "title": "Form and Structure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "125",
+              "title": "Introduction to Computer Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "126",
+              "title": "Computer Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "207",
+              "title": "Modelmaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "230",
+              "title": "Intermediate Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "167",
+              "title": "Introduction to African Art",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services: Mental Health",
+      "credential": "AA",
+      "program_code": "HSMNTH-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/HSMNTH-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "101",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "102",
+              "title": "Social Policy & Welfare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "214",
+              "title": "Social Gerontology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "216",
+              "title": "Introduction to Motivational Interviewing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "290",
+              "title": "Human Services Internship Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "295",
+              "title": "Community Organizing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "208",
+              "title": "Human Services and Disabilities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "218",
+              "title": "Group Interviewing and Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "200",
+              "title": "Introductory Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "150",
+              "title": "Drugs, Society and Human Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "210",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "194",
+              "title": "HIV/AIDS, Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "240",
+              "title": "Food and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "160",
+              "title": "Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "196",
+              "title": "Community Health Research",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Hospitality, Tourism, & Events Management",
+      "credential": "AS",
+      "program_code": "HTEMGT-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/HTEMGT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associates in Sciences",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements- Flexible Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTF",
+              "number": "101",
+              "title": "First Year Seminar for Business",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "101",
+              "title": "Introduction to Hospitality Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "202",
+              "title": "Global Tourism Destinations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "203",
+              "title": "Hospitality Technology Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "212",
+              "title": "Customer Service and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "225",
+              "title": "Hospitality Human Resources Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "233",
+              "title": "Hospitality Industry Project",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "234",
+              "title": "Hospitality Internship",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "205",
+              "title": "Hospitality Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "223",
+              "title": "Meeting and Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "231",
+              "title": "Hotel and Lodging Operations and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTN",
+              "number": "211",
+              "title": "Hospitality and Destination Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTR",
+              "number": "100",
+              "title": "Introduction to Recreation and Leisure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "114",
+              "title": "Culinary Arts I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "250",
+              "title": "Menu Planning and Production",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Industrial Design Technology",
+      "credential": "AAS",
+      "program_code": "IDSTH-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/IDSTH-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "259",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "IDF",
+              "number": "90",
+              "title": "First Year Seminar Industrial Design Technology",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "107",
+              "title": "3D Form and Space",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "111",
+              "title": "Industrial Design Studio I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "114",
+              "title": "Introduction to Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "129",
+              "title": "Computer Aided Industrial Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "190",
+              "title": "Industrial Design Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "211",
+              "title": "Industrial Design Studio II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "214",
+              "title": "Manufacturing Processes and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "229",
+              "title": "Computer Aided Industrial Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "295",
+              "title": "Industrial Design Capstone",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "109",
+              "title": "Solidworks",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "113",
+              "title": "History of Industrial Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "209",
+              "title": "Digital Prototyping",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "259",
+              "title": "Computer Aided Industrial Design III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "260",
+              "title": "Human Factors",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUI",
+              "number": "290",
+              "title": "Industrial Design Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts: Social Science and Humanities",
+      "credential": "AA",
+      "program_code": "LIBART-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/LIBART-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements  - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - General Social Science and Humanities Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "101",
+              "title": "Introduction to Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "150",
+              "title": "Introduction to Integrative Research Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Deaf Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "101",
+              "title": "Introduction to Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELM",
+              "number": "101",
+              "title": "American Sign Language 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELM",
+              "number": "102",
+              "title": "American Sign Language 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELM",
+              "number": "103",
+              "title": "American Sign Language 3",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELM",
+              "number": "104",
+              "title": "American Sign Language 4",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELM",
+              "number": "210",
+              "title": "Sign Language Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "190",
+              "title": "Sociology of the American Deaf Communities",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Ethnic Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "105",
+              "title": "Introduction to Ethnic Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Afro-American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "235",
+              "title": "Cultural Identity in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "248",
+              "title": "Latino/Latina Writing of the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "268",
+              "title": "The Immigrant Experience in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "269",
+              "title": "Contemporary Black American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "295",
+              "title": "World Literatures Written in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "101",
+              "title": "Introduction to Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "105",
+              "title": "Languages of the World and of New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "194",
+              "title": "The Latine Community: A Minority Group Experience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIS",
+              "number": "215",
+              "title": "Language Issues in a Global World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "204",
+              "title": "Race and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "110",
+              "title": "Introduction to Jazz",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "110",
+              "title": "Hip Hop:Music, Culture and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "190",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "196",
+              "title": "Film and New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "212",
+              "title": "Photography in New York",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "220",
+              "title": "Contemporary Latina/o Theatre in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "231",
+              "title": "African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "183",
+              "title": "History of Minorities",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "186",
+              "title": "Sociology of the Black Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "240",
+              "title": "History of New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "280",
+              "title": "Urban Black Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "240",
+              "title": "The Politics of Crime and Punishment in the U.S.",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "233",
+              "title": "Sociology of Race and Racism in the US",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Health Humanities Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIN",
+              "number": "190",
+              "title": "Pandemics in Global Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "160",
+              "title": "Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "196",
+              "title": "Community Health Research",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "215",
+              "title": "Social and Behavioral Determinants of Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "216",
+              "title": "Introduction to Motivational Interviewing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "Literature, Health, and Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "114",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "192",
+              "title": "Health Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - History Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "101",
+              "title": "Introduction to Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "103",
+              "title": "Beginning Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "110",
+              "title": "Beginning Painting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "120",
+              "title": "Beginning Sculpture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "130",
+              "title": "Beginning Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "101",
+              "title": "Introduction to Communication Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "106",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "155",
+              "title": "Voice Class I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "170",
+              "title": "Guitar I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "American Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "195",
+              "title": "Art in New York: A Museum/Gallery Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "104",
+              "title": "Ethics and Moral Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "105",
+              "title": "Philosophy of Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "106",
+              "title": "Social and Political Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "101",
+              "title": "Art of Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "110",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "270",
+              "title": "American Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "101",
+              "title": "Themes in American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "110",
+              "title": "East Asian Civilization and Societies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "113",
+              "title": "Modern Chinese History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "114",
+              "title": "Modern Japanese History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "121",
+              "title": "Ancient Greek Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "122",
+              "title": "History of the Roman State and People",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "131",
+              "title": "Latin American History 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "132",
+              "title": "Latin American History 2",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "151",
+              "title": "Women and Gender in U.S. History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "153",
+              "title": "History of the United States and World Affairs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "171",
+              "title": "The World Since 1900",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "231",
+              "title": "African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "103",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "104",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "250",
+              "title": "Political Ideas and Ideologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - International Studies Option",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIS",
+              "number": "216",
+              "title": "International Schooling in Global Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELA",
+              "number": "250",
+              "title": "Modern Arabic Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELA",
+              "number": "260",
+              "title": "Arab Cinema: Cultural Insights through Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Arts in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELF",
+              "number": "250",
+              "title": "Modern French Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELJ",
+              "number": "250",
+              "title": "Japanese Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "101",
+              "title": "Introduction to Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "220",
+              "title": "Introduction to Sociolinguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "101",
+              "title": "Introduction to Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "250",
+              "title": "Latin American Fiction in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "295",
+              "title": "World Literatures Written in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "167",
+              "title": "Introduction to African Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "107",
+              "title": "Music of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "109",
+              "title": "World Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "121",
+              "title": "Eastern Philosophy and Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EIS",
+              "number": "215",
+              "title": "Language Issues in a Global World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "120",
+              "title": "Peoples and Cultures of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "104",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "105",
+              "title": "International Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "110",
+              "title": "East Asian Civilization and Societies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "113",
+              "title": "Modern Chinese History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "114",
+              "title": "Modern Japanese History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "153",
+              "title": "History of the United States and World Affairs",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "107",
+              "title": "Environmental Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "210",
+              "title": "Women in Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "200",
+              "title": "Global Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "245",
+              "title": "Law and Human Rights in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "250",
+              "title": "Political Ideas and Ideologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Japanese Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELJ",
+              "number": "103",
+              "title": "Intermediate Japanese I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELJ",
+              "number": "104",
+              "title": "Intermediate Japanese II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELJ",
+              "number": "250",
+              "title": "Japanese Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "101",
+              "title": "Elementary Modern Chinese I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "102",
+              "title": "Elementary Modern Chinese II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "103",
+              "title": "Intermediate Chinese",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "105",
+              "title": "Chinese for Heritage Students",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "201",
+              "title": "Modern Chinese Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "202",
+              "title": "Contemporary Chinese Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELC",
+              "number": "203",
+              "title": "Classic Chinese Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELK",
+              "number": "101",
+              "title": "Elementary Korean I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELK",
+              "number": "102",
+              "title": "Elementary Korean II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELK",
+              "number": "103",
+              "title": "Intermediate Korean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELK",
+              "number": "201",
+              "title": "Modern Korean Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "101",
+              "title": "Introduction to Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "191",
+              "title": "The Art of Eastern Asia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "106",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "195",
+              "title": "Art in New York: A Museum/Gallery Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "104",
+              "title": "Ethics and Moral Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "105",
+              "title": "International Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "125",
+              "title": "World Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "200",
+              "title": "Global Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "110",
+              "title": "East Asian Civilization and Societies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "231",
+              "title": "African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "220",
+              "title": "Politics of Latin America and the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Journalism Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "219",
+              "title": "Introduction to Digital Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "209",
+              "title": "Advanced Digital Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Journalism: Its Scope and Use",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "211",
+              "title": "Craft of Reporting News",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "212",
+              "title": "Feature Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "213",
+              "title": "Broadcast Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "274",
+              "title": "Creative Nonfiction Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "288",
+              "title": "English Major Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "101",
+              "title": "Introduction to Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "106",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "195",
+              "title": "Art in New York: A Museum/Gallery Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "104",
+              "title": "Ethics and Moral Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "105",
+              "title": "International Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "125",
+              "title": "World Geography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "200",
+              "title": "Global Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "110",
+              "title": "East Asian Civilization and Societies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "231",
+              "title": "African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "220",
+              "title": "Politics of Latin America and the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Latin American Studies Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELF",
+              "number": "201",
+              "title": "French Literature from a Global Perspective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELF",
+              "number": "250",
+              "title": "Modern French Literature in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "200",
+              "title": "Latin American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "201",
+              "title": "Latin American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "204",
+              "title": "Latin American Civilizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "205",
+              "title": "Latin American Civilizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "250",
+              "title": "Latin American Fiction in Translation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "196",
+              "title": "Latin American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "107",
+              "title": "Music of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "116",
+              "title": "Latin American Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "220",
+              "title": "Contemporary Latina/o Theatre in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "106",
+              "title": "Anthropology of Latin America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "120",
+              "title": "Peoples and Cultures of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "200",
+              "title": "Global Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "220",
+              "title": "Politics of Latin America and the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Political Science Option",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "200",
+              "title": "Global Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "245",
+              "title": "Law and Human Rights in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "250",
+              "title": "Political Ideas and Ideologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "192",
+              "title": "Practical Politics of New York City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "210",
+              "title": "The Politics of Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "101",
+              "title": "Themes in American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "103",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "104",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "220",
+              "title": "Politics of Latin America and the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - TESOL (Teaching English to Speakers of Other Languages) /Linguistics Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "101",
+              "title": "Introduction to Language",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "120",
+              "title": "Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "220",
+              "title": "Introduction to Sociolinguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "101",
+              "title": "Introduction to Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "115",
+              "title": "Phonetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "122",
+              "title": "Foundations of American Education: Grades 7-12",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "105",
+              "title": "Learning & Education: Childhood to Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "210",
+              "title": "English Morphology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Women, Gender, and Sexuality Studies Option",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "101",
+              "title": "Introduction to Women, Gender and Sexuality Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "201",
+              "title": "Transnational Feminisms",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "103",
+              "title": "The Research Paper",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "Images of Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "247",
+              "title": "The Woman Writer: Her Vision & Her Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "LGBTQ Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "Sexuality in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "122",
+              "title": "Philosophy of Gender and Sex",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "118",
+              "title": "Gender and Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "151",
+              "title": "Women and Gender in U.S. History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "210",
+              "title": "The Politics of Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSI",
+              "number": "210",
+              "title": "Women in Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "205",
+              "title": "Psychology of Gender",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts: Childhood Education",
+      "credential": "AA",
+      "program_code": "LIBCHED-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/LIBCHED-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "101",
+              "title": "Composition I: An Introduction to Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDF",
+              "number": "101",
+              "title": "First Year Seminar for Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "110",
+              "title": "Arts in Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELE",
+              "number": "203",
+              "title": "Language and Literacy in Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "120",
+              "title": "Foundations of American Education: Grades 1-6",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "116",
+              "title": "Survey of Speech, Language & Hearing Disorders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "101",
+              "title": "Themes in American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "105",
+              "title": "Learning & Education: Childhood to Adolescence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "104",
+              "title": "Mathematics in Elementary Education",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts:Mathematics and Science",
+      "credential": "AS",
+      "program_code": "LIBMS-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/LIBMS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "259",
+              "title": "Technical Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "201",
+              "title": "Fundamentals of Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "231",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LMF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts: Math & Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "150",
+              "title": "Introduction to Integrative Research Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "103",
+              "title": "Beginning Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "106",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "150",
+              "title": "The Art of Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "210",
+              "title": "American Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "104",
+              "title": "Ethics and Moral Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "103",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "100",
+              "title": "Introduction to Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "104",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "200",
+              "title": "Global Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Math/Science Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "121",
+              "title": "Elementary Statistics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "212",
+              "title": "Linear Algebra and Vector Analysis for Engineers",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "221",
+              "title": "Introduction to Probability",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "115",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "204",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "208",
+              "title": "Vertebrate Anatomy and Physiology 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "209",
+              "title": "Vertebrate Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "252",
+              "title": "Fundamentals of Biotechniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "255",
+              "title": "Cell Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "260",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "265",
+              "title": "Ecology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "202",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCG",
+              "number": "120",
+              "title": "Introduction to Oceanography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCG",
+              "number": "150",
+              "title": "Introduction to Geographic Information Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "201",
+              "title": "Fundamentals of Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "202",
+              "title": "Fundamentals of Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "231",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "232",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "233",
+              "title": "Introduction to Modern Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "204",
+              "title": "Research in Natural Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "204",
+              "title": "Experiential Learning in Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Unrestricted Electives",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Applied Math Option",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LMF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts: Math & Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIB",
+              "number": "200",
+              "title": "Humanism, Science and Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "210",
+              "title": "Linear Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "231",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "101",
+              "title": "Introduction to Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "190",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Music Recording Technology",
+      "credential": "AAS",
+      "program_code": "MSRT-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/MSRT-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "105",
+              "title": "Introduction to Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MRF",
+              "number": "101",
+              "title": "First Year Seminar for Music Recording Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "140",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "146",
+              "title": "Music Audio Recording I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "147",
+              "title": "Music Audio Recording II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "180",
+              "title": "Piano I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "102",
+              "title": "Basics of Digital Audio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "103",
+              "title": "Ear Training and Acoustics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "104",
+              "title": "The Business of Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "106",
+              "title": "Digital Music Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "107",
+              "title": "Analog Equipment and Microphones",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "108",
+              "title": "Mixing Music I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "110",
+              "title": "Recording Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "112",
+              "title": "Post Production Audio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUX",
+              "number": "114",
+              "title": "Audio Career Applications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Performance",
+      "credential": "AS",
+      "program_code": "MUSPERF-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/MUSPERF-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "101",
+              "title": "Introduction to Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "140",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "240",
+              "title": "Harmony and Counterpoint",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "144",
+              "title": "Musicianship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "244",
+              "title": "Musicianship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "180",
+              "title": "Piano I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "181",
+              "title": "Piano II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "182",
+              "title": "Piano III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "183",
+              "title": "Piano IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "160",
+              "title": "Applied Music I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "161",
+              "title": "Applied Music II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "261",
+              "title": "Applied Music III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "152",
+              "title": "Contemporary Vocal Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "174",
+              "title": "Ensemble I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "252",
+              "title": "Vocal Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "274",
+              "title": "Ensemble II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "253",
+              "title": "Contemporary Vocal Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "275",
+              "title": "Ensemble III",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nutrition and Culinary Management",
+      "credential": "AAS",
+      "program_code": "NCMGMT-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/NCMGMT-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements -  Associate of Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements  - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 27,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "107",
+              "title": "Careers in Nutrition and Culinary Management",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "114",
+              "title": "Culinary Arts I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "200",
+              "title": "Introductory Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "214",
+              "title": "Culinary Arts II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "240",
+              "title": "Food and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "250",
+              "title": "Menu Planning and Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "251",
+              "title": "Principles of Sanitation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "252",
+              "title": "Principles of Purchasing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "253",
+              "title": "Culinary Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "266",
+              "title": "Nutrition and Culinary Management Internship",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "203",
+              "title": "Life Cycle Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "204",
+              "title": "Nutrition and Disease",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "206",
+              "title": "Nutrition Counseling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "160",
+              "title": "Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTA",
+              "number": "111",
+              "title": "Principles of Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "212",
+              "title": "Customer Service and Sales",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTT",
+              "number": "223",
+              "title": "Meeting and Event Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "New Media Technology",
+      "credential": "AAS",
+      "program_code": "NMDTH-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/NMDTH-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "112",
+              "title": "Introduction to New Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "162",
+              "title": "3D Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "163",
+              "title": "Visual Effects in Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "166",
+              "title": "Introduction to Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "269",
+              "title": "New Media Project Lab",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "189",
+              "title": "Urban Studies with New Media Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "260",
+              "title": "Experiential Learning in New Media Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "170",
+              "title": "E-Commerce Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Track",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HUW",
+              "number": "125",
+              "title": "Introduction to Computer Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "126",
+              "title": "Computer Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "103",
+              "title": "Beginning Drawing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUA",
+              "number": "131",
+              "title": "Digital Photography I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "240",
+              "title": "Video Production Workshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "241",
+              "title": "Video Production Workshop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "146",
+              "title": "Music Audio Recording I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "160",
+              "title": "Topics in New Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "161",
+              "title": "Principles of Multimedia and Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "164",
+              "title": "Virtual Reality and Interactive Media",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "167",
+              "title": "AI-Generated Art and Creative Code",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUW",
+              "number": "169",
+              "title": "Internet Game Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "101",
+              "title": "Introduction to Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "104",
+              "title": "Principles of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "110",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "116",
+              "title": "Introduction to E-Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "251",
+              "title": "New Venture Creation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "209",
+              "title": "Advanced Digital Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "210",
+              "title": "Journalism: Its Scope and Use",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "211",
+              "title": "Craft of Reporting News",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "212",
+              "title": "Feature Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "213",
+              "title": "Broadcast Journalism",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "238",
+              "title": "Screenwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277",
+              "title": "Advanced Creative Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NRS-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/NRS-AAS",
+      "total_credits": 66,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 66,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCC",
+              "number": "110",
+              "title": "Foundations of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "240",
+              "title": "Developmental Psychology I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "204",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "260",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCL",
+              "number": "103",
+              "title": "Concepts in Pharmacology and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCR",
+              "number": "110",
+              "title": "Fundamentals of Nursing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCR",
+              "number": "200",
+              "title": "Psychiatric Mental Health Nursing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCR",
+              "number": "210",
+              "title": "Medical Surgical Nursing I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCR",
+              "number": "270",
+              "title": "Parent Child Health Nursing",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCR",
+              "number": "280",
+              "title": "Leadership and Delegation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCR",
+              "number": "290",
+              "title": "Medical Surgical Nursing II",
+              "credits": 9,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Occupational Therapy Assistant",
+      "credential": "AAS",
+      "program_code": "OCTHR-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/OCTHR-AAS",
+      "total_credits": 63,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 63,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements -  Common Core (Required & Flexible)",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "204",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "240",
+              "title": "Developmental Psychology I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Program Core",
+          "credits_required": 35,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "101",
+              "title": "Introduction to Occupational Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "110",
+              "title": "Legal Ethical Ot",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "114",
+              "title": "Documentation for Occupational Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "175",
+              "title": "Clinical Reasoning in Occupational Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "200",
+              "title": "Physical Aspects of Human Growth and Development",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "204",
+              "title": "OT Process Psychosocial and Geriatric Conditions",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "205",
+              "title": "OT Process Physical and Developmental Disabilities",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "214",
+              "title": "OT Skills and Functional Activities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "215",
+              "title": "OT Skills and Functional Activities II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "230",
+              "title": "Functional Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "284",
+              "title": "OTA Level I Fieldwork A",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "285",
+              "title": "OTA Level I Fieldwork B",
+              "credits": 1.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "294",
+              "title": "OTA Level II Fieldwork A",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "295",
+              "title": "OTA Level II Fieldwork B",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal Studies",
+      "credential": "AAS",
+      "program_code": "PARST-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PARST-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associates of Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core -12 credits",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core - 39 credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTF",
+              "number": "101",
+              "title": "First Year Seminar for Business",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTM",
+              "number": "110",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "101",
+              "title": "Introduction to Paralegal Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "203",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "204",
+              "title": "Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "205",
+              "title": "Civil Litigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "209",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "211",
+              "title": "Computer Applications for Paralegals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "212",
+              "title": "Immigration Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "201",
+              "title": "Administrative Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "202",
+              "title": "Wills, Trusts and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "207",
+              "title": "Real Estate Law for Paralegals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "208",
+              "title": "The Law of Business Enterprises for Paralegals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "213",
+              "title": "Bankruptcy Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "206",
+              "title": "Paralegal Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTI",
+              "number": "202",
+              "title": "Business Internship II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paralegal",
+      "credential": "certificate",
+      "program_code": "PARST-CERT",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PARST-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Certificate",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BTP",
+              "number": "101",
+              "title": "Introduction to Paralegal Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "204",
+              "title": "Legal Research and Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "205",
+              "title": "Civil Litigation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "211",
+              "title": "Computer Applications for Paralegals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "201",
+              "title": "Administrative Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "202",
+              "title": "Wills, Trusts and Estates",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "203",
+              "title": "Family Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "207",
+              "title": "Real Estate Law for Paralegals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "208",
+              "title": "The Law of Business Enterprises for Paralegals",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "209",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "212",
+              "title": "Immigration Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTP",
+              "number": "213",
+              "title": "Bankruptcy Law",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Public and Community Health",
+      "credential": "AS",
+      "program_code": "PCHLTH-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PCHLTH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program  Core",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "160",
+              "title": "Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "196",
+              "title": "Community Health Research",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "205",
+              "title": "History and Principles of Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "225",
+              "title": "Health Behavior Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "285",
+              "title": "Health and Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "235",
+              "title": "Epidemiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "215",
+              "title": "Social and Behavioral Determinants of Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BTO",
+              "number": "280",
+              "title": "U.S. Healthcare Administration and Delivery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSS",
+              "number": "216",
+              "title": "Introduction to Motivational Interviewing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "192",
+              "title": "Health Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "114",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LIN",
+              "number": "190",
+              "title": "Pandemics in Global Contexts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "200",
+              "title": "Introductory Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "203",
+              "title": "Life Cycle Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "150",
+              "title": "Drugs, Society and Human Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "210",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "240",
+              "title": "Food and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "194",
+              "title": "HIV/AIDS, Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "103",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSE",
+              "number": "104",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program  Core",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "150",
+              "title": "Drugs, Society and Human Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "210",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCD",
+              "number": "200",
+              "title": "Introductory Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "160",
+              "title": "Health and Wellness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "194",
+              "title": "HIV/AIDS, Science and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "196",
+              "title": "Community Health Research",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "285",
+              "title": "Health and Diversity",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "205",
+              "title": "History and Principles of Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "215",
+              "title": "Social and Behavioral Determinants of Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "225",
+              "title": "Health Behavior Change",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCH",
+              "number": "235",
+              "title": "Epidemiology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Philosophy",
+      "credential": "AA",
+      "program_code": "PHL-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PHL-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "190",
+              "title": "Ethics and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "192",
+              "title": "Art and Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUN",
+              "number": "195",
+              "title": "Art in New York: A Museum/Gallery Seminar",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "101",
+              "title": "Introduction to Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "275",
+              "title": "Landmarks in Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "102",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "104",
+              "title": "Ethics and Moral Issues",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "105",
+              "title": "Philosophy of Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "106",
+              "title": "Social and Political Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "107",
+              "title": "Philosophy of Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "108",
+              "title": "Environmental Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "109",
+              "title": "Philosophy of Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "112",
+              "title": "Logic & Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "114",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "115",
+              "title": "Ethical Leadership in the Global Economy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "116",
+              "title": "Latin American Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "118",
+              "title": "African Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "121",
+              "title": "Eastern Philosophy and Religion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "122",
+              "title": "Philosophy of Gender and Sex",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "125",
+              "title": "Introduction to Philosophy of Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "215",
+              "title": "Philosophy of Love",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "220",
+              "title": "Political and Social Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "280",
+              "title": "Experiential Learning in Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Physical Sciences",
+      "credential": "AS",
+      "program_code": "PHYSCI-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PHYSCI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "200",
+              "title": "Precalculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "231",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NSF",
+              "number": "101",
+              "title": "First Year Seminar for Natural Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "202",
+              "title": "General Chemistry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "232",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "233",
+              "title": "Introduction to Modern Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "211",
+              "title": "Research Methods in Physical Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Programming and Software Development",
+      "credential": "AAS",
+      "program_code": "PRGSYS-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PRGSYS-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associates of Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSF",
+              "number": "101",
+              "title": "First Year Seminar for Computer Science",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "101",
+              "title": "Introduction to Computer Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "109",
+              "title": "Introduction to Visual C# Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "110",
+              "title": "Systems Analysis and Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "250",
+              "title": "Database Concepts and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "232",
+              "title": "Unix Network Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "221",
+              "title": "Application Development for iPhone/iPad",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "190",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "220",
+              "title": "Application Development for Android Devices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "125",
+              "title": "Advanced C++ Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "280",
+              "title": "Game Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "172",
+              "title": "Web Development I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "272",
+              "title": "Web Development II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Elective",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nursing Certificate",
+      "credential": "certificate",
+      "program_code": "PRNRS-CERT",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PRNRS-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Major Requirements - Core",
+          "credits_required": 48,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "106",
+              "title": "Mathematics of Medical Dosages",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "204",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCL",
+              "number": "101",
+              "title": "Fundamentals of Practical Nursing",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCL",
+              "number": "103",
+              "title": "Concepts in Pharmacology and Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCL",
+              "number": "105",
+              "title": "Mental Health Nursing- Practical Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCL",
+              "number": "114",
+              "title": "Parent-Child Nursing-PN",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCL",
+              "number": "120",
+              "title": "Transition to Practical Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCL",
+              "number": "119",
+              "title": "Medical-Surgical Nursing-PN",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "240",
+              "title": "Developmental Psychology I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Psychology",
+      "credential": "AA",
+      "program_code": "PSYCHOL-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PSYCHOL-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 21,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SYF",
+              "number": "101",
+              "title": "First Year Seminar in Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "240",
+              "title": "Developmental Psychology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "250",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "200",
+              "title": "Personality Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "205",
+              "title": "Psychology of Gender",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "241",
+              "title": "Developmental Psychology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "184",
+              "title": "Environmental Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "280",
+              "title": "Urban Black Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSS",
+              "number": "100",
+              "title": "Introduction to Sociology Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "101",
+              "title": "Themes in American History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "102",
+              "title": "Themes in American History since 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "103",
+              "title": "Western Civilization from Ancient Times to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "104",
+              "title": "Western Civilization from the Renaissance to Modern Times",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "105",
+              "title": "World History from Ancient Times to 1500",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "106",
+              "title": "World History from 1500 to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "110",
+              "title": "East Asian Civilization and Societies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "231",
+              "title": "African American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSH",
+              "number": "232",
+              "title": "Survey of Latin America and Caribbean History",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Physical Therapist Assistant",
+      "credential": "AAS",
+      "program_code": "PYTRA-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/PYTRA-AAS",
+      "total_credits": 68,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 68,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCB",
+              "number": "204",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "240",
+              "title": "Developmental Psychology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "102",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "106",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCO",
+              "number": "230",
+              "title": "Functional Pathology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "101",
+              "title": "Introduction to Physical Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "102",
+              "title": "Professionalism in Physical Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "203",
+              "title": "Clinical Kinesiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "211",
+              "title": "Therapeutic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "212",
+              "title": "Therapeutic Procedures II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "220",
+              "title": "Functional Mobility Skills I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "221",
+              "title": "Functional Mobility Skills II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "230",
+              "title": "Orthopedic Therapeutic Exercise",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "231",
+              "title": "Neuromuscular Rehabilitation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "290",
+              "title": "PTA Clinical Education and Seminar I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "291",
+              "title": "PTA Clinical Education and Seminar II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCT",
+              "number": "292",
+              "title": "PTA Clinical Education and Seminar III",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Radiologic Technology",
+      "credential": "AAS",
+      "program_code": "RDTCH-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/RDTCH-AAS",
+      "total_credits": 67,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree  Requirements - Candidacy",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "187",
+              "title": "Urban Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 67,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCB",
+              "number": "204",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSN",
+              "number": "187",
+              "title": "Urban Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "101",
+              "title": "Radiologic Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "102",
+              "title": "Radiologic Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "105",
+              "title": "Radiographic Procedures I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "106",
+              "title": "Radiographic Positioning & Procedures II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "109",
+              "title": "Clinical Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "110",
+              "title": "Principles of Radiographic Exposure I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "111",
+              "title": "Principles of Radiographic Exposure II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "119",
+              "title": "Clinical Practicum II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "129",
+              "title": "Clinical Practicum III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "201",
+              "title": "Radiologic Technology III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "205",
+              "title": "Radiographic Procedures III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "209",
+              "title": "Clinical Practicum IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "219",
+              "title": "Clinical Practicum V",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "229",
+              "title": "Clinical Practicum VI",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "240",
+              "title": "Cross Sectional Anatomy",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "245",
+              "title": "Pathology and Fracture Radiography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "250",
+              "title": "Imaging Modalities I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCX",
+              "number": "260",
+              "title": "Film Evaluation and Critique",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Spanish-English Translation",
+      "credential": "AA",
+      "program_code": "SPNTRN-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/SPNTRN-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "101",
+              "title": "Composition I: An Introduction to Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "LIF",
+              "number": "101",
+              "title": "First Year Seminar for Liberal Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUC",
+              "number": "106",
+              "title": "Public Speaking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "101",
+              "title": "Cultural Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSA",
+              "number": "120",
+              "title": "Peoples and Cultures of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSP",
+              "number": "101",
+              "title": "U.S. Power and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "200",
+              "title": "Latin American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "201",
+              "title": "Latin American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "209",
+              "title": "Spanish Grammar & Usage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "204",
+              "title": "Latin American Civilizations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELS",
+              "number": "210",
+              "title": "Advanced Spanish Composition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "120",
+              "title": "Structure of English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELN",
+              "number": "101",
+              "title": "Introduction to Bilingualism",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theater",
+      "credential": "AS",
+      "program_code": "THEATER-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/THEATER-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HAF",
+              "number": "90",
+              "title": "First Year Seminar Theater, Photo",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "101",
+              "title": "Art of Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "110",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "111",
+              "title": "Acting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "115",
+              "title": "Script Analysis for the Theater",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "119",
+              "title": "Stagecraft",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "122",
+              "title": "Introduction to Design for the Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "210",
+              "title": "Theatre: Pre-History to the Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "299",
+              "title": "Experiential Learning in Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "175",
+              "title": "Directing for the Stage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "195",
+              "title": "Theatre Production Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "201",
+              "title": "American Musical Theatre Workshop 1",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUM",
+              "number": "202",
+              "title": "American Musical Theatre Workshop 2",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "220",
+              "title": "Contemporary Latina/o Theatre in the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "230",
+              "title": "Acting III: Auditioning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUT",
+              "number": "250",
+              "title": "Voice and Movement for the Stage",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Therapeutic Recreation",
+      "credential": "AS",
+      "program_code": "THERARC-AS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/THERARC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science in Therapeutic Recreation",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "203",
+              "title": "Human Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SSY",
+              "number": "240",
+              "title": "Developmental Psychology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "204",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCN",
+              "number": "195",
+              "title": "Community Health",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUP",
+              "number": "102",
+              "title": "Critical Thinking",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "101",
+              "title": "General Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SSY",
+              "number": "241",
+              "title": "Developmental Psychology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTR",
+              "number": "100",
+              "title": "Introduction to Recreation and Leisure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTR",
+              "number": "101",
+              "title": "Introduction to Recreational Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTR",
+              "number": "102",
+              "title": "Professional Issues in Therapeutic Recreation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTR",
+              "number": "200",
+              "title": "Therapeutic Recreation in Long Term Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HTR",
+              "number": "201",
+              "title": "Therapeutic Recreation Clinical Fieldwork",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Veterinary Technology",
+      "credential": "AAS",
+      "program_code": "VTCH-AAS",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/VTCH-AAS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENC",
+              "number": "101",
+              "title": "Composition I: An Introduction to Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "117",
+              "title": "Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "110",
+              "title": "Foundations of Chemistry",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "201",
+              "title": "General Chemistry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SCB",
+              "number": "208",
+              "title": "Vertebrate Anatomy and Physiology 1",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSF",
+              "number": "90",
+              "title": "First Year Seminar for Health Sciences",
+              "credits": 0,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "209",
+              "title": "Vertebrate Anatomy and Physiology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "260",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "101",
+              "title": "Introduction to Veterinary Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "151",
+              "title": "Shelter Medicine and Management",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "201",
+              "title": "Research Animal Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "203",
+              "title": "Veterinary Nursing Techniques I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "204",
+              "title": "Veterinary Nursing Techniques I - Off Campus Option",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "211",
+              "title": "Veterinary Nursing II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "212",
+              "title": "Veterinary Radiography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "213",
+              "title": "Veterinary Laboratory Techniques",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "214",
+              "title": "Farm Animal Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "220",
+              "title": "Principles of Exotic Animal Medical Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "231",
+              "title": "Research Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "234",
+              "title": "Full-Time Clinical Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "247",
+              "title": "Veterinary Pathophysiology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "262",
+              "title": "Veterinary Pharmacology and Toxicology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCV",
+              "number": "202",
+              "title": "Introduction to Veterinary Nursing",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "English",
+      "credential": "AA",
+      "program_code": "WRTLT-AA",
+      "catalog_url": "https://laguardia.catalog.cuny.edu/programs/WRTLT-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts in English",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Required Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "Composition I: An Introduction to Composition and Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENA",
+              "number": "101",
+              "title": "Composition I Accelerated",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "102",
+              "title": "Composition II: Writing through Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "Mathematics in the Modern World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "123",
+              "title": "Modern Problem Solving",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "115",
+              "title": "College Algebra and Trigonometry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "119",
+              "title": "Statistics with Elementary Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "120",
+              "title": "Elementary Statistics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "101",
+              "title": "Topics in Biological Sciences",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCB",
+              "number": "206",
+              "title": "Introduction to Neuroscience",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "101",
+              "title": "Topics in Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCC",
+              "number": "102",
+              "title": "Chemistry of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "101",
+              "title": "Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "105",
+              "title": "Life in the Universe",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCP",
+              "number": "140",
+              "title": "Topics in Astronomy",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "General Education Requirements - Flexible Core",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENF",
+              "number": "101",
+              "title": "First Year Seminar for English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "289",
+              "title": "Introduction to Literary Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "296",
+              "title": "Literature in Historical Context",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "290",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "292",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "205",
+              "title": "The Bible as Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "294",
+              "title": "Classical Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Afro-American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "248",
+              "title": "Latino/Latina Writing of the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "235",
+              "title": "Cultural Identity in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "Images of Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "247",
+              "title": "The Woman Writer: Her Vision & Her Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "252",
+              "title": "Sexuality in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "LGBTQ Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "268",
+              "title": "The Immigrant Experience in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "269",
+              "title": "Contemporary Black American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "291",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "293",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "295",
+              "title": "World Literatures Written in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "222",
+              "title": "The Graphic Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "The Short Story",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "260",
+              "title": "The Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "265",
+              "title": "The Drama",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "270",
+              "title": "Introduction to Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Literature and Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "280",
+              "title": "Children's Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Grammar Syntax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "211",
+              "title": "Craft of Reporting News",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "220",
+              "title": "Seminar in Writing Education and Peer Tutoring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "Literature, Health, and Medicine",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "256",
+              "title": "Humor in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "Poetry Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "273",
+              "title": "Playwriting Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "274",
+              "title": "Creative Nonfiction Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "275",
+              "title": "The Great Writer",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "276",
+              "title": "Fictional Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "288",
+              "title": "English Major Internship",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Creative Writing Track",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENF",
+              "number": "101",
+              "title": "First Year Seminar for English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENN",
+              "number": "198",
+              "title": "Introduction to Creative Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "289",
+              "title": "Introduction to Literary Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "277",
+              "title": "Advanced Creative Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "271",
+              "title": "Poetry Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "273",
+              "title": "Playwriting Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "274",
+              "title": "Creative Nonfiction Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "276",
+              "title": "Fictional Writing Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "250",
+              "title": "The Short Story",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "260",
+              "title": "The Novel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "265",
+              "title": "The Drama",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "270",
+              "title": "Introduction to Poetry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "290",
+              "title": "British Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "291",
+              "title": "British Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "292",
+              "title": "American Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "293",
+              "title": "American Literature II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "294",
+              "title": "Classical Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "110",
+              "title": "English Grammar Syntax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ELL",
+              "number": "110",
+              "title": "English Grammar Syntax",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "204",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "205",
+              "title": "The Bible as Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "220",
+              "title": "Seminar in Writing Education and Peer Tutoring",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "225",
+              "title": "Afro-American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "235",
+              "title": "Cultural Identity in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "245",
+              "title": "Images of Women in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "247",
+              "title": "The Woman Writer: Her Vision & Her Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "248",
+              "title": "Latino/Latina Writing of the United States",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "261",
+              "title": "LGBTQ Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "266",
+              "title": "Shakespeare",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "268",
+              "title": "The Immigrant Experience in American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "269",
+              "title": "Contemporary Black American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "272",
+              "title": "Literature and Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "280",
+              "title": "Children's Literature I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "288",
+              "title": "English Major Internship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "295",
+              "title": "World Literatures Written in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENN",
+              "number": "191",
+              "title": "Art, Politics, and Protest",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENN",
+              "number": "195",
+              "title": "Violence in American Art and Culture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENN",
+              "number": "240",
+              "title": "Literature of the City",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "238",
+              "title": "Screenwriting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUV",
+              "number": "238",
+              "title": "Screenwriting",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/data/ny/programs/queensborough-cc.json
+++ b/data/ny/programs/queensborough-cc.json
@@ -1,0 +1,13994 @@
+{
+  "college_slug": "queensborough-cc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://qcc.catalog.cuny.edu/programs",
+  "scraped_at": "2026-05-07T15:28:14.892Z",
+  "programs": [
+    {
+      "title": "Accounting for Forensic Accounting",
+      "credential": "AS",
+      "program_code": "AF-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/AF-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "260",
+              "title": "Pre-Calculus and Elements of Calculus for Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "101",
+              "title": "Principles of Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "102",
+              "title": "Principles of Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "103",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "104",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "111",
+              "title": "Computer Applications in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "203",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "101",
+              "title": "Introduction to Computing and Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "101",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "102",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Major Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Gallery and Museum Studies",
+      "credential": "AS",
+      "program_code": "AM-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/AM-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "106",
+              "title": "Chemistry and the Arts",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTH",
+              "number": "101",
+              "title": "History of Art I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "150",
+              "title": "Introduction to Gallery and Museum Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "202",
+              "title": "History of Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "251",
+              "title": "Art Curating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "252",
+              "title": "Art Institutions and the Business of Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "380",
+              "title": "Gallery Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "381",
+              "title": "Gallery Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "201",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HE",
+              "number": "101",
+              "title": "Personal Health and Wellness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Architectural Technology",
+      "credential": "AAS",
+      "program_code": "ARC-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/ARC-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "201",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TECH",
+              "number": "100",
+              "title": "Introduction to Engineering & Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "111",
+              "title": "Architectural Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "113",
+              "title": "Building Technology I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "119",
+              "title": "Visualization I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "121",
+              "title": "Architectural Design II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "123",
+              "title": "Building Technology II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "125",
+              "title": "Surveying and Site Planning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "129",
+              "title": "Visualization II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "231",
+              "title": "Architectural Design III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "237",
+              "title": "Environmental Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "241",
+              "title": "Advanced Architectural Modeling",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "248",
+              "title": "Structures I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "341",
+              "title": "Applied Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "345",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art",
+      "credential": "AS",
+      "program_code": "ART-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/ART-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "321",
+              "title": "Mathematics in Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "101",
+              "title": "Personal Health and Wellness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Art and Design",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTH",
+              "number": "100",
+              "title": "Introductory Survey of Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "101",
+              "title": "History of Art I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "115",
+              "title": "Modern Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "116",
+              "title": "American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "117",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "120",
+              "title": "Contemporary Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "126",
+              "title": "History of Asian Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "128",
+              "title": "History of African Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "150",
+              "title": "Introduction to Gallery and Museum Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "202",
+              "title": "History of Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "225",
+              "title": "History of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "122",
+              "title": "Introduction to Sculpture: Three-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "130",
+              "title": "Art Methods for the K-8 Curriculum I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "131",
+              "title": "Art Methods for the K-8 Curriculum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "132",
+              "title": "Introduction to Art Therapy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "141",
+              "title": "Introduction to Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "151",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "161",
+              "title": "Painting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "182",
+              "title": "Sculpture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "186",
+              "title": "Ceramics I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "191",
+              "title": "Introduction to Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "192",
+              "title": "Digital Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "251",
+              "title": "Art Curating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "252",
+              "title": "Art Institutions and the Business of Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "221",
+              "title": "Color Theory",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "242",
+              "title": "Advanced Photographic Skills",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "243",
+              "title": "Digital Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "252",
+              "title": "Drawing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "253",
+              "title": "Illustration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "262",
+              "title": "Painting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "263",
+              "title": "Painting III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "270",
+              "title": "Printmaking: Relief and Stencil",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "271",
+              "title": "Printmaking: Intaglio",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "286",
+              "title": "Ceramics II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "290",
+              "title": "Digital Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "291",
+              "title": "Digital Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "292",
+              "title": "Digital Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "293",
+              "title": "Motion Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "380",
+              "title": "Gallery Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "381",
+              "title": "Gallery Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "343",
+              "title": "Large Format and Studio Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "344",
+              "title": "Photography As Fine Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "345",
+              "title": "Creating the Documentary Image",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "346",
+              "title": "Color Photography: Traditional and Computer Methods",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "348",
+              "title": "Photographing People",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "349",
+              "title": "Illustration and Fashion Photography",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "380",
+              "title": "Artist Apprentice Internship I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "381",
+              "title": "Artist Apprentice Internship II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "382",
+              "title": "Special Problems in Studio Art I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "383",
+              "title": "Special Problems in Studio Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "390",
+              "title": "Portfolio Project In Studio Art",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Art History",
+          "credits_required": 15,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTH",
+              "number": "101",
+              "title": "History of Art I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "202",
+              "title": "History of Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "115",
+              "title": "Modern Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "116",
+              "title": "American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "117",
+              "title": "History of Photography",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "120",
+              "title": "Contemporary Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "126",
+              "title": "History of Asian Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "128",
+              "title": "History of African Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "150",
+              "title": "Introduction to Gallery and Museum Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "225",
+              "title": "History of Graphic Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "251",
+              "title": "Art Curating",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "252",
+              "title": "Art Institutions and the Business of Arts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Accounting",
+      "credential": "AAS",
+      "program_code": "BA-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/BA-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science Degree",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "260",
+              "title": "Pre-Calculus and Elements of Calculus for Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "101",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "102",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "101",
+              "title": "Principles of Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "102",
+              "title": "Principles of Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "103",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "104",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "108",
+              "title": "Income Taxation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "110",
+              "title": "Cost Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "111",
+              "title": "Computer Applications in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "201",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "203",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "301",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "701",
+              "title": "Principles of Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "101",
+              "title": "Introduction to Computing and Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "accounting"
+    },
+    {
+      "title": "Biology",
+      "credential": "AS",
+      "program_code": "BIO-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/BIO-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "203",
+              "title": "Cell Biology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Electives",
+          "credits_required": 18,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "356",
+              "title": "Principles Of Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "357",
+              "title": "Bioinformatics/Computational Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "453",
+              "title": "Biotechnology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "456",
+              "title": "Introduction to Biological Research",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "461",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "554",
+              "title": "Research Laboratory Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "302",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Management",
+      "credential": "AAS",
+      "program_code": "BM-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/BM-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "321",
+              "title": "Mathematics in Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "101",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "102",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "101",
+              "title": "Principles of Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "201",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "203",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "301",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "401",
+              "title": "Elements of Marketing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "701",
+              "title": "Principles of Finance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "101",
+              "title": "Introduction to Computing and Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "402",
+              "title": "Marketing Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "404",
+              "title": "Integrated Marketing Communications",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARCH",
+              "number": "121",
+              "title": "Architectural Design II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "102",
+              "title": "Principles of Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "103",
+              "title": "Intermediate Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "104",
+              "title": "Intermediate Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "108",
+              "title": "Income Taxation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "110",
+              "title": "Cost Accounting",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "111",
+              "title": "Computer Applications in Accounting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "208",
+              "title": "Entrepreneurship I: Starting Your Own Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "402",
+              "title": "Marketing Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "403",
+              "title": "Sales Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "404",
+              "title": "Integrated Marketing Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "405",
+              "title": "Retailing and Promotion",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "600",
+              "title": "Business Internships",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "903",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "906",
+              "title": "Advanced Microsoft Office",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "916",
+              "title": "Medical Coding and Billing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "917",
+              "title": "Healthcare Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "918",
+              "title": "Medical Coding and Billing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "102",
+              "title": "Computer Programming Fundamentals for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "152",
+              "title": "Computer Programming for Business I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "201",
+              "title": "Local Area Network Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Computer Programming for Business II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "203",
+              "title": "Object Oriented Programming for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "204",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "205",
+              "title": "Introduction to Information Systems and Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "206",
+              "title": "Spreadsheet Business Applications and Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Database Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "Analysis and Design of Systems Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "252",
+              "title": "Application Development for Mobile Devices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "254",
+              "title": "Data Security for Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration",
+      "credential": "AS",
+      "program_code": "BT-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/BT-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "101",
+              "title": "Principles of Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "102",
+              "title": "Principles of Accounting II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "201",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "203",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "301",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "205",
+              "title": "Introduction to Information Systems and Technologies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "101",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "102",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Additional Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Biotechnology",
+      "credential": "AS",
+      "program_code": "BY-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/BY-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "453",
+              "title": "Biotechnology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "356",
+              "title": "Principles Of Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "357",
+              "title": "Bioinformatics/Computational Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "554",
+              "title": "Research Laboratory Internship",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Degree Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Chemistry",
+      "credential": "AS",
+      "program_code": "CHY-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/CHY-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Information Systems",
+      "credential": "AS",
+      "program_code": "CIS-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/CIS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "101",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "102",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "102",
+              "title": "Computer Programming Fundamentals for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "101",
+              "title": "Principles of Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "201",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "101",
+              "title": "Introduction to Computing and Information Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "152",
+              "title": "Computer Programming for Business I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "Operating Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "201",
+              "title": "Local Area Network Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "208",
+              "title": "Database Management Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Major Electives",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "203",
+              "title": "Business Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "202",
+              "title": "Computer Programming for Business II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "203",
+              "title": "Object Oriented Programming for Business",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "204",
+              "title": "Web Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "206",
+              "title": "Spreadsheet Business Applications and Data Analytics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "251",
+              "title": "Analysis and Design of Systems Projects",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "252",
+              "title": "Application Development for Mobile Devices",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "254",
+              "title": "Data Security for Business",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Additional Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Criminal Justice",
+      "credential": "AS",
+      "program_code": "CJ-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/CJ-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CRIM",
+              "number": "101",
+              "title": "Introduction to the American Criminal Justice System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "106",
+              "title": "Introduction to Criminal Justice Research",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "202",
+              "title": "Corrections and Sentencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "203",
+              "title": "Criminal Law",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "201",
+              "title": "Policing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "204",
+              "title": "Crime and Justice in the Urban Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "205",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "criminal-justice"
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "CSCI-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/CSCI-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "101",
+              "title": "Algorithmic Problem Solving I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "201",
+              "title": "Computer Organization and Assembly Language (2E1)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "203",
+              "title": "Algorithmic Problem Solving II in C++",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "204",
+              "title": "Algorithmic Problem Solving II in Java",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "471",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Major Electives",
+          "credits_required": 11,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "100",
+              "title": "Introduction to Computers and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "102",
+              "title": "Spreadsheet Programming with MS Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "103",
+              "title": "Relational Databases with SQL",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "203",
+              "title": "Algorithmic Problem Solving II in C++",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "204",
+              "title": "Algorithmic Problem Solving II in Java",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "220",
+              "title": "Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "506",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "540",
+              "title": "Digital Computer Theory I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "710",
+              "title": "Front-End UI/UX Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "481",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "905",
+              "title": "Undergraduate Research in Mathematics and/or Computer Science I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "906",
+              "title": "Undergraduate Research in Mathematics and/or Computer Science II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Science and Information Security",
+      "credential": "AS",
+      "program_code": "CSS-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/CSS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "471",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "506",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "574",
+              "title": "Python Development Using Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "580",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "585",
+              "title": "Computer Architecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Computer Engineering Technology",
+      "credential": "AAS",
+      "program_code": "CT-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/CT-AAS",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "201",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "202",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "110",
+              "title": "Electric Circuit Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "210",
+              "title": "Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "350",
+              "title": "Computer Control Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "420",
+              "title": "Computer Project Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "502",
+              "title": "Introduction to Computer Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "504",
+              "title": "Operating Systems and System Deployment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "509",
+              "title": "Programming for Embedded Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "540",
+              "title": "Digital Computer Theory I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "542",
+              "title": "Computer and Electrical Device Applications",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "560",
+              "title": "Microprocessors and Microcomputers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "100",
+              "title": "Introduction to Engineering & Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Major Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "140",
+              "title": "Sinusoidal and Transient Circuit Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "220",
+              "title": "Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "230",
+              "title": "Telecommunications I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "231",
+              "title": "Telecommunications II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "232",
+              "title": "Wireless Mobile Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "305",
+              "title": "Transients and Electromechanical Transducers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "360",
+              "title": "Electronics and Automation for the Home",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "375",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "481",
+              "title": "Personal Computer Technology, Architecture and Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "506",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "570",
+              "title": "Creating Smartphone Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "574",
+              "title": "Python Development Using Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "580",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "581",
+              "title": "Object-Oriented Programming in Java",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "705",
+              "title": "Networking Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "706",
+              "title": "Network Configuration I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "707",
+              "title": "Network Configuration II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "710",
+              "title": "Front-End UI/UX Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "712",
+              "title": "JavaScript Programming: Client and Server",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "720",
+              "title": "Advanced Web and Multimedia Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "726",
+              "title": "Advanced Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "754",
+              "title": "Security Policies and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "756",
+              "title": "Database Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "757",
+              "title": "Cloud Technology Developing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "758",
+              "title": "Cloud Technology Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "760",
+              "title": "Ethical Hacking and Penetration Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "841",
+              "title": "The Science of Energy and Power in the Modern World-also take ET842 for lab science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "880",
+              "title": "Science and Technology in Modern Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "991",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "992",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "993",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Cybersecurity",
+      "credential": "AAS",
+      "program_code": "CYB-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/CYB-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "506",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "574",
+              "title": "Python Development Using Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "581",
+              "title": "Object-Oriented Programming in Java",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "705",
+              "title": "Networking Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "726",
+              "title": "Advanced Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "754",
+              "title": "Security Policies and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "756",
+              "title": "Database Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "760",
+              "title": "Ethical Hacking and Penetration Testing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "232",
+              "title": "Wireless Mobile Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "580",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "585",
+              "title": "Computer Architecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "712",
+              "title": "JavaScript Programming: Client and Server",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "716",
+              "title": "Java Programming Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "757",
+              "title": "Cloud Technology Developing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "758",
+              "title": "Cloud Technology Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "991",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "992",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "100",
+              "title": "Introduction to Engineering & Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Digital Art and Design",
+      "credential": "AS",
+      "program_code": "DA-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/DA-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "321",
+              "title": "Mathematics in Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "106",
+              "title": "Chemistry and the Arts",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ARTS",
+              "number": "121",
+              "title": "Two-Dimensional Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "151",
+              "title": "Drawing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "191",
+              "title": "Introduction to Video",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "192",
+              "title": "Digital Animation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "290",
+              "title": "Digital Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "291",
+              "title": "Digital Imaging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "292",
+              "title": "Digital Design II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "293",
+              "title": "Motion Graphics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Free Electives",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Dance",
+      "credential": "AS",
+      "program_code": "DAN-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/DAN-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "111",
+              "title": "Introduction to the Art of Dance",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "DAN",
+              "number": "110",
+              "title": "Foundations of Dance Movement",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "249",
+              "title": "Dance Improvisation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "251",
+              "title": "Choreography I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "124",
+              "title": "Beginning Modern Dance for Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "125",
+              "title": "Advanced Beginning Modern Dance I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "126",
+              "title": "Advanced Beginning Modern Dance II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "127",
+              "title": "Advanced Beginning Modern Dance III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "220",
+              "title": "Intermediate Modern Dance I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "221",
+              "title": "Intermediate Modern Dance II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "222",
+              "title": "Intermediate Modern Dance III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "223",
+              "title": "Intermediate Modern Dance IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "134",
+              "title": "Beginning Ballet for Majors",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "135",
+              "title": "Advanced Beginning Ballet I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "136",
+              "title": "Advanced Beginning Ballet II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "137",
+              "title": "Advanced Beginning Ballet III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "230",
+              "title": "Intermediate Ballet I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "231",
+              "title": "Intermediate Ballet II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "232",
+              "title": "Intermediate Ballet III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "233",
+              "title": "Intermediate Ballet IV",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "160",
+              "title": "Repertory I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "161",
+              "title": "Repertory II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "260",
+              "title": "Dance Workshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "261",
+              "title": "Dance Workshop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "262",
+              "title": "Dance Workshop III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "103",
+              "title": "African and Afro-Caribbean Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "140",
+              "title": "Advanced Beginning Jazz Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "252",
+              "title": "Contact Improvisation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "270",
+              "title": "Special Topics in Modern Dance I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "271",
+              "title": "Special Topics in Modern Dance II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "272",
+              "title": "Special Topics in Modern Dance III",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HE",
+              "number": "101",
+              "title": "Personal Health and Wellness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "103",
+              "title": "African and Afro-Caribbean Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "530",
+              "title": "Yoga",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "841",
+              "title": "The Science of Energy and Power in the Modern World-also take ET842 for lab science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Internet and Information Technology",
+      "credential": "AAS",
+      "program_code": "EM-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/EM-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "506",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "574",
+              "title": "Python Development Using Artificial Intelligence",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "710",
+              "title": "Front-End UI/UX Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "712",
+              "title": "JavaScript Programming: Client and Server",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "713",
+              "title": "Full Stack Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "721",
+              "title": "Software Development Practicum",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Major Electives",
+          "credits_required": 17,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "232",
+              "title": "Wireless Mobile Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "375",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "481",
+              "title": "Personal Computer Technology, Architecture and Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "504",
+              "title": "Operating Systems and System Deployment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "570",
+              "title": "Creating Smartphone Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "580",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "582",
+              "title": "Data Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "581",
+              "title": "Object-Oriented Programming in Java",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "585",
+              "title": "Computer Architecture",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "705",
+              "title": "Networking Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "714",
+              "title": "Web Technologies II: Building Database-Driven Web Sites",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "716",
+              "title": "Java Programming Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "720",
+              "title": "Advanced Web and Multimedia Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "756",
+              "title": "Database Administration",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "991",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "992",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "726",
+              "title": "Advanced Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "754",
+              "title": "Security Policies and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "757",
+              "title": "Cloud Technology Developing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "758",
+              "title": "Cloud Technology Operations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "760",
+              "title": "Ethical Hacking and Penetration Testing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "931",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "932",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Internet and Information Technology",
+      "credential": "certificate",
+      "program_code": "EN-CERT",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/EN-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "321",
+              "title": "Mathematics in Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "504",
+              "title": "Operating Systems and System Deployment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "710",
+              "title": "Front-End UI/UX Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "712",
+              "title": "JavaScript Programming: Client and Server",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "375",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "481",
+              "title": "Personal Computer Technology, Architecture and Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "570",
+              "title": "Creating Smartphone Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "714",
+              "title": "Web Technologies II: Building Database-Driven Web Sites",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "716",
+              "title": "Java Programming Technology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "718",
+              "title": "Database Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "720",
+              "title": "Advanced Web and Multimedia Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "728",
+              "title": "Web Technology: XML",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTS",
+              "number": "192",
+              "title": "Digital Animation",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Environmental Science",
+      "credential": "AS",
+      "program_code": "ES-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/ES-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "160",
+              "title": "Ecology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "461",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "480",
+              "title": "Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GE",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Electives",
+          "credits_required": 5,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "505",
+              "title": "Current Environmental Issues",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "554",
+              "title": "Research Laboratory Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "840",
+              "title": "Energy and Power for a Green Society",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "843",
+              "title": "The Role of Energy in Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GE",
+              "number": "102",
+              "title": "Historical Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "120",
+              "title": "Introduction to Meteorology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "121",
+              "title": "Meteorology Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "124",
+              "title": "Global Warming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Electronic Engineering Technology",
+      "credential": "AAS",
+      "program_code": "ET-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/ET-AAS",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "201",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "202",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "110",
+              "title": "Electric Circuit Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "140",
+              "title": "Sinusoidal and Transient Circuit Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "210",
+              "title": "Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "220",
+              "title": "Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "230",
+              "title": "Telecommunications I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "320",
+              "title": "Electrical Controls Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "410",
+              "title": "Electronic Project Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "509",
+              "title": "Programming for Embedded Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "540",
+              "title": "Digital Computer Theory I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "560",
+              "title": "Microprocessors and Microcomputers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "100",
+              "title": "Introduction to Engineering & Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "232",
+              "title": "Wireless Mobile Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "305",
+              "title": "Transients and Electromechanical Transducers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "360",
+              "title": "Electronics and Automation for the Home",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "375",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "481",
+              "title": "Personal Computer Technology, Architecture and Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "502",
+              "title": "Introduction to Computer Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "504",
+              "title": "Operating Systems and System Deployment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "505",
+              "title": "Introduction to C++ Object Oriented Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "506",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "570",
+              "title": "Creating Smartphone Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "580",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "705",
+              "title": "Networking Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "710",
+              "title": "Front-End UI/UX Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "712",
+              "title": "JavaScript Programming: Client and Server",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "720",
+              "title": "Advanced Web and Multimedia Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "754",
+              "title": "Security Policies and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "841",
+              "title": "The Science of Energy and Power in the Modern World-also take ET842 for lab science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "880",
+              "title": "Science and Technology in Modern Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "991",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "992",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "993",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Health Sciences",
+      "credential": "AS",
+      "program_code": "HS-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/HS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "301",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "140",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "302",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "150",
+              "title": "Organization and Delivery of Health Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - General Health Sciences Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "311",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "356",
+              "title": "Principles Of Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "520",
+              "title": "Introduction to Public Health",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "127",
+              "title": "Introductory General Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "101",
+              "title": "Principles of Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "425",
+              "title": "Pathophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "503",
+              "title": "General Epidemiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "201",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "917",
+              "title": "Healthcare Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "100",
+              "title": "Introduction to Computers and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "103",
+              "title": "Fundamentals of Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "403",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "550",
+              "title": "Field Internship in Health Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "128",
+              "title": "Introductory Organic Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "151",
+              "title": "The Health of The Nation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "302",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Health Services Administration Concentration",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "403",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "520",
+              "title": "Introduction to Public Health",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "550",
+              "title": "Field Internship in Health Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "101",
+              "title": "Principles of Accounting I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "201",
+              "title": "Business Organization and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "301",
+              "title": "Business Law I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "917",
+              "title": "Healthcare Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "101",
+              "title": "Introduction to Macroeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "102",
+              "title": "Introduction to Microeconomics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Occupational Therapy Concentration",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "403",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "550",
+              "title": "Field Internship in Health Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "551",
+              "title": "Field Internship in Health Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "127",
+              "title": "Introductory General Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "128",
+              "title": "Introductory Organic Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "101",
+              "title": "Principles of Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Respiratory Care Concentration",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "311",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "550",
+              "title": "Field Internship in Health Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "551",
+              "title": "Field Internship in Health Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "127",
+              "title": "Introductory General Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "128",
+              "title": "Introductory Organic Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "101",
+              "title": "Principles of Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Medical Imaging Concentration",
+          "credits_required": 20,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "403",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "520",
+              "title": "Introduction to Public Health",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "550",
+              "title": "Field Internship in Health Sciences",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "127",
+              "title": "Introductory General Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "128",
+              "title": "Introductory Organic Chemistry",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "100",
+              "title": "Introduction to Computers and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "151",
+              "title": "The Health of The Nation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "101",
+              "title": "Principles of Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "302",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts and Sciences",
+      "credential": "AA",
+      "program_code": "LA-AA",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/LA-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HE",
+              "number": "101",
+              "title": "Personal Health and Wellness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in American Studies",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "215",
+              "title": "American Literature I: Colonial Period to American Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "216",
+              "title": "American Literature II: Civil War to Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "252",
+              "title": "Film and Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "262",
+              "title": "New York",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "140",
+              "title": "North American Indians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLSC",
+              "number": "101",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLSC",
+              "number": "180",
+              "title": "American Foreign Policy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "116",
+              "title": "American Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "127",
+              "title": "United States History I: Beginnings through Reconstruction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "128",
+              "title": "United States History II: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "135",
+              "title": "History of New York",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "239",
+              "title": "Recent American Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "104",
+              "title": "Jazz: An Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "165",
+              "title": "American Philosophy",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "276",
+              "title": "Immigration and Ethnic Groups in American History",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Black, Race, and Ethnic Studies",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "101",
+              "title": "Introduction to Communication Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "212",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "213",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "214",
+              "title": "Communication in a Professional Setting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "215",
+              "title": "Phonetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "216",
+              "title": "Introduction to Language Science and Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "217",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "321",
+              "title": "Oral Performance for the Actor and Speaker",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "INTE",
+              "number": "219",
+              "title": "Introduction to Black, Race and Ethnic Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "133",
+              "title": "Introduction to Modern East Asian Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "136",
+              "title": "African-American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "140",
+              "title": "Latin American History I: Ancient Times to Independence (1500 BC - 1825)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "140",
+              "title": "North American Indians",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "103",
+              "title": "African and Afro-Caribbean Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "DAN",
+              "number": "106",
+              "title": "Latin Dance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "223",
+              "title": "African American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "224",
+              "title": "Asian American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "225",
+              "title": "Latinx American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "263",
+              "title": "Holocaust Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "265",
+              "title": "The Immigrant Experience in Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "204",
+              "title": "Topics in the History of Slavery",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "247",
+              "title": "History of the Modern Middle East, 1795-2011",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "276",
+              "title": "Immigration and Ethnic Groups in American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "281",
+              "title": "Nationalism and Identity Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "291",
+              "title": "History of Genocide in the Twentieth Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "245",
+              "title": "Cross-Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "240",
+              "title": "Racial and Ethnic Relations",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "101",
+              "title": "Urban Studies Internship Program",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Communication Studies",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "106",
+              "title": "Chemistry and the Arts",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "101",
+              "title": "Introduction to Communication Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "212",
+              "title": "Interpersonal Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "213",
+              "title": "Intercultural Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "214",
+              "title": "Communication in a Professional Setting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "215",
+              "title": "Phonetics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "216",
+              "title": "Introduction to Language Science and Linguistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "217",
+              "title": "Business Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "321",
+              "title": "Oral Performance for the Actor and Speaker",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "120",
+              "title": "Acting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMP",
+              "number": "245",
+              "title": "Introduction to Electronic Media",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Education",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "101",
+              "title": "Contemporary Education: Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "Music for Teachers of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "230",
+              "title": "Childhood Learning and Development in Cultural Context",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in English",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "101",
+              "title": "Introduction to the American Criminal Justice System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "205",
+              "title": "Criminology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLSC",
+              "number": "101",
+              "title": "American Government and Politics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "125",
+              "title": "Sociology and the Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "201",
+              "title": "Introduction to Literary Studies",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Gender Studies",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "170",
+              "title": "Sex and Gender in Cross-Cultural Perspective",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "231",
+              "title": "Special Topics in Writing Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "232",
+              "title": "Special Topics in Writing Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "105",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "152",
+              "title": "Women in World History: From Prehistoric Times to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "226",
+              "title": "Women in America",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "255",
+              "title": "The Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "230",
+              "title": "Sociology of the Family",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "250",
+              "title": "Sociology of Gender",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in History",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in International Studies",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "213",
+              "title": "World Literature I: Ancient Through Renaissance",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "214",
+              "title": "World Literature II: Masterpieces from the Seventeenth to the Twenty-First Centuries",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "217",
+              "title": "Contemporary Literature in English",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "100",
+              "title": "Introductory Survey of Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "130",
+              "title": "Cultures and Peoples of Asia",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ANTH",
+              "number": "150",
+              "title": "Peoples and Cultures of the Caribbean",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "101",
+              "title": "History of Art I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "126",
+              "title": "History of Asian Art",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "128",
+              "title": "History of African Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ARTH",
+              "number": "202",
+              "title": "History of Art II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECON",
+              "number": "235",
+              "title": "International Economics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "140",
+              "title": "Latin American History I: Ancient Times to Independence (1500 BC - 1825)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "141",
+              "title": "Latin American History II: Independence to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "152",
+              "title": "Women in World History: From Prehistoric Times to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "218",
+              "title": "Ancient Greek History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "291",
+              "title": "History of Genocide in the Twentieth Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "295",
+              "title": "Judaism, Christianity, and Islam",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LF",
+              "number": "401",
+              "title": "French and Francophone Cultures Today",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LG",
+              "number": "401",
+              "title": "The Culture of German-Speaking Countries Today",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LG",
+              "number": "613",
+              "title": "Business and Technical German",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LG",
+              "number": "811",
+              "title": "German Literature in Translation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LG",
+              "number": "812",
+              "title": "German Literature in Translation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LH",
+              "number": "811",
+              "title": "Hebrew Literature in Translation: Commentaries on the Pentateuch I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LI",
+              "number": "401",
+              "title": "Italian Culture through Film",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "402",
+              "title": "Latin American and Caribbean Cultures Today",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "The European Classical Music Tradition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Music Around the World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PLSC",
+              "number": "140",
+              "title": "Comparative Political Systems",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Liberal Studies",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Nutrition",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "103",
+              "title": "Fundamentals of Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "114",
+              "title": "Principles and Practices of Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "151",
+              "title": "The Health of The Nation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "540",
+              "title": "Introduction to Physical Fitness",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements- Concentration in Social Work",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "185",
+              "title": "Introduction to Social Work",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Sociology",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Spanish Language",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "111",
+              "title": "Elementary Spanish I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "112",
+              "title": "Elementary Spanish II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "213",
+              "title": "Intermediate Spanish I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "214",
+              "title": "Intermediate Spanish II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "221",
+              "title": "Workshop in Reading and Writing for Spanish Heritage Speakers I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "222",
+              "title": "Workshop in Reading and Writing for Spanish Heritage Speakers II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "223",
+              "title": "Workshop in Reading and Writing for Spanish Heritage Speakers III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "311",
+              "title": "Spanish Literature of the Nineteenth Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "312",
+              "title": "Spanish Literature of the Twentieth Century",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "315",
+              "title": "Reading in Contemporary Spanish-American Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "401",
+              "title": "Spain Today",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "LS",
+              "number": "402",
+              "title": "Latin American and Caribbean Cultures Today",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Concentration in Urban Studies",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIST",
+              "number": "110",
+              "title": "Introduction to Ancient Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "111",
+              "title": "Introduction to Medieval and Early Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "112",
+              "title": "Introduction to Modern Western Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "136",
+              "title": "African-American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "239",
+              "title": "Recent American Civilization",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "276",
+              "title": "Immigration and Ethnic Groups in American History",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "125",
+              "title": "Sociology and the Arts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "220",
+              "title": "Urban Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "260",
+              "title": "Sociology of Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "101",
+              "title": "Urban Studies Internship Program",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "102",
+              "title": "Urban Studies Internship Program",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "UBST",
+              "number": "202",
+              "title": "Urban Studies Internship Program",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CRIM",
+              "number": "101",
+              "title": "Introduction to the American Criminal Justice System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "231",
+              "title": "Special Topics in Writing Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "232",
+              "title": "Special Topics in Writing Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "262",
+              "title": "New York",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts and Sciences",
+      "credential": "AA",
+      "program_code": "LE-AA",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/LE-AA",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Arts",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "GE",
+              "number": "101",
+              "title": "Physical Geology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "140",
+              "title": "Principles of Biology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "127",
+              "title": "United States History I: Beginnings through Reconstruction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIST",
+              "number": "128",
+              "title": "United States History II: Reconstruction to the Present",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDUC",
+              "number": "101",
+              "title": "Contemporary Education: Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "230",
+              "title": "Childhood Learning and Development in Cultural Context",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "303",
+              "title": "Number Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "Music for Teachers of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "101",
+              "title": "Principles of Physics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts and Sciences (Mathematics and Science)",
+      "credential": "AS",
+      "program_code": "LS-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/LS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "311",
+              "title": "College Physics A",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "101",
+              "title": "Algorithmic Problem Solving I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "201",
+              "title": "Computer Organization and Assembly Language (2E1)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "203",
+              "title": "Algorithmic Problem Solving II in C++",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "302",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "312",
+              "title": "College Physics B",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Biology Concentration",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "356",
+              "title": "Principles Of Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "357",
+              "title": "Bioinformatics/Computational Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "453",
+              "title": "Biotechnology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "311",
+              "title": "College Physics A",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "312",
+              "title": "College Physics B",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Chemistry Concentration",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "900",
+              "title": "Cooperative Education in Chemical Instrumental Analysis I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "901",
+              "title": "Cooperative Education in Chemical Instrumental Analysis I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "911",
+              "title": "Independent Study and Research I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "912",
+              "title": "Independent Study and Research I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "913",
+              "title": "Independent Study and Research II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "914",
+              "title": "Independent Study & Research II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Computer Science Concentration",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "101",
+              "title": "Algorithmic Problem Solving I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "201",
+              "title": "Computer Organization and Assembly Language (2E1)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "203",
+              "title": "Algorithmic Problem Solving II in C++",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "204",
+              "title": "Algorithmic Problem Solving II in Java",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "471",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "481",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Mathematics Concentration",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "311",
+              "title": "College Physics A",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "302",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "312",
+              "title": "College Physics B",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "471",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "481",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Physics Concentration",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PH",
+              "number": "240",
+              "title": "Computerized Physical Measurement Using Graphical Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "303",
+              "title": "Scientific Use of Computers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "414",
+              "title": "Analytical Mechanics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "415",
+              "title": "Electricity and Magnetism",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "416",
+              "title": "Thermodynamics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "431",
+              "title": "Calculus Optics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "440",
+              "title": "Modern Physics and Quantum Mechanics for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "450",
+              "title": "Introduction to Physics Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "900",
+              "title": "Research Projects",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "356",
+              "title": "Principles Of Genetics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "357",
+              "title": "Bioinformatics/Computational Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "453",
+              "title": "Biotechnology",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "900",
+              "title": "Cooperative Education in Chemical Instrumental Analysis I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "901",
+              "title": "Cooperative Education in Chemical Instrumental Analysis I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "911",
+              "title": "Independent Study and Research I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "912",
+              "title": "Independent Study and Research I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "913",
+              "title": "Independent Study and Research II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "914",
+              "title": "Independent Study & Research II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "101",
+              "title": "Algorithmic Problem Solving I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "201",
+              "title": "Computer Organization and Assembly Language (2E1)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "203",
+              "title": "Algorithmic Problem Solving II in C++",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "204",
+              "title": "Algorithmic Problem Solving II in Java",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "220",
+              "title": "Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "471",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "481",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "302",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "311",
+              "title": "College Physics A",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "312",
+              "title": "College Physics B",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "440",
+              "title": "Modern Physics and Quantum Mechanics for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "450",
+              "title": "Introduction to Physics Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "900",
+              "title": "Research Projects",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "101",
+              "title": "Radiation Safety I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "102",
+              "title": "Radiation Safety II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Major Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HE",
+              "number": "101",
+              "title": "Personal Health and Wellness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Medical Assistant",
+      "credential": "AAS",
+      "program_code": "MA-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/MA-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Sciences",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "520",
+              "title": "Introduction to Public Health",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHIL",
+              "number": "140",
+              "title": "Medical Ethics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "111",
+              "title": "Introduction to Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "150",
+              "title": "Organization and Delivery of Health Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "260",
+              "title": "Patient Care Coordination",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "340",
+              "title": "Assisting in the Medical Office:Clinical Testing Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "341",
+              "title": "Assisting in the Medical Office: Medical Assisting Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "451",
+              "title": "Phlebotomy Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "452",
+              "title": "Electrocardiogram Technology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "903",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "916",
+              "title": "Medical Coding and Billing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "917",
+              "title": "Healthcare Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "918",
+              "title": "Medical Coding and Billing II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "200",
+              "title": "Emergency Medical Technician",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "403",
+              "title": "Medical Terminology",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "510",
+              "title": "Pharmacology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "952",
+              "title": "Field Experience in Medical Assisting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "120",
+              "title": "Fundamentals of Chemistry",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "103",
+              "title": "Fundamentals of Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Internship Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BU",
+              "number": "600",
+              "title": "Business Internships",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "961",
+              "title": "Phlebotomy Practice",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "950",
+              "title": "Field Experience in Medical Assisting",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "951",
+              "title": "Field Experience in Medical Assisting",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music Production",
+      "credential": "AAS",
+      "program_code": "ME-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/ME-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "321",
+              "title": "Mathematics in Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "140",
+              "title": "Acoustics: The Physics of Sound",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Musicianship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "112",
+              "title": "Musicianship II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122",
+              "title": "Music Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "225",
+              "title": "Jazz Theory and Improvisation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221",
+              "title": "Music Theory III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "226",
+              "title": "Jazz Theory and Improvisation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "101",
+              "title": "Introduction to the Recording Studio and MIDI",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "102",
+              "title": "Digital Music Sequencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "103",
+              "title": "Recording Techniques I: Studio Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "204",
+              "title": "Digital Sound Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "205",
+              "title": "Recording Techniques II: Studio Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "206",
+              "title": "Virtual Instruments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "207",
+              "title": "Microphones and Amplification Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "208",
+              "title": "Digital Recording",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "The Business of Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Class Instruction in Piano II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231",
+              "title": "Class Instruction Piano III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "232",
+              "title": "Class Instruction in Piano IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "124",
+              "title": "Sight Reading and Ear Training II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "133",
+              "title": "Class Instruction in Voice I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "134",
+              "title": "Class Instruction in Voice II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "135",
+              "title": "Class Instruction in Guitar I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "136",
+              "title": "Class Instruction in Guitar II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "137",
+              "title": "Class Instruction in Percussion I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "138",
+              "title": "Class Instruction in Percussion II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Music Theory IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "223",
+              "title": "Sight Reading and Ear Training III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "224",
+              "title": "Sight Reading and Ear Training IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "209",
+              "title": "Recording Techniques III: Production Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "401",
+              "title": "Instrumental and Vocal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "402",
+              "title": "Instrumental and Vocal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "403",
+              "title": "Instrumental and Vocal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "404",
+              "title": "Instrumental and Vocal Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "411",
+              "title": "Pop Choir",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "412",
+              "title": "Pop Choir",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "413",
+              "title": "Pop Choir",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "414",
+              "title": "Pop Choir",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "421",
+              "title": "Queensborough Chorus",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "422",
+              "title": "Queensborough Chorus",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "423",
+              "title": "Queensborough Chorus",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "424",
+              "title": "Queensborough Chorus",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "431",
+              "title": "Queensborough Orchestra",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "432",
+              "title": "Queensborough Orchestra",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "433",
+              "title": "Queensborough Orchestra",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "434",
+              "title": "Queensborough Orchestra",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "441",
+              "title": "Queens Symphonic Band",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "442",
+              "title": "Queens Symphonic Band",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "443",
+              "title": "Queens Symphonic Band",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "444",
+              "title": "Queens Symphonic Band",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "461",
+              "title": "Jazz Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "462",
+              "title": "Jazz Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "463",
+              "title": "Jazz Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "464",
+              "title": "Jazz Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "471",
+              "title": "Global Rhythms Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "472",
+              "title": "Global Rhythms Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "473",
+              "title": "Global Rhythms Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "474",
+              "title": "Global Rhythms Ensemble",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "481",
+              "title": "Improvisation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "482",
+              "title": "Improvisation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "483",
+              "title": "Improvisation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "484",
+              "title": "Improvisation Lab",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "900",
+              "title": "Cooperative Education Internship in Music Production",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Medical Office Assistant",
+      "credential": "certificate",
+      "program_code": "MO-CERT",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/MO-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "111",
+              "title": "Introduction to Human Biology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "150",
+              "title": "Organization and Delivery of Health Care",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "260",
+              "title": "Patient Care Coordination",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "340",
+              "title": "Assisting in the Medical Office:Clinical Testing Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "341",
+              "title": "Assisting in the Medical Office: Medical Assisting Procedures",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "903",
+              "title": "Medical Office Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "916",
+              "title": "Medical Coding and Billing I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "917",
+              "title": "Healthcare Information Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BU",
+              "number": "918",
+              "title": "Medical Coding and Billing II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Mechanical Engineering Technology",
+      "credential": "AAS",
+      "program_code": "MT-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/MT-AAS",
+      "total_credits": 64,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 64,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "201",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "202",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "111",
+              "title": "Technical Graphics",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "122",
+              "title": "Manufacturing Processes",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "124",
+              "title": "Metallurgy and Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "140",
+              "title": "Engineering Analysis",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "161",
+              "title": "Fundamentals of Computer Numerical Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "293",
+              "title": "Parametric Computer-Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "341",
+              "title": "Applied Mechanics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "345",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "369",
+              "title": "Computer Applications in Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "491",
+              "title": "Computer Controlled Manufacturing",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "492",
+              "title": "Introduction to Virtual Automation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "523",
+              "title": "Thermodynamics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "100",
+              "title": "Introduction to Engineering & Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 4,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MT",
+              "number": "125",
+              "title": "Metallurgy and Materials Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "162",
+              "title": "Microcomputer Programming for Computer Numerical Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "163",
+              "title": "Computer-Aided Manufacturing (CAM)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "164",
+              "title": "Computer-Integrated Manufacturing (CIM)",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "346",
+              "title": "Strength of Materials Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "488",
+              "title": "Computer Aided Design I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "513",
+              "title": "Thermo-Fluid Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "514",
+              "title": "Thermo-Fluid Systems - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "525",
+              "title": "Measurement Techniques in the Thermal Sciences",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "900",
+              "title": "Cooperative Education/Design Projects in Engineering Technology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Mathematics",
+      "credential": "AS",
+      "program_code": "MTH-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/MTH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate of Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "481",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Advised Major Electives",
+          "credits_required": 14,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CS",
+              "number": "100",
+              "title": "Introduction to Computers and Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "101",
+              "title": "Algorithmic Problem Solving I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "102",
+              "title": "Spreadsheet Programming with MS Excel",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "103",
+              "title": "Relational Databases with SQL",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "201",
+              "title": "Computer Organization and Assembly Language (2E1)",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "203",
+              "title": "Algorithmic Problem Solving II in C++",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "204",
+              "title": "Algorithmic Problem Solving II in Java",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "220",
+              "title": "Discrete Structures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "101",
+              "title": "Contemporary Education: Principles and Practices",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDUC",
+              "number": "240",
+              "title": "Middle Childhood and Adolescent Learning and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "471",
+              "title": "Introduction to Discrete Mathematics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "481",
+              "title": "Probability and Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "905",
+              "title": "Undergraduate Research in Mathematics and/or Computer Science I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "906",
+              "title": "Undergraduate Research in Mathematics and/or Computer Science II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Music",
+      "credential": "AS",
+      "program_code": "MUS-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/MUS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "102",
+              "title": "The European Classical Music Tradition",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "121",
+              "title": "Music Theory I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "122",
+              "title": "Music Theory II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "221",
+              "title": "Music Theory III",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Music Theory IV",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "124",
+              "title": "Sight Reading and Ear Training II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "223",
+              "title": "Sight Reading and Ear Training III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "224",
+              "title": "Sight Reading and Ear Training IV",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "132",
+              "title": "Class Instruction in Piano II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231",
+              "title": "Class Instruction Piano III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "232",
+              "title": "Class Instruction in Piano IV",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "103",
+              "title": "Twentieth-Century Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "104",
+              "title": "Jazz: An Introduction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "105",
+              "title": "Music Around the World",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "106",
+              "title": "Special Topics in Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "107",
+              "title": "Special Topics in Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "111",
+              "title": "Musicianship I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "201",
+              "title": "The Business of Music",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "210",
+              "title": "Music for Teachers of Children",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "225",
+              "title": "Jazz Theory and Improvisation I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "226",
+              "title": "Jazz Theory and Improvisation II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "290",
+              "title": "Study in Chamber Music Performance I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "291",
+              "title": "Study in Chamber Music Performance II",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "292",
+              "title": "Study in Chamber Music Performance III",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "293",
+              "title": "Study in Chamber Music Performance",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "101",
+              "title": "Introduction to the Recording Studio and MIDI",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "102",
+              "title": "Digital Music Sequencing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "103",
+              "title": "Recording Techniques I: Studio Equipment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "204",
+              "title": "Digital Sound Design",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "205",
+              "title": "Recording Techniques II: Studio Operation",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "206",
+              "title": "Virtual Instruments",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "207",
+              "title": "Microphones and Amplification Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MP",
+              "number": "208",
+              "title": "Digital Recording",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Movement Science",
+      "credential": "AS",
+      "program_code": "MVSC-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/MVSC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "103",
+              "title": "Fundamentals of Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "108",
+              "title": "Health and Physical Fitness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "416",
+              "title": "Weight Training",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "815",
+              "title": "Foundations of Physical Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "825",
+              "title": "Introduction to Exercise Science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "841",
+              "title": "Games and Sports for Children",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "302",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "104",
+              "title": "Addictions and Dependencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "105",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "106",
+              "title": "First Aid and Safety Education",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "107",
+              "title": "Mental Health: Understanding Your Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "111",
+              "title": "Stress Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "826",
+              "title": "Concepts of Personal Training I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PE",
+              "number": "827",
+              "title": "Concepts of Personal Training II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Other Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NH-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/NH-AAS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Sciences",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "301",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NU",
+              "number": "101",
+              "title": "Safe and Effective Nursing Care of Clients Level I",
+              "credits": 6.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "110",
+              "title": "Technical / Clinical Work Credit",
+              "credits": 3.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "111",
+              "title": "Fundamental Pathway to Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "102",
+              "title": "Safe and Effective Nursing Care Level II",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "201",
+              "title": "Safe and Effective Nursing Care of Clients Level III",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "202",
+              "title": "Safe and Effective Nursing Care Level IV",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "204",
+              "title": "Nursing and Societal Forces",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "302",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "311",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing - Pre-Clinical Sequence",
+      "credential": "AAS",
+      "program_code": "NP-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/NP-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Sciences",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "301",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NU",
+              "number": "101",
+              "title": "Safe and Effective Nursing Care of Clients Level I",
+              "credits": 6.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "102",
+              "title": "Safe and Effective Nursing Care Level II",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "201",
+              "title": "Safe and Effective Nursing Care of Clients Level III",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "202",
+              "title": "Safe and Effective Nursing Care Level IV",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "204",
+              "title": "Nursing and Societal Forces",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "302",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "311",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NPS-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/NPS-AAS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "301",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NU",
+              "number": "101",
+              "title": "Safe and Effective Nursing Care of Clients Level I",
+              "credits": 6.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "110",
+              "title": "Technical / Clinical Work Credit",
+              "credits": 3.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "111",
+              "title": "Fundamental Pathway to Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "102",
+              "title": "Safe and Effective Nursing Care Level II",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "201",
+              "title": "Safe and Effective Nursing Care of Clients Level III",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "202",
+              "title": "Safe and Effective Nursing Care Level IV",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "204",
+              "title": "Nursing and Societal Forces",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NS-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/NS-AAS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Sciences",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "301",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NU",
+              "number": "101",
+              "title": "Safe and Effective Nursing Care of Clients Level I",
+              "credits": 6.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "110",
+              "title": "Technical / Clinical Work Credit",
+              "credits": 3.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "111",
+              "title": "Fundamental Pathway to Nursing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "102",
+              "title": "Safe and Effective Nursing Care Level II",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "201",
+              "title": "Safe and Effective Nursing Care of Clients Level III",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "202",
+              "title": "Safe and Effective Nursing Care Level IV",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "204",
+              "title": "Nursing and Societal Forces",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "302",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "311",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing",
+      "credential": "AAS",
+      "program_code": "NY-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/NY-AAS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "301",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "NU",
+              "number": "101",
+              "title": "Safe and Effective Nursing Care of Clients Level I",
+              "credits": 6.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "102",
+              "title": "Safe and Effective Nursing Care Level II",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "201",
+              "title": "Safe and Effective Nursing Care of Clients Level III",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "202",
+              "title": "Safe and Effective Nursing Care Level IV",
+              "credits": 8.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NU",
+              "number": "204",
+              "title": "Nursing and Societal Forces",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "302",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "311",
+              "title": "Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Public Health",
+      "credential": "AS",
+      "program_code": "PBH-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/PBH-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "520",
+              "title": "Introduction to Public Health",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "503",
+              "title": "General Epidemiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "521",
+              "title": "Public Health Biology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "103",
+              "title": "Fundamentals of Human Nutrition",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "114",
+              "title": "Principles and Practices of Public Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "202",
+              "title": "Social and Behavioral Determinants of Health",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "IS",
+              "number": "151",
+              "title": "The Health of The Nation",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 8,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "461",
+              "title": "General Microbiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "501",
+              "title": "Environmental Health Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "522",
+              "title": "Applied Biostatistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "505",
+              "title": "Current Environmental Issues",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "554",
+              "title": "Research Laboratory Internship",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "104",
+              "title": "Addictions and Dependencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "105",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "107",
+              "title": "Mental Health: Understanding Your Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "108",
+              "title": "Health and Physical Fitness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "110",
+              "title": "Cardiopulmonary Resuscitation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "111",
+              "title": "Stress Management",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Engineering Science",
+      "credential": "AS",
+      "program_code": "PE-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/PE-AS",
+      "total_credits": 65,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 65,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EE",
+              "number": "101",
+              "title": "Engineering Design I",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "103",
+              "title": "Computer-Aided Analysis for Electrical Engineers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "204",
+              "title": "Electrical Circuits",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CS",
+              "number": "101",
+              "title": "Algorithmic Problem Solving I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "505",
+              "title": "Introduction to C++ Object Oriented Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "240",
+              "title": "Computerized Physical Measurement Using Graphical Programming",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements – Major Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "345",
+              "title": "Strength of Materials",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "416",
+              "title": "Thermodynamics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EE",
+              "number": "205",
+              "title": "Linear Systems Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "540",
+              "title": "Digital Computer Theory I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MT",
+              "number": "293",
+              "title": "Parametric Computer-Aided Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "440",
+              "title": "Modern Physics and Quantum Mechanics for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Physics",
+      "credential": "AS",
+      "program_code": "PHYS-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/PHYS-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "440",
+              "title": "Pre-Calculus Mathematics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "443",
+              "title": "Analytic Geometry and Calculus III",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "440",
+              "title": "Modern Physics and Quantum Mechanics for Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "160",
+              "title": "Physics Colloquium",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Major Electives",
+          "credits_required": 10,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "119",
+              "title": "College Algebra",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "121",
+              "title": "Elementary Trigonometry",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "451",
+              "title": "Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "461",
+              "title": "Linear Algebra",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "240",
+              "title": "Computerized Physical Measurement Using Graphical Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "414",
+              "title": "Analytical Mechanics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "415",
+              "title": "Electricity and Magnetism",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "416",
+              "title": "Thermodynamics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "450",
+              "title": "Introduction to Physics Research",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "451",
+              "title": "Numerical Methods for Scientists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "501",
+              "title": "Special Topics in Physics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "900",
+              "title": "Research Projects",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Psychology",
+      "credential": "AS",
+      "program_code": "PSYC-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/PSYC-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "201",
+              "title": "Research Methods in Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "215",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "250",
+              "title": "Personality",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ANTH",
+              "number": "101",
+              "title": "Anthropology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "104",
+              "title": "Addictions and Dependencies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "105",
+              "title": "Human Sexuality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "125",
+              "title": "Psychology of Personal Adjustment",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "215",
+              "title": "Child Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "220",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "230",
+              "title": "Abnormal Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "240",
+              "title": "Social Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "245",
+              "title": "Cross-Cultural Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "250",
+              "title": "Personality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "255",
+              "title": "The Psychology of Women",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "260",
+              "title": "Psychological Disorders of Childhood",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "270",
+              "title": "The Psychology of Aging",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "290",
+              "title": "States of Consciousness",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOCY",
+              "number": "101",
+              "title": "Sociology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "280",
+              "title": "Positive Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Courses",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MA",
+              "number": "336",
+              "title": "Statistics",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "101",
+              "title": "Personal Health and Wellness",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HE",
+              "number": "102",
+              "title": "Health, Behavior and Society",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Free Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "psychology"
+    },
+    {
+      "title": "Radiation Safety",
+      "credential": "certificate",
+      "program_code": "RADS-CERT",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/RADS-CERT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "101",
+              "title": "Radiation Safety I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "RAD",
+              "number": "102",
+              "title": "Radiation Safety II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "301",
+              "title": "College Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "302",
+              "title": "College Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Science for Forensics",
+      "credential": "AS",
+      "program_code": "SF-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/SF-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science Degree",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "441",
+              "title": "Analytic Geometry and Calculus I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "151",
+              "title": "General Chemistry I",
+              "credits": 4.5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "201",
+              "title": "General Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "152",
+              "title": "General Chemistry II",
+              "credits": 4.5,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CH",
+              "number": "251",
+              "title": "Organic Chemistry I",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "252",
+              "title": "Organic Chemistry II",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "202",
+              "title": "General Biology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "442",
+              "title": "Analytic Geometry and Calculus II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "421",
+              "title": "General Calculus Physics A",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "422",
+              "title": "General Calculus Physics B",
+              "credits": 5,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Telecommunications Technology",
+      "credential": "AAS",
+      "program_code": "TC-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/TC-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "114",
+              "title": "College Algebra and Trigonometry for Technical Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "201",
+              "title": "General Physics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "202",
+              "title": "General Physics II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "110",
+              "title": "Electric Circuit Analysis",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "210",
+              "title": "Electronics I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "230",
+              "title": "Telecommunications I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "232",
+              "title": "Wireless Mobile Communications",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "509",
+              "title": "Programming for Embedded Systems",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "540",
+              "title": "Digital Computer Theory I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "560",
+              "title": "Microprocessors and Microcomputers",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "704",
+              "title": "Networking Fundamentals I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "705",
+              "title": "Networking Fundamentals II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "128",
+              "title": "Calculus for Technical and Business Students",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TECH",
+              "number": "100",
+              "title": "Introduction to Engineering & Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ET",
+              "number": "140",
+              "title": "Sinusoidal and Transient Circuit Analysis",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "220",
+              "title": "Electronics II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "305",
+              "title": "Transients and Electromechanical Transducers",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "360",
+              "title": "Electronics and Automation for the Home",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "375",
+              "title": "Introduction to Robotics",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "481",
+              "title": "Personal Computer Technology, Architecture and Troubleshooting",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "502",
+              "title": "Introduction to Computer Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "504",
+              "title": "Operating Systems and System Deployment",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "505",
+              "title": "Introduction to C++ Object Oriented Programming",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "506",
+              "title": "Linux Operating System",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "570",
+              "title": "Creating Smartphone Apps",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "575",
+              "title": "Introduction to Computing and Programming in C++",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "580",
+              "title": "Object-Oriented Programming",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "706",
+              "title": "Network Configuration I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "707",
+              "title": "Network Configuration II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "710",
+              "title": "Front-End UI/UX Web Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "712",
+              "title": "JavaScript Programming: Client and Server",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "720",
+              "title": "Advanced Web and Multimedia Programming",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "725",
+              "title": "Computer Network Security",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "754",
+              "title": "Security Policies and Procedures",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "841",
+              "title": "The Science of Energy and Power in the Modern World-also take ET842 for lab science",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "880",
+              "title": "Science and Technology in Modern Life",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "991",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "992",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "993",
+              "title": "Cooperative Education in Engineering Technology",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Theatre",
+      "credential": "AS",
+      "program_code": "THE-AS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/THE-AS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": 3,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "211",
+              "title": "Speech Communication",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "111",
+              "title": "Introduction to Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TH",
+              "number": "121",
+              "title": "Introduction to Acting for the Major",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "131",
+              "title": "Stagecraft I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "132",
+              "title": "Production Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "153",
+              "title": "Voice and Speech for the Actor",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Acting or Technical Theatre Concentration",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TH",
+              "number": "221",
+              "title": "Acting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "231",
+              "title": "Stagecraft II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "TH",
+              "number": "122",
+              "title": "Actors' Workshop I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "124",
+              "title": "Summer Theatre Workshop",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "134",
+              "title": "Stage Makeup",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "135",
+              "title": "Costume Construction",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "154",
+              "title": "Movement for the Actor",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "221",
+              "title": "Acting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "222",
+              "title": "Actors' Workshop II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "231",
+              "title": "Stagecraft II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "232",
+              "title": "Production Practicum II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "235",
+              "title": "Stage Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMP",
+              "number": "141",
+              "title": "Introduction to Digital Media Production",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FMP",
+              "number": "242",
+              "title": "Writing for the Screen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SP",
+              "number": "321",
+              "title": "Oral Performance for the Actor and Speaker",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "TH",
+              "number": "901",
+              "title": "Independent Study in Theatre",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Additional Requirements",
+          "credits_required": 1,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "132",
+              "title": "Foundations of Biology: Laboratory experience",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "171",
+              "title": "Laboratory: Plants and People",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "102",
+              "title": "Living in A Chemical World Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "111",
+              "title": "Chemistry and the Environment - Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CH",
+              "number": "121",
+              "title": "Fundamentals of Chemistry Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ET",
+              "number": "842",
+              "title": "Energy Production and Conservation for a Sustainable World",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PH",
+              "number": "112",
+              "title": "Space, Astronomy, and Our Universe Laboratory",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Massage Therapy",
+      "credential": "AAS",
+      "program_code": "TM-AAS",
+      "catalog_url": "https://qcc.catalog.cuny.edu/programs/TM-AAS",
+      "total_credits": 60,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Degree Requirements - Associate in Applied Science",
+          "credits_required": 60,
+          "choose_n": null,
+          "courses": []
+        },
+        {
+          "name": "General Education Requirements - Common Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "301",
+              "title": "Anatomy and Physiology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "101",
+              "title": "English Composition I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENGL",
+              "number": "102",
+              "title": "English Composition II: Introduction to Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MA",
+              "number": "321",
+              "title": "Mathematics in Contemporary Society",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "302",
+              "title": "Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSYC",
+              "number": "101",
+              "title": "Psychology",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Program Core",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BI",
+              "number": "325",
+              "title": "Neurophysiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "330",
+              "title": "Myology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BI",
+              "number": "331",
+              "title": "Kinesiology",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "100",
+              "title": "Foundations of Therapeutic Massage",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "101",
+              "title": "Eastern Massage I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "102",
+              "title": "Western Massage I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "103",
+              "title": "Eastern Massage II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "104",
+              "title": "Western Massage II",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "202",
+              "title": "Western Massage III",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "203",
+              "title": "Massage Practicum I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "204",
+              "title": "Massage Practicum II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "205",
+              "title": "Professional Issues in Massage Therapy",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "220",
+              "title": "Pathology for Massage Therapy I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "221",
+              "title": "Pathology for Massage Therapy II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Major Requirements - Electives",
+          "credits_required": 2,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HA",
+              "number": "206",
+              "title": "Pregnancy Massage",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "207",
+              "title": "Hospital-Based Massage",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "208",
+              "title": "Sports Massage",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HA",
+              "number": "209",
+              "title": "Thai Massage",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/ny/config.ts
+++ b/lib/states/ny/config.ts
@@ -101,7 +101,7 @@ const nyConfig: StateConfig = {
     courses: [{ scripts: ["scripts/ny/scrape-cuny.ts"], runner: "http" }],
     transfers: [{ scripts: ["scripts/ny/scrape-transfer-trex.ts"], runner: "http" }],
     prereqs: [{ scripts: ["scripts/ny/scrape-catalog-prereqs.ts"], runner: "playwright" }],
-    // manual-only: programs — Acalog program scraper not yet wired up for this state.
+    programs: [{ scripts: ["scripts/ny/scrape-programs.ts"], runner: "playwright" }],
   },
 };
 

--- a/scripts/lib/scrape-coursedog-programs.ts
+++ b/scripts/lib/scrape-coursedog-programs.ts
@@ -1,0 +1,582 @@
+/**
+ * scrape-coursedog-programs.ts — shared Coursedog program scraper.
+ *
+ * Coursedog is a hosted catalog/curriculum platform used by CUNY (all 7
+ * community colleges), MA's Greenfield CC, and most SUNY community
+ * colleges. Each customer publishes a Nuxt SSR catalog at a tenant
+ * subdomain (e.g. bmcc.catalog.cuny.edu) which fetches data
+ * client-side from app.coursedog.com. Cookies set by the catalog
+ * subdomain are required for the API to return non-401 responses, so
+ * we drive everything through Playwright + page.evaluate(fetch(...))
+ * to inherit the page session — same pattern as the existing course
+ * prereq scraper at scripts/ny/scrape-catalog-prereqs.ts.
+ *
+ * Architecture
+ * ------------
+ * 1. Open the catalog's /programs page; capture tenantId + catalogId
+ *    from the first programs/search request that fires.
+ * 2. List all programs via /api/v1/cm/{tenantId}/programs/search/$filters.
+ * 3. For each program, GET /api/v1/cm/{tenantId}/programs/{programId}
+ *    to retrieve its full document. The requirement structure lives
+ *    in `requisites.requisitesSimple[]` — an array of top-level
+ *    "requirement groups" (Common Core, Major Core, Electives, etc.)
+ *    each containing a tree of rules.
+ * 4. Walk the rules recursively to collect:
+ *       - course-id leaves (rule.value.condition === "courses")
+ *       - credit floors (rule.condition === "minimumCredits")
+ *       - "choose N of" restrictions (completedAtLeastXOf / anyOf)
+ * 5. Resolve internal course IDs to "PREFIX NUMBER" + title + credits
+ *    via /api/v1/cm/{tenantId}/courses?courseGroupIds=… (batched).
+ * 6. Emit one ProgramRequirement per program in the standard schema.
+ *
+ * Caveats
+ * -------
+ * - The Coursedog rule tree is more expressive than our flat
+ *   RequirementGroup schema (recursive subRules, anyOf alternatives,
+ *   minimumCreditsHere overrides). v1 flattens each top-level
+ *   requisitesSimple entry into one RequirementGroup whose `courses`
+ *   contains every concrete course referenced anywhere inside.
+ *   choose_n is pulled from the *outermost* completedAtLeastXOf or
+ *   anyOf restriction that wraps the group; credits_required from
+ *   the outermost minimumCredits rule.
+ * - degreeMaps (semester-by-semester suggested sequences) are
+ *   ignored — they duplicate course coverage from requisitesSimple
+ *   and would inflate counts.
+ * - Total credits: prefer the program-wide minimumCredits rule
+ *   under the "Degree Requirements" group; fall back to summing
+ *   required-course credits across all groups.
+ */
+
+import { chromium, type Browser, type Page } from "playwright";
+import type {
+  CollegePrograms,
+  ProgramCredential,
+  ProgramRequirement,
+  RequiredCourse,
+  RequirementGroup,
+} from "../../lib/types.js";
+
+export interface CoursedogProgramConfig {
+  collegeSlug: string;
+  /** Catalog domain, e.g. "bmcc.catalog.cuny.edu" (no scheme, no path). */
+  catalogDomain: string;
+  /** Catalog year for output metadata, e.g. "2025-2026". */
+  catalogYear: string;
+}
+
+const CONCURRENCY = 4;
+const PROGRAMS_PAGE_SIZE = 200;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// Session capture
+// ---------------------------------------------------------------------------
+
+async function captureSession(
+  page: Page,
+  catalogDomain: string,
+): Promise<{ tenantId: string; catalogId: string } | null> {
+  let tenantId: string | null = null;
+  let catalogId: string | null = null;
+
+  const handler = (req: { url(): string }) => {
+    const u = req.url();
+    const m = u.match(/app\.coursedog\.com\/api\/v1\/cm\/([^/]+)\/programs\/search/);
+    if (m && !tenantId) {
+      tenantId = m[1];
+      const cm = u.match(/catalogId=([^&]+)/);
+      if (cm) catalogId = decodeURIComponent(cm[1]);
+    }
+  };
+  page.on("request", handler);
+
+  const url = `https://${catalogDomain}/programs`;
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60000 });
+  } catch (e) {
+    console.warn(`  [${catalogDomain}] goto error: ${(e as Error).message}`);
+  }
+
+  for (let i = 0; i < 60 && !tenantId; i++) {
+    await page.waitForTimeout(500);
+  }
+  page.off("request", handler);
+
+  if (!tenantId || !catalogId) return null;
+  return { tenantId, catalogId };
+}
+
+// ---------------------------------------------------------------------------
+// Coursedog API types
+// ---------------------------------------------------------------------------
+
+interface ProgramListItem {
+  _id: string;
+  id: string;
+  code?: string;
+  name?: string;
+  longName?: string;
+  catalogDisplayName?: string;
+  degreeDesignation?: string;
+  status?: string;
+}
+
+interface RequisiteRule {
+  id?: string;
+  condition?: string;
+  credits?: number;
+  restriction?: { selectN?: number; minimumCredits?: number };
+  value?: {
+    condition?: string;
+    values?: Array<{ value: string[] | string; logic?: string }>;
+    subSelections?: unknown[];
+  };
+  subRules?: RequisiteRule[];
+  gradeType?: string;
+  grade?: string;
+}
+
+interface RequisiteGroup {
+  id?: string;
+  name?: string;
+  type?: string;
+  rules?: RequisiteRule[];
+}
+
+interface ProgramDetail {
+  _id: string;
+  id: string;
+  code?: string;
+  name?: string;
+  longName?: string;
+  catalogDisplayName?: string;
+  degreeDesignation?: string;
+  type?: string;
+  status?: string;
+  requisites?: { requisitesSimple?: RequisiteGroup[] };
+  customFields?: Record<string, unknown>;
+}
+
+interface CourseDoc {
+  _id: string;
+  code?: string;
+  subjectCode?: string;
+  courseNumber?: string;
+  name?: string;
+  longName?: string;
+  credits?: { creditHours?: { min?: number; max?: number } };
+}
+
+// ---------------------------------------------------------------------------
+// API helpers — run inside the page so session cookies attach automatically
+// ---------------------------------------------------------------------------
+
+async function apiGet<T>(page: Page, url: string): Promise<T | null> {
+  const result = await page.evaluate(async (u) => {
+    try {
+      const r = await fetch(u, {
+        headers: { "x-requested-with": "catalog", Accept: "application/json" },
+      });
+      if (!r.ok) return { ok: false, status: r.status, data: null };
+      return { ok: true, status: r.status, data: await r.json() };
+    } catch (e) {
+      return { ok: false, status: 0, data: null, error: String(e) };
+    }
+  }, url);
+  if (!result.ok) return null;
+  return result.data as T;
+}
+
+async function apiPost<T>(
+  page: Page,
+  url: string,
+  body: unknown,
+): Promise<T | null> {
+  const result = await page.evaluate(
+    async ({ u, b }) => {
+      try {
+        const r = await fetch(u, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-requested-with": "catalog",
+            Accept: "application/json",
+          },
+          body: JSON.stringify(b),
+        });
+        if (!r.ok) return { ok: false, status: r.status, data: null };
+        return { ok: true, status: r.status, data: await r.json() };
+      } catch (e) {
+        return { ok: false, status: 0, data: null, error: String(e) };
+      }
+    },
+    { u: url, b: body },
+  );
+  if (!result.ok) return null;
+  return result.data as T;
+}
+
+// Minimal filter body — only "Active" + catalogPrint, matching the same
+// shape the catalog UI itself uses for the courses search.
+const PROGRAMS_FILTER_BODY = {
+  condition: "AND",
+  filters: [
+    {
+      filters: [
+        {
+          id: "status-program",
+          condition: "field",
+          name: "status",
+          inputType: "select",
+          group: "program",
+          type: "is",
+          value: "Active",
+          customField: false,
+        },
+      ],
+      id: "I5KglKp3",
+      condition: "and",
+    },
+  ],
+};
+
+async function listAllPrograms(
+  page: Page,
+  tenantId: string,
+  catalogId: string,
+): Promise<ProgramListItem[]> {
+  const url =
+    `https://app.coursedog.com/api/v1/cm/${tenantId}/programs/search/%24filters` +
+    `?catalogId=${encodeURIComponent(catalogId)}` +
+    `&skip=0&limit=${PROGRAMS_PAGE_SIZE}` +
+    `&orderBy=code&formatDependents=false`;
+  const resp = await apiPost<{ data: ProgramListItem[]; listLength: number }>(
+    page,
+    url,
+    PROGRAMS_FILTER_BODY,
+  );
+  if (!resp) return [];
+  return resp.data ?? [];
+}
+
+async function getProgramDetail(
+  page: Page,
+  tenantId: string,
+  programId: string,
+): Promise<ProgramDetail | null> {
+  const url = `https://app.coursedog.com/api/v1/cm/${tenantId}/programs/${encodeURIComponent(programId)}`;
+  return apiGet<ProgramDetail>(page, url);
+}
+
+/**
+ * Returns a map keyed by the BARE courseGroupId (no date suffix). The
+ * Coursedog response keys docs as "{groupId}-{effectiveDate}" — we
+ * strip the suffix so callers can look up by groupId directly.
+ */
+async function getCoursesByGroupIds(
+  page: Page,
+  tenantId: string,
+  courseGroupIds: string[],
+): Promise<Record<string, CourseDoc>> {
+  if (courseGroupIds.length === 0) return {};
+  const out: Record<string, CourseDoc> = {};
+  const chunkSize = 60;
+  for (let i = 0; i < courseGroupIds.length; i += chunkSize) {
+    const ids = courseGroupIds.slice(i, i + chunkSize).join(",");
+    const url =
+      `https://app.coursedog.com/api/v1/cm/${tenantId}/courses` +
+      `?courseGroupIds=${encodeURIComponent(ids)}` +
+      `&useFetchingDegreeMapsCoursesLatestRevisionSettings=true`;
+    const resp = await apiGet<Record<string, CourseDoc>>(page, url);
+    if (resp) {
+      for (const [k, doc] of Object.entries(resp)) {
+        // "0875411-2025-08-25" → "0875411"
+        const bare = k.replace(/-\d{4}-\d{2}-\d{2}$/, "");
+        if (!out[bare]) out[bare] = doc;
+      }
+    }
+    await sleep(50);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rule walker — flatten the rule tree into (courseIds, choose_n, credits)
+// ---------------------------------------------------------------------------
+
+interface FlattenedGroup {
+  courseGroupIds: Set<string>;
+  /** First non-null choose-N restriction encountered. */
+  chooseN: number | null;
+  /** First non-null minimumCredits rule encountered. */
+  creditsRequired: number | null;
+}
+
+function walkRules(rules: RequisiteRule[] | undefined, acc: FlattenedGroup) {
+  if (!rules) return;
+  for (const rule of rules) {
+    // Top-level credit floor — record once
+    if (rule.condition === "minimumCredits" && typeof rule.credits === "number") {
+      if (acc.creditsRequired === null) acc.creditsRequired = rule.credits;
+    }
+    // "Pick N of" / "earn at least N credits from" patterns
+    if (
+      rule.condition === "completedAtLeastXOf" ||
+      rule.condition === "anyOf" ||
+      rule.condition === "atLeastXCredits"
+    ) {
+      const n = rule.restriction?.selectN ?? null;
+      if (n !== null && acc.chooseN === null) acc.chooseN = n;
+    }
+    // Leaf with course IDs
+    if (rule.value?.condition === "courses") {
+      for (const v of rule.value.values ?? []) {
+        const arr = Array.isArray(v.value) ? v.value : [v.value];
+        for (const id of arr) {
+          if (typeof id === "string" && id.length > 0) acc.courseGroupIds.add(id);
+        }
+      }
+    }
+    // Recurse into nested rule structures
+    walkRules(rule.subRules, acc);
+    if (rule.value && Array.isArray(rule.value.subSelections)) {
+      for (const sub of rule.value.subSelections) {
+        if (typeof sub === "object" && sub !== null && "rules" in sub) {
+          walkRules((sub as { rules?: RequisiteRule[] }).rules, acc);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Course-doc → RequiredCourse mapping
+// ---------------------------------------------------------------------------
+
+function courseToRequired(doc: CourseDoc | undefined): RequiredCourse | null {
+  if (!doc) return null;
+  // CUNY's `code` field is what the catalog displays ("ACC 122"); subjectCode
+  // is sometimes a different SIS-side prefix ("ACCT"). Prefer `code` so the
+  // emitted prefix matches what the rest of our system uses (course
+  // search, prereq aggregation).
+  const code = doc.code?.trim() ?? "";
+  const codeMatch = code.match(/^([A-Z]{2,5})\s+(\d{2,4}[A-Z]?)$/);
+  if (codeMatch) {
+    const titleSrc = doc.longName ?? doc.name ?? "";
+    return {
+      prefix: codeMatch[1],
+      number: codeMatch[2],
+      title: titleSrc.replace(/\s+/g, " ").trim(),
+      credits: doc.credits?.creditHours?.max ?? doc.credits?.creditHours?.min ?? null,
+      or_alternatives: [],
+    };
+  }
+  // Fall back to subjectCode + courseNumber if `code` is missing or oddly
+  // formatted.
+  const prefix = doc.subjectCode?.trim();
+  const number = doc.courseNumber?.trim();
+  if (!prefix || !number) return null;
+  const titleSrc = doc.longName ?? doc.name ?? "";
+  return {
+    prefix: prefix.toUpperCase(),
+    number,
+    title: titleSrc.replace(/\s+/g, " ").trim(),
+    credits: doc.credits?.creditHours?.max ?? doc.credits?.creditHours?.min ?? null,
+    or_alternatives: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Credential classifier
+// ---------------------------------------------------------------------------
+
+function classifyCredential(
+  degreeDesignation: string | undefined,
+  type: string | undefined,
+): ProgramCredential {
+  const t = (degreeDesignation ?? "").toLowerCase();
+  if (t.includes("aas") || t.includes("applied science")) return "AAS";
+  if (t.includes("a.a.s")) return "AAS";
+  if (t.includes("aa - associate in arts") || t.includes("associate in arts")) return "AA";
+  if (t.includes("as - associate in science") || t.includes("associate in science")) return "AS";
+  if (t.includes("certificate") || t.includes("certge") || t.includes("ge30") || t.includes("ge15")) return "certificate";
+  if (t.includes("diploma")) return "diploma";
+  if (type && type.toLowerCase().includes("certificate")) return "certificate";
+  return "other";
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export async function scrapeCoursedogPrograms(
+  config: CoursedogProgramConfig,
+): Promise<CollegePrograms> {
+  const { collegeSlug, catalogDomain, catalogYear } = config;
+
+  let browser: Browser | null = null;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    console.log(`  [${collegeSlug}] Capturing session at ${catalogDomain}…`);
+    const session = await captureSession(page, catalogDomain);
+    if (!session) {
+      console.warn(`  [${collegeSlug}] Failed to capture tenantId/catalogId; aborting.`);
+      return {
+        college_slug: collegeSlug,
+        catalog_year: catalogYear,
+        catalog_url: `https://${catalogDomain}/programs`,
+        scraped_at: new Date().toISOString(),
+        programs: [],
+      };
+    }
+    const { tenantId, catalogId } = session;
+    console.log(`  [${collegeSlug}] tenant=${tenantId} catalog=${catalogId}`);
+
+    const list = await listAllPrograms(page, tenantId, catalogId);
+    console.log(`  [${collegeSlug}] Found ${list.length} programs`);
+
+    // Walk all programs sequentially (Coursedog rate-limits are sensitive
+    // to bursts; ~6/sec is comfortable). For each program: detail → flatten
+    // → resolve courses → emit.
+    const programs: ProgramRequirement[] = [];
+    let parsed = 0;
+    let skipped = 0;
+
+    for (const item of list) {
+      try {
+        const detail = await getProgramDetail(page, tenantId, item._id);
+        if (!detail) {
+          skipped++;
+          continue;
+        }
+        const requisitesSimple = detail.requisites?.requisitesSimple ?? [];
+        if (requisitesSimple.length === 0) {
+          skipped++;
+          continue;
+        }
+
+        // Flatten each top-level requisitesSimple entry.
+        const flattened: { name: string; flat: FlattenedGroup }[] = [];
+        const allCourseIds = new Set<string>();
+        for (const group of requisitesSimple) {
+          const flat: FlattenedGroup = {
+            courseGroupIds: new Set(),
+            chooseN: null,
+            creditsRequired: null,
+          };
+          walkRules(group.rules, flat);
+          for (const id of flat.courseGroupIds) allCourseIds.add(id);
+          flattened.push({ name: (group.name ?? "Required Courses").trim(), flat });
+        }
+
+        // Resolve all course IDs once
+        const courseDocs = await getCoursesByGroupIds(
+          page,
+          tenantId,
+          [...allCourseIds],
+        );
+
+        // Build RequirementGroups
+        const requirementGroups: RequirementGroup[] = [];
+        for (const { name, flat } of flattened) {
+          const courses: RequiredCourse[] = [];
+          const seen = new Set<string>();
+          for (const id of flat.courseGroupIds) {
+            const doc = courseDocs[id];
+            const rc = courseToRequired(doc);
+            if (!rc) continue;
+            const key = `${rc.prefix} ${rc.number}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            courses.push(rc);
+          }
+          if (courses.length === 0 && flat.creditsRequired === null) continue;
+          requirementGroups.push({
+            name,
+            credits_required: flat.creditsRequired,
+            choose_n: flat.chooseN,
+            courses,
+          });
+        }
+        if (requirementGroups.length === 0) {
+          skipped++;
+          continue;
+        }
+
+        // Total credits — prefer the explicit "Degree Requirements"
+        // minimumCredits floor. Don't fall back to summing course credits:
+        // many CUNY programs encode alternative "Options" (concentrations)
+        // as parallel top-level groups, and naïvely summing inflates the
+        // total to absurd values (e.g. Bronx CC Liberal Arts had 14
+        // option groups summing to 690 credits when the real answer is
+        // ~60). Better to emit null than a misleading number.
+        let totalCredits: number | null = null;
+        const degreeReqGroup = requirementGroups.find((g) =>
+          /degree requirement/i.test(g.name),
+        );
+        if (degreeReqGroup && degreeReqGroup.credits_required !== null) {
+          totalCredits = degreeReqGroup.credits_required;
+        } else {
+          // Fallback: any group that names itself as a credit total
+          // ("Total Credits", "Major Requirements - Total Credits", etc.).
+          // Bronx CC encodes the program-wide credit floor this way.
+          const anchor = requirementGroups.find(
+            (g) =>
+              g.credits_required !== null &&
+              /(total credits|minimum credits|credits required)/i.test(g.name),
+          );
+          if (anchor) totalCredits = anchor.credits_required;
+        }
+
+        const credential = classifyCredential(detail.degreeDesignation, detail.type);
+        const title =
+          detail.catalogDisplayName?.trim() ||
+          detail.longName?.trim() ||
+          detail.name?.trim() ||
+          item.code ||
+          item._id;
+
+        programs.push({
+          title,
+          credential,
+          program_code: detail.code ?? null,
+          catalog_url: `https://${catalogDomain}/programs/${detail.code ?? item._id}`,
+          total_credits: totalCredits,
+          gpa_minimum: 2.0,
+          description: null,
+          requirement_groups: requirementGroups,
+          matched_program_slug: null,
+        });
+        parsed++;
+      } catch (e) {
+        console.warn(
+          `  [${collegeSlug}]   ! ${item.code ?? item._id}: ${e instanceof Error ? e.message : e}`,
+        );
+        skipped++;
+      }
+      if ((parsed + skipped) % 10 === 0) {
+        console.log(
+          `  [${collegeSlug}]   progress: ${parsed} parsed, ${skipped} skipped`,
+        );
+      }
+      await sleep(120);
+    }
+
+    console.log(
+      `  [${collegeSlug}] Done: ${parsed} parsed, ${skipped} skipped`,
+    );
+    return {
+      college_slug: collegeSlug,
+      catalog_year: catalogYear,
+      catalog_url: `https://${catalogDomain}/programs`,
+      scraped_at: new Date().toISOString(),
+      programs,
+    };
+  } finally {
+    if (browser) await browser.close();
+  }
+}

--- a/scripts/ny/scrape-programs.ts
+++ b/scripts/ny/scrape-programs.ts
@@ -1,0 +1,92 @@
+/**
+ * scrape-programs.ts (NY / CUNY)
+ *
+ * Closes #230. Scrapes program/degree requirements for the 7 CUNY
+ * community colleges via the Coursedog catalog at app.coursedog.com.
+ *
+ * The college_slug values match data/ny/institutions.json — note that
+ * Coursedog subdomains differ from our institution ids (e.g. our slug
+ * "bronx-cc" maps to subdomain "bcc.catalog.cuny.edu").
+ *
+ * Usage:
+ *   npx tsx scripts/ny/scrape-programs.ts
+ *   npx tsx scripts/ny/scrape-programs.ts --college bmcc
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { scrapeCoursedogPrograms } from "../lib/scrape-coursedog-programs.js";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type { CoursedogProgramConfig } from "../lib/scrape-coursedog-programs.js";
+
+const COLLEGES: CoursedogProgramConfig[] = [
+  { collegeSlug: "bmcc", catalogDomain: "bmcc.catalog.cuny.edu", catalogYear: "2025-2026" },
+  { collegeSlug: "bronx-cc", catalogDomain: "bcc.catalog.cuny.edu", catalogYear: "2025-2026" },
+  { collegeSlug: "guttman-cc", catalogDomain: "guttman.catalog.cuny.edu", catalogYear: "2025-2026" },
+  { collegeSlug: "hostos-cc", catalogDomain: "hostos.catalog.cuny.edu", catalogYear: "2025-2026" },
+  { collegeSlug: "kingsborough-cc", catalogDomain: "kbcc.catalog.cuny.edu", catalogYear: "2025-2026" },
+  { collegeSlug: "laguardia-cc", catalogDomain: "laguardia.catalog.cuny.edu", catalogYear: "2025-2026" },
+  { collegeSlug: "queensborough-cc", catalogDomain: "qcc.catalog.cuny.edu", catalogYear: "2025-2026" },
+];
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeArg =
+    args.find((a) => a.startsWith("--college="))?.split("=")[1] ||
+    (args.indexOf("--college") >= 0 ? args[args.indexOf("--college") + 1] : null);
+
+  let colleges = COLLEGES;
+  if (collegeArg) {
+    colleges = COLLEGES.filter((c) => c.collegeSlug === collegeArg);
+    if (colleges.length === 0) {
+      console.error(
+        `Unknown college: ${collegeArg}. Available: ${COLLEGES.map((c) => c.collegeSlug).join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const outDir = path.join(process.cwd(), "data", "ny", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`NY/CUNY program scraper — ${colleges.length} college(s)\n`);
+
+  let totalPrograms = 0;
+  for (const config of colleges) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`Scraping ${config.collegeSlug} (${config.catalogDomain})`);
+    console.log("=".repeat(60));
+
+    try {
+      const data = await scrapeCoursedogPrograms(config);
+      if (data.programs.length === 0) {
+        console.log(`  No programs scraped for ${config.collegeSlug}, skipping write.`);
+        continue;
+      }
+
+      const { matched, unmatched } = applyProgramMatching(data.programs);
+      console.log(
+        `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+      );
+
+      const outPath = path.join(outDir, `${config.collegeSlug}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+      console.log(`  ✓ Wrote ${data.programs.length} programs to ${outPath}`);
+      totalPrograms += data.programs.length;
+    } catch (e) {
+      console.error(
+        `  ERROR scraping ${config.collegeSlug}: ${e instanceof Error ? e.message : e}`,
+      );
+    }
+  }
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(
+    `Done. Total: ${totalPrograms} programs across ${colleges.length} college(s).`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Shared Coursedog program scraper at [scripts/lib/scrape-coursedog-programs.ts](scripts/lib/scrape-coursedog-programs.ts) — first program scraper for the Coursedog platform.
- NY runner at [scripts/ny/scrape-programs.ts](scripts/ny/scrape-programs.ts) covering all 7 CUNY community colleges.
- Wires `programs:` into [lib/states/ny/config.ts](lib/states/ny/config.ts), replacing the `manual-only` marker.
- **278 programs** across 7 colleges; `total_credits` 27–73 (sane range, 30/278 nulls).

## Architecture

Mirrors the existing CUNY course-prereq scraper at [scripts/ny/scrape-catalog-prereqs.ts](scripts/ny/scrape-catalog-prereqs.ts) since the auth model is the same: Coursedog catalogs are Nuxt SSR apps that fetch from `app.coursedog.com` client-side, and the API requires session cookies set by the catalog subdomain. We drive everything through Playwright + `page.evaluate(fetch(...))` so cookies attach automatically.

1. Open `{college}.catalog.cuny.edu/programs`, capture `tenantId` + `catalogId` from the first request.
2. List programs via `cm/{tenantId}/programs/search/$filters`.
3. GET `cm/{tenantId}/programs/{programId}` for each — requirements live in `requisites.requisitesSimple[]`.
4. Recursively walk the rule tree (`allOf` / `anyOf` / `completedAllOf` / `completedAtLeastXOf` / `minimumCredits` …) collecting course IDs, choose-n restrictions, and credit floors.
5. Resolve Coursedog course IDs to `PREFIX NUMBER` via `cm/{tenantId}/courses?courseGroupIds=…` (batched 60/request).
6. Emit one `ProgramRequirement` per program in the standard schema.

## Two non-obvious bugs found in development

- **Course-doc keying.** Coursedog responses key course docs as `"{groupId}-{date}"` (e.g. `0875411-2025-08-25`), but the rule tree references the bare `groupId`. The doc map has to be re-keyed by the bare ID for lookups to work.
- **`subjectCode` ≠ catalog prefix.** CUNY's SIS-side `subjectCode` ("ACCT") doesn't always match what the catalog displays ("ACC"). Prefer the `code` field ("ACC 122") and split it; only fall back to `subjectCode` + `courseNumber` when `code` is malformed.

## `total_credits` handling

Don't naïvely sum course-level credits — many CUNY programs encode parallel "Option" concentrations as separate top-level groups (Bronx CC's Liberal Arts AA had 14 alternative options summing to 690 credits before this fix). Prefer the explicit `minimumCredits` floor on the program-wide "Degree Requirements" group; fall back to any named "Total Credits" anchor group; otherwise emit `null`. Better honest nulls than misleading 690s.

## Result per college

| Slug | Programs | total_credits | nulls |
|---|---|---|---|
| bmcc | 61 | 60–73 | 5 |
| bronx-cc | 44 | 27–60 | 10 |
| guttman-cc | 9 | 33–60 | 0 |
| hostos-cc | 28 | 60–71 | 1 |
| kingsborough-cc | 41 | 30–68 | 7 |
| laguardia-cc | 48 | 33–68 | 4 |
| queensborough-cc | 47 | 60–65 | 3 |

## Side benefit

The shared lib also unblocks MA's GCC (Greenfield CC, deferred during the #228 MA push) since it's also Coursedog. Adding GCC will be a one-config-entry follow-up.

## Test plan

- [x] `npx tsc --noEmit` exits 0
- [x] `npm run lint` exits 0
- [x] `scripts/check-scraper-coverage.ts` passes (18 states × 4 datatypes)
- [x] Scraper produces 278 programs with sane credentials and credit totals
- [x] Spot-check BMCC Accounting AAS: 60 credits, Major Core has 19 courses (ACC 122, ACC 222, …)
- [x] Local dev: `/ny/college/bmcc/programs` and `/ny/college/bronx-cc/programs` render the new data
- [ ] CI green
- [ ] Post-merge: confirm Vercel ships and prod URL shows the new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)