### PR TITLE
fix: synthesize pathway secondary for bare-word course intents (closes #266)

### DIFF
--- a/lib/search-intent/answer/__tests__/index.test.ts
+++ b/lib/search-intent/answer/__tests__/index.test.ts
@@ -200,4 +200,119 @@ describe("lookupAnswers (multi-intent)", () => {
     expect(result.primary).toBeDefined();
     expect(result.secondary).toBeUndefined();
   });
+
+  // ---- #266: bare-word course intents synthesize a pathway secondary -------
+
+  it("bare-word course intent ('biology') synthesizes a pathway secondary", async () => {
+    const lookupPathwayMock = vi.mocked(lookupPathway);
+    lookupPathwayMock.mockResolvedValue({
+      type: "pathway",
+      status: "found-related",
+      university: null,
+      major: "biology",
+      college: null,
+      degreeRequirements: [
+        {
+          title: "Health Science (A.S.)",
+          credential: "AS",
+          total_credits: 60,
+          gpa_minimum: 2.0,
+          catalog_url: "",
+          groups: [],
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: { type: "course", keyword: "biology", filters: {} },
+      secondaryIntent: null,
+    };
+    const result = await lookupAnswers(classification, "vt");
+
+    // Pathway lookup must have been invoked with the synthesized intent
+    expect(lookupPathwayMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "pathway", major: "biology" }),
+      "vt",
+    );
+    // Primary stays course (intent-not-supported); secondary is the pathway result
+    expect(result.primary.type).toBe("none");
+    expect(result.secondary?.type).toBe("pathway");
+  });
+
+  it("course intent WITH a specific course code does NOT synthesize pathway", async () => {
+    const lookupPathwayMock = vi.mocked(lookupPathway);
+    lookupPathwayMock.mockClear();
+
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: {
+        type: "course",
+        keyword: "biology",
+        filters: { course: { prefix: "BIO", number: "101" } },
+      },
+      secondaryIntent: null,
+    };
+    await lookupAnswers(classification, "vt");
+    expect(lookupPathwayMock).not.toHaveBeenCalled();
+  });
+
+  it("course intent WITH scheduling filters does NOT synthesize pathway", async () => {
+    const lookupPathwayMock = vi.mocked(lookupPathway);
+    lookupPathwayMock.mockClear();
+
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: {
+        type: "course",
+        keyword: "biology",
+        filters: { days: ["W"], mode: "online" },
+      },
+      secondaryIntent: null,
+    };
+    await lookupAnswers(classification, "vt");
+    expect(lookupPathwayMock).not.toHaveBeenCalled();
+  });
+
+  it("synthetic pathway secondary that returns no-data is dropped", async () => {
+    const lookupPathwayMock = vi.mocked(lookupPathway);
+    lookupPathwayMock.mockResolvedValue({
+      type: "pathway",
+      status: "no-data",
+      university: null,
+      major: "biology",
+      college: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: { type: "course", keyword: "biology", filters: {} },
+      secondaryIntent: null,
+    };
+    const result = await lookupAnswers(classification, "vt");
+    // The pathway lookup ran...
+    expect(lookupPathwayMock).toHaveBeenCalled();
+    // ...but its empty result is hidden so we don't surface a confusing
+    // "no degree info" card next to course search results.
+    expect(result.secondary).toBeUndefined();
+  });
+
+  it("does NOT synthesize for non-field-like keywords (digits, too long, etc.)", async () => {
+    const lookupPathwayMock = vi.mocked(lookupPathway);
+    lookupPathwayMock.mockClear();
+
+    const classification: ClassifiedIntent = {
+      ...BASE_CLASSIFICATION,
+      intent: {
+        type: "course",
+        keyword: "the quick brown fox jumps over",
+        filters: {},
+      },
+      secondaryIntent: null,
+    };
+    await lookupAnswers(classification, "vt");
+    expect(lookupPathwayMock).not.toHaveBeenCalled();
+  });
 });

--- a/lib/search-intent/answer/index.ts
+++ b/lib/search-intent/answer/index.ts
@@ -5,7 +5,7 @@
 // the per-domain lookups and returns an `Answer` discriminated union the
 // UI can render directly.
 
-import type { ClassifiedIntent, SearchIntent } from "../types";
+import type { ClassifiedIntent, SearchIntent, CourseIntent } from "../types";
 import type { Answer } from "./types";
 import { lookupEligibility } from "./eligibility";
 import { lookupPathway } from "./pathway";
@@ -19,29 +19,95 @@ export type { Answer, SourceCitation } from "./types";
  * always, and a secondary answer when the classifier identified a second
  * intent. The two lookups run in parallel.
  *
+ * In addition to the LLM-extracted secondary intent, we synthesize a
+ * pathway secondary when the primary is a bare-word course intent
+ * ("biology", "data science"). The classifier reasonably routes these
+ * to `course`, but the student often also wants degree info — so we run
+ * pathway alongside and surface both cards. Same heuristic gates the
+ * `unknown`-branch fallback in `lookupUnknown`. See #266.
+ *
  * Secondary answers that are NoAnswer with `intent-not-supported` (course
  * intent) or `out-of-scope` (unknown) are filtered out — they would render
  * as a confusing empty card with no studentSummary to anchor them. The
