### PR TITLE
fix: bootstrap-state.ts registry edits — match real file shapes

### DIFF
--- a/scripts/lib/bootstrap-state.ts
+++ b/scripts/lib/bootstrap-state.ts
@@ -325,12 +325,25 @@ function capitalize(s: string): string {
 // alphabetical-ish but non-strict ordering so simple append is safe.
 // ---------------------------------------------------------------------------
 
-function applyRegistryEdit(
+export function applyRegistryEdit(
   filePath: string,
   importLine: string,
   importAnchor: RegExp,
   registryLine: string,
   registryEntryAnchor: RegExp,
+  /**
+   * Pattern that matches *any* existing registry entry in this file, used
+   * as the anchor for "append my entry after the last matching one." Must
+   * be per-file because the three files use two different shapes:
+   *   - registry.ts ALL_CONFIGS is a `StateConfig[]` array → entries look
+   *     like `  vaConfig,`
+   *   - institutions.ts REGISTRY and geo.ts ZIP_REGISTRY are
+   *     `Record<string, …>` objects → entries look like `  va: vaInstitutions as ...,`
+   * A single hardcoded pattern can't catch both. (See PRs #285 #286 — KY
+   * and AL bootstrap runs both required hand-fixes because the previous
+   * one-pattern-fits-all approach failed silently in registry.ts.)
+   */
+  registryAnchorPattern: RegExp,
   dryRun: boolean
 ): { applied: boolean; reason: string } {
   if (!fs.existsSync(filePath)) {
@@ -344,17 +357,13 @@ function applyRegistryEdit(
   }
 
   // Insert the import after the last matching import line; insert the
-  // registry entry after the last matching registry entry line. The
-  // registry-entry anchor is a generic "any 2-space-indented `key:` line
-  // ending in a comma" pattern, which matches every existing entry across
-  // all three files.
-  const REGISTRY_ENTRY_PATTERN = /^(\s+[a-z]{2}:\s.+,)$/gm;
+  // registry entry after the last matching registry entry line.
   let updated = content;
   if (!updated.includes(importLine.trim())) {
     updated = appendAfterLastMatch(updated, importAnchor, importLine);
   }
   if (!registryEntryAnchor.test(updated)) {
-    updated = appendAfterLastMatch(updated, REGISTRY_ENTRY_PATTERN, registryLine);
+    updated = appendAfterLastMatch(updated, registryAnchorPattern, registryLine);
   }
 
   if (!dryRun) fs.writeFileSync(filePath, updated);
@@ -479,36 +488,51 @@ export async function bootstrapState(
   }
 
   // --- Registry edits (idempotent) ---
+
+  // lib/states/registry.ts: ALL_CONFIGS is `StateConfig[]` — entries are
+  // bare values (`  vaConfig,`), no `slug:` key prefix. The anchor pattern
+  // matches existing array entries; the registry line must match the
+  // same array shape.
   const regEdit = applyRegistryEdit(
     path.join(process.cwd(), "lib", "states", "registry.ts"),
     `import ${slug}Config from "./${slug}/config";`,
     /^import [a-z]{2}Config from "\.\/[a-z]{2}\/config";$/gm,
-    `  ${slug}: ${slug}Config,`,
-    new RegExp(`^\\s+${slug}:\\s+${slug}Config,$`, "m"),
+    `  ${slug}Config,`,
+    new RegExp(`^\\s+${slug}Config,$`, "m"),
+    /^\s+[a-z]{2}Config,$/gm,
     opts.dryRun ?? false
   );
   if (regEdit.applied) result.registryEdits.push("lib/states/registry.ts");
   else if (regEdit.reason !== "already present")
     result.manualTodos.push(`registry.ts: ${regEdit.reason}`);
 
+  // lib/institutions.ts: REGISTRY is `Record<string, Institution[]>` —
+  // every entry uses an `as unknown as Institution[]` double-cast to
+  // appease TS's structural comparison of the JSON-inferred narrow
+  // null-types vs. the stricter Institution interface. Bootstrap output
+  // MUST include the cast or the build fails with TS2322.
   const instEdit = applyRegistryEdit(
     path.join(process.cwd(), "lib", "institutions.ts"),
     `import ${slug}Institutions from "@/data/${slug}/institutions.json";`,
     /^import [a-z]{2}Institutions from "@\/data\/[a-z]{2}\/institutions\.json";$/gm,
-    `  ${slug}: ${slug}Institutions,`,
-    new RegExp(`^\\s+${slug}:\\s+${slug}Institutions,$`, "m"),
+    `  ${slug}: ${slug}Institutions as unknown as Institution[],`,
+    new RegExp(`^\\s+${slug}:\\s+${slug}Institutions\\s+as\\s+unknown\\s+as\\s+Institution\\[\\],$`, "m"),
+    /^\s+[a-z]{2}:\s+[a-z]{2}Institutions\s+as\s+unknown\s+as\s+Institution\[\],$/gm,
     opts.dryRun ?? false
   );
   if (instEdit.applied) result.registryEdits.push("lib/institutions.ts");
   else if (instEdit.reason !== "already present")
     result.manualTodos.push(`institutions.ts: ${instEdit.reason}`);
 
+  // lib/geo.ts: ZIP_REGISTRY is `Record<string, Record<string, ZipEntry>>`
+  // — every entry uses `as Record<string, ZipEntry>` cast.
   const geoEdit = applyRegistryEdit(
     path.join(process.cwd(), "lib", "geo.ts"),
     `import ${slug}Zipcodes from "@/data/${slug}/zipcodes.json";`,
     /^import [a-z]{2}Zipcodes from "@\/data\/[a-z]{2}\/zipcodes\.json";$/gm,
     `  ${slug}: ${slug}Zipcodes as Record<string, ZipEntry>,`,
     new RegExp(`^\\s+${slug}:\\s+${slug}Zipcodes`, "m"),
+    /^\s+[a-z]{2}:\s+[a-z]{2}Zipcodes\s+as\s+Record<string,\s+ZipEntry>,$/gm,
     opts.dryRun ?? false
   );
   if (geoEdit.applied) result.registryEdits.push("lib/geo.ts");


### PR DESCRIPTION
The KY ([#285](https://github.com/rohan-c0de/cc-coursemap/pull/285)) and AL ([#286](https://github.com/rohan-c0de/cc-coursemap/pull/286)) auto-add-state runs both surfaced bugs in \`applyRegistryEdit\` that forced hand-fixes before Phase 2 could even attempt to run. **Until this lands, no state can complete the orchestrator pipeline end-to-end without intervention** — the autonomous skill isn't actually autonomous.

## The three bugs

| # | File | Old output | Why broken | Fix |
|---|---|---|---|---|
| 1 | \`lib/states/registry.ts\` | \`  ky: kyConfig,\` | \`ALL_CONFIGS\` is \`StateConfig[]\` (array). Record-style entries are syntax errors in array context. | Emit \`  kyConfig,\` and use an array-shape anchor pattern. |
| 2 | \`lib/institutions.ts\` | \`  ky: kyInstitutions,\` | Existing entries all use \`as unknown as Institution[]\` to satisfy TS's structural check. Old emit hits TS2322 at build. | Emit \`  ky: kyInstitutions as unknown as Institution[],\`. |
| 3 | \`applyRegistryEdit\` itself | hardcoded \`REGISTRY_ENTRY_PATTERN = /^(\\s+[a-z]{2}:\\s.+,)$/gm\` | Pattern only matches Record-shape entries — silently misses registry.ts's array entries, so the append target lands in the wrong place. | Take the entry-anchor pattern as a function parameter; each call site passes its own. |

## Verification — real repo files in a tmp copy with fake slug \"zz\"

\`\`\`
registry.ts:
  import alConfig from \"./al/config\";
  import zzConfig from \"./zz/config\";    ← clean import append
    alConfig,
    zzConfig,                            ← array entry, correct shape

institutions.ts:
  import alInstitutions from \"@/data/al/institutions.json\";
  import zzInstitutions from \"@/data/zz/institutions.json\";
    al: alInstitutions as unknown as Institution[],
    zz: zzInstitutions as unknown as Institution[],   ← cast included

geo.ts:
  import alZipcodes from \"@/data/al/zipcodes.json\";
  import zzZipcodes from \"@/data/zz/zipcodes.json\";
    al: alZipcodes as Record<string, ZipEntry>,
    zz: zzZipcodes as Record<string, ZipEntry>,        ← unchanged (was correct)
\`\`\`

## Safety re. ongoing runs

- **In-progress Node processes**: loaded the old code into memory; immune to file changes.
- **MS work-in-progress** (in some working trees): registry edits already hand-corrected to the right shape. This fix won't disturb that — the WIP files are already what bootstrap WOULD produce post-fix.
- **GitHub Actions / scheduled-scrape**: no workflow uses bootstrap-state.ts (verified via grep).
- **Future \`/auto-add-state\` runs**: get the fixed code automatically. The next state (AR, MO, IA, whatever) skips the hand-fix step.

## Side effect

\`applyRegistryEdit\` is now exported from the module so future tests can call it directly without spinning up the full \`bootstrapState\` IPEDS network call. No other API changes.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run lint\` — 0 errors / 0 new warnings on this file
- [x] End-to-end test against real repo files in tmp dir confirmed correct output for all three files
- [ ] CI green
- [ ] Real proof: next \`/auto-add-state\` run completes Phase 1 without hand-fix

## Roadmap relevance

This unblocks the auto-add-state skill's \"fire and forget\" promise. After this lands:
- KY can resume — Phase 2 (PeopleSoft template needed)
- AL can resume — Phase 2 should work via Banner SSB / Colleague templates depending on OneACCS fingerprint
- Any new state run gets full Phase 1-4 sweep without intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)