### PR TITLE
auto-add-state PR 8/8: skill ships — one-command state onboarding

### DIFF
--- a/.claude/skills/auto-add-state/SKILL.md
+++ b/.claude/skills/auto-add-state/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: auto-add-state
+description: Add a US state to Community College Path end-to-end — bootstrap files, fingerprint per-college SIS, scrape courses where templates exist, fetch transfers if a state portal is registered, aggregate prereqs, open a PR — autonomously via scripts/lib/add-state.ts. Use this when the user wants to add a new state (e.g. "/auto-add-state ohio", "add Kentucky", "spin up Iowa"). For phase-by-phase manual control over each step instead, use the older `add-new-state` skill.
+---
+
+# auto-add-state
+
+Autonomous version of the manual `add-new-state` skill. The manual one walks
+you through 5 phases over 5 PRs; this one runs the entire pipeline via
+`scripts/lib/add-state.ts` and ships **one** PR. Designed for the user to
+type the command, walk away, and come back to a PR ready to review.
+
+The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
+- Phase 1 — bootstrap (`scripts/lib/bootstrap-state.ts`)
+- Phase 2a — fingerprint per college (`scripts/lib/fingerprint-college.ts`)
+- Phase 2b — course scraping via the right template
+  (`scripts/lib/scrape-{banner-ssb,colleague,banner-8}.ts`)
+- Phase 3 — articulation lookup (`data/articulation-portals.json`)
+- Phase 4 — prereq aggregation (`scripts/lib/aggregate-prereqs.ts`)
+
+## Workflow
+
+1. **Parse the slug** from the user's invocation. Lowercase, 2-letter US
+   state abbr (e.g. `oh`, `ky`, `ia`, `tx`). If they typed a full name
+   ("ohio"), convert. Reject anything that isn't a known state.
+
+2. **Create the branch.** Off `main`:
+   ```
+   git checkout main && git pull --ff-only
+   git checkout -b claude/{slug}-auto-add-state
+   ```
+
+3. **Run the orchestrator.** This is the long-running step (typically
+   20–60 minutes; OH took 7m for fingerprint + several minutes per scraper
+   cohort). Use `Bash` with `run_in_background: true` so the conversation
+   doesn't block, then poll for completion:
+   ```
+   npx tsx scripts/lib/add-state.ts --state {slug} --json
+   ```
+   Save the JSON output to `/tmp/add-state-{slug}-result.json`.
+
+4. **While it runs**, give the user a single status sentence ("Orchestrator
+   started for {slug}; I'll be back when it finishes."). Don't poll-narrate
+   every minute — let it run.
+
+5. **Read the result JSON** when the subprocess exits. Parse:
+   - `bootstrap.collegesDiscovered`
+   - `fingerprint.byPlatform` (counts per platform)
+   - `courses.bannerSsb.grandTotal` + `courses.colleague.grandTotal` +
+     `courses.banner8.grandTotal`
+   - `transfers.portal` (or null + `fallbackSuggestion`)
+   - `prereqs.aggregated`
+   - `manualTodos[]`
+
+6. **Sanity-check the result.** If `bootstrap.collegesDiscovered === 0`,
+   abort: nothing to commit. Tell the user the state probably isn't
+   supported by IPEDS sector ∈ {1,4} + cat ∈ {3,4} (rare; e.g. AK has
+   only one CC and may need manual handling). Don't commit. Don't push.
+
+7. **Pre-PR feature check** (per `CLAUDE.md`'s three-checks-in-order rule).
+   Per Section "Verifying your work" item 1: load `/{slug}/colleges` in
+   local dev. Use the preview tools:
+   - `preview_start` (dev server reads from `.claude/launch.json`)
+   - `preview_eval`: navigate to `http://localhost:3000/{slug}/colleges`
+   - `preview_snapshot`: confirm all `bootstrap.collegesDiscovered`
+     colleges render, not an empty grid
+   - If empty grid: the registry edits didn't apply correctly — abort,
+     tell the user, do not commit. Almost always means a regex in
+     `bootstrap-state.ts`'s `applyRegistryEdit` matched in the wrong place.
+
+8. **Commit in three logical chunks.** This makes the PR reviewable;
+   reviewers can scan Phase 1 (~thousands of lines of generated data),
+   Phase 2 (~tens of thousands of lines of scraped course data), and
+   Phase 3-4 separately:
+
+   ```
+   # Phase 1
+   git add data/{slug}/institutions.json data/{slug}/zipcodes.json \
+           data/{slug}/transfer-equiv.json lib/states/{slug}/ \
+           lib/states/registry.ts lib/institutions.ts lib/geo.ts
+   git commit -m "feat: bootstrap {state} — {N} colleges, Phase 1 ($n PR1/8)"
+
+   # Phase 2 (if any course data)
+   git add data/{slug}/courses/
+   git commit -m "feat: scrape {state} courses — {sections} sections across {N} colleges"
+
+   # Phase 3 + 4 (if any transfer / prereq data)
+   git add data/{slug}/prereqs.json
+   git commit -m "feat: aggregate {state} prereqs — {N} courses"
+   ```
+
+   Skip a chunk if its files don't exist (e.g. if every college had a
+   custom platform, there's no Phase 2 commit).
+
+9. **Push:**
+   ```
+   git push -u origin claude/{slug}-auto-add-state
+   ```
+
+10. **Open the PR.** Title: `Add {Full State Name} to Community College
+    Path (auto-add-state)`. Body: paste the orchestrator's text report
+    plus the manual-TODO list. Use `gh pr create --body-file` so multi-
+    line content survives shell escaping.
+
+11. **Surface the TODO list** to the user in the conversation. Group by
+    category (`[bootstrap]`, `[fingerprint]`, `[transfers]`, etc.) so the
+    user can decide quickly which to address before merging vs which can
+    wait. Don't merge for the user — they review and click Squash & merge.
+
+## Manual TODOs to expect
+
+The orchestrator's `manualTodos[]` is the most important output. Categories:
+
+- **`[bootstrap]`** — state-metadata.json doesn't have curated entries for
+  the state's full name / system name / senior-waiver citation. The
+  bootstrap proceeds with placeholder values; the user fills in the right
+  values before merging. Always present for a never-before-added state.
+
+- **`[fingerprint]`** — colleges whose SIS platform isn't in the
+  banner-ssb-9 / colleague / banner-8 trio. Specifics:
+  - `custom HTML/SPA` — bespoke scraper needed; out of scope for this skill
+  - `auth-gated` — SSO-only; can't scrape without credentials; user accepts
+    the gap or contacts the college
+  - `jenzabar` / `peoplesoft` / `workday` / etc. — known platforms with no
+    template yet; future PR could add one
+  - `acalog` / `courseleaf` — programs/catalog platforms, not course-search;
+    irrelevant for Phase 2
+  - `unknown` — no SIS detected; usually means the homepage doesn't link
+    to the registration system on a discoverable nav path. Manual lookup.
+
+- **`[transfers]`** — state has no entry in `data/articulation-portals.json`.
+  Fallback to CollegeTransfer.Net is suggested but requires per-college
+  SourceInstitutionIds (one-time research per college). Or the user adds a
+  registry entry once they identify the state's articulation portal.
+
+- **`[prereqs]`** — aggregation failed. Usually means Phase 2 produced no
+  data (every college had a custom platform). Re-run after Phase 2 issues
+  are resolved.
+
+## Failure modes
+
+- **Bootstrap fails** (IPEDS API down, FIPS wrong, etc.): abort; tell the
+  user to retry. No partial commit, no branch left behind.
+  ```
+  git checkout main && git branch -D claude/{slug}-auto-add-state
+  ```
+
+- **Bootstrap succeeds, every later phase fails**: commit Phase 1 only;
+  open the PR with a clear "Phases 2–4 deferred" note. User merges Phase 1
+  to unblock the registry, then runs the orchestrator again with
+  `--skip-bootstrap` to retry the rest.
+
+- **Some scraper cohort fails (e.g. Banner SSB) but Colleague succeeds**:
+  the orchestrator records the failure in `manualTodos`; commit the data
+  that did land. PR body explicitly lists which cohorts ran clean.
+
+- **Pre-PR feature check shows empty `/colleges` grid**: don't commit.
+  Means the registry edits got applied to the wrong place. Manually
+  inspect `lib/institutions.ts`, `lib/geo.ts`, `lib/states/registry.ts`
+  for the new state's import + entry. If the registry-edit regex
+  appended to the wrong section, fix manually and re-run from step 7.
+
+## What this skill does NOT do
+
+- Refactor any existing scraper (additive-only invariant)
+- Import scraped data to Supabase directly (the existing
+  `import-on-merge.yml` workflow handles that when the PR lands)
+- Phase 5 (programs) — left as a manual follow-up
+- Custom-platform scrapers — flagged as TODOs, not built
+
+## Adding new platform support later
+
+If, after using this skill, you find that 5+ states keep flagging the
+same untemplated platform (Jenzabar, Workday, etc.), that's the signal
+to add a new template under `scripts/lib/scrape-{platform}.ts`, register
+it in `add-state.ts`'s `TEMPLATED_COURSE_PLATFORMS` array, and ship as
+its own PR (same shape as PRs 2–4 of this series).
+
+## After-merge follow-ups (for the user, not the skill)
+
+After the PR merges and Vercel redeploys (~3 minutes):
+- Verify `/{slug}/colleges` renders all colleges on prod
+- Verify `/{slug}` zip-code search returns at least one college
+- Watch the Vercel build for any "statement_timeout" errors on
+  `/colleges/page` — see `add-new-state` skill for the SQL fix
+
+The TODO items in the PR body are the user's review checklist. Most can
+be deferred (the state is functional without senior-waiver curation),
+but a few (custom-portal colleges with high enrollment) are worth
+addressing before the state launches publicly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,10 @@ Source of truth: `.env.example` in repo root. Local dev uses `.env.local` (gitig
 
 ## Adding a new state
 
-This is the most frequent multi-step workflow. See the `add-new-state` skill (`.claude/skills/add-new-state/`). Short version: bootstrap (data + config + registry) → course scraper → transfer data → prereqs → Supabase import. Each phase is its own PR.
+This is the most frequent multi-step workflow. Two skills cover it:
+
+- **`auto-add-state`** (`.claude/skills/auto-add-state/`) — autonomous; one command, one PR. Runs `scripts/lib/add-state.ts` end-to-end: bootstrap → fingerprint → scrape (Banner SSB / Colleague / Banner 8 templates) → articulation lookup → prereq aggregation. Surfaces a manual-TODO list for what couldn't be automated. Use when the user says "/auto-add-state ohio", "add Kentucky", or similar.
+- **`add-new-state`** (`.claude/skills/add-new-state/`) — manual fallback; 5 phases, 5 PRs, full human control over each step. Use when the autonomous flow's TODOs need to be addressed one-by-one, when adding bespoke scrapers for custom-platform colleges, or when the user explicitly asks for the manual flow.
 
 ## Where guidance lives
 


### PR DESCRIPTION
**Final PR in the 8-PR series.** Ships the user-facing \`/auto-add-state {slug}\` skill that wraps the orchestrator (\`scripts/lib/add-state.ts\`, merged in PR 7) with the git / branch / commit / PR layer the orchestrator deliberately doesn't do.

## Files

\`\`\`
$ git diff --stat main
 .claude/skills/auto-add-state/SKILL.md | 190 +++++++++++++++++++++
 CLAUDE.md                              |   5 +-
 2 files changed, 194 insertions(+), 1 deletion(-)
\`\`\`

## What the user types

\`\`\`
/auto-add-state ohio
\`\`\`

Or any of: \`/auto-add-state oh\`, \`add Kentucky\`, \`spin up Iowa\`. The skill description triggers on these phrasings.

## What the skill does

10 procedural steps, each with a concrete tool call:

1. Parse + validate slug
2. Branch off \`main\`: \`claude/{slug}-auto-add-state\`
3. Run orchestrator in background: \`npx tsx scripts/lib/add-state.ts --state {slug} --json\`
4. Brief status to user; let it run (20-60 min)
5. Read JSON result, sanity-check (\`collegesDiscovered > 0\`)
6. Pre-PR feature check: load \`/{slug}/colleges\` in dev (per CLAUDE.md's three-checks-in-order rule)
7. Commit in 3 logical chunks (Phase 1 / Phase 2 / Phase 3-4) for reviewability
8. Push branch
9. Open PR with full orchestrator report + manual-TODO list as body
10. Surface the TODO list in the conversation, grouped by category

## Failure modes covered explicitly

| Scenario | Skill behavior |
|---|---|
| Bootstrap fails (IPEDS down, etc.) | Abort, no commit, branch deleted |
| Bootstrap OK, later phases fail | Commit Phase 1, defer rest with note in PR body |
| One scraper cohort fails (e.g. SSB), others succeed | Commit what landed, PR body lists which cohorts ran clean |
| Pre-PR check shows empty \`/colleges\` grid | Don't commit; registry edits got applied to wrong place; manual fix needed |

## CLAUDE.md update

The existing \`add-new-state\` skill stays as the manual fallback. CLAUDE.md now points at both:

- **\`auto-add-state\`** — autonomous, default for new states
- **\`add-new-state\`** — manual 5-phase fallback for custom-platform colleges and edge cases

## The 8-PR series — totals

| PR | What | LOC |
|---|---|---:|
| 1 | \`fingerprint-college.ts\` | 810 |
| 2 | \`scrape-banner-ssb.ts\` (template) | 802 |
| 3 | \`scrape-colleague.ts\` (template) | 1,006 |
| 4 | \`scrape-banner-8.ts\` (template) | 930 |
| 5 | articulation-portals registry + loader | 505 |
| 6 | bootstrap-state pipeline | 1,566 |
| 7 | \`add-state.ts\` orchestrator | 779 |
| **8 (this)** | \`auto-add-state\` skill ships | 190 |
| | **Total new code** | **6,588** |

**Across all 8 PRs: zero modifications to any existing scraper, zero modifications to any existing state's data.** The autonomy is built entirely as additive code on top of what was already shipping.

## Test plan

- [x] Skill loader picks up the new skill (description visible in available-skills list)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — 0 errors / 0 new warnings
- [x] End-to-end orchestrator validated in PR 7 against Ohio (22 colleges, 7 covered by templates, 19 specific manual TODOs)
- [x] CLAUDE.md change verified — both skills cross-referenced
- [ ] CI green
- [ ] First real-world use: \`/auto-add-state ky\` (or whichever state the user picks first) lands a clean PR

## After this merges

Type \`/auto-add-state {slug}\` for any unsupported state. Walk away. Come back to a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)