- * primary's studentSummary already covers the whole query.
+ * primary's studentSummary already covers the whole query. Pathway
+ * secondaries that resolved to no-data / missing-entity are also filtered:
+ * we synthesized them speculatively, an empty result means no signal.
  */
 export async function lookupAnswers(
   classification: ClassifiedIntent,
   state: string,
 ): Promise<{ primary: Answer; secondary?: Answer }> {
   const primaryPromise = lookupAnswer(classification.intent, state);
-  const secondaryPromise = classification.secondaryIntent
-    ? lookupAnswer(classification.secondaryIntent, state)
+
+  // Use the explicit secondary the classifier provided, otherwise consider
+  // synthesizing one for bare-word course intents.
+  let effectiveSecondaryIntent: SearchIntent | null =
+    classification.secondaryIntent;
+  if (
+    !effectiveSecondaryIntent &&
+    shouldSynthesizePathway(classification.intent)
+  ) {
+    const major = (classification.intent.keyword ?? "").trim().toLowerCase();
+    effectiveSecondaryIntent = {
+      type: "pathway",
+      university: null,
+      major,
+      college: null,
+      credential: null,
+    };
+  }
+
+  const secondaryPromise = effectiveSecondaryIntent
+    ? lookupAnswer(effectiveSecondaryIntent, state)
     : Promise.resolve(null);
 
-  const [primary, secondary] = await Promise.all([primaryPromise, secondaryPromise]);
+  const [primary, secondary] = await Promise.all([
+    primaryPromise,
+    secondaryPromise,
+  ]);
 
   if (!secondary) return { primary };
   if (secondary.type === "none") {
-    if (secondary.reason === "intent-not-supported" || secondary.reason === "out-of-scope") {
+    if (
+      secondary.reason === "intent-not-supported" ||
+      secondary.reason === "out-of-scope"
+    ) {
       return { primary };
     }
   }
+  // Speculative pathway secondaries that returned no-data / missing-entity
+  // are noise — drop them.
+  if (
+    secondary.type === "pathway" &&
+    (secondary.status === "no-data" || secondary.status === "missing-entity")
+  ) {
+    return { primary };
+  }
   return { primary, secondary };
+}
+
+/**
+ * Should a course intent get a synthetic pathway secondary?
+ *
+ *   ✓ "biology"              → keyword="biology", no filters
+ *   ✓ "data science"         → keyword="data science", no filters
+ *   ✗ "BIO 101"              → has filters.course → student wants the section
+ *   ✗ "biology on Wednesday" → has filters.days   → student wants scheduling
+ *   ✗ "online biology"       → has filters.mode   → ditto
+ *   ✗ "biology classes for spring 2026" → filters.term → ditto
+ *
+ * We never synthesize for course intents that have ANY structured filter
+ * other than the keyword — those are unambiguously course-search queries
+ * and a degree card would just clutter the page.
+ */
+function shouldSynthesizePathway(
+  intent: SearchIntent,
+): intent is CourseIntent {
+  if (intent.type !== "course") return false;
+  if (!intent.keyword) return false;
+  const f = intent.filters;
+  if (f.course || f.mode || f.days || f.timeOfDay || f.term) return false;
+  return looksLikeFieldOfStudy(intent.keyword);
 }
 
 export async function lookupAnswer(


### PR DESCRIPTION
Closes [#266](https://github.com/rohan-c0de/cc-coursemap/issues/266). Parallel gap to [#264](https://github.com/rohan-c0de/cc-coursemap/pull/264).

## Problem

After #264 routed bare-word \`unknown\`-intent queries to pathway, curl on prod surfaced the same shape on the **course-intent branch**:

```
/api/vt/ask?q=biology      classifier=course → answer.type=none, no pathway card
/api/ny/ask?q=data%20science  same
```

The classifier isn't wrong — "biology" alone IS plausibly a course-search query. But it's also plausibly a degree query. Treating bare-word course intents as dual-intent is the most generous read for the user.

## Fix — option A from #266

In \`lookupAnswers\`, when there's no explicit \`secondaryIntent\` AND the primary is a \`course\` intent whose **keyword looks like a field-of-study term** (same heuristic as #264) AND **no structured filters are set**, synthesize a \`PathwayIntent { major: keyword }\` and run it as the secondary. The existing parallel-lookup + result-filter machinery in \`lookupAnswers\` handles the rest.

**Filter-out rule:** speculative pathway secondaries returning \`no-data\` / \`missing-entity\` are hidden (we synthesized them; empty result = no signal).

## What synthesizes vs doesn't

| Query | Outcome |
|---|---|
| \`biology\` | ✓ synthesizes pathway secondary |
| \`data science\` | ✓ synthesizes |
| \`computer science\` | ✓ synthesizes |
| \`premed\` | already handled by \#264 (classifier marks it \`unknown\`, not \`course\`) |
| \`BIO 101\` | ✗ has \`filters.course\` — clearly course-search |
| \`biology on Wednesday\` | ✗ has \`filters.days\` |
| \`online biology\` | ✗ has \`filters.mode\` |
| \`spring biology\` | ✗ has \`filters.term\` |
| \`the quick brown fox jumps over\` | ✗ fails the field-of-study heuristic |

## Test plan

- [x] \`npx tsc --noEmit\` exits 0
- [x] \`npm run lint\` exits 0
- [x] **5 new tests** in \`lib/search-intent/answer/__tests__/index.test.ts\` (bare-word triggers synthesis, course-with-code doesn't, course-with-filters doesn't, synthetic no-data is filtered, non-field-like keyword doesn't)
- [x] **Full suite: 362/362 pass**
- [ ] CI green
- [ ] Post-merge: curl prod for \`/api/vt/ask?q=biology\` and \`/api/ny/ask?q=data%20science\` — confirm both return a populated \`secondaryAnswer\` of type \`pathway\` alongside the \`intent-not-supported\` primary

End-to-end browser verification in dev not possible: \`/api/[state]/ask\` returns 401 from the LLM classifier without a valid \`ANTHROPIC_API_KEY\`. Same pattern as #258/#259/#263/#264/#267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)