### PR TITLE
feat: Coursedog program scraper for Greenfield CC (MA 15/15, closes #228)

### DIFF
--- a/data/ma/programs/gcc.json
+++ b/data/ma/programs/gcc.json
@@ -1,0 +1,3362 @@
+{
+  "college_slug": "gcc",
+  "catalog_year": "2025-2026",
+  "catalog_url": "https://catalog.gcc.mass.edu/programs",
+  "scraped_at": "2026-05-07T17:02:32.715Z",
+  "programs": [
+    {
+      "title": "Adventure Education",
+      "credential": "AS",
+      "program_code": "ADE",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/ADE",
+      "total_credits": 55,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 32-33 Credits",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "104",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements: 23 Credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OLP",
+              "number": "111",
+              "title": "Introduction to Outdoor Adventure Skills",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "112",
+              "title": "Wilderness Orientation Expedition for Outdoor Leaders",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "120",
+              "title": "Wilderness Medical Preparedness and Rescue",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "143",
+              "title": "Backcountry Travel Instructor I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "210",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "216",
+              "title": "Wilderness-Based Adventure Planning and Fieldwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "116",
+              "title": "Teambuilding, Group-Development, and Fieldwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "150",
+              "title": "Fundamentals of Technical Rock Climbing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Allied Health",
+      "credential": "AS",
+      "program_code": "ALH",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/ALH",
+      "total_credits": 34,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 34-36 Credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "209",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "217",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "126",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "216",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "114",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Addiction Studies Certificate",
+      "credential": "certificate",
+      "program_code": "ASC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/ASC",
+      "total_credits": 29,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements: 29 Credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "107",
+              "title": "Introduction to Addiction Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "115",
+              "title": "The Helping Relationship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "168",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "172",
+              "title": "Practicum in Addiction Studies I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "215",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "241",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "272",
+              "title": "Practicum in Addiction Studies II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "210",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art/Visual Arts",
+      "credential": "AS",
+      "program_code": "AVA",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/AVA",
+      "total_credits": 42,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements: 21-23 Credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "102",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements: 21 Credits",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "123",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "151",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "161",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "290",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Art/Visual Arts Transfer Block",
+      "credential": "AS",
+      "program_code": "AVC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/AVC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "102",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "207",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "123",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "151",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "161",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Business Administration Gen",
+      "credential": "AS",
+      "program_code": "BAG",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/BAG",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "114",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "151",
+              "title": "Concepts of Financial Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "140",
+              "title": "Computer Applications and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Business Administration Trans",
+      "credential": "AA",
+      "program_code": "BAT",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/BAT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "102",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "151",
+              "title": "Concepts of Financial Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "152",
+              "title": "Concepts of Financial Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "209",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "140",
+              "title": "Computer Applications and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Biology",
+      "credential": "AS",
+      "program_code": "BIO",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/BIO",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "126",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "127",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "111",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "112",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "102",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "General Physics I with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "General Physics II with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "biology"
+    },
+    {
+      "title": "Early Childhood Ed Cert",
+      "credential": "certificate",
+      "program_code": "CECE",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/CECE",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Growth and Development: Conception to Age 8",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "148",
+              "title": "Understanding and Guiding Children's Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "123",
+              "title": "Infant and Toddler Learning and Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "215",
+              "title": "Student Teaching: Co-Constructed Curriculum, Documentation, and Culturally Responsive Teaching",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Student Teaching: Health, Safety, Program Planning, and Environmental Design",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Chemistry",
+      "credential": "AS",
+      "program_code": "CHE",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/CHE",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "111",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "112",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "202",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "General Physics I with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "General Physics II with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Computer Science",
+      "credential": "AS",
+      "program_code": "CSC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/CSC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "126",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "127",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "111",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "112",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "General Physics I with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "General Physics II with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "CSC",
+              "number": "101",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "201",
+              "title": "Introduction to Discrete Computation",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "251",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CSC",
+              "number": "254",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "computer-science"
+    },
+    {
+      "title": "Early Childhood Education",
+      "credential": "AS",
+      "program_code": "ECE",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/ECE",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "Survey of Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "116",
+              "title": "Mathematics for Early Childhood and Elementary Educators",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "101",
+              "title": "Introduction to Early Childhood Education",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "103",
+              "title": "Creativity, Thinking, and Learning",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "111",
+              "title": "Inclusion and Accommodation, Birth through Age Sixteen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "123",
+              "title": "Infant and Toddler Learning and Care",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "141",
+              "title": "Relationships, Families, and Community",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Growth and Development: Conception to Age 8",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "148",
+              "title": "Understanding and Guiding Children's Behavior",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "201",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "215",
+              "title": "Student Teaching: Co-Constructed Curriculum, Documentation, and Culturally Responsive Teaching",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "216",
+              "title": "Student Teaching: Health, Safety, Program Planning, and Environmental Design",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "early-childhood-education"
+    },
+    {
+      "title": "Engineering Science",
+      "credential": "AS",
+      "program_code": "EGS",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/EGS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PHY",
+              "number": "111",
+              "title": "General Physics I with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "112",
+              "title": "General Physics II with Calculus",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EGR",
+              "number": "105",
+              "title": "Introduction to Engineering, Science, Technology, and Society",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "114",
+              "title": "Computational Tools for Engineers and Scientists",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "107",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "124",
+              "title": "Introduction to Digital and Computer Systems",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EGR",
+              "number": "213",
+              "title": "Probability and Statistics for Scientists and Engineers",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "engineering"
+    },
+    {
+      "title": "Environmental Conservation",
+      "credential": "AS",
+      "program_code": "ENC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/ENC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ECO",
+              "number": "113",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "126",
+              "title": "Biology I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "127",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "114",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "151",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introduction to Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "111",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": 12,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Fire Science Technology",
+      "credential": "AS",
+      "program_code": "FST",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/FST",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FST",
+              "number": "151",
+              "title": "Principles of Emergency Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "152",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "153",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "154",
+              "title": "Principles of Fire and Emergency Services Safety and Survival",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "155",
+              "title": "Building Construction for Fire Protection",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "159",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FST",
+              "number": "253",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Human Services",
+      "credential": "AS",
+      "program_code": "HSE",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/HSE",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "101",
+              "title": "Introduction to Human Services",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Social Inequality",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ASL",
+              "number": "101",
+              "title": "Elementary American Sign Language I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHI",
+              "number": "104",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "114",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "132",
+              "title": "Lifestyle, Health, and Medicine",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HSV",
+              "number": "115",
+              "title": "The Helping Relationship",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "168",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "215",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "271",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HSV",
+              "number": "272",
+              "title": "Practicum in Addiction Studies II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Justice Studies",
+      "credential": "AS",
+      "program_code": "JUS",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/JUS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "POL",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "106",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "219",
+              "title": "Legal History of American Civil Rights",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "JUS",
+              "number": "101",
+              "title": "Introduction to Justice Studies",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JUS",
+              "number": "103",
+              "title": "Criminal Law and Procedure",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JUS",
+              "number": "105",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JUS",
+              "number": "107",
+              "title": "Principles of Adjudication and Punishment I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JUS",
+              "number": "109",
+              "title": "Principles of Adjudication and Punishment II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JUS",
+              "number": "121",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "JUS",
+              "number": "201",
+              "title": "Ethics and Social Control",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "106",
+              "title": "Social Inequality",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Liberal Arts/Theater",
+      "credential": "AA",
+      "program_code": "LAT",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/LAT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "THE",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "113",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "133",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "THE",
+              "number": "225",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "102",
+              "title": "Career Planning and Job Search Skills",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HUD",
+              "number": "135",
+              "title": "Career Exploration and Planning",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts/Cont Mus Studies",
+      "credential": "AA",
+      "program_code": "LCMS",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/LCMS",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "138",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "153",
+              "title": "The World of Music and the Human Spirit",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "154",
+              "title": "Audio Recording and Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "230",
+              "title": "",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "231",
+              "title": "",
+              "credits": 0,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": 6,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MUS",
+              "number": "139",
+              "title": "",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "151",
+              "title": "The Beatles and Radiohead Ensemble",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "208",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "220",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Audio Recording and Production II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "223",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "224",
+              "title": "Independent Music Production Project",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts/Education",
+      "credential": "AA",
+      "program_code": "LEO",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/LEO",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "241",
+              "title": "Survey of Children's Literature",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization to 1500 CE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization Since 1500 CE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "105",
+              "title": "U.S. History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "106",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EDU",
+              "number": "111",
+              "title": "Inclusion and Accommodation, Birth through Age Sixteen",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EDU",
+              "number": "144",
+              "title": "Child Growth and Development: Conception to Age 8",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts/Farm and Food Sys",
+      "credential": "AA",
+      "program_code": "LFF",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/LFF",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EVS",
+              "number": "101",
+              "title": "Environmental Studies: Issues in Sustainability",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EVS",
+              "number": "118",
+              "title": "Introduction to Food Systems",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ECO",
+              "number": "113",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "124",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "137",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "138",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": 9,
+          "choose_n": null,
+          "courses": []
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts/History",
+      "credential": "AA",
+      "program_code": "LHI",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/LHI",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "HIS",
+              "number": "101",
+              "title": "Western Civilization to 1500 CE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "102",
+              "title": "Western Civilization Since 1500 CE",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "133",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "134",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "105",
+              "title": "U.S. History to 1865",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "HIS",
+              "number": "106",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts/Math",
+      "credential": "AA",
+      "program_code": "LMA",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/LMA",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAT",
+              "number": "201",
+              "title": "Calculus with Analytic Geometry I",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "202",
+              "title": "Calculus with Analytic Geometry II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "203",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "204",
+              "title": "Elementary Differential Equations",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "205",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Liberal Arts/Plant & Soil Sci",
+      "credential": "AA",
+      "program_code": "LPL",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/LPL",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "102",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "120",
+              "title": "Introduction to Environmental Science",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "220",
+              "title": "Foundations of Ecology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "108",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "126",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "127",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "111",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "112",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SCI",
+              "number": "138",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Electives",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AGR",
+              "number": "109",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "110",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "111",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "112",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "113",
+              "title": "Mushroom Foraging and Cultivation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "115",
+              "title": "Permaculture Landscape Management and Installation",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "118",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AGR",
+              "number": "119",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "124",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CHE",
+              "number": "201",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAT",
+              "number": "107",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PHY",
+              "number": "101",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "liberal-arts"
+    },
+    {
+      "title": "Medical Assistant Certificate",
+      "credential": "certificate",
+      "program_code": "MAC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/MAC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "MAC",
+              "number": "101",
+              "title": "Fundamentals of Medical Assisting",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "103",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "105",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "111",
+              "title": "Pharmacology for Medical Assistants",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "112",
+              "title": "Human Body in Health and Disease",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "113",
+              "title": "Phlebotomy for Medical Assistants",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "114",
+              "title": "Dosage Calculations For Health Professionals",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "120",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MAC",
+              "number": "271",
+              "title": "",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MOM",
+              "number": "110",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Management Certificate",
+      "credential": "certificate",
+      "program_code": "MGT",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/MGT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "ACC",
+              "number": "151",
+              "title": "Concepts of Financial Accounting I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ACC",
+              "number": "152",
+              "title": "Concepts of Financial Accounting II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "205",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "209",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "140",
+              "title": "Computer Applications and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "155",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "203",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "business-administration"
+    },
+    {
+      "title": "Music Recording & Production",
+      "credential": "certificate",
+      "program_code": "MRP",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/MRP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "138",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "139",
+              "title": "",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "153",
+              "title": "The World of Music and the Human Spirit",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "154",
+              "title": "Audio Recording and Production I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "208",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "220",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "222",
+              "title": "Audio Recording and Production II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "223",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "MUS",
+              "number": "224",
+              "title": "Independent Music Production Project",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Pre-Nursing Certificate",
+      "credential": "certificate",
+      "program_code": "NUC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/NUC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "126",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "217",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "194",
+              "title": "Comprehensive Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "216",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Nursing",
+      "credential": "AS",
+      "program_code": "NUR",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/NUR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "217",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "194",
+              "title": "Comprehensive Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "205",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "216",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Outdoor Leadership",
+      "credential": "certificate",
+      "program_code": "OLP",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/OLP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "OLP",
+              "number": "111",
+              "title": "Introduction to Outdoor Adventure Skills",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "112",
+              "title": "Wilderness Orientation Expedition for Outdoor Leaders",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "120",
+              "title": "Wilderness Medical Preparedness and Rescue",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "143",
+              "title": "Backcountry Travel Instructor I",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "201",
+              "title": "Individual Project in Outdoor Leadership",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "210",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "216",
+              "title": "Wilderness-Based Adventure Planning and Fieldwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "116",
+              "title": "Teambuilding, Group-Development, and Fieldwork",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "OLP",
+              "number": "150",
+              "title": "Fundamentals of Technical Rock Climbing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Paramedic Certificate",
+      "credential": "certificate",
+      "program_code": "PMC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/PMC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "EMS",
+              "number": "105",
+              "title": "Principles of Advanced Life Support",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "202",
+              "title": "",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "203",
+              "title": "Management of Medical and Shock-Trauma Emergencies",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "204",
+              "title": "Management of Cardiovascular Emergencies",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "210",
+              "title": "",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "211",
+              "title": "Paramedic Fieldwork Internships I",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "EMS",
+              "number": "212",
+              "title": "Paramedic Fieldwork Internships II",
+              "credits": 2,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Practical Nurse",
+      "credential": "certificate",
+      "program_code": "PNC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/PNC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "194",
+              "title": "Comprehensive Anatomy and Physiology",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "216",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "103A",
+              "title": "Fundamentals of Practical Nursing",
+              "credits": 9,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "103C",
+              "title": "Fundamentals of Practical Nursing Clinical",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "105C",
+              "title": "",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "107A",
+              "title": "Nursing Care of Patients and Families",
+              "credits": 10,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "107C",
+              "title": "Nursing Care of Patients and Families Clinical",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "109A",
+              "title": "Advanced Concepts in Practical Nursing",
+              "credits": 5,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "NUR",
+              "number": "109C",
+              "title": "Advanced Concepts in Practical Nursing Clinical",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "217",
+              "title": "Human Growth and Development",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": "nursing"
+    },
+    {
+      "title": "Surgical Technology",
+      "credential": "AAS",
+      "program_code": "SGT",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/SGT",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "General Education Requirements",
+          "credits_required": 7,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BIO",
+              "number": "215",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BIO",
+              "number": "216",
+              "title": "Human Anatomy and Physiology II",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I: Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "PSY",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SOC",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        },
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SGT",
+              "number": "101",
+              "title": "",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "120",
+              "title": "Introduction to the Professional Surgical Technologist and the Allied Health Field",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "122",
+              "title": "Surgical Technology II",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "124",
+              "title": "Healthcare Science for the Surgical Technologist",
+              "credits": 2,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "201",
+              "title": "",
+              "credits": 6,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "210",
+              "title": "",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "220",
+              "title": "",
+              "credits": 8,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "221",
+              "title": "Advanced Surgical Procedures",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SGT",
+              "number": "223",
+              "title": "",
+              "credits": 1,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Visual Arts Certificate",
+      "credential": "certificate",
+      "program_code": "VAC",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/VAC",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "AHS",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "AHS",
+              "number": "102",
+              "title": "Art History Survey II",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "121",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "123",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "131",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "132",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "155",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ART",
+              "number": "161",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "Web Development & Design",
+      "credential": "certificate",
+      "program_code": "WDD",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/WDD",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "BUS",
+              "number": "111",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "164",
+              "title": "Introduction to Digital Design Tools",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "224",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "BUS",
+              "number": "226",
+              "title": "Digital Design",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "140",
+              "title": "Computer Applications and Concepts",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "145",
+              "title": "Database Design and Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "151",
+              "title": "Web Site Design and Development",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "CIS",
+              "number": "153",
+              "title": "Web Site Management",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "ENG",
+              "number": "101",
+              "title": "English Composition I: Expository Writing",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "World Language in French",
+      "credential": "certificate",
+      "program_code": "WFR",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/WFR",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Pogram Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "FRE",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "102",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "201",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "FRE",
+              "number": "202",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    },
+    {
+      "title": "World Language in Spanish",
+      "credential": "certificate",
+      "program_code": "WSP",
+      "catalog_url": "https://catalog.gcc.mass.edu/programs/WSP",
+      "total_credits": null,
+      "gpa_minimum": 2,
+      "description": null,
+      "requirement_groups": [
+        {
+          "name": "Program Requirements",
+          "credits_required": null,
+          "choose_n": null,
+          "courses": [
+            {
+              "prefix": "SPA",
+              "number": "124",
+              "title": "Spanish for Health Professionals",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "133",
+              "title": "Spanish for Law Enforcement",
+              "credits": 4,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "153",
+              "title": "Spanish for Emergency Responders",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "202",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "101",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "102",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            },
+            {
+              "prefix": "SPA",
+              "number": "201",
+              "title": "",
+              "credits": 3,
+              "or_alternatives": []
+            }
+          ]
+        }
+      ],
+      "matched_program_slug": null
+    }
+  ]
+}

--- a/lib/states/ma/config.ts
+++ b/lib/states/ma/config.ts
@@ -114,6 +114,10 @@ const maConfig: StateConfig = {
         scripts: ["scripts/ma/scrape-massasoit-programs.ts"],
         runner: "http",
       },
+      {
+        scripts: ["scripts/ma/scrape-coursedog-programs.ts"],
+        runner: "playwright",
+      },
     ],
   },
 };

