### PR TITLE
phase 2: stem-aware lexical matching for findRelatedPrograms

### DIFF
--- a/lib/programs/__tests__/semantic-match.test.ts
+++ b/lib/programs/__tests__/semantic-match.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  stemPrefix,
+  tokenize,
+  stemSet,
+  titleMatchesMajor,
+} from "../semantic-match";
+
+describe("stemPrefix", () => {
+  it("returns the whole word for short inputs", () => {
+    expect(stemPrefix("art")).toBe("art");
+    expect(stemPrefix("law")).toBe("law");
+    expect(stemPrefix("math")).toBe("math");
+  });
+
+  it("returns first 5 chars for ≥6 char inputs", () => {
+    expect(stemPrefix("history")).toBe("histo");
+    expect(stemPrefix("biology")).toBe("biolo");
+    expect(stemPrefix("geography")).toBe("geogr");
+    expect(stemPrefix("computer")).toBe("compu");
+    expect(stemPrefix("mathematics")).toBe("mathe");
+  });
+
+  it("collapses morphology variants of common subjects", () => {
+    expect(stemPrefix("biological")).toBe(stemPrefix("biology"));
+    expect(stemPrefix("geographic")).toBe(stemPrefix("geography"));
+    expect(stemPrefix("historical")).toBe(stemPrefix("history"));
+    expect(stemPrefix("chemical")).toBe(stemPrefix("chemistry"));
+    expect(stemPrefix("psychological")).toBe(stemPrefix("psychology"));
+  });
+
+  it("strips non-alpha and lowercases", () => {
+    expect(stemPrefix("Geography!")).toBe("geogr");
+    expect(stemPrefix("123abc")).toBe("abc");
+    expect(stemPrefix("")).toBe("");
+  });
+});
+
+describe("tokenize", () => {
+  it("drops fillers and short words", () => {
+    expect(tokenize("the art of war")).toEqual(["art", "war"]);
+    expect(tokenize("computer science and engineering")).toEqual([
+      "computer",
+      "science",
+      "engineering",
+    ]);
+  });
+
+  it("splits on punctuation", () => {
+    expect(tokenize("Geographic Information Systems, C.S.C.")).toEqual([
+      "geographic",
+      "information",
+      "systems",
+    ]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("   ")).toEqual([]);
+  });
+});
+
+describe("stemSet", () => {
+  it("dedupes repeated stems", () => {
+    const s = stemSet("Computer Computers Computing");
+    expect(s.size).toBe(1);
+    expect(s.has("compu")).toBe(true);
+  });
+});
+
+describe("titleMatchesMajor", () => {
+  it("matches geography/Geographic stem variant", () => {
+    expect(
+      titleMatchesMajor("Geographic Information Systems, C.S.C.", "geography"),
+    ).toBe(true);
+  });
+
+  it("matches biology/Biological stem variant", () => {
+    expect(titleMatchesMajor("Biological Sciences, A.S.", "biology")).toBe(
+      true,
+    );
+  });
+
+  it("matches history/Historical stem variant", () => {
+    expect(
+      titleMatchesMajor("Historical Preservation, C.S.C.", "history"),
+    ).toBe(true);
+  });
+
+  it("requires ALL multi-word stems to match", () => {
+    // "computer science" should match a CS-titled program ...
+    expect(
+      titleMatchesMajor("Computer Science Transfer, A.S.", "computer science"),
+    ).toBe(true);
+    // ... but should NOT match "Communication Science" (only "science"
+    // matches; "computer" doesn't).
+    expect(
+      titleMatchesMajor("Communication Science", "computer science"),
+    ).toBe(false);
+    // ... and should NOT match "Computer Forensics" (only "computer"
+    // matches; "science" doesn't).
+    expect(titleMatchesMajor("Computer Forensics", "computer science")).toBe(
+      false,
+    );
+  });
+
+  it("returns false when no stems match", () => {
+    expect(titleMatchesMajor("Welding Technology", "biology")).toBe(false);
+    expect(titleMatchesMajor("Underwater Basketweaving", "computer")).toBe(
+      false,
+    );
+  });
+
+  it("returns false on empty inputs", () => {
+    expect(titleMatchesMajor("", "biology")).toBe(false);
+    expect(titleMatchesMajor("Biology", "")).toBe(false);
+  });
+
+  it("ignores filler-only tokens in the major term", () => {
+    // "the of and" tokenizes to nothing significant → empty needles → false
+    expect(titleMatchesMajor("Biology", "the of and")).toBe(false);
+  });
+
+  it("handles short single-word majors via exact stem match", () => {
+    expect(titleMatchesMajor("Studio Art (Certificate)", "art")).toBe(true);
+    expect(titleMatchesMajor("Mathematics, A.S.", "math")).toBe(true);
+  });
+});

