### PR TITLE
feat: course-level pivot — surface subjectPrefixes from semantic resolver

### DIFF
--- a/components/AnswerCard.tsx
+++ b/components/AnswerCard.tsx
@@ -583,6 +583,35 @@ function PathwayBody({
             </a>
           </Note>
         )}
+        {answer.relatedSubjects && answer.relatedSubjects.length > 0 && (
+          <RelatedSubjectsPanel
+            subjects={answer.relatedSubjects}
+            // For found-related we add it as a "you can also" extension; for
+            // found-degree it would be unusual but harmless.
+            label={
+              answer.status === "found-related"
+                ? "Related courses you could take in this state"
+                : "Related courses"
+            }
+          />
+        )}
+      </>
+    );
+  }
+
+  if (
+    answer.status === "found-courses-only" &&
+    answer.relatedSubjects?.length
+  ) {
+    const majorLabel = answer.major?.replace(/-/g, " ") ?? null;
+    return (
+      <>
+        <Headline tone="info" icon="📚">
+          {majorLabel
+            ? `No standalone ${majorLabel} associate degree found in this state, but ${answer.relatedSubjects.length === 1 ? "this subject is" : "these subjects are"} taught in the catalog:`
+            : `No matching degree found, but related subjects are taught in the catalog:`}
+        </Headline>
+        <RelatedSubjectsPanel subjects={answer.relatedSubjects} />
       </>
     );
   }
@@ -646,6 +675,53 @@ function Note({ children }: { children: React.ReactNode }) {
     <p className="text-xs text-slate-500 dark:text-slate-400 italic">
       {children}
     </p>
+  );
+}
+
+function RelatedSubjectsPanel({
+  subjects,
+  label,
+}: {
+  subjects: Array<{
+    prefix: string;
+    name: string;
+    course_count: number;
+    section_count: number;
+    college_count: number;
+    search_url: string;
+  }>;
+  label?: string;
+}) {
+  return (
+    <div className="mt-4 pt-3 border-t border-slate-200 dark:border-slate-700 space-y-1.5">
+      {label && (
+        <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+          {label}
+        </p>
+      )}
+      <ul className="space-y-1">
+        {subjects.map((s) => (
+          <li
+            key={s.prefix}
+            className="text-sm text-slate-700 dark:text-slate-300"
+          >
+            <a
+              href={s.search_url}
+              className="text-teal-600 dark:text-teal-400 hover:underline font-medium"
+            >
+              {s.name} ({s.prefix})
+            </a>
+            <span className="text-xs text-slate-500 dark:text-slate-400 ml-2">
+              {s.course_count}{" "}
+              {s.course_count === 1 ? "course" : "courses"}
+              {s.college_count > 0 &&
+                ` across ${s.college_count} ${s.college_count === 1 ? "college" : "colleges"}`}
+              {s.section_count > 0 && ` · ${s.section_count} sections`}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/lib/programs/__tests__/subject-vocab.test.ts
+++ b/lib/programs/__tests__/subject-vocab.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const FIXTURE = {
+  state: "vt",
+  generated_at: "2026-05-08T00:00:00Z",
+  subjects: [
+    {
+      prefix: "BIO",
+      name: "Biology",
+      course_count: 8,
+      section_count: 50,
+      colleges: ["ccv"],
+      sample_titles: ["Biology I", "Biology II"],
+    },
+    {
+      prefix: "GEO",
+      name: "Geography",
+      course_count: 3,
+      section_count: 12,
+      colleges: ["ccv"],
+      sample_titles: ["Physical Geography"],
+    },
+  ],
+  program_titles: ["Liberal Arts (A.A.)"],
+};
+
+// Module-level fs mocks. ESM doesn't permit vi.spyOn on namespace exports,
+// and vi.mock is hoisted above the file so its factory can't reference
+// later top-level vars — vi.hoisted lets us share refs across both.
+const { existsSyncMock, readFileSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(() => true),
+  readFileSyncMock: vi.fn(() => "{}"),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+import {
+  loadSubjectVocab,
+  summariseSubjectsByPrefix,
+  _resetSubjectVocabCache,
+} from "../subject-vocab";
+
+beforeEach(() => {
+  _resetSubjectVocabCache();
+  existsSyncMock.mockReset();
+  readFileSyncMock.mockReset();
+  // Defaults: file exists and contains the fixture.
+  existsSyncMock.mockReturnValue(true);
+  readFileSyncMock.mockReturnValue(JSON.stringify(FIXTURE));
+});
+
+describe("loadSubjectVocab", () => {
+  it("returns null when the file doesn't exist", () => {
+    existsSyncMock.mockReturnValue(false);
+    expect(loadSubjectVocab("nonexistent")).toBeNull();
+  });
+
+  it("returns null on parse error", () => {
+    readFileSyncMock.mockReturnValue("not json{{");
+    expect(loadSubjectVocab("broken")).toBeNull();
+  });
+
+  it("returns parsed vocab when the file is valid", () => {
+    const v = loadSubjectVocab("vt");
+    expect(v).not.toBeNull();
+    expect(v!.subjects.length).toBe(2);
+  });
+
+  it("memoizes — second call doesn't re-read the file", () => {
+    loadSubjectVocab("vt");
+    loadSubjectVocab("vt");
+    loadSubjectVocab("vt");
+    expect(existsSyncMock).toHaveBeenCalledTimes(1);
+    expect(readFileSyncMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("summariseSubjectsByPrefix", () => {
+  it("returns [] when state has no vocab", () => {
+    existsSyncMock.mockReturnValue(false);
+    expect(summariseSubjectsByPrefix("nope", ["BIO"])).toEqual([]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(summariseSubjectsByPrefix("vt", [])).toEqual([]);
+  });
+
+  it("hydrates known prefixes with name + counts + search_url", () => {
+    const result = summariseSubjectsByPrefix("vt", ["BIO"]);
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual({
+      prefix: "BIO",
+      name: "Biology",
+      course_count: 8,
+      section_count: 50,
+      college_count: 1,
+      search_url: "/vt/courses?q=BIO",
+    });
+  });
+
+  it("filters out unknown prefixes (defense against LLM hallucination)", () => {
+    const result = summariseSubjectsByPrefix("vt", ["BIO", "FAKE", "GEO"]);
+    expect(result.map((s) => s.prefix)).toEqual(["BIO", "GEO"]);
+  });
+
+  it("normalizes input prefixes to uppercase", () => {
+    const result = summariseSubjectsByPrefix("vt", ["bio", "geo"]);
+    expect(result.map((s) => s.prefix)).toEqual(["BIO", "GEO"]);
+  });
+
+  it("preserves input order", () => {
+    expect(
+      summariseSubjectsByPrefix("vt", ["GEO", "BIO"]).map((s) => s.prefix),
+    ).toEqual(["GEO", "BIO"]);
+  });
+});

--- a/lib/programs/subject-vocab.ts
+++ b/lib/programs/subject-vocab.ts
@@ -1,0 +1,99 @@
+/**
+ * subject-vocab.ts — runtime loader and helpers for
+ * data/{state}/subject-vocab.json (built by scripts/build-subject-vocab.ts).
+ *
+ * The vocab files are produced offline; this module is the read-side that
+ * powers the course-level pivot in the pathway answer ("no degree, but
+ * here are N Geography courses across M colleges"). See the relatedSubjects
+ * field on PathwayAnswer.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import type { SubjectMatchSummary } from "../search-intent/answer/types";
+
+interface SubjectEntry {
+  prefix: string;
+  name: string;
+  course_count: number;
+  section_count: number;
+  colleges: string[];
+  sample_titles: string[];
+}
+
+interface SubjectVocab {
+  state: string;
+  generated_at: string;
+  subjects: SubjectEntry[];
+  program_titles: string[];
+}
+
+const cache = new Map<string, SubjectVocab | null>();
+
+/**
+ * Load (and memoize) the subject-vocab JSON for a state. Returns null
+ * when the file is missing — callers should treat that as "no signal"
+ * rather than an error.
+ */
+export function loadSubjectVocab(state: string): SubjectVocab | null {
+  if (cache.has(state)) return cache.get(state) ?? null;
+  const file = path.join(
+    process.cwd(),
+    "data",
+    state,
+    "subject-vocab.json",
+  );
+  if (!fs.existsSync(file)) {
+    cache.set(state, null);
+    return null;
+  }
+  try {
+    const data = JSON.parse(fs.readFileSync(file, "utf-8")) as SubjectVocab;
+    cache.set(state, data);
+    return data;
+  } catch {
+    cache.set(state, null);
+    return null;
+  }
+}
+
+/**
+ * Hydrate a list of subject prefixes (as returned by the Phase 3 LLM
+ * resolver) into structured summaries that include the prefix's
+ * human-readable name, course/section counts, and a deep link into
+ * the state's course-search page filtered to that prefix.
+ *
+ * Filters out prefixes the vocab doesn't know about (defense against
+ * an LLM that hallucinates a prefix). Preserves input order.
+ */
+export function summariseSubjectsByPrefix(
+  state: string,
+  prefixes: string[],
+): SubjectMatchSummary[] {
+  if (prefixes.length === 0) return [];
+  const vocab = loadSubjectVocab(state);
+  if (!vocab) return [];
+  const byPrefix = new Map(vocab.subjects.map((s) => [s.prefix, s]));
+  const out: SubjectMatchSummary[] = [];
+  for (const raw of prefixes) {
+    const prefix = raw.toUpperCase().trim();
+    const entry = byPrefix.get(prefix);
+    if (!entry) continue;
+    out.push({
+      prefix: entry.prefix,
+      name: entry.name,
+      course_count: entry.course_count,
+      section_count: entry.section_count,
+      college_count: entry.colleges.length,
+      search_url: `/${state}/courses?q=${encodeURIComponent(entry.prefix)}`,
+    });
+  }
+  return out;
+}
+
+/**
+ * For tests — clears the in-process cache.
+ */
+export function _resetSubjectVocabCache(): void {
+  cache.clear();
+}

--- a/lib/search-intent/answer/__tests__/pathway.test.ts
+++ b/lib/search-intent/answer/__tests__/pathway.test.ts
@@ -24,6 +24,10 @@ vi.mock("../../../programs/semantic-resolve", () => ({
   semanticResolveMajor: vi.fn(async () => null),
 }));
 
+vi.mock("../../../programs/subject-vocab", () => ({
+  summariseSubjectsByPrefix: vi.fn(() => []),
+}));
+
 import { lookupPathway } from "../pathway";
 import { resolveUniversity } from "../validate";
 import {
@@ -33,6 +37,7 @@ import {
   loadProgramsByTitles,
 } from "../../../programs/requirements";
 import { semanticResolveMajor } from "../../../programs/semantic-resolve";
+import { summariseSubjectsByPrefix } from "../../../programs/subject-vocab";
 
 const resolveMock = vi.mocked(resolveUniversity);
 const loadProgramsMock = vi.mocked(loadProgramAcrossColleges);
@@ -40,6 +45,7 @@ const findRelatedMock = vi.mocked(findRelatedPrograms);
 const stateHasDataMock = vi.mocked(stateHasProgramData);
 const loadByTitlesMock = vi.mocked(loadProgramsByTitles);
 const semanticResolveMock = vi.mocked(semanticResolveMajor);
+const summariseSubjectsMock = vi.mocked(summariseSubjectsByPrefix);
 
 describe("lookupPathway", () => {
   it("looks up degree by major when no university or college specified", async () => {
@@ -436,5 +442,121 @@ describe("lookupPathway", () => {
     );
     if (result.type !== "pathway") return;
     expect(result.followups!.some((f) => f.toLowerCase().includes("nursing"))).toBe(true);
+  });
+
+  // ---- course-pivot: surface subjectPrefixes from semantic resolver ---------
+
+  it("course pivot: when LLM returns subjects but no programs, status=found-courses-only", async () => {
+    loadProgramsMock.mockResolvedValue([]);
+    stateHasDataMock.mockReturnValue(true);
+    findRelatedMock.mockResolvedValue([]);
+
+    semanticResolveMock.mockResolvedValue({
+      programTitles: [], // no degree match
+      subjectPrefixes: ["GEO", "GIS"], // but courses exist
+      rationale: "no Geography degree, but GEO and GIS courses are taught.",
+      source: "llm",
+    });
+    summariseSubjectsMock.mockReturnValue([
+      {
+        prefix: "GEO",
+        name: "Geography",
+        course_count: 7,
+        section_count: 130,
+        college_count: 23,
+        search_url: "/va/courses?q=GEO",
+      },
+      {
+        prefix: "GIS",
+        name: "Geographic Information Systems",
+        course_count: 5,
+        section_count: 12,
+        college_count: 6,
+        search_url: "/va/courses?q=GIS",
+      },
+    ]);
+
+    const result = await lookupPathway(
+      { type: "pathway", university: null, major: "geography", college: null, credential: null },
+      "va",
+    );
+    if (result.type !== "pathway") return;
+    expect(result.status).toBe("found-courses-only");
+    expect(result.relatedSubjects?.length).toBe(2);
+    expect(result.relatedSubjects?.[0].prefix).toBe("GEO");
+    expect(result.relatedSubjects?.[0].search_url).toBe("/va/courses?q=GEO");
+    expect(result.degreeRequirements).toBeUndefined();
+  });
+
+  it("course pivot: found-related ALSO carries relatedSubjects when LLM returns both", async () => {
+    loadProgramsMock.mockResolvedValue([]);
+    stateHasDataMock.mockReturnValue(true);
+    findRelatedMock.mockResolvedValue([]);
+
+    semanticResolveMock.mockResolvedValue({
+      programTitles: ["Health Science (A.S.)"],
+      subjectPrefixes: ["BIO", "HLT"],
+      rationale: "premed = bio + health.",
+      source: "llm",
+    });
+    loadByTitlesMock.mockResolvedValue([
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        college: { id: "ccv", name: "Community College of Vermont" } as any,
+        programs: [
+          {
+            title: "Health Science (A.S.)",
+            credential: "AS" as const,
+            program_code: null,
+            catalog_url: "",
+            total_credits: 60,
+            gpa_minimum: 2.0,
+            description: null,
+            requirement_groups: [],
+            matched_program_slug: null,
+          },
+        ],
+      },
+    ]);
+    summariseSubjectsMock.mockReturnValue([
+      {
+        prefix: "BIO",
+        name: "Biology",
+        course_count: 8,
+        section_count: 50,
+        college_count: 1,
+        search_url: "/vt/courses?q=BIO",
+      },
+    ]);
+
+    const result = await lookupPathway(
+      { type: "pathway", university: null, major: "premed", college: null, credential: null },
+      "vt",
+    );
+    if (result.type !== "pathway") return;
+    expect(result.status).toBe("found-related");
+    expect(result.degreeRequirements?.length).toBe(1);
+    expect(result.relatedSubjects?.length).toBe(1);
+    expect(result.relatedSubjects?.[0].prefix).toBe("BIO");
+  });
+
+  it("course pivot: no programs AND no subjects → still no-data", async () => {
+    loadProgramsMock.mockResolvedValue([]);
+    stateHasDataMock.mockReturnValue(true);
+    findRelatedMock.mockResolvedValue([]);
+    semanticResolveMock.mockResolvedValue({
+      programTitles: [],
+      subjectPrefixes: [],
+      rationale: "nothing matches.",
+      source: "llm",
+    });
+    summariseSubjectsMock.mockReturnValue([]);
+
+    const result = await lookupPathway(
+      { type: "pathway", university: null, major: "underwater-basketweaving", college: null, credential: null },
+      "vt",
+    );
+    if (result.type !== "pathway") return;
+    expect(result.status).toBe("no-data");
   });
 });

--- a/lib/search-intent/answer/pathway.ts
+++ b/lib/search-intent/answer/pathway.ts
@@ -16,7 +16,11 @@ import {
   loadProgramsByTitles,
 } from "../../programs/requirements";
 import { matchProgramSlug } from "../../programs/matcher";
-import { semanticResolveMajor } from "../../programs/semantic-resolve";
+import {
+  semanticResolveMajor,
+  type SemanticResolveResult,
+} from "../../programs/semantic-resolve";
+import { summariseSubjectsByPrefix } from "../../programs/subject-vocab";
 import type { Institution } from "../../types";
 import type { ProgramRequirement } from "../../programs/requirements";
 
@@ -164,11 +168,16 @@ async function lookupDegreeByMajor(
       // Phase 2: lexical stems
       let related = await findRelatedPrograms(state, majorLabel, 8);
 
+      // We hold onto the semantic result (if it was called) so we can
+      // surface its subjectPrefixes alongside or instead of programs —
+      // see the `relatedSubjects` field on PathwayAnswer.
+      let semantic: SemanticResolveResult | null = null;
+
       // Phase 3a: lexical found nothing → try LLM. Wrapped in try/catch
       // so a transient classifier failure can't break the request.
       if (related.length === 0) {
         try {
-          const semantic = await semanticResolveMajor(state, majorLabel);
+          semantic = await semanticResolveMajor(state, majorLabel);
           if (semantic && semantic.programTitles.length > 0) {
             related = await loadProgramsByTitles(state, semantic.programTitles);
           }
@@ -179,7 +188,7 @@ async function lookupDegreeByMajor(
         // Phase 3b: lexical was promiscuous — ask the LLM to refine.
         // Keep the lexical pool as fallback if the LLM returns nothing.
         try {
-          const semantic = await semanticResolveMajor(state, majorLabel);
+          semantic = await semanticResolveMajor(state, majorLabel);
           if (semantic && semantic.programTitles.length > 0) {
             const refined = await loadProgramsByTitles(
               state,
@@ -192,6 +201,10 @@ async function lookupDegreeByMajor(
         }
       }
 
+      const relatedSubjects = semantic?.subjectPrefixes
+        ? summariseSubjectsByPrefix(state, semantic.subjectPrefixes)
+        : [];
+
       if (related.length > 0) {
         return makeAnswer({
           status: "found-related",
@@ -199,10 +212,29 @@ async function lookupDegreeByMajor(
           major: intent.major,
           college: null,
           degreeRequirements: summariseRequirements(related),
+          relatedSubjects: relatedSubjects.length > 0 ? relatedSubjects : undefined,
           state,
           followups: [
             `${majorLabel} courses available this term`,
             `What are the prereqs for common ${majorLabel} courses?`,
+          ],
+        });
+      }
+
+      // No programs anywhere, but the LLM identified course-level
+      // subjects we *do* have. Pivot to a course-level answer instead
+      // of returning no-data.
+      if (relatedSubjects.length > 0) {
+        return makeAnswer({
+          status: "found-courses-only",
+          university: null,
+          major: intent.major,
+          college: null,
+          relatedSubjects,
+          state,
+          followups: [
+            `${majorLabel} courses available this term`,
+            `Browse all programs in this state`,
           ],
         });
       }

--- a/lib/search-intent/answer/types.ts
+++ b/lib/search-intent/answer/types.ts
@@ -123,12 +123,15 @@ export interface EligibilityAnswer {
 // ─── Pathway ────────────────────────────────────────────────────────────
 
 export type PathwayStatus =
-  | "found" //              pathway data exists for this university/major
-  | "found-degree" //       CC degree requirement data found
-  | "found-related" //      no exact-major match, but related programs found
-  | "no-data" //            no pathway data available yet
-  | "unknown-university" // university not recognized
-  | "missing-entity"; //    no university specified
+  | "found" //                pathway data exists for this university/major
+  | "found-degree" //         CC degree requirement data found
+  | "found-related" //        no exact-major match, but related programs found
+  | "found-courses-only" //   no degree match at any level, but related courses
+                              // exist in the state's catalog (Phase 3 LLM
+                              // returned subjectPrefixes but no programTitles)
+  | "no-data" //              no pathway data available yet
+  | "unknown-university" //   university not recognized
+  | "missing-entity"; //      no university specified
 
 export interface DegreeRequirementSummary {
   title: string;
@@ -143,6 +146,21 @@ export interface DegreeRequirementSummary {
   }>;
 }
 
+/**
+ * Aggregated info about a subject prefix used in a state's course catalog.
+ * Surfaces when the answer pivots from "no degree" to "but here are
+ * related courses you can take" — see #265 follow-up.
+ */
+export interface SubjectMatchSummary {
+  prefix: string; // e.g. "GEO"
+  name: string; // human-readable, e.g. "Geography"
+  course_count: number;
+  section_count: number;
+  college_count: number;
+  // Pre-built deep link into the per-state course search.
+  search_url: string;
+}
+
 export interface PathwayAnswer {
   type: "pathway";
   status: PathwayStatus;
@@ -150,6 +168,12 @@ export interface PathwayAnswer {
   major: string | null;
   college: { slug: string; name: string } | null;
   degreeRequirements?: DegreeRequirementSummary[];
+  /**
+   * Optional course-level pivot. Populated either alongside
+   * degreeRequirements (when found-related and the LLM also returned
+   * subjects) or as the only content (when status is found-courses-only).
+   */
+  relatedSubjects?: SubjectMatchSummary[];
   source: SourceCitation;
   followups?: string[];
 }


### PR DESCRIPTION
Finishes the loop opened by [#263](https://github.com/rohan-c0de/cc-coursemap/pull/263). The Phase 3 LLM resolver already returns \`subjectPrefixes\` (e.g. for "geography" → \`["GEO", "GIS"]\`) but they were never surfaced. When a state has the **courses** but not a matching **degree**, the answer card returned \`no-data\` even though we had something useful to say.

## What changes for the user

| Query (state without that degree but with the courses) | Before | After |
|---|---|---|
| "geography" → state has GEO/GIS courses but no GIS degree | no-data ❌ | 📚 _No standalone Geography degree, but these subjects are taught_ + clickable list ✅ |
| "premed" → state has BIO/HLT but no premed program | no-data ❌ | found-courses-only with BIO/HLT pivot ✅ |
| "geography" → state HAS related programs | found-related (programs only) | found-related + bonus _Related courses you could take_ panel ✅ |

## Architecture

| Component | What it does |
|---|---|
| [lib/programs/subject-vocab.ts](lib/programs/subject-vocab.ts) | Runtime loader for \`data/{state}/subject-vocab.json\` (built in #261). Memoized. Includes \`summariseSubjectsByPrefix\` which validates against the vocab so an LLM that hallucinates a prefix produces nothing instead of a broken link. |
| [lib/search-intent/answer/types.ts](lib/search-intent/answer/types.ts) | New \`PathwayStatus: "found-courses-only"\`, new \`SubjectMatchSummary\` type, new optional \`PathwayAnswer.relatedSubjects\` field. |
| [lib/search-intent/answer/pathway.ts](lib/search-intent/answer/pathway.ts) | \`lookupDegreeByMajor\` captures the \`SemanticResolveResult\` so it can hydrate \`subjectPrefixes\` whether or not \`programTitles\` resolved. Three outcomes: programs+subjects (found-related with bonus), subjects-only (found-courses-only), neither (no-data). |
| [components/AnswerCard.tsx](components/AnswerCard.tsx) | New \`RelatedSubjectsPanel\` component renders the prefix list with course/section/college counts and a deep link into the per-state course search (\`/{state}/courses?q=PREFIX\`). |

## Test plan

- [x] \`npx tsc --noEmit\` exits 0
- [x] \`npm run lint\` exits 0 (0 errors)
- [x] **375/375 tests pass** (13 new + 362 existing)
  - 3 new pathway integration tests cover: courses-only branch, found-related-with-subjects branch, no-programs+no-subjects → no-data
  - 10 new subject-vocab tests cover: missing file, parse error, memoization, prefix hydration, hallucination filtering, case normalization, order preservation
- [x] Local dev: \`/va/courses\` renders without runtime errors (no AnswerCard surfaces in dev because LLM key returns 401, but the page builds + serves clean — verified via \`preview_logs\` error-only filter)
- [ ] CI green
- [ ] Post-merge: curl prod for queries that previously returned no-data and confirm at least one returns \`found-courses-only\` with a populated \`relatedSubjects\` list

## What this does NOT do

- Doesn't change the existing \`found-degree\` and \`found-related\` happy paths beyond the optional bonus subject panel. Existing prod behavior is unchanged.
- Doesn't add a course-level pivot for queries the classifier marks as \`course\` intent (those go through the dual-intent path in #268). This PR is specifically for the \`pathway\` branch where the LLM identifies subjects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)