### PR TITLE
feat: add history/math/english/art slugs to program registry + matcher

### DIFF
--- a/data/ct/programs/ctstate.json
+++ b/data/ct/programs/ctstate.json
@@ -1086,7 +1086,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Automotive Technology: Advanced Engine Performance Certificate",
@@ -17910,7 +17910,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "EMT to Paramedic Pathway Certificate",
@@ -20930,7 +20930,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design: Web Design Certificate",
@@ -21067,7 +21067,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design: Digital Media/Web Design, AS",
@@ -21357,7 +21357,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design, AS",
@@ -21711,7 +21711,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Health Information Technology - Data Management, AS",
@@ -22383,7 +22383,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Horticulture Certificate",
@@ -25447,7 +25447,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Library Technology Certificate",
@@ -26217,7 +26217,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Mechanical/Electrical Manufacturing Basics",
@@ -28667,7 +28667,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "New Media Production: Audio and Music, AAS",
@@ -43571,7 +43571,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Art: Design, AA",
@@ -43844,7 +43844,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Art: Illustration, AA",
@@ -44103,7 +44103,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Art: Photography, AA",
@@ -44321,7 +44321,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Ophthalmic Design & Dispensing, AS",

--- a/data/ma/programs/berkshire.json
+++ b/data/ma/programs/berkshire.json
@@ -2749,7 +2749,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Technical Theatre (Certificate)",
@@ -3056,7 +3056,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Fire Science (A.S.)",

--- a/data/ma/programs/bhcc.json
+++ b/data/ma/programs/bhcc.json
@@ -1869,7 +1869,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Electrical Engineering Transfer Option, A.S.",
@@ -2138,7 +2138,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Entrepreneurship Option, A.S.",
@@ -2993,7 +2993,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Integrated Media Design Option, A.S.",
@@ -3356,7 +3356,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Medical Radiography Option Full-time, A.S.",

--- a/data/ma/programs/bristol.json
+++ b/data/ma/programs/bristol.json
@@ -540,7 +540,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design",
@@ -678,7 +678,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Art Certificate",
@@ -732,7 +732,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Web Design and Media Arts",
@@ -971,7 +971,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Accounting",
@@ -7564,7 +7564,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Humanities",
@@ -7719,7 +7719,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Psychology Transfer",
@@ -10320,7 +10320,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Spanish/English Community Interpreting Certificate",
@@ -10395,7 +10395,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Administrative Assistant Certificate",

--- a/data/ma/programs/capecod.json
+++ b/data/ma/programs/capecod.json
@@ -276,7 +276,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Arts Concentration",
@@ -414,7 +414,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Performing Arts Concentration",
@@ -5042,7 +5042,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Data Science Concentration",
@@ -5428,7 +5428,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Medical Assisting",
@@ -7236,7 +7236,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Human Services Concentration",