--- a/lib/programs/requirements.ts
+++ b/lib/programs/requirements.ts
@@ -10,6 +10,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { supabase } from "@/lib/supabase";
 import { loadInstitutions } from "@/lib/institutions";
+import { titleMatchesMajor } from "@/lib/programs/semantic-match";
 import type {
   ProgramRequirement,
   RequirementGroup,
@@ -194,8 +195,10 @@ function loadProgramsBySlugFromFiles(
 /**
  * Find programs whose title loosely relates to a major term — used as a
  * fallback when no program in the state has matched_program_slug exactly
- * equal to the requested major. Substring match on title (case-insensitive),
- * grouped by college. Returns up to `limit` programs total across colleges.
+ * equal to the requested major. Stem-aware match (see semantic-match.ts):
+ * "geography" matches "Geographic Information Systems", "biology" matches
+ * "Biological Sciences", etc., across the common -y/-ic/-ical/-tion/-ing
+ * morphology variations. Grouped by college; up to `limit` programs total.
  */
 export async function findRelatedPrograms(
   state: string,
@@ -205,7 +208,7 @@ export async function findRelatedPrograms(
   const dir = path.join(process.cwd(), "data", state, "programs");
   if (!fs.existsSync(dir)) return [];
 
-  const needle = majorTerm.toLowerCase().replace(/-/g, " ").trim();
+  const needle = majorTerm.replace(/-/g, " ").trim();
   if (!needle) return [];
 
   const institutions = loadInstitutions(state);
@@ -217,8 +220,7 @@ export async function findRelatedPrograms(
       const data = JSON.parse(raw);
       const collegeSlug = file.replace(".json", "");
       for (const p of data.programs ?? []) {
-        const title = (p.title ?? "").toLowerCase();
-        if (title.includes(needle)) {
+        if (titleMatchesMajor(p.title ?? "", needle)) {
           if (!byCollege.has(collegeSlug)) byCollege.set(collegeSlug, []);
           byCollege.get(collegeSlug)!.push({
             ...p,

--- a/lib/programs/semantic-match.ts
+++ b/lib/programs/semantic-match.ts
@@ -1,0 +1,146 @@
+/**
+ * semantic-match.ts — stem-aware lexical matching of free-text major terms
+ * against program titles.
+ *
+ * Phase 2 of the major-resolution effort (see #228 follow-up). The previous
+ * approach (`title.toLowerCase().includes(rawNeedle)`) failed on stem
+ * variants — e.g. searching "geography" missed "Geographic Information
+ * Systems" because no title literally contains "geography". We can't
+ * enumerate every variant in regex rules; we need a structural matcher.
+ *
+ * The strategy here is intentionally simple: stem each word to a
+ * lowercase prefix (first 5 chars for words ≥6 chars long, the whole word
+ * otherwise). Two words match if they share the same stem prefix. This
+ * catches the common -y/-ic/-ical/-ing/-tion/-al/-s morphology variations
+ * without pulling in a full Porter stemmer:
+ *
+ *   geography  → "geogr"   ↔   geographic  → "geogr"   ✓
+ *   biology    → "biolo"   ↔   biological  → "biolo"   ✓
+ *   history    → "histo"   ↔   historical  → "histo"   ✓
+ *   chemistry  → "chemi"   ↔   chemical    → "chemi"   ✓
+ *   computer   → "compu"   ↔   computers   → "compu"   ✓
+ *
+ * For multi-word majors ("computer science"), ALL stems must appear in
+ * the title — that prevents false positives like "Communication Science"
+ * matching "computer science".
+ *
+ * What this is NOT:
+ *   - A stemmer that handles every English suffix (good — too aggressive
+ *     stemming creates more false positives than it fixes).
+ *   - A synonym layer ("law" → Criminal Justice). That's Phase 3 — an
+ *     LLM call seeded with subject-vocab.json.
+ */
+
+const FILLER_TOKENS = new Set([
+  "and",
+  "or",
+  "of",
+  "the",
+  "for",
+  "to",
+  "in",
+  "on",
+  "at",
+  "with",
+  "from",
+  "into",
+  "an",
+  "a",
+  "as",
+  "by",
+]);
+
+const MIN_TOKEN_LEN = 3;
+const STEM_PREFIX_LEN = 5;
+
+/**
+ * Lowercase a single word and trim non-alpha. Returns "" if nothing left.
+ */
+function normalizeWord(word: string): string {
+  return word.toLowerCase().replace(/[^a-z]/g, "");
+}
+
+/**
+ * Reduce a word to a stem prefix:
+ *   - lowercase, alpha-only
+ *   - first STEM_PREFIX_LEN chars when the word is long enough to plausibly
+ *     have suffix variation; otherwise the whole word
+ *
+ * For our matching purposes the goal isn't a "real" linguistic stem, just
+ * a string that's stable across common English morphology variants.
+ */
+export function stemPrefix(word: string): string {
+  const w = normalizeWord(word);
+  if (w.length === 0) return "";
+  if (w.length <= STEM_PREFIX_LEN) return w;
+  return w.slice(0, STEM_PREFIX_LEN);
+}
+
+/**
+ * Tokenize free text into significant lowercase words: drops fillers,
+ * drops anything shorter than MIN_TOKEN_LEN. Returns words in original
+ * order, no deduplication.
+ */
+export function tokenize(text: string): string[] {
+  return text
+    .split(/[^A-Za-z]+/)
+    .map(normalizeWord)
+    .filter((w) => w.length >= MIN_TOKEN_LEN && !FILLER_TOKENS.has(w));
+}
+
+/**
+ * Set of stem prefixes for a piece of text (deduped).
+ */
+export function stemSet(text: string): Set<string> {
+  const stems = new Set<string>();
+  for (const t of tokenize(text)) {
+    const s = stemPrefix(t);
+    if (s) stems.add(s);
+  }
+  return stems;
+}
+
+/**
+ * Two stems "match" if one is a prefix of the other. Equal stems trivially
+ * match. We require the shorter side to be ≥ MIN_PREFIX_OVERLAP chars
+ * (4) before allowing an asymmetric prefix match — otherwise 3-char
+ * tokens like "art"/"law"/"med" over-match into "artificial"/"lawyer"/
+ * "medical" and corrupt results when the slug match misses for an
+ * unrelated reason.
+ */
+const MIN_PREFIX_OVERLAP = 4;
+
+function stemsOverlap(a: string, b: string): boolean {
+  if (a === b) return a.length > 0;
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  if (shorter.length < MIN_PREFIX_OVERLAP) return false;
+  return longer.startsWith(shorter);
+}
+
+function haystackContainsStem(haystack: Set<string>, needle: string): boolean {
+  for (const h of haystack) {
+    if (stemsOverlap(h, needle)) return true;
+  }
+  return false;
+}
+
+/**
+ * Does `title` match `majorTerm` via stem-prefix overlap?
+ *
+ *   - Single-word major: at least one haystack stem must overlap the
+ *     needle stem.
+ *   - Multi-word major: ALL needle stems must overlap *some* haystack
+ *     stem (prevents "Communication Science" matching "computer science").
+ *
+ * Returns false on empty inputs.
+ */
+export function titleMatchesMajor(title: string, majorTerm: string): boolean {
+  const needles = stemSet(majorTerm);
+  if (needles.size === 0) return false;
+  const haystack = stemSet(title);
+  if (haystack.size === 0) return false;
+  for (const n of needles) {
+    if (!haystackContainsStem(haystack, n)) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Second step in the cohesive fix (continuing from [#261](https://github.com/rohan-c0de/cc-coursemap/pull/261)). Replaces the strict substring fallback in \`findRelatedPrograms\` with a stem-aware lexical layer that handles the common -y/-ic/-ical/-tion/-ing/-al/-s morphology variations without enumerating rules.

## What this PR adds

- **[lib/programs/semantic-match.ts](lib/programs/semantic-match.ts)** — small, focused module with three helpers:
  - \`stemPrefix(word)\` — first 5 chars for ≥6-char words, otherwise whole word.
  - \`tokenize(text)\` — drops fillers and short tokens.
  - \`titleMatchesMajor(title, majorTerm)\` — multi-word majors require ALL needle stems to overlap *some* haystack stem.
- **[lib/programs/__tests__/semantic-match.test.ts](lib/programs/__tests__/semantic-match.test.ts)** — 16 unit tests covering morphology variants, multi-word AND semantics, the 3-char short-circuit guard, and empty inputs.
- **[lib/programs/requirements.ts](lib/programs/requirements.ts)** — \`findRelatedPrograms\` now calls \`titleMatchesMajor\` instead of \`title.includes(rawNeedle)\`. No public API change.

## Why "first 5 chars" and not a real Porter stemmer

Pragmatic. The 5-char prefix collapses the morphology cases that were actually breaking real queries:

| term         | stem    | matches |
|--------------|---------|---------|
| geography    | geogr   | Geographic, Geographers |
| biology      | biolo   | Biological, Biologist |
| history      | histo   | Historical, Historian |
| chemistry    | chemi   | Chemical, Chemicals |
| psychology   | psych   | Psychological, Psychologist |
| computer     | compu   | Computers, Computing |

A real Porter stemmer would handle a few more long-tail cases ("babies"→"babi") but pulls in dependencies and processes nothing the prefix doesn't already catch for our corpus. We can swap to a stemmer later if a real-world failure shows up.

## The 3-char short-circuit guard

Naïve prefix matching makes "art" (3) match "artificial" (5+), "law" (3) match "lawyer", etc. The \`stemsOverlap\` rule requires the shorter side to be ≥4 chars before allowing an asymmetric prefix match — so \`art ↔ art\` matches by exact equality but \`art ↔ artif\` does not. 4-char queries like \`math\` still match \`mathe\` (Mathematics) because 4 ≥ 4.

## Real-data verification on current main

| state | term | matches | sample |
|---|---|---|---|
| va | geography | **6** | "Geographic Information Systems" at NOVA, MECC, SWCC, TCC, Camp, Brightpoint |
| va | biology | 5 | "Biology, A.S." at NOVA, "Science (Biology Pathway)" at CVCC, … |
| va | history | 3 | "Social Sciences: History Major" + "Public History" at NOVA |
| va | computer science | 28 | (multi-word AND works; "Communication Science" correctly excluded) |
| va | premed | **0** | _lexically unrelated to any title — Phase 3 LLM territory_ |
| vt | biology | 0 | _CCV's "Behavioral / Health / Environmental Science" share zero stems with "biology" — Phase 3 territory_ |

The wins (geography, biology, history) are exactly the cases that were producing misleading "Degree requirement data isn't available" copy through PRs #258–#260. The remaining misses (premed, VT biology) are precisely the cases the structural plan called out as needing semantic resolution, not lexical.

## What this PR does NOT do

- **No LLM calls.** Phase 3 adds those — single Claude call seeded with \`subject-vocab.json\` from [#261](https://github.com/rohan-c0de/cc-coursemap/pull/261), only when stem matching produces 0 results. Caches by \`(state, normalize(term))\`.
- **No course-level pivot.** "VA doesn't have a Geography degree but offers 8 GEO courses" is a Phase 3 follow-up; this PR keeps the existing answer-card statuses (\`found-related\` from #259, \`no-data\`).

## Test plan

- [x] \`npx tsc --noEmit\` exits 0
- [x] \`npm run lint\` exits 0 (0 errors)
- [x] \`npx vitest run\` — 662/662 tests pass (16 new + 646 existing)
- [x] Real-data spot checks (table above) confirm wins on current failing cases and honest misses on Phase 3 cases
- [ ] CI green
- [ ] Post-merge: hit prod \`/va/courses\` with the geography query and confirm the answer card now lists NOVA's GIS programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)