### PR TITLE
fix: course-search input — raise maxLength + dim stale answer card

### DIFF
--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -517,7 +517,7 @@ export default function CourseSearchClient({ state, systemName, collegeCount, co
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder='e.g. "PSY 200", "ENG", "psychology"'
                 className="w-full rounded-lg border border-gray-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 px-4 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-200"
-                maxLength={50}
+                maxLength={250}
               />
             </div>
             <div className="w-full sm:w-36">


### PR DESCRIPTION
Two related fixes for the natural-language search UX on /{state}/courses, both reported in the same screenshot:

## 1. maxLength 50 → 250

The search input had \`maxLength={50}\`, fine for course-code searches ("PSY 200", "biology") but silently rejects keystrokes for natural-language questions past the cap. Reported case: "what sort of courses can I take to earn an associates in biology" is 56 chars — once the user hit 50, they couldn't reach a sensible phrasing because new chars were dropped without feedback.

Bumped to **250**, which covers the longest reasonable natural-language question without inviting paste-spam abuse on the downstream \`/ask\` endpoint.

## 2. Dim the answer card while user edits

When the answer is showing and the user starts editing the input, the answer no longer reflects what's typed but it just sits there at full saturation — read by users (correctly) as the live response to whatever's currently in the field. Reported case: input said "what sort of courses can I take to earns associates In" while the answer claimed "you're asking about an Associate degree in biology" (left over from a prior submit), making the input feel disconnected.

Track the trimmed query that produced the current answer (\`answerQuery\`, set inside \`doSearch\`). When the input diverges from it:

- wrap with \`opacity-50\` plus a transition
- prepend an italic note: _"Answer below is for your previous query — press Search to refresh."_

Card stays visible (useful as reference) but no longer reads as live.

## Test plan

- [x] \`npx tsc --noEmit\` exits 0
- [x] \`npm run lint\` exits 0
- [x] Local dev: rendered HTML on \`/va/courses\` shows \`maxLength="250"\`
- [ ] CI green
- [ ] Post-merge on prod: type a 100+ char question, then edit it after the answer renders — confirm the card visibly dims and the "previous query" note appears

End-to-end verification of the dim behavior in dev wasn't possible: \`/api/[state]/ask\` returns 401 from the LLM classifier without a valid \`ANTHROPIC_API_KEY\` in \`.env.local\`, so no answer card populates locally. The state logic and JSX both compile clean and the conditional is small and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)