--- a/data/ma/programs/gcc.json
+++ b/data/ma/programs/gcc.json
@@ -337,7 +337,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Art/Visual Arts Transfer Block",
@@ -426,7 +426,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Business Administration Gen",
@@ -2084,7 +2084,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "history"
     },
     {
       "title": "Liberal Arts/Math",
@@ -2138,7 +2138,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Liberal Arts/Plant & Soil Sci",
@@ -3159,7 +3159,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Web Development & Design",

--- a/data/ma/programs/hcc.json
+++ b/data/ma/programs/hcc.json
@@ -2637,7 +2637,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Early Education and Care Option, Birth-Age 8, Early Childhood Education, A.S.",
@@ -3378,7 +3378,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Engineering Science Option, Engineering Studies, A.S.",
@@ -4052,7 +4052,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Human Resource Management Option, Business Administration, A.S.",
@@ -5209,7 +5209,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Music, A.A.",
@@ -6795,7 +6795,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Accounting Certificate",
@@ -7714,7 +7714,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Mental Health Studies Certificate",

--- a/data/ma/programs/massasoit.json
+++ b/data/ma/programs/massasoit.json
@@ -5302,7 +5302,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Arts - Art & Graphic Design",
@@ -5419,7 +5419,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Alternative Fuels & Emissions",

--- a/data/ma/programs/massbay.json
+++ b/data/ma/programs/massbay.json
@@ -2515,7 +2515,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "english"
     },
     {
       "title": "Liberal Arts: Psychology/Sociology",
@@ -3733,7 +3733,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Engineering",

--- a/data/ma/programs/middlesex.json
+++ b/data/ma/programs/middlesex.json
@@ -7827,7 +7827,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Fire Protection & Safety Technology Associates Degree",
@@ -10704,7 +10704,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Nursing (Day) Associates Degree",
@@ -12761,7 +12761,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Paralegal Studies Transfer Associates Degree",
@@ -13717,7 +13717,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Design Transfer Associates Degree",
@@ -16159,7 +16159,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Hospitality Management Certificate",
@@ -17800,7 +17800,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Communication Skills Micro Credential",

--- a/data/ma/programs/mwcc.json
+++ b/data/ma/programs/mwcc.json
@@ -629,7 +629,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Biology — Associate of Science",
@@ -2157,7 +2157,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Human Services — Associate of Science",
@@ -2623,7 +2623,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Media Communications — Associate of Arts",

--- a/data/ma/programs/necc.json
+++ b/data/ma/programs/necc.json
@@ -512,7 +512,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "art"
     },
     {
       "title": "Entrepreneurial Business, Associate in Science",

--- a/data/ma/programs/northshore.json
+++ b/data/ma/programs/northshore.json
@@ -2779,7 +2779,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design - Integrated Media (IMD)",
@@ -2924,7 +2924,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design Print (GDD)",
@@ -3076,7 +3076,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Healthcare Business Management Certificate (HCMC)",
@@ -7517,7 +7517,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "english"
     },
     {
       "title": "Liberal Arts (LAT) Fine Arts Pathway",
@@ -7679,7 +7679,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "history"
     },
     {
       "title": "Liberal Arts (LAT) Political Science Pathway",
@@ -9977,7 +9977,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "STEM Foundation (STE) - Biology Pathway",
@@ -12689,7 +12689,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "High Tech Manufacturing Management Certificate (HTMC)",
@@ -17397,7 +17397,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design-Print (GDD)",
@@ -17570,7 +17570,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Health Studies (SHD)",

--- a/data/ma/programs/qcc.json
+++ b/data/ma/programs/qcc.json
@@ -8942,7 +8942,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "english"
     },
     {
       "title": "Liberal Arts - History Option",
@@ -9017,7 +9017,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "history"
     },
     {
       "title": "Liberal Arts - Media Communications Option",
@@ -10634,7 +10634,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Criminal Justice",

--- a/data/ma/programs/rcc.json
+++ b/data/ma/programs/rcc.json
@@ -267,7 +267,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Biological Science",
@@ -873,7 +873,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Health Careers",
@@ -1182,7 +1182,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Physical Science",

--- a/data/ma/programs/stcc.json
+++ b/data/ma/programs/stcc.json
@@ -74,7 +74,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Applied Psychology - APSY.AA",
@@ -1070,7 +1070,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Fire Protection and Safety Technology - FIRE.AS",
@@ -1203,7 +1203,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Health Science - HLTH.AS",
@@ -1361,7 +1361,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Medical Assistant - MAST.AS",
@@ -2500,7 +2500,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Medical Office Administrative Assistant - MOAA.COC",

--- a/data/ny/programs/bmcc.json
+++ b/data/ny/programs/bmcc.json
@@ -598,7 +598,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Art Foundations Studio Art",
@@ -866,7 +866,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Animation and Motion Graphics",
@@ -6084,7 +6084,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Health Information Technology",
@@ -8216,7 +8216,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Modern Languages",
@@ -12255,7 +12255,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Secondary Education for Social Studies",

--- a/data/ny/programs/bronx-cc.json
+++ b/data/ny/programs/bronx-cc.json
@@ -3234,7 +3234,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Engineering Science",
@@ -6574,7 +6574,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Medical Laboratory Technician",

--- a/data/ny/programs/hostos-cc.json
+++ b/data/ny/programs/hostos-cc.json
@@ -5905,7 +5905,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Mechanical Engineering Science",

--- a/data/ny/programs/kingsborough-cc.json
+++ b/data/ny/programs/kingsborough-cc.json
@@ -3443,7 +3443,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Design and Illustration",
@@ -3607,7 +3607,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Hospitality and Meeting Planning",
@@ -4066,7 +4066,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Media Arts",

--- a/data/ny/programs/laguardia-cc.json
+++ b/data/ny/programs/laguardia-cc.json
@@ -4718,7 +4718,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Human Services: Mental Health",
@@ -8336,7 +8336,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Music Recording Technology",
@@ -12195,7 +12195,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Theater",
@@ -13554,7 +13554,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     }
   ]
 }

