### PR TITLE
feat: register Oklahoma articulation portal (OCEP)

### DIFF
--- a/data/articulation-portals.json
+++ b/data/articulation-portals.json
@@ -70,6 +70,13 @@
       ],
       "notes": "UNC System Course Numbering System covers in-system universities. Per-receiver scripts cover the private/independent destinations CNS doesn't include."
     },
+    "ok": {
+      "type": "state-portal",
+      "name": "Oklahoma Course Equivalency Project (OCEP)",
+      "url": "https://vita.okhighered.org/CourseSearch/",
+      "scripts": ["scripts/ok/scrape-transfer-ocep.ts"],
+      "notes": "Run by the Oklahoma State Regents for Higher Education. Covers OK two-year colleges ↔ OK senior institutions. Public landing: https://okhighered.org/transfer-students/course-transfer/. The referenced script is currently a stub; once a real OCEP scraper is implemented, the orchestrator will start producing OK transfer data automatically."
+    },
     "nh": {
       "type": "mixed",
       "name": "CollegeTransfer.Net + Keene direct",

--- a/scripts/ok/scrape-transfer-ocep.ts
+++ b/scripts/ok/scrape-transfer-ocep.ts
@@ -1,0 +1,40 @@
+/**
+ * scrape-transfer-ocep.ts
+ *
+ * Stub scraper for the Oklahoma Course Equivalency Project (OCEP), the
+ * state-mandated articulation portal run by the Oklahoma State Regents
+ * for Higher Education (OSRHE).
+ *
+ *   Public landing:    https://okhighered.org/transfer-students/course-transfer/
+ *   Search tool (SPA): https://vita.okhighered.org/CourseSearch/
+ *
+ * STATUS: not yet implemented. This file exists so OK can be registered
+ * in data/articulation-portals.json (the registry validator requires the
+ * `scripts` field to point at a real file on disk). Running it currently
+ * exits 0 with a clear TODO message; the auto-add-state orchestrator
+ * treats that as a no-op and the per-run TODO list will still surface
+ * "OCEP scraper not implemented" so it doesn't get silently skipped.
+ *
+ * Implementation notes for whoever picks this up:
+ *   - The search tool is an ASP.NET MVC app (jQuery-driven), not a SPA.
+ *     Inspect bundles/custom and the underlying form actions to see if
+ *     it can be driven via plain HTTP POST (preferred) or needs Playwright.
+ *   - OCEP covers ~all 13 OK two-year colleges × the OK state university
+ *     system. A successful scrape would replace the per-receiver fallback
+ *     for the entire state in one run (closer to the FL SCNS pattern than
+ *     the VA per-receiver pattern).
+ *   - Output schema: write to data/ok/transfer-equiv.json in the same
+ *     shape the existing per-state transfer scrapers produce — see
+ *     scripts/nc/scrape-transfer-cns.ts for a reference implementation.
+ *
+ * Usage:
+ *   npx tsx scripts/ok/scrape-transfer-ocep.ts
+ */
+
+console.log(
+  "[ok] OCEP scraper not yet implemented. Portal is registered in " +
+    "data/articulation-portals.json so the auto-add-state orchestrator " +
+    "no longer falls back to CollegeTransfer.Net for OK, but no transfer " +
+    "data was written. See file header for implementation notes."
+);
+process.exit(0);


### PR DESCRIPTION
## Summary
- Registers the Oklahoma Course Equivalency Project (OCEP) — the OSRHE-run state articulation portal at https://vita.okhighered.org/CourseSearch/ — in `data/articulation-portals.json`.
- Adds `scripts/ok/scrape-transfer-ocep.ts` as a stub (the registry validator requires `scripts` to reference a real file). The stub exits 0 with a clear "not yet implemented" message and a header full of implementation notes.

## Why
When `/auto-add-state` runs OK (next time someone adds the state), Phase 3 will surface "Portal: OCEP" instead of "no portal registered" — flagging that a state-level articulation source exists rather than silently defaulting to per-college CollegeTransfer.Net fallback. Documents the portal's existence even before anyone writes the real scraper.

OCEP at `vita.okhighered.org/CourseSearch/` is an ASP.NET MVC / jQuery app (not a SPA), so a real implementation is plausibly HTTP-driven — closer in shape to FL's SCNS pattern than VA's per-receiver scrapers. One scrape would replace per-receiver fallback for the entire OK system.

## Test plan
- [x] `npx tsx scripts/lib/articulation-portals.ts --validate` → ✓ 18 states + 1 fallback, 40 script references, all exist on disk
- [x] `npx tsx scripts/lib/articulation-portals.ts --lookup ok` → returns the new entry
- [x] `npx tsx scripts/ok/scrape-transfer-ocep.ts` → exits 0 with the documented TODO message
- [ ] Future PR: replace the stub with a real OCEP scraper

🤖 Generated with [Claude Code](https://claude.com/claude-code)