### PR TITLE
fix: route bare-word "unknown" intents through pathway lookup

### DIFF
--- a/lib/search-intent/answer/__tests__/index.test.ts
+++ b/lib/search-intent/answer/__tests__/index.test.ts
@@ -71,7 +71,9 @@ describe("lookupAnswer dispatch", () => {
     expect(result.reason).toBe("intent-not-supported");
   });
 
-  it("returns NoAnswer with out-of-scope for unknown intents", async () => {
+  it("returns NoAnswer with out-of-scope for unknown intents whose pathway lookup also misses", async () => {
+    // Mocked lookupPathway returns no-data above, so the fallback short-circuits
+    // back to the unknown out-of-scope copy.
     const result = await lookupAnswer(
       { type: "unknown", raw: "good professors" },
       "va",
@@ -79,6 +81,71 @@ describe("lookupAnswer dispatch", () => {
     expect(result.type).toBe("none");
     if (result.type !== "none") return;
     expect(result.reason).toBe("out-of-scope");
+  });
+
+  it("unknown intent with field-of-study-like raw query falls back to pathway lookup", async () => {
+    const lookupPathwayMock = vi.mocked(lookupPathway);
+    lookupPathwayMock.mockResolvedValueOnce({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      type: "pathway",
+      status: "found-related",
+      university: null,
+      major: "premed",
+      college: null,
+      degreeRequirements: [
+        {
+          title: "Health Science (A.S.)",
+          credential: "AS",
+          total_credits: 60,
+          gpa_minimum: 2.0,
+          catalog_url: "",
+          groups: [],
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const result = await lookupAnswer(
+      { type: "unknown", raw: "premed" },
+      "va",
+    );
+
+    expect(lookupPathwayMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "pathway", major: "premed" }),
+      "va",
+    );
+    expect(result.type).toBe("pathway");
+    if (result.type !== "pathway") return;
+    expect(result.status).toBe("found-related");
+  });
+
+  it("unknown intent does NOT call pathway when raw doesn't look like a field of study", async () => {
+    const lookupPathwayMock = vi.mocked(lookupPathway);
+    lookupPathwayMock.mockClear();
+
+    // Has digits → fails the field-of-study heuristic
+    const result1 = await lookupAnswer(
+      { type: "unknown", raw: "blah 123" },
+      "va",
+    );
+    expect(result1.type).toBe("none");
+
+    // Too many words
+    const result2 = await lookupAnswer(
+      { type: "unknown", raw: "the quick brown fox jumps" },
+      "va",
+    );
+    expect(result2.type).toBe("none");
+
+    // Stop-words only
+    const result3 = await lookupAnswer(
+      { type: "unknown", raw: "hi" },
+      "va",
+    );
+    expect(result3.type).toBe("none");
+
+    // The pathway lookup must NOT have been invoked for any of these
+    expect(lookupPathwayMock).not.toHaveBeenCalled();
   });
 });
 

--- a/lib/search-intent/answer/index.ts
+++ b/lib/search-intent/answer/index.ts
@@ -64,11 +64,75 @@ export async function lookupAnswer(
         message: "Use the course search results below.",
       };
     case "unknown":
-      return {
-        type: "none",
-        reason: "out-of-scope",
-        message:
-          "I'm not sure what you're asking. Try a course code (like ENG 111), 'prereqs for BIO 256', or 'does ENG 111 transfer to GMU'.",
-      };
+      return lookupUnknown(intent.raw, state);
   }
+}
+
+/**
+ * Bare-word queries like "premed", "law", "coding", "teaching" land here:
+ * the classifier doesn't have enough context to mark them as a specific
+ * intent type, but they're almost always asking about a field of study.
+ *
+ * Heuristic: if `raw` looks like a field-of-study term (1–3 words,
+ * letters-and-spaces only, 3–40 chars, not a known stop-word), try a
+ * pathway lookup with `major = raw`. The 3-layer pathway resolution
+ * (canonical slug → lexical stem → LLM semantic) takes it from there
+ * and either returns a populated answer or its own no-data. If the
+ * heuristic doesn't fit, fall through to the original out-of-scope copy.
+ */
+async function lookupUnknown(raw: string, state: string): Promise<Answer> {
+  const trimmed = raw.trim();
+  if (looksLikeFieldOfStudy(trimmed)) {
+    const pathwayAnswer = await lookupPathway(
+      {
+        type: "pathway",
+        university: null,
+        major: trimmed.toLowerCase(),
+        college: null,
+        credential: null,
+      },
+      state,
+    );
+    if (
+      pathwayAnswer.type === "pathway" &&
+      (pathwayAnswer.status === "found-degree" ||
+        pathwayAnswer.status === "found-related")
+    ) {
+      return pathwayAnswer;
+    }
+  }
+  return {
+    type: "none",
+    reason: "out-of-scope",
+    message:
+      "I'm not sure what you're asking. Try a course code (like ENG 111), 'prereqs for BIO 256', or 'does ENG 111 transfer to GMU'.",
+  };
+}
+
+const FIELD_STOP_WORDS = new Set([
+  "help",
+  "what",
+  "when",
+  "where",
+  "how",
+  "the",
+  "a",
+  "an",
+  "yes",
+  "no",
+  "ok",
+  "okay",
+  "test",
+  "hello",
+  "hi",
+  "thanks",
+]);
+
+function looksLikeFieldOfStudy(s: string): boolean {
+  if (s.length < 3 || s.length > 40) return false;
+  if (!/^[a-zA-Z][a-zA-Z\s]*$/.test(s)) return false; // letters + spaces, must start with letter
+  const words = s.toLowerCase().split(/\s+/);
+  if (words.length === 0 || words.length > 3) return false;
+  if (words.every((w) => FIELD_STOP_WORDS.has(w))) return false;
+  return true;
 }


### PR DESCRIPTION
Smoke-testing #263 on prod surfaced a gate I'd missed.

## What's broken

Bare-word queries — "premed", "law", "coding", "teaching" — never reach the Phase 3 semantic resolver because the **LLM classifier** marks them \`intent.type = "unknown"\` with low confidence, and \`lookupAnswer\`'s \`unknown\` case returns \`out-of-scope\` immediately.

Curl evidence on prod (post-#263 deploy):

| Query | Classifier intent | Answer |
|---|---|---|
| `?q=premed` | unknown (0.15) | out-of-scope |
| `?q=law` | unknown (0.10) | out-of-scope |
| `?q=coding` | unknown (0.10) | out-of-scope |
| `?q=teaching` | unknown (0.05) | out-of-scope |
| `?q=data%20science` | **pathway** (0.65) | **found-related, 4 programs** |

Multi-word queries reach the pathway layer and Phase 3 fires correctly. Single-word ones don't.

## Fix

The classifier IS technically correct that "premed" alone is ambiguous — could be courses, could be transfer, could be a degree. But the overwhelmingly-likely intent for a free-text bare word that *looks like a field-of-study term* is pathway. Adding a server-side fallback rather than tweaking the classifier prompt:

- Classifier stays conservative for genuinely vague inputs
- Field-like inputs get a real shot at the pathway layer
- 3-layer cascade (canonical → stem → LLM) does the rest, returning \`no-data\` when nothing fits → original \`out-of-scope\` copy

## Heuristic for "looks like a field of study"

- 1–3 words
- Letters + spaces only (no digits, course codes, punctuation)
- 3–40 chars
- Not entirely stop-words (\`hi\`, \`test\`, \`what\`, …)

If it fits, synthesize \`PathwayIntent { major: raw.toLowerCase() }\`, call \`lookupPathway\`. If \`pathway.status\` is \`found-degree\` or \`found-related\` → return it. Otherwise → fall through to existing \`out-of-scope\` copy.

## Cost profile

At most one extra LLM call per "unknown" query, and only when the heuristic matches. Same caching as #263 (24h, in-process), so repeat queries are free.

## Effect on the failing queries (after deploy)

| Query | Expected outcome |
|---|---|
| `premed` | Pathway → Phase 3 LLM → Health Science / Biology |
| `law` | Pathway → Phase 3 LLM → Criminal Justice / Paralegal |
| `coding` | Pathway → Phase 3 LLM → Computer Science / IT |
| `teaching` | Pathway → Phase 3 LLM → Education / Early Childhood |

## Test plan

- [x] \`npx tsc --noEmit\` exits 0
- [x] \`npm run lint\` exits 0
- [x] \`npx vitest run\` — 353/353 pass (10 existing + 2 new in `index.test.ts`)
- [x] New tests cover: field-of-study raw triggers pathway and returns its result when populated; non-field raw (digits / too-many-words / stop-words-only) does NOT call pathway
- [ ] CI green
- [ ] Post-merge: curl prod with each of \`premed\`, \`law\`, \`coding\`, \`teaching\` and confirm each returns a populated answer instead of out-of-scope

End-to-end browser verification in dev not possible: \`/api/[state]/ask\` returns 401 from the LLM classifier without a valid \`ANTHROPIC_API_KEY\` in \`.env.local\`. Same pattern as #258/#259/#263 — verified on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)