### PR TITLE
auto-add-state PR 5/8: articulation portal registry + loader

### DIFF
--- a/data/articulation-portals.json
+++ b/data/articulation-portals.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "../scripts/lib/articulation-portals.schema.json",
+  "$comment": "Registry of known state-run articulation portals. Read by scripts/lib/articulation-portals.ts and consumed by the auto-add-state orchestrator (PR 7) to decide how to scrape transfer data for a given state. Each entry pairs a state slug with a portal type, the URL, and pointers to the existing per-state scraper script(s) that handle it. Entries with type='state-portal-flatfile' or 'state-portal' typically yield much higher coverage than the per-receiver fallbacks. The orchestrator falls back to CollegeTransfer.Net for any state without a registered portal.",
+  "portals": {
+    "ct": {
+      "type": "per-receiver",
+      "name": "Per-receiver (CCSU, SCSU, ECSU)",
+      "scripts": ["scripts/ct/scrape-transfer-all.ts"],
+      "notes": "Orchestrator runs CCSU, SCSU, and ECSU adapters sequentially. CT does not have a centralized state portal."
+    },
+    "de": {
+      "type": "mixed",
+      "name": "UDel + CollegeTransfer.Net",
+      "scripts": [
+        "scripts/de/scrape-transfer-udel.ts",
+        "scripts/de/scrape-transfer-collegetransfer.ts"
+      ],
+      "notes": "UDel direct equivalency table plus CT.Net fallback for other DE 4-years."
+    },
+    "fl": {
+      "type": "state-portal-flatfile",
+      "name": "SCNS / FloridaShines",
+      "url": "https://flscns.fldoe.org/",
+      "scripts": ["scripts/fl/scrape-scns-flatfile.ts"],
+      "notes": "Statewide course numbering system. By FL Stat. § 1007.24, courses with the same prefix + 3-digit number + lab code at any FL public institution are equivalent. One ~80MB POST yields the entire system; algorithmic mapping replaces per-receiver scraping. Covers all 28 FCS colleges × 12 SUS universities."
+    },
+    "ga": {
+      "type": "mixed",
+      "name": "USG + per-receiver",
+      "scripts": [
+        "scripts/ga/scrape-transfer-usg.ts",
+        "scripts/ga/scrape-transfer-uga.ts",
+        "scripts/ga/scrape-transfer-gsu.ts",
+        "scripts/ga/scrape-transfer-gatech.ts"
+      ],
+      "notes": "USG (University System of Georgia) state portal plus per-receiver scrapers for UGA / GSU / GaTech."
+    },
+    "ma": {
+      "type": "state-portal",
+      "name": "MassTransfer",
+      "url": "https://www.mass.edu/masstransfer/equivalencies/",
+      "scripts": ["scripts/ma/scrape-masstransfer.ts"],
+      "notes": "Mass DHE state portal. One scrape yields ~45k mappings across all 15 MA community colleges × 14 receivers."
+    },
+    "md": {
+      "type": "state-portal",
+      "name": "ARTSYS",
+      "url": "https://artsys.usmd.edu/",
+      "scripts": ["scripts/md/scrape-transfer-artsys.ts"],
+      "notes": "USM Articulation System (Quottly-powered). Covers all 16 MD community colleges to top transfer destinations."
+    },
+    "me": {
+      "type": "collegetransfer-net",
+      "name": "CollegeTransfer.Net",
+      "scripts": ["scripts/me/scrape-transfer.ts"],
+      "notes": "ME's 7 MCCS colleges feed CollegeTransfer.Net. Free tier rate-limits at ~5 source institutions per run; merge-preserve."
+    },
+    "nc": {
+      "type": "state-portal",
+      "name": "UNC System CNS",
+      "url": "https://coursetransfer.northcarolina.edu/",
+      "scripts": [
+        "scripts/nc/scrape-transfer-cns.ts",
+        "scripts/nc/scrape-transfer-catawba.ts",
+        "scripts/nc/scrape-transfer-elon.ts",
+        "scripts/nc/scrape-transfer-hpu.ts",
+        "scripts/nc/scrape-transfer-ncstate.ts",
+        "scripts/nc/scrape-transfer-uncg.ts",
+        "scripts/nc/scrape-transfer-wingate.ts"
+      ],
+      "notes": "UNC System Course Numbering System covers in-system universities. Per-receiver scripts cover the private/independent destinations CNS doesn't include."
+    },
+    "nh": {
+      "type": "mixed",
+      "name": "CollegeTransfer.Net + Keene direct",
+      "scripts": [
+        "scripts/nh/scrape-transfer.ts",
+        "scripts/nh/scrape-transfer-keene.ts"
+      ],
+      "notes": "USNH does not publish to CT.Net for in-state destinations; Keene gets a direct scrape."
+    },
+    "nj": {
+      "type": "state-portal",
+      "name": "NJTransfer.org",
+      "url": "https://njtransfer.org/",
+      "scripts": ["scripts/nj/scrape-transfer.ts"],
+      "notes": "State-mandated CGI app. All 19 NJ community college campuses → major NJ universities."
+    },
+    "ny": {
+      "type": "state-portal",
+      "name": "CUNY T-Rex (Transfer Explorer)",
+      "url": "https://explorer.cuny.edu/",
+      "scripts": ["scripts/ny/scrape-transfer-trex.ts"],
+      "notes": "CUNY 7 community colleges → CUNY senior colleges + a few post-bac specialty institutions."
+    },
+    "pa": {
+      "type": "collegetransfer-net",
+      "name": "PA TRAC (CollegeTransfer.Net-backed)",
+      "url": "https://collegetransfer.pa.gov/",
+      "scripts": ["scripts/pa/scrape-transfer.ts"],
+      "notes": "PA TRAC is a CT.Net-powered branded interface. Same OData v2 API as DE/ME/NH."
+    },
+    "ri": {
+      "type": "tes-public-view",
+      "name": "TES Public View (URI + RIC)",
+      "scripts": ["scripts/ri/scrape-transfer.ts"],
+      "notes": "CCRI uses Transfer Evaluation System Public View at URI and RIC. RI does not have a unified state portal."
+    },
+    "sc": {
+      "type": "per-receiver",
+      "name": "Per-receiver (Clemson + others)",
+      "scripts": [
+        "scripts/sc/scrape-transfer-clemson.ts",
+        "scripts/sc/scrape-transfer-universities.ts"
+      ],
+      "notes": "SC Commission on Higher Education's universal-articulation page is too coarse; per-receiver is the practical pattern."
+    },
+    "tn": {
+      "type": "per-receiver",
+      "name": "Per-receiver (UTK / APSU / MTSU)",
+      "scripts": [
+        "scripts/tn/transfer/scrape-all.ts",
+        "scripts/tn/transfer/scrape-utk.ts",
+        "scripts/tn/transfer/scrape-apsu.ts",
+        "scripts/tn/transfer/scrape-mtsu.ts"
+      ],
+      "notes": "TNTransfers.org exists but is not machine-readable in a useful way; per-receiver scrapes orchestrate via scrape-all.ts."
+    },
+    "va": {
+      "type": "per-receiver",
+      "name": "Per-receiver (UVA, VT, ODU, VCU, VSU, VWU, GMU, UMW)",
+      "scripts": [
+        "scripts/va/scrape-transfer-uva.ts",
+        "scripts/va/scrape-transfer-equiv.ts",
+        "scripts/va/scrape-transfer-odu.ts",
+        "scripts/va/scrape-transfer-vcu.ts",
+        "scripts/va/scrape-transfer-vsu.ts",
+        "scripts/va/scrape-transfer-vwu.ts",
+        "scripts/va/scrape-transfer-gmu.ts",
+        "scripts/va/scrape-transfer-umw.ts"
+      ],
+      "notes": "VCCS does not publish a unified articulation feed. Each receiving university has its own equivalency tool."
+    },
+    "vt": {
+      "type": "collegetransfer-net",
+      "name": "CollegeTransfer.Net (CCV)",
+      "scripts": ["scripts/vt/scrape-transfer.ts"],
+      "notes": "VT has a single community college (CCV); CT.Net coverage is its primary articulation source."
+    }
+  },
+  "fallback": {
+    "type": "collegetransfer-net",
+    "name": "CollegeTransfer.Net (universal fallback)",
+    "url": "https://www.collegetransfer.net/",
+    "templateLib": "scripts/lib/scrape-collegetransfer.ts",
+    "notes": "When a new state has no entry in this registry, the orchestrator should attempt CollegeTransfer.Net. This requires (a) a sender SourceInstitutionId for each CC and (b) a list of receiver TargetInstitutionIds. The free OData tier rate-limits after ~4-5 source institutions per run, so multi-CC states must merge-preserve across runs. Coverage is uneven: MA / NJ / FL all have data here too but their state portals deliver more accurate, higher-coverage data and are preferred."
+  }
+}