--- a/data/ny/programs/queensborough-cc.json
+++ b/data/ny/programs/queensborough-cc.json
@@ -1068,7 +1068,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Accounting",
@@ -4080,7 +4080,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Dance",
@@ -9395,7 +9395,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Medical Assistant",
@@ -10760,7 +10760,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Music",

--- a/data/tn/programs/chattanooga-state.json
+++ b/data/tn/programs/chattanooga-state.json
@@ -11393,7 +11393,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Universal Parallel, Arts Concentration, A.A.",
@@ -11830,7 +11830,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Music, A.F.A.",
@@ -12690,7 +12690,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "University Parallel, Humanities Concentration, A.S.",
@@ -14847,7 +14847,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "University Parallel, Pre Allied Health Concentration, A.S.",
@@ -15331,7 +15331,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "University Parallel, Pre-Registered Nursing Concentration, A.S.",
@@ -20633,7 +20633,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Early Childhood Education A.S.T. (Pre K-3) TTP",
@@ -21095,7 +21095,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Special Education, A.S.",
@@ -22369,7 +22369,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Criminal Justice A.S.",
@@ -23187,7 +23187,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Physical Education, A.S.",

--- a/data/tn/programs/cleveland-state.json
+++ b/data/tn/programs/cleveland-state.json
@@ -13,7 +13,7 @@
       "gpa_minimum": null,
       "description": "Cleveland State Community College is a Tennessee Board of Regents institution",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "History Emphasis: University Parallel, A.A.",
@@ -24,7 +24,7 @@
       "gpa_minimum": null,
       "description": "Cleveland State Community College is a Tennessee Board of Regents institution",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Psychology Emphasis: University Parallel, A.A.",
@@ -68,7 +68,7 @@
       "gpa_minimum": null,
       "description": "Cleveland State Community College is a Tennessee Board of Regents institution",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Accounting Emphasis: University Parallel, A.S.",
@@ -277,7 +277,7 @@
       "gpa_minimum": null,
       "description": "Cleveland State Community College is a Tennessee Board of Regents institution",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Information Systems Emphasis: University Parallel, A.S.",
@@ -332,7 +332,7 @@
       "gpa_minimum": null,
       "description": "Cleveland State Community College is a Tennessee Board of Regents institution",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Mass Communication Emphasis: University Parallel, A.S.",
@@ -365,7 +365,7 @@
       "gpa_minimum": null,
       "description": "Cleveland State Community College is a Tennessee Board of Regents institution",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Mechanical Engineering Emphasis: University Parallel, A.S.",

--- a/data/tn/programs/columbia-state.json
+++ b/data/tn/programs/columbia-state.json
@@ -238,7 +238,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Agriculture-Plant and Soil Science, A.S.",
@@ -1717,7 +1717,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Finance, A.S.",
@@ -2162,7 +2162,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Foreign Language, A.A.",
@@ -2934,7 +2934,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Exercise Science, A.S.",
@@ -3661,7 +3661,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "International Affairs, A.A.",
@@ -4146,7 +4146,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Pre-Clinical Laboratory Science, A.S.",
@@ -5391,7 +5391,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Sociology, A.A./A.S.",
@@ -5591,7 +5591,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Pre-Occupational Therapy, A.S.",
@@ -6239,7 +6239,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Sport & Leisure Management, A.S.",