--- a/scripts/lib/scrape-coursedog-programs.ts
+++ b/scripts/lib/scrape-coursedog-programs.ts
@@ -521,7 +521,7 @@ export async function scrapeCoursedogPrograms(
         if (degreeReqGroup && degreeReqGroup.credits_required !== null) {
           totalCredits = degreeReqGroup.credits_required;
         } else {
-          // Fallback: any group that names itself as a credit total
+          // Fallback 1: any group that names itself as a credit total
           // ("Total Credits", "Major Requirements - Total Credits", etc.).
           // Bronx CC encodes the program-wide credit floor this way.
           const anchor = requirementGroups.find(
@@ -530,6 +530,21 @@ export async function scrapeCoursedogPrograms(
               /(total credits|minimum credits|credits required)/i.test(g.name),
           );
           if (anchor) totalCredits = anchor.credits_required;
+          // Fallback 2: GCC (Greenfield) embeds credits directly in group
+          // names ("General Education Requirements: 32-33 Credits"). Sum
+          // those tags across groups.
+          if (totalCredits === null) {
+            let sum = 0;
+            let any = false;
+            for (const g of requirementGroups) {
+              const m = g.name.match(/:\s*(\d+)(?:\s*[-–]\s*\d+)?\s*credits?\b/i);
+              if (m) {
+                sum += Number(m[1]);
+                any = true;
+              }
+            }
+            if (any) totalCredits = sum;
+          }
         }
 
         const credential = classifyCredential(detail.degreeDesignation, detail.type);

--- a/scripts/ma/scrape-coursedog-programs.ts
+++ b/scripts/ma/scrape-coursedog-programs.ts
@@ -1,0 +1,82 @@
+/**
+ * scrape-coursedog-programs.ts — MA Coursedog program scraper.
+ *
+ * Closes #228 MA tail. Adds Greenfield Community College (gcc), the one
+ * MassCC college whose catalog runs on Coursedog rather than CourseLeaf,
+ * Acalog, SmartCatalogIQ, or CleanCatalog. Reuses the shared library
+ * introduced for CUNY in #256.
+ *
+ * Usage:
+ *   npx tsx scripts/ma/scrape-coursedog-programs.ts
+ *   npx tsx scripts/ma/scrape-coursedog-programs.ts --college gcc
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { scrapeCoursedogPrograms } from "../lib/scrape-coursedog-programs.js";
+import { applyProgramMatching } from "../../lib/programs/matcher.js";
+import type { CoursedogProgramConfig } from "../lib/scrape-coursedog-programs.js";
+
+const COLLEGES: CoursedogProgramConfig[] = [
+  { collegeSlug: "gcc", catalogDomain: "catalog.gcc.mass.edu", catalogYear: "2025-2026" },
+];
+
+async function main() {
+  const args = process.argv.slice(2);
+  const collegeArg =
+    args.find((a) => a.startsWith("--college="))?.split("=")[1] ||
+    (args.indexOf("--college") >= 0 ? args[args.indexOf("--college") + 1] : null);
+
+  let colleges = COLLEGES;
+  if (collegeArg) {
+    colleges = COLLEGES.filter((c) => c.collegeSlug === collegeArg);
+    if (colleges.length === 0) {
+      console.error(
+        `Unknown college: ${collegeArg}. Available: ${COLLEGES.map((c) => c.collegeSlug).join(", ")}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const outDir = path.join(process.cwd(), "data", "ma", "programs");
+  fs.mkdirSync(outDir, { recursive: true });
+
+  console.log(`MA Coursedog program scraper — ${colleges.length} college(s)\n`);
+
+  let totalPrograms = 0;
+  for (const config of colleges) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`Scraping ${config.collegeSlug} (${config.catalogDomain})`);
+    console.log("=".repeat(60));
+
+    try {
+      const data = await scrapeCoursedogPrograms(config);
+      if (data.programs.length === 0) {
+        console.log(`  No programs scraped for ${config.collegeSlug}, skipping write.`);
+        continue;
+      }
+      const { matched, unmatched } = applyProgramMatching(data.programs);
+      console.log(
+        `  Matcher: ${matched} matched to registry slugs, ${unmatched} unmatched`,
+      );
+      const outPath = path.join(outDir, `${config.collegeSlug}.json`);
+      fs.writeFileSync(outPath, JSON.stringify(data, null, 2));
+      console.log(`  ✓ Wrote ${data.programs.length} programs to ${outPath}`);
+      totalPrograms += data.programs.length;
+    } catch (e) {
+      console.error(
+        `  ERROR scraping ${config.collegeSlug}: ${e instanceof Error ? e.message : e}`,
+      );
+    }
+  }
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(
+    `Done. Total: ${totalPrograms} programs across ${colleges.length} college(s).`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds Greenfield CC — the lone MassCC college left out of the #228 push because it runs Coursedog. Reuses the shared Coursedog scraper landed in [#256](https://github.com/rohan-c0de/cc-coursemap/pull/256).

- New runner [scripts/ma/scrape-coursedog-programs.ts](scripts/ma/scrape-coursedog-programs.ts) (mirrors the NY runner; one config entry).
- Wires it into [lib/states/ma/config.ts](lib/states/ma/config.ts).
- One small lib tweak in [scripts/lib/scrape-coursedog-programs.ts](scripts/lib/scrape-coursedog-programs.ts): GCC encodes credit counts directly in group names ("General Education Requirements: 32-33 Credits") instead of using a `minimumCredits` rule or a "Total Credits" anchor group. Added a third `total_credits` fallback that sums these `:N Credits` tags.

**37 programs** (1 AAS, 8 AA, 15 AS, 13 certificate). `total_credits` populated for 4 (29–55), null for 33 — null is honest where the source data is silent.

## Coverage

MA program coverage now **15/15**. **Issue [#228](https://github.com/rohan-c0de/cc-coursemap/issues/228) fully closed.**

| State | Coverage |
|---|---|
| CT | 1/1 ✅ |
| VT | 1/1 ✅ |
| TN | 12/12 ✅ |
| VA | 23/23 ✅ |
| **MA** | **15/15** ✅ |

## Test plan

- [x] `npx tsc --noEmit` exits 0
- [x] `npm run lint` exits 0
- [x] Scraper produces 37 programs with sane credentials
- [x] Local dev: `/ma/college/gcc/programs` renders (Adventure Education, Liberal Arts, Nursing, Business, etc.)
- [ ] CI green
- [ ] Post-merge: confirm prod URL shows the new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)