### PR TITLE
blog: session-timing hub + detector wiring (BRIEF.md §9 cluster)

### DIFF
--- a/.claude/skills/blog-pipeline/scripts/detect-cluster-gaps.ts
+++ b/.claude/skills/blog-pipeline/scripts/detect-cluster-gaps.ts
@@ -71,8 +71,11 @@ function detect(): Candidate[] {
     const isSeniorTheme =
       hub.category === "senior-waivers" ||
       hub.tags.includes("seniors");
+    const isSessionTheme =
+      hub.category === "session-timing" ||
+      hub.tags.includes("session-timing");
 
-    if (!isTransferTheme && !isSeniorTheme) continue;
+    if (!isTransferTheme && !isSeniorTheme && !isSessionTheme) continue;
 
     const gaps = states.filter((s) => {
       if (coveredStates.has(s.slug)) return false;
@@ -81,6 +84,13 @@ function detect(): Candidate[] {
       }
       if (isSeniorTheme) {
         return Boolean(s.seniorWaiver);
+      }
+      if (isSessionTheme) {
+        // Session-timing spokes only make sense for states where we have
+        // real course data — the spoke needs to cite actual session codes
+        // and start dates from the schedule. Use institution count as the
+        // proxy for "we have data here."
+        return institutionCount(s.slug) >= 1;
       }
       return false;
     });
@@ -102,19 +112,31 @@ function detect(): Candidate[] {
     const stateName = top.name;
     const slicePaths = isTransferTheme
       ? [`data/${top.slug}/transfer-equiv.json`, `lib/states/${top.slug}/config.ts`]
-      : [`lib/states/${top.slug}/config.ts`];
+      : isSessionTheme
+        ? [`data/${top.slug}/courses`, `lib/states/${top.slug}/config.ts`]
+        : [`lib/states/${top.slug}/config.ts`];
+
+    const topic = isTransferTheme
+      ? `${stateName} community college transfer: state-specific spoke for "${hub.title}"`
+      : isSessionTheme
+        ? `${stateName} community college sessions and calendar timing: state-specific spoke for "${hub.title}"`
+        : `${stateName} senior tuition waivers: state-specific spoke for "${hub.title}"`;
+    const targetReader = isTransferTheme
+      ? `${stateName} community college student planning to transfer`
+      : isSessionTheme
+        ? `${stateName} community college student planning a schedule across full-term, 8-week, mini-mester, and summer sessions`
+        : `${stateName} resident 60+ considering free or reduced-cost classes`;
+    const searchIntentHypothesis = isTransferTheme
+      ? `User searching "${stateName.toLowerCase()} community college transfer" wants to know how the in-state articulation works and what their credits will count for`
+      : isSessionTheme
+        ? `User searching "${stateName.toLowerCase()} community college 8-week classes" or "${stateName.toLowerCase()} mini-mester" wants to know what session formats local colleges actually offer and when they run`
+        : `User searching "${stateName.toLowerCase()} senior tuition waiver" wants to know if they qualify and what restrictions apply`;
 
     candidates.push({
       triggerSource: "cluster-gap",
-      topic: isTransferTheme
-        ? `${stateName} community college transfer: state-specific spoke for "${hub.title}"`
-        : `${stateName} senior tuition waivers: state-specific spoke for "${hub.title}"`,
-      targetReader: isTransferTheme
-        ? `${stateName} community college student planning to transfer`
-        : `${stateName} resident 60+ considering free or reduced-cost classes`,
-      searchIntentHypothesis: isTransferTheme
-        ? `User searching "${stateName.toLowerCase()} community college transfer" wants to know how the in-state articulation works and what their credits will count for`
-        : `User searching "${stateName.toLowerCase()} senior tuition waiver" wants to know if they qualify and what restrictions apply`,
+      topic,
+      targetReader,
+      searchIntentHypothesis,
       articleType: "state-spoke",
       state: top.slug,
       cluster,

--- a/content/blog/community-college-sessions-explained.mdx
+++ b/content/blog/community-college-sessions-explained.mdx
@@ -1,0 +1,119 @@
+# Community College Sessions Explained: Full-Term, 8-Week, Mini-Mester, Late-Start, and Summer
+
+Most people picture a community college semester as a 16-week block that starts in late August and ends in mid-December. That picture is half right. The full-term semester exists, but at almost every community college in the country it shares the calendar with several shorter sessions running on different start and end dates.
+
+Those shorter sessions are how working adults, parents, and anyone with an unpredictable life actually finish a degree. They're also one of the most common reasons community college students underestimate how much they can complete in a year — or accidentally overload themselves and burn out.
+
+Here's how the session types actually work, when each one makes sense, and how to combine them.
+
+## The session types you'll actually see
+
+Different colleges use different names for the same thing, but at any community college you'll see most of these structures on the schedule:
+
+### Full-term (sometimes "full session" or "regular session")
+The standard 15- or 16-week semester. Classes meet from the first week of the term to finals week. This is the default — every college's catalog is built around it. If you take 12+ credits of full-term classes you're a full-time student for that term.
+
+### 8-week sessions (sometimes "first half" / "second half" or "8-week 1" / "8-week 2")
+The full term split into two halves. The first 8-week session runs roughly the first half of the term; the second 8-week session runs the second half. Each session has its own registration deadline, its own drop dates, and its own finals.
+
+The course meets twice as often (or twice as long) as the full-term equivalent to fit the same content into half the calendar weeks. A 3-credit class that would meet 3 hours per week for 16 weeks meets roughly 6 hours per week for 8 weeks. Total seat-time is the same.
+
+### Mini-mester (sometimes "intersession", "winter session", "May-mester")
+A compressed session of 2 to 5 weeks, typically wedged between fall and spring or between spring and summer. Course content from a full 3-credit class is delivered in a few weeks of intensive meetings. Often only certain courses are offered — gen-ed staples like English Composition, Public Speaking, or Intro to Psychology are common; lab sciences and math sequences are rare.
+
+### Late-start sections
+Not really a separate session type — late-start is a *start date*, not a session length. A "late-start" class is any section that begins after the main term has already started. The class might still be 12 weeks long (just shifted), or it might be an 8-week section that starts when the second 8-week session begins. The defining feature is that you can register for it after the regular semester is already underway. We have a [dedicated guide to finding late-start classes](/blog/how-to-find-late-start-community-college-classes) if your semester just fell apart.
+
+### Summer sessions
+Summer term itself is usually 8–12 weeks total, and within it most colleges offer multiple parallel session lengths: a "summer A" first half, a "summer B" second half, a full summer running across both, and sometimes a 4-week "summer C" intensive. The catalog is meaningfully smaller than fall or spring — you'll see the most common gen-eds and a thinner long tail.
+
+### Open-entry / self-paced (less common)
+A handful of community colleges offer non-traditional formats where you start and finish on your own schedule within a window. These are most common for workforce-skill courses (welding, certain IT certifications) and developmental math, less common for transfer credit. If you see "open-entry" on a schedule, read the section description carefully — the format varies more than the label.
+
+## What "credits" mean across session types
+
+A 3-credit course is a 3-credit course no matter the session length. The credits transfer the same, count for financial aid the same, and post to your transcript the same. What changes is your week-to-week workload.
+
+A useful mental model: a single 3-credit class represents about 9 hours of total work per week (3 hours in class + 6 hours of reading, problem sets, and assignments) when it runs for 16 weeks. Compress it into 8 weeks and the weekly load doubles to about 18 hours. Compress it into a 4-week mini-mester and the weekly load roughly quadruples to about 36 hours — practically a full-time job for one course alone.
+
+That math is why "I'll knock out this class in the mini-mester" works for some students and breaks others. It's not a smaller class. It's the same class on a much steeper curve.
+
+## When each session type makes sense
+
+There's no universally correct session type. There's the right one for what you're trying to do this term.
+
+**Pick a full-term class when:**
+- You're new to college coursework and want time to build a study rhythm.
+- The subject is dense (chemistry, calculus, anatomy) and you need weeks of repetition.
+- You have a stable work or family schedule and want a predictable week-to-week load.
+
+**Pick an 8-week class when:**
+- You want to focus on one subject deeply for half a term, then switch.
+- You finished a class early in the term and want to add another to the back half.
+- You're trying to graduate a term sooner and need to fit two sequential courses in one term (e.g., MATH 101 first 8 weeks → MATH 102 second 8 weeks).
+- You don't want to commit 16 weeks to a subject before knowing whether you like it.
+
+**Pick a mini-mester or intersession when:**
+- You want to bank a single course between terms without a full term commitment.
+- The course is on the conceptual/lighter side (most gen-ed humanities) and the compressed pace is manageable.
+- You can clear your calendar to focus on one course for a few weeks.
+
+**Avoid mini-mesters for:**
+- Lab sciences, calculus sequences, and other content that needs spaced repetition.
+- Courses you expect to find genuinely difficult — there's no time to recover from a bad week.
+
+**Pick summer when:**
+- You want to lighten a future fall or spring load.
+- You need to repeat a course you didn't pass.
+- You're trying to compress a 2-year associate into closer to 18 months by adding a summer.
+
+## How to actually stack sessions to finish faster
+
+Most students who finish an associate degree faster than two years are doing some version of this:
+
+1. **Carry a normal full-term load (12–15 credits) in fall and spring.**
+2. **Add one 8-week class in the back half of fall or spring** if the front half went well. This is the highest-leverage move — it adds 3 credits to your year without committing 16 weeks upfront.
+3. **Use winter intersession or summer for one specific course you want out of the way.** Common picks: a writing-intensive gen-ed, a lab science you're nervous about (full summer length, not 4-week), or a major prerequisite that's a bottleneck.
+4. **Don't take a heavy course in a mini-mester on top of full-term courses already in progress.** That's where most overload-and-drop stories start.
+
+A student doing this consistently can finish a 60-credit associate in roughly 18–20 months instead of 24, while still carrying part-time work. They are not taking 21 credits a term — they're sequencing work cleverly across session types.
+
+## Why the schedule is structured this way
+
+Community colleges built out the menu of session lengths because their students aren't 18-year-old residents on a four-month rhythm. They're working adults, returning students, parents, military, and high-schoolers in dual enrollment, all on different calendars. The 8-week and mini-mester models came out of decades of evidence that compressed-format courses with intentional design produce comparable learning outcomes to full-term versions for many subjects — and that the rigidity of a 16-week semester is actively a barrier for adult learners.
+
+For you, that means: the schedule menu is a feature, not a quirk. Use it deliberately.
+
+## How to find the sessions on your college's schedule
+
+This is the most common practical confusion. Most community college search tools surface "courses" without making session lengths obvious. To find specific sessions:
+
+- **Search by date.** Filter by start date or session/part-of-term code if your college's search supports it. Sessions like "8W1", "DYN" (dynamically dated), "MM" (mini-mester), or "SUM-A" appear as part-of-term codes.
+- **Look at the date column, not the course code.** The same course (ENG 101) often runs in multiple sessions in the same term — full-term, both 8-week halves, and sometimes a mini-mester. The course code doesn't tell you which.
+- **Watch for credit-hour mismatches.** A "3-credit" class that meets only 3 weeks should make you double-check the schedule — sometimes that's a real intensive, sometimes it's a data issue.
+
+<ProductCallout
+  text="Community College Path lets you filter community college courses by start date and session type, so you can find an 8-week, late-start, or mini-mester section without scrolling through a college's full schedule."
+  feature="search"
+  label="Search Community College Courses by Session"
+/>
+
+## Common mistakes
+
+- **Treating an 8-week class like a 16-week class.** If you fall a week behind, you're 12.5% behind, not 6%. Recovery is harder.
+- **Stacking mini-mesters with a full-term overload.** A mini-mester course is essentially a full-time commitment for those weeks. Adding it to 12 credits of full-term work usually means dropping something.
+- **Assuming summer sections will be there.** Summer catalogs are smaller. The course you need may run in summer, or may not. If a summer plan depends on a specific course, check by March.
+- **Missing the separate registration deadlines.** Late-start, mini-mester, and second-half-of-term sections typically have their own registration cutoffs. Missing the main-term deadline does not necessarily mean you've missed everything.
+- **Overlooking the drop calendar.** Each session has its own withdrawal deadlines. An 8-week class hits the "no refund / W on transcript" line halfway as fast as a full-term class. Know the dates before the term starts.
+
+## Where this connects to planning your schedule
+
+Session timing is one of the inputs into a workable schedule, alongside format (in-person vs online vs hybrid) and total course load. Our [guide to building a community college schedule](/blog/how-to-build-community-college-schedule) covers the full picture; the [hybrid format explainer](/blog/hybrid-community-college-classes-explained) and [online vs in-person comparison](/blog/online-vs-in-person-community-college-classes) cover format. This article is the calendar piece.
+
+If your goal is to finish a degree faster, the lever isn't usually heroic full-term overloads — it's smarter use of 8-week sessions, summer terms, and one well-chosen mini-mester per year. Most students who try to brute-force it end up dropping courses; most who stack sessions deliberately don't.
+
+## The bottom line
+
+Community college schedules look like one 16-week term but actually contain a stack of overlapping sessions. Each session length has a workload curve, a registration window, and a refund/withdrawal calendar that's separate from the main term. Used well, the menu lets you fit education into a real life. Used carelessly, it lets you sign up for a workload that quietly exceeds 60 hours a week.
+
+Pick the session that matches what you're trying to do this term, not the one that sounds clever.

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -30,6 +30,7 @@ export const CATEGORIES: Record<string, string> = {
   "senior-waivers": "Senior Waivers & Auditing",
   "state-system-explainers": "State System Explainers",
   "mistake-avoidance": "Mistake Avoidance",
+  "session-timing": "Sessions & Calendar Timing",
 };
 
 export const articles: ArticleMeta[] = [
@@ -609,5 +610,39 @@ export const articles: ArticleMeta[] = [
     state: null,
     author: "Community College Path",
     tags: ["hybrid", "hyflex", "online", "in-person", "course-format", "scheduling"],
+  },
+
+  // --- Cluster C: Sessions and academic calendar timing (hub + future spokes) ---
+  {
+    slug: "community-college-sessions-explained",
+    title:
+      "Community College Sessions Explained: Full-Term, 8-Week, Mini-Mester, Late-Start, and Summer",
+    description:
+      "Community college schedules look like one 16-week term but actually contain a stack of overlapping sessions. Here's how each format works, when to use which, and how to stack them to finish faster.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: null,
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "academic-calendar", "8-week", "mini-mester", "summer", "scheduling"],
+    cluster: "session-timing-guide",
+    clusterRole: "hub",
+    faqs: [
+      {
+        q: "What's the difference between a full-term and 8-week community college class?",
+        a: "Full-term classes run for the standard 15-16 weeks of the semester. 8-week classes cover the same content and award the same credits, but meet twice as often or twice as long to fit into half the calendar. Each 8-week session has its own registration, drop, and refund deadlines separate from the main term.",
+      },
+      {
+        q: "What is a mini-mester?",
+        a: "A mini-mester (also called intersession, winter session, or May-mester) is a compressed 2-5 week term, usually wedged between fall and spring or spring and summer. Course content from a full 3-credit class is delivered in a few weeks of intensive meetings — roughly 36 hours per week of total work for a single course.",
+      },
+      {
+        q: "Are 8-week or summer credits worth less than full-term credits?",
+        a: "No. A 3-credit course is a 3-credit course regardless of session length. Credits transfer the same, count toward financial aid the same, and post to your transcript the same. What changes is the weekly workload, not the value of the credit.",
+      },
+      {
+        q: "Can I take 8-week classes back-to-back to fit two courses in one semester?",
+        a: "Yes — this is one of the most common ways students compress an associate degree timeline. Take one course in the first 8-week session, finish it, then take another in the second 8-week session. You earn 6 credits over the same calendar period as a single full-term course.",
+      },
+    ],
   },
 ];


### PR DESCRIPTION
## Summary

New blog hub opening a third content cluster (`session-timing-guide`) anchored on BRIEF.md §9 ("academic calendar and session timing"). Pure hub PR — state spokes will land via subsequent pipeline runs.

### The hub article
- **Slug:** `community-college-sessions-explained`
- **Title:** Community College Sessions Explained: Full-Term, 8-Week, Mini-Mester, Late-Start, and Summer
- **Word count:** 1,805 (hub range 1500–2500)
- **Cluster:** `session-timing-guide` (new), `clusterRole: hub`
- **Category:** `session-timing` (new — added to `CATEGORIES`)

Covers full-term vs 8-week vs mini-mester vs late-start vs summer vs open-entry, the workload-curve math (a 3-credit class is ~9 hr/wk for 16 weeks but ~36 hr/wk for a 4-week mini-mester), when each format makes sense, how to stack 8-week sessions to compress an associate timeline, and the most common scheduling mistakes.

Embeds a 4-entry FAQ JSON-LD and links to existing posts on late-start classes, schedule-building, hybrid, and online-vs-in-person.

### Pipeline detector wiring
`detect-cluster-gaps.ts` now recognizes the session-timing theme:
- A hub qualifies if `category === "session-timing"` or its tags include `"session-timing"`
- A state qualifies as a gap if it's in the registry and has at least one institution (`institutionCount >= 1`)
- New topic / target reader / search-intent strings for session-timing candidates
- Data slice paths point at `data/{state}/courses` and the state config

**Verified:** running the detector immediately after this PR's changes surfaces a session-timing state-spoke candidate (Maryland topped the gap list this run, score 122409 — high institution data + transfer volume).

That means future weekly pipeline runs will systematically surface session-timing state spokes — one per run, in priority order — alongside the existing transfer-credit and senior-waiver candidates.

## Quality gates

| Gate | Result |
|---|---|
| G1 — word count | ✅ 1805 words / hub range 1500–2500 |
| G2 — internal-link density | ✅ ProductCallout + 4 article-to-article links |
| G3 — banned phrases | ✅ |
| G4 — embedding similarity | ⚠️ skipped (no embeddings API in worktree) |
| G5 — `npm run build` | ⚠️ worktree env can't reach Supabase; `npm run lint` passes with 0 errors. Vercel preview is the real G5. |
| G6 — BRIEF.md output block | ✅ |

## Why now

Per the pipeline-skill design, a single hub addition is the highest-leverage move available for unlocking new spoke candidates. Before this PR, the cluster-gap detector recognized exactly two themes (transfer + senior waivers). Adding a hub in a third theme that BRIEF.md §9 explicitly prioritizes turns the existing covered-states list into a backlog of legitimate state-spoke candidates the pipeline can work through over coming weeks — without changing rate limits, gates, or detector thresholds.

## Reviewer checklist
- [ ] Read for fluff. Any "Top N tips" energy or generic education-blog filler?
- [ ] Verify factual claims (workload-hour math, session-length conventions, drop-deadline behavior). The numbers are conventions, not citations — confirm they match the way our covered-state colleges actually run.
- [ ] Click every internal link — confirm all four resolve to existing posts
- [ ] FAQ JSON-LD: 4 entries, no overlap with existing FAQPage entries on the senior-waivers hub
- [ ] Detector change: confirm `npx tsx .claude/skills/blog-pipeline/scripts/detect-cluster-gaps.ts` returns a session-timing candidate post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)