--- a/data/tn/programs/dyersburg-state.json
+++ b/data/tn/programs/dyersburg-state.json
@@ -2455,7 +2455,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Foreign Language Emphasis (Tennessee Transfer Pathway), A.A.",
@@ -2689,7 +2689,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "English Emphasis (Tennessee Transfer Pathway), A.A.",
@@ -2778,7 +2778,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Music Emphasis, A.S.",
@@ -4312,7 +4312,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Secondary Education - Social Studies Emphasis (Tennessee Transfer Pathway), A.S.T.",
@@ -4878,7 +4878,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "General Studies Emphasis, A.A.",
@@ -9287,7 +9287,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Fermentation Emphasis (Tennessee Transfer Pathway), A.S.",

--- a/data/tn/programs/jackson-state.json
+++ b/data/tn/programs/jackson-state.json
@@ -510,7 +510,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Biology",
@@ -1306,7 +1306,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Foreign Language",
@@ -1503,7 +1503,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Information Systems",
@@ -1756,7 +1756,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Mechanical Engineering",

--- a/data/tn/programs/motlow-state.json
+++ b/data/tn/programs/motlow-state.json
@@ -1250,7 +1250,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "English (A.A.) TTP",
@@ -2218,7 +2218,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Criminal Justice Administration (A.A.) TTP",
@@ -9338,7 +9338,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Pre-Law (A.A.)",
@@ -14073,7 +14073,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Music (A.F.A.) TTP",

--- a/data/tn/programs/nashville-state.json
+++ b/data/tn/programs/nashville-state.json
@@ -1227,7 +1227,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Criminal Justice A.A.",
@@ -2765,7 +2765,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Electrical Engineering A.S.",
@@ -3498,7 +3498,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "History A.S.",
@@ -3662,7 +3662,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Exercise Science A.S.",
@@ -4012,7 +4012,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Mechanical Engineering A.S.",
@@ -7786,7 +7786,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Social Work A.A.",
@@ -8268,7 +8268,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Sociology A.S.",
@@ -18685,7 +18685,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Accounting Clerk Technical Certificate",

--- a/data/tn/programs/northeast-state.json
+++ b/data/tn/programs/northeast-state.json
@@ -9691,7 +9691,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Economics (A.A. Degree) Tennessee Transfer Pathway",
@@ -10598,7 +10598,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Mass Communication (A.A. Degree) Tennessee Transfer Pathway",
@@ -12764,7 +12764,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Art and Design (Emphasis: Studio) (A.A. Degree) Tennessee Transfer Pathway",
@@ -12930,7 +12930,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Accounting (A.S. Degree) Tennessee Transfer Pathway",
@@ -18021,7 +18021,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Imaging Sciences (A.S. Degree) Tennessee Transfer Pathway",
@@ -19169,7 +19169,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Mass Communication (A.S. Degree) Tennessee Transfer Pathway",
@@ -27255,7 +27255,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Pre-Teacher Education: Pre K-3 Early Childhood Education (A.S.T. Degree) Tennessee Transfer Pathway",

--- a/data/tn/programs/pstcc.json
+++ b/data/tn/programs/pstcc.json
@@ -954,7 +954,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Anthropology (A.S.)",
@@ -3183,7 +3183,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Electrical Engineering (A.S.)",
@@ -4467,7 +4467,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "History (A.S.)",
@@ -4570,7 +4570,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Imaging Sciences (A.S.)",
@@ -6027,7 +6027,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Mathematics (A.S.)",
@@ -6095,7 +6095,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Middle School Science (A.S.T.)",
@@ -6843,7 +6843,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Nutrition and Food Science (A.S.)",
@@ -8864,7 +8864,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Secondary Education Social Studies (A.S.T.)",
@@ -9126,7 +9126,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Social Work (A.A.)",

--- a/data/tn/programs/southwest-tn.json
+++ b/data/tn/programs/southwest-tn.json
@@ -1571,7 +1571,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Graphic Arts Technology, Interactive Multimedia Production Concentration, A.A.S.",
@@ -3871,7 +3871,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Political Science Emphasis, A.A.",
@@ -4104,7 +4104,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Social Work Emphasis, A.A.",
@@ -4287,7 +4287,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Sociology Emphasis, A.A.",
@@ -5807,7 +5807,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Nutrition & Food Science Emphasis, A.S.",
@@ -5887,7 +5887,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Physics Emphasis, A.S.",

--- a/data/tn/programs/volunteer-state.json
+++ b/data/tn/programs/volunteer-state.json
@@ -8539,7 +8539,7 @@
           ]
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "University Parallel, A.S. - Environmental Science",
@@ -10083,7 +10083,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "University Parallel, A.S. - Pre-Nursing",
@@ -11169,7 +11169,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Teaching, A.S.T. - Early Childhood Education (Pre K-3)",
@@ -11702,7 +11702,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Teaching, A.S.T. - Mid-Level (Middle School) Education (Math)",
@@ -11942,7 +11942,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Teaching, A.S.T. - Mid-Level (Middle School) Education (Science)",
@@ -12409,7 +12409,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Teaching, A.S.T. - Mid-Level (Middle School) Education (Social Studies)",
@@ -12952,7 +12952,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Teaching, A.S.T. - Secondary Education (Social Studies)",
@@ -13889,7 +13889,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "University Parallel, A.A. - Communication Studies",
@@ -14816,7 +14816,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "University Parallel, A.A. - History",
@@ -15036,7 +15036,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "University Parallel, A.A. - Mass Communication",
@@ -21120,7 +21120,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "University Parallel, A.S. - Mathematics",
@@ -21362,7 +21362,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "University Parallel, A.S. - Marketing",

--- a/data/tn/programs/walters-state.json
+++ b/data/tn/programs/walters-state.json
@@ -402,7 +402,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Liberal Arts",
@@ -11920,7 +11920,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Physical Education, Health and Recreation",
@@ -12581,7 +12581,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Physics",
@@ -19595,7 +19595,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "TTP - A.A. Economics",
@@ -20142,7 +20142,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "TTP - A.A. Foreign Language",
@@ -20675,7 +20675,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "TTP - A.A. Mass Communication",
@@ -22829,7 +22829,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "TTP - A.F.A. Music",
@@ -27419,7 +27419,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "TTP - A.S. Geosciences",
@@ -29629,7 +29629,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "TTP - A.S. Nutrition and Food Science",

--- a/data/va/programs/brcc.json
+++ b/data/va/programs/brcc.json
@@ -6634,7 +6634,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Health Sciences — Associate of Science",

--- a/data/va/programs/brightpoint.json
+++ b/data/va/programs/brightpoint.json
@@ -8937,7 +8937,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Arts, AAA",
@@ -9110,7 +9110,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Arts, Film and Media Production Specialization, AAA",
@@ -9451,7 +9451,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Accounting, AAS",
@@ -16037,7 +16037,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Energy Technology Certificate",

--- a/data/va/programs/dcc.json
+++ b/data/va/programs/dcc.json
@@ -2191,7 +2191,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Digital Art & Design",
@@ -2245,7 +2245,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Digital Imaging & Photography",

--- a/data/va/programs/escc.json
+++ b/data/va/programs/escc.json
@@ -5779,7 +5779,7 @@
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Welding Level 1",

--- a/data/va/programs/gcc.json
+++ b/data/va/programs/gcc.json
@@ -17791,7 +17791,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Science - AS - 880 - Environmental Science Advising Pathway",

--- a/data/va/programs/laurelridge.json
+++ b/data/va/programs/laurelridge.json
@@ -20293,7 +20293,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     }
   ]
 }

--- a/data/va/programs/mgcc.json
+++ b/data/va/programs/mgcc.json
@@ -5651,7 +5651,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "NCCER HVACR, CSC",

--- a/data/va/programs/nova.json
+++ b/data/va/programs/nova.json
@@ -3525,7 +3525,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": "liberal-arts"
+      "matched_program_slug": "english"
     },
     {
       "title": "Music A.F.A.",
@@ -4120,7 +4120,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Visual Art, A.F.A.",
@@ -4296,7 +4296,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Interior Design, A.A.S.",
@@ -4743,7 +4743,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Graphic Design: Interactive Design Specialization, A.A.S.",
@@ -4960,7 +4960,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Photography and Media, A.A.S.",
@@ -12064,7 +12064,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "Early Childhood Development, A.A.S.",
@@ -13300,7 +13300,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "history"
     },
     {
       "title": "General Studies, A.S.",
@@ -19027,7 +19027,7 @@
           "courses": []
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Engineering, A.S.",

--- a/data/va/programs/pvcc.json
+++ b/data/va/programs/pvcc.json
@@ -2853,7 +2853,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Business Administration",

--- a/data/va/programs/reynolds.json
+++ b/data/va/programs/reynolds.json
@@ -2810,7 +2810,7 @@
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Education: Health and Physical Education Major AS",
@@ -2843,7 +2843,7 @@
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Education: Secondary Science Education Major AS",
@@ -5307,7 +5307,7 @@
       "gpa_minimum": null,
       "description": "Powered by Modern Campus Catalog™.",
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Social Sciences AS - Pre - Social Work Major",

--- a/data/va/programs/swcc.json
+++ b/data/va/programs/swcc.json
@@ -13887,7 +13887,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Substance Abuse Rehabilitation Counselor (Certificate)",

--- a/data/va/programs/tcc.json
+++ b/data/va/programs/tcc.json
@@ -2729,7 +2729,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "english"
     },
     {
       "title": "Artificial Intelligence, Career Studies Certificate",
@@ -12306,7 +12306,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Government Accountant, Career Studies Certificate",

--- a/data/va/programs/vhcc.json
+++ b/data/va/programs/vhcc.json
@@ -2263,7 +2263,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Liberal Arts – Major in Music (AA)",
@@ -2895,7 +2895,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Social Sciences (AS)",

--- a/data/va/programs/vpcc.json
+++ b/data/va/programs/vpcc.json
@@ -1718,7 +1718,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Digital Video (221-512-04) Career Studies Certificate",

--- a/data/va/programs/vwcc.json
+++ b/data/va/programs/vwcc.json
@@ -4261,7 +4261,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Science: Integrated Environmental Studies Major, A.S.",

--- a/data/va/programs/wcc.json
+++ b/data/va/programs/wcc.json
@@ -76,7 +76,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Mathematics Essentials",
@@ -87,7 +87,7 @@
       "gpa_minimum": null,
       "description": null,
       "requirement_groups": [],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Social Science General Electives",
@@ -679,7 +679,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "mathematics"
     },
     {
       "title": "Social Science, AS",

--- a/data/vt/programs/ccv.json
+++ b/data/vt/programs/ccv.json
@@ -4649,7 +4649,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     },
     {
       "title": "Human Resource Management +",
@@ -6245,7 +6245,7 @@
           ]
         }
       ],
-      "matched_program_slug": null
+      "matched_program_slug": "art"
     }
   ]
 }

--- a/lib/programs/matcher.ts
+++ b/lib/programs/matcher.ts
@@ -42,6 +42,28 @@ const RULES: MatchRule[] = [
     slug: "criminal-justice",
     keywords: /\bcriminal\s+justice\b|\blaw\s+enforcement\b|\bcorrections\b/i,
   },
+  // History / Math / English / Art are placed BEFORE liberal-arts so that a
+  // title like "Liberal Arts: History Major, A.A." gets the more specific
+  // slug — falls back to liberal-arts only if none of these fire.
+  {
+    slug: "history",
+    keywords: /\bhistory\b/i,
+    antiKeywords: /\bart\s+history\b|\bnatural\s+history\b/i,
+  },
+  {
+    slug: "mathematics",
+    keywords: /\b(?:mathematics|math)\b/i,
+  },
+  {
+    slug: "english",
+    keywords: /\benglish\b|\bcomposition\b/i,
+    antiKeywords: /\benglish\s+as\s+a\s+second\s+language\b|\besl\b/i,
+  },
+  {
+    slug: "art",
+    keywords: /\b(?:art|fine\s+arts|visual\s+arts|studio\s+art|graphic\s+design)\b/i,
+    antiKeywords: /\bculinary\s+arts\b|\bliberal\s+arts\b|\bmartial\s+arts\b|\blanguage\s+arts\b/i,
+  },
   {
     slug: "liberal-arts",
     keywords: /\bliberal\s+arts\b|\bgeneral\s+studies\b|\bliberal\s+studies\b/i,

--- a/lib/programs/registry.ts
+++ b/lib/programs/registry.ts
@@ -105,6 +105,34 @@ export const PROGRAMS: ProgramDef[] = [
       "Automotive technology programs at community colleges in this state. ASE-aligned coursework for technicians and service writers.",
     prefixes: ["AUT", "AUTO", "AUMT", "ATR"],
   },
+  {
+    slug: "history",
+    name: "History",
+    description:
+      "History coursework at community colleges in this state. U.S., world, and topical history sequences for transfer-track liberal-arts students.",
+    prefixes: ["HIS", "HIST"],
+  },
+  {
+    slug: "mathematics",
+    name: "Mathematics",
+    description:
+      "Mathematics coursework at community colleges in this state. College algebra, precalculus, calculus, and statistics for transfer to four-year programs.",
+    prefixes: ["MTH", "MAT", "MATH"],
+  },
+  {
+    slug: "english",
+    name: "English",
+    description:
+      "English coursework at community colleges in this state. Composition, literature, and writing-track classes for transfer-track liberal-arts students.",
+    prefixes: ["ENG", "ENGL"],
+  },
+  {
+    slug: "art",
+    name: "Art",
+    description:
+      "Art and visual-arts coursework at community colleges in this state. Studio art, art history, and design-track classes for fine-arts transfer.",
+    prefixes: ["ART", "ARTS", "ARTG", "ARTH"],
+  },
 ];
 
 export function getProgramBySlug(slug: string): ProgramDef | undefined {

--- a/scripts/reapply-program-matcher.ts
+++ b/scripts/reapply-program-matcher.ts
@@ -1,0 +1,98 @@
+/**
+ * reapply-program-matcher.ts
+ *
+ * One-shot utility: walks every data/{state}/programs/*.json file and
+ * recomputes `matched_program_slug` for each program by running the
+ * current matcher (lib/programs/matcher.ts) against each program title.
+ *
+ * Use after adding new slugs to the registry or new rules to the matcher
+ * so existing scraped data picks them up without re-scraping. Idempotent —
+ * running it again with no rule changes produces no diff.
+ *
+ * Usage:
+ *   npx tsx scripts/reapply-program-matcher.ts
+ *   npx tsx scripts/reapply-program-matcher.ts --dry-run
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { matchProgramSlug } from "../lib/programs/matcher.js";
+
+interface ProgramFile {
+  programs: Array<{
+    title: string;
+    matched_program_slug: string | null;
+    [k: string]: unknown;
+  }>;
+  [k: string]: unknown;
+}
+
+const DATA_ROOT = path.join(process.cwd(), "data");
+const dryRun = process.argv.includes("--dry-run");
+
+function listProgramFiles(): string[] {
+  const out: string[] = [];
+  for (const stateEntry of fs.readdirSync(DATA_ROOT, { withFileTypes: true })) {
+    if (!stateEntry.isDirectory()) continue;
+    const programsDir = path.join(DATA_ROOT, stateEntry.name, "programs");
+    if (!fs.existsSync(programsDir)) continue;
+    for (const f of fs.readdirSync(programsDir)) {
+      if (f.endsWith(".json")) out.push(path.join(programsDir, f));
+    }
+  }
+  return out;
+}
+
+let totalPrograms = 0;
+let totalChanged = 0;
+let filesChanged = 0;
+const changesByTransition = new Map<string, number>();
+
+for (const file of listProgramFiles().sort()) {
+  let data: ProgramFile;
+  try {
+    data = JSON.parse(fs.readFileSync(file, "utf-8"));
+  } catch (e) {
+    console.warn(`! could not parse ${file}: ${(e as Error).message}`);
+    continue;
+  }
+
+  let fileChanged = false;
+  for (const program of data.programs ?? []) {
+    totalPrograms += 1;
+    const newSlug = matchProgramSlug(program.title ?? "");
+    if (newSlug !== program.matched_program_slug) {
+      const before = program.matched_program_slug ?? "null";
+      const after = newSlug ?? "null";
+      const key = `${before} → ${after}`;
+      changesByTransition.set(key, (changesByTransition.get(key) ?? 0) + 1);
+      program.matched_program_slug = newSlug;
+      totalChanged += 1;
+      fileChanged = true;
+    }
+  }
+
+  if (fileChanged) {
+    filesChanged += 1;
+    if (!dryRun) {
+      fs.writeFileSync(file, JSON.stringify(data, null, 2));
+    }
+    console.log(
+      `${dryRun ? "[dry-run] " : ""}${path.relative(process.cwd(), file)}`,
+    );
+  }
+}
+
+console.log(
+  `\n${totalChanged} of ${totalPrograms} programs reassigned across ${filesChanged} file(s).`,
+);
+if (changesByTransition.size > 0) {
+  console.log(`\nTransitions:`);
+  const sorted = [...changesByTransition.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [transition, count] of sorted) {
+    console.log(`  ${count.toString().padStart(5)}  ${transition}`);
+  }
+}
+if (dryRun) {
+  console.log(`\n(dry run — no files written)`);
+}


### PR DESCRIPTION
## Summary

Surfaced via "what are the courses I need to take to get associates in history" on \`/va/courses\` — the answer card said _"Degree requirement data isn't available yet"_ even though VA has **1,918 programs across 23 colleges**.

Root cause: the program-slug registry had only 12 canonical majors and "history" wasn't one of them. \`loadProgramAcrossColleges("va", "history")\` returned 0 → \`status: "no-data"\` → misleading copy.

[PR #259](https://github.com/rohan-c0de/cc-coursemap/pull/259) adds a graceful fallback when the slug match returns empty. **This PR closes the underlying gap so exact matches actually resolve** for the most common natural-language major queries.

## Changes

- **[lib/programs/registry.ts](lib/programs/registry.ts)** — adds 4 \`PROGRAMS\` entries: \`history\`, \`mathematics\`, \`english\`, \`art\`.
- **[lib/programs/matcher.ts](lib/programs/matcher.ts)** — adds 4 rules placed **before** \`liberal-arts\` so titles like _"Liberal Arts: History Major, A.A."_ get the more specific slug. Anti-keywords prevent false positives:
  - \`history\`: skip "art history", "natural history"
  - \`english\`: skip "ESL"
  - \`art\`: skip "liberal arts", "culinary arts", "martial arts", "language arts"
  - \`mathematics\`: no antis needed
- **[scripts/reapply-program-matcher.ts](scripts/reapply-program-matcher.ts)** — one-shot utility that walks \`data/{state}/programs/*.json\` and recomputes \`matched_program_slug\` for every program. Idempotent. Reusable after any future matcher rule change.

## Re-match results (data diff)

Ran the utility: **221 of 5,108 programs newly matched across 51 files**.

|  Count  | Transition                          |
|--------:|-------------------------------------|
|   86    | null → art                          |
|   50    | null → mathematics                  |
|   39    | null → english                      |
|   31    | null → history                      |
|    7    | liberal-arts → mathematics          |
|    4    | liberal-arts → english              |
|    3    | liberal-arts → history              |
|    1    | liberal-arts → art                  |

15 programs promoted from \`liberal-arts\` to a more specific slug (correct — "Liberal Arts: Math Major" should be tagged math). **0 demotions** (no false negatives introduced).

## Effect on the original report

Searching "history associates" on \`/va/courses\` now matches **2 NOVA programs directly** (Social Sciences: History Major, Public History and Historic Preservation), rather than relying on #259's substring fallback.

## Test plan

- [x] \`npx tsc --noEmit\` exits 0
- [x] \`npm run lint\` exits 0
- [x] \`npx vitest run\` — all 321 tests pass
- [x] Local dev: \`/va/program/{history,mathematics,english,art}\` hub pages all return 200
- [x] Spot-check: NOVA's "Social Sciences: History Major, A.S." now \`matched_program_slug = "history"\`; "Liberal Arts: Art History Major, A.A." correctly stays as \`liberal-arts\` (anti-keyword caught it)
- [ ] CI green
- [ ] Post-merge: confirm Vercel ships and the original "history associates" query on prod \`/va/courses\` produces a populated answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)