--- a/scripts/lib/articulation-portals.ts
+++ b/scripts/lib/articulation-portals.ts
@@ -1,0 +1,347 @@
+/**
+ * articulation-portals.ts
+ *
+ * Loader and types for `data/articulation-portals.json` — the registry of
+ * known state-run transfer-articulation portals. Read by the auto-add-state
+ * orchestrator (PR 7) to decide how to scrape transfer data for a given
+ * state.
+ *
+ * For a known state, the orchestrator looks up the entry, reads `scripts`,
+ * and runs each one against the registry's existing per-state scrapers.
+ * For an unknown state, the orchestrator falls back to CollegeTransfer.Net
+ * via the `fallback` entry — which depends on the caller having (or
+ * discovering) per-college SourceInstitutionIds.
+ *
+ * This PR is purely additive: the registry + loader + types ship as a
+ * new file pair. No existing scrapers are modified. The orchestrator
+ * (PR 7) will be the first consumer.
+ *
+ * Usage as a library:
+ *
+ *   import {
+ *     loadArticulationPortals,
+ *     lookupArticulationPortal,
+ *     getFallbackPortal,
+ *   } from "../lib/articulation-portals";
+ *
+ *   const portal = lookupArticulationPortal("oh");
+ *   if (portal) {
+ *     for (const script of portal.scripts) await runScript(script);
+ *   } else {
+ *     const fb = getFallbackPortal();
+ *     console.log(`No registered portal for oh; fall back to ${fb.name}.`);
+ *   }
+ *
+ * CLI smoke (read-only):
+ *
+ *   npx tsx scripts/lib/articulation-portals.ts --list
+ *   npx tsx scripts/lib/articulation-portals.ts --lookup fl
+ *   npx tsx scripts/lib/articulation-portals.ts --validate
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Portal classification. Drives orchestrator decisions about how to
+ * interpret the entry's `scripts` field and whether to expect high vs
+ * sparse coverage.
+ */
+export type PortalType =
+  /** Single-file dump from a state DOE site. Highest leverage; one
+   *  scrape covers every public institution in the state. Example: FL SCNS. */
+  | "state-portal-flatfile"
+  /** A state-mandated articulation app or system that aggregates per-pair
+   *  data. Example: MA MassTransfer, MD ARTSYS, NJ NJTransfer, CUNY T-Rex. */
+  | "state-portal"
+  /** State articulation goes through CollegeTransfer.Net's OData API
+   *  (state-branded or generic). Example: PA TRAC, ME, VT. */
+  | "collegetransfer-net"
+  /** TES (Transfer Evaluation System) Public View pattern — receiver
+   *  university publishes a TES-backed equivalency search. Example: RI. */
+  | "tes-public-view"
+  /** No state-level portal; one scraper per receiving university.
+   *  Example: VA, SC, TN, CT. */
+  | "per-receiver"
+  /** Combination — a state portal exists but covers only some destinations
+   *  and per-receiver scripts handle the rest. Example: NC, NH, GA, DE. */
+  | "mixed";
+
+export interface PortalEntry {
+  type: PortalType;
+  name: string;
+  url?: string;
+  scripts: string[];
+  notes?: string;
+}
+
+export interface FallbackPortal {
+  type: PortalType;
+  name: string;
+  url?: string;
+  templateLib: string;
+  notes?: string;
+}
+
+interface ArticulationRegistry {
+  $schema?: string;
+  $comment?: string;
+  portals: Record<string, PortalEntry>;
+  fallback: FallbackPortal;
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+const REGISTRY_PATH = path.join(
+  process.cwd(),
+  "data",
+  "articulation-portals.json"
+);
+
+let cached: ArticulationRegistry | null = null;
+
+/**
+ * Load and validate `data/articulation-portals.json`. Cached after first
+ * call. Throws on missing file or schema violation — fail loudly so the
+ * orchestrator never silently proceeds with a corrupt registry.
+ */
+export function loadArticulationPortals(): ArticulationRegistry {
+  if (cached) return cached;
+
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    throw new Error(`articulation-portals.json not found at ${REGISTRY_PATH}`);
+  }
+
+  const raw = fs.readFileSync(REGISTRY_PATH, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(
+      `articulation-portals.json failed to parse as JSON: ${(e as Error).message}`
+    );
+  }
+
+  validate(parsed);
+  cached = parsed as ArticulationRegistry;
+  return cached;
+}
+
+/**
+ * Look up the registered articulation portal for a state slug. Returns
+ * null when the state has no entry — caller should consult the fallback.
+ */
+export function lookupArticulationPortal(
+  state: string
+): PortalEntry | null {
+  const registry = loadArticulationPortals();
+  return registry.portals[state.toLowerCase()] ?? null;
+}
+
+/** Return the universal fallback (CollegeTransfer.Net by default). */
+export function getFallbackPortal(): FallbackPortal {
+  return loadArticulationPortals().fallback;
+}
+
+/** Slugs of all states with a registered portal. */
+export function listRegisteredStates(): string[] {
+  return Object.keys(loadArticulationPortals().portals).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Validation — enforce shape + that referenced scripts actually exist on
+// disk. Catches typos in the registry before the orchestrator tries to
+// `tsx` a bad path. (We don't typecheck the scripts; just check the path
+// resolves to a regular file.)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_TYPES: PortalType[] = [
+  "state-portal-flatfile",
+  "state-portal",
+  "collegetransfer-net",
+  "tes-public-view",
+  "per-receiver",
+  "mixed",
+];
+
+function validate(parsed: unknown): asserts parsed is ArticulationRegistry {
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("articulation-portals.json must be an object");
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.portals !== "object" || obj.portals === null) {
+    throw new Error("articulation-portals.json: missing or invalid 'portals'");
+  }
+  if (typeof obj.fallback !== "object" || obj.fallback === null) {
+    throw new Error("articulation-portals.json: missing or invalid 'fallback'");
+  }
+
+  for (const [slug, entry] of Object.entries(obj.portals as Record<string, unknown>)) {
+    if (typeof entry !== "object" || entry === null) {
+      throw new Error(`portals['${slug}'] is not an object`);
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.type !== "string" || !ALLOWED_TYPES.includes(e.type as PortalType)) {
+      throw new Error(
+        `portals['${slug}'].type must be one of ${ALLOWED_TYPES.join(", ")}`
+      );
+    }
+    if (typeof e.name !== "string" || !e.name) {
+      throw new Error(`portals['${slug}'].name must be a non-empty string`);
+    }
+    if (!Array.isArray(e.scripts) || e.scripts.length === 0) {
+      throw new Error(`portals['${slug}'].scripts must be a non-empty array`);
+    }
+    for (const s of e.scripts as unknown[]) {
+      if (typeof s !== "string") {
+        throw new Error(`portals['${slug}'].scripts must contain strings`);
+      }
+      const fullPath = path.join(process.cwd(), s);
+      if (!fs.existsSync(fullPath)) {
+        throw new Error(
+          `portals['${slug}']: script '${s}' does not exist on disk`
+        );
+      }
+    }
+    if (e.url !== undefined && typeof e.url !== "string") {
+      throw new Error(`portals['${slug}'].url must be a string`);
+    }
+    if (e.notes !== undefined && typeof e.notes !== "string") {
+      throw new Error(`portals['${slug}'].notes must be a string`);
+    }
+  }
+
+  const fb = obj.fallback as Record<string, unknown>;
+  if (
+    typeof fb.type !== "string" ||
+    !ALLOWED_TYPES.includes(fb.type as PortalType)
+  ) {
+    throw new Error(`fallback.type must be one of ${ALLOWED_TYPES.join(", ")}`);
+  }
+  if (typeof fb.name !== "string" || !fb.name) {
+    throw new Error("fallback.name must be a non-empty string");
+  }
+  if (typeof fb.templateLib !== "string" || !fb.templateLib) {
+    throw new Error("fallback.templateLib must be a non-empty string");
+  }
+  if (!fs.existsSync(path.join(process.cwd(), fb.templateLib as string))) {
+    throw new Error(
+      `fallback.templateLib '${fb.templateLib}' does not exist on disk`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function printHelp() {
+  console.log(`Usage:
+  npx tsx scripts/lib/articulation-portals.ts --list
+  npx tsx scripts/lib/articulation-portals.ts --lookup <state>
+  npx tsx scripts/lib/articulation-portals.ts --validate
+
+Operations on data/articulation-portals.json:
+  --list      Print all registered states + portal name + type
+  --lookup    Print the registry entry for a single state slug
+  --validate  Re-load + re-validate (verifies all referenced scripts exist
+              on disk). Exits 1 if validation fails.
+
+Examples:
+  npx tsx scripts/lib/articulation-portals.ts --list
+  npx tsx scripts/lib/articulation-portals.ts --lookup fl
+`);
+}
+
+interface CliArgs {
+  list: boolean;
+  lookup?: string;
+  validate: boolean;
+  help: boolean;
+  err?: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { list: false, validate: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--list") out.list = true;
+    else if (a === "--validate") out.validate = true;
+    else if (a === "--lookup") out.lookup = argv[++i];
+    else if (a === "--help" || a === "-h") out.help = true;
+    else out.err = `Unknown argument: ${a}`;
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.err || (!args.list && !args.lookup && !args.validate)) {
+    if (args.err) console.error(`Error: ${args.err}`);
+    printHelp();
+    process.exit(args.err ? 1 : 0);
+  }
+
+  try {
+    const registry = loadArticulationPortals();
+
+    if (args.validate) {
+      const states = listRegisteredStates();
+      console.log(
+        `✓ Registry valid: ${states.length} states + 1 fallback. ${
+          Object.values(registry.portals).reduce((n, e) => n + e.scripts.length, 0)
+        } total script references — all exist on disk.`
+      );
+      return;
+    }
+
+    if (args.list) {
+      const states = listRegisteredStates();
+      console.log(`Registered states: ${states.length}\n`);
+      const byType = new Map<PortalType, string[]>();
+      for (const slug of states) {
+        const e = registry.portals[slug];
+        const arr = byType.get(e.type) ?? [];
+        arr.push(slug);
+        byType.set(e.type, arr);
+        console.log(
+          `  ${slug.padEnd(4)} ${e.type.padEnd(24)} ${e.name}`
+        );
+      }
+      console.log(`\nBy type:`);
+      for (const [type, slugs] of [...byType.entries()].sort()) {
+        console.log(`  ${type.padEnd(24)} ${slugs.length}: ${slugs.join(", ")}`);
+      }
+      console.log(`\nFallback: ${registry.fallback.name} → ${registry.fallback.templateLib}`);
+      return;
+    }
+
+    if (args.lookup) {
+      const e = lookupArticulationPortal(args.lookup);
+      if (!e) {
+        console.log(
+          `No registered portal for '${args.lookup}'. Fallback: ${registry.fallback.name}.`
+        );
+        process.exit(0);
+      }
+      console.log(JSON.stringify({ state: args.lookup, ...e }, null, 2));
+      return;
+    }
+  } catch (e) {
+    console.error(`Error: ${(e as Error).message}`);
+    process.exit(1);
+  }
+}
+
+const isMain =
+  import.meta.url.startsWith("file:") &&
+  process.argv[1] &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isMain) main();


### PR DESCRIPTION
PR 5 of 8 toward the auto-add-state skill. Adds a registry of known state-run transfer-articulation portals plus a loader the orchestrator (PR 7) will use to decide how to scrape transfer data for any state.

## Strictly additive — no existing scrapers touched

\`\`\`
$ git diff --stat main
 data/articulation-portals.json     | 158 ++++++++++++++++++
 scripts/lib/articulation-portals.ts | 347 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 505 insertions(+)
\`\`\`

## What's in

Two new files:

### \`data/articulation-portals.json\`
Registry keyed by state slug. Each entry pairs a portal type with the URL and the existing per-state scraper script(s) that handle it. 17 states currently have entries (every state with transfer data on main today: ct / de / fl / ga / ma / md / me / nc / nh / nj / ny / pa / ri / sc / tn / va / vt). Plus a universal fallback entry pointing at CollegeTransfer.Net for unknown states.

### \`scripts/lib/articulation-portals.ts\`
TypeScript loader + types + small CLI. Exports \`loadArticulationPortals\`, \`lookupArticulationPortal(state)\`, \`getFallbackPortal()\`, \`listRegisteredStates()\`. Validation runs at load time and catches typo'd script paths before the orchestrator can fail at runtime.

## Portal classification

| Type | States | Description |
|---|---|---|
| \`state-portal-flatfile\` | fl | Single-file dump (FL SCNS, ~80MB) |
| \`state-portal\` | ma, md, nc, nj, ny | Aggregator app (MassTransfer / ARTSYS / NJTransfer / CUNY T-Rex / UNC CNS) |
| \`collegetransfer-net\` | me, pa, vt | OData v2 API |
| \`tes-public-view\` | ri | TES-backed receiver search |
| \`per-receiver\` | ct, sc, tn, va | Each university scraped independently |
| \`mixed\` | de, ga, nh | State portal partial coverage + per-receiver fill |

## Why this is smaller than the original \"3-4 portal-type scrapers\" proposal

The existing per-state transfer scrapers are too source-specific to templatize cleanly — NC's CNS HTML differs from MA's MassTransfer JSON differs from FL's SCNS fixed-width. The pragmatic move is to enumerate them and let the orchestrator dispatch by state. The one truly parameterized template — CollegeTransfer.Net via [scripts/lib/scrape-collegetransfer.ts](scripts/lib/scrape-collegetransfer.ts) — already exists; the registry just declares it as the fallback for unknown states.

## CLI modes

\`\`\`
npx tsx scripts/lib/articulation-portals.ts --list
npx tsx scripts/lib/articulation-portals.ts --lookup fl
npx tsx scripts/lib/articulation-portals.ts --validate
\`\`\`

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — 0 errors / 0 new warnings on these files
- [x] \`--validate\` — registry valid: 17 states + 1 fallback, 39 total script references, all exist on disk
- [x] \`--list\` — clean tabular output, grouped by type
- [x] \`--lookup fl\` — returns full SCNS entry with notes
- [x] \`--lookup oh\` (unknown state) — falls back to CollegeTransfer.Net message
- [ ] CI green

## Roadmap

| PR | What | Status |
|---|---|---|
| 1 | \`fingerprint-college.ts\` | merged |
| 2 | \`scrape-banner-ssb.ts\` template | merged |
| 3 | \`scrape-colleague.ts\` template | merged |
| 4 | \`scrape-banner-8.ts\` template | merged |
| **5 (this)** | articulation-portals registry + loader | this PR |
| 6 | \`bootstrap-state.ts\` + zipcodes + college discovery | next |
| 7 | \`add-state.ts\` orchestrator | |
| 8 | \`auto-add-state\` skill ships | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)