### PR TITLE
blog-pipeline: prereq-bottleneck detector (data-driven trigger D)

### DIFF
--- a/.claude/skills/blog-pipeline/SKILL.md
+++ b/.claude/skills/blog-pipeline/SKILL.md
@@ -37,17 +37,20 @@ Stages 3 and 4 loop per candidate. A single invocation can produce N draft PRs w
 
 ### Stage 1 — Detect
 
-Run the three detectors in parallel. Each returns 0..N candidate briefs. See `references/triggers.md` for the full design of each trigger source.
+Run the detectors in parallel. Each returns 0..N candidate briefs. See `references/triggers.md` for the full design of each trigger source.
 
 ```bash
 npx tsx .claude/skills/blog-pipeline/scripts/detect-cluster-gaps.ts > /tmp/blog-candidates-c.json
 npx tsx .claude/skills/blog-pipeline/scripts/detect-data-deltas.ts > /tmp/blog-candidates-a.json
+npx tsx .claude/skills/blog-pipeline/scripts/detect-prereq-bottlenecks.ts > /tmp/blog-candidates-d.json
 # Trigger B (keyword/search) is manual-input for now — see references/triggers.md
 ```
 
 A candidate brief is JSON with: `triggerSource`, `topic`, `targetReader`, `searchIntentHypothesis`, `articleType` (`general` | `state-spoke` | `hub`), `state` (or `null`), `cluster` (or `null`), `nonDuplicateRationale`, `dataSlicePaths` (file paths whose contents the drafter must read).
 
-If all three detectors return zero candidates, **stop and report "no triggers fired this run"**. This is the expected outcome most of the time.
+If all detectors return zero candidates, **stop and report "no triggers fired this run"**. This is the expected outcome most of the time.
+
+**Data-driven detectors write precomputed slice files** (under `.blog-pipeline/slices/`) and reference them in `dataSlicePaths`. The drafter consumes those slices verbatim — every numeric claim in the article must come from a slice file, not LLM speculation. The prereq-bottleneck detector is the first such detector; future ones (course-availability, instructor-density, transfer-mapping patterns) follow the same convention.
 
 ### Stage 2 — Prioritize
 
@@ -141,6 +144,7 @@ If you (Claude) are invoked from inside the workflow, behave identically to a ma
 |---|---|
 | `scripts/detect-cluster-gaps.ts` | Trigger C — find hubs with missing state spokes |
 | `scripts/detect-data-deltas.ts` | Trigger A — diff current data against last snapshot |
+| `scripts/detect-prereq-bottlenecks.ts` | Trigger D — mine `data/{state}/prereqs.json` for chain depth and blocker courses; emits a candidate per state with ≥5 chains of depth ≥3, plus a precomputed stats slice the drafter must consume |
 | `scripts/snapshot-state.ts` | Capture current registry/data state |
 | `scripts/quality-gates.ts` | Run all quality gates against a draft |
 

--- a/.claude/skills/blog-pipeline/scripts/detect-prereq-bottlenecks.ts
+++ b/.claude/skills/blog-pipeline/scripts/detect-prereq-bottlenecks.ts
@@ -1,0 +1,265 @@
+#!/usr/bin/env tsx
+/**
+ * Trigger D — prereq-bottleneck detection (data-driven).
+ *
+ * Mines `data/{state}/prereqs.json` for each covered state and emits a
+ * candidate when the state has enough deep prereq chains to support a
+ * useful "[state] community college prereq chains" article that doesn't
+ * already exist as a spoke of the prereq-chains-guide cluster.
+ *
+ * The detector emits not just a candidate, but a precomputed
+ * statistics slice — number of courses with prereqs, number of deep
+ * (depth >= 3) chains, and the top "blocker" courses (those that gate
+ * the most downstream courses transitively). The drafter consumes that
+ * slice via dataSlicePaths and writes prose around real numbers, not
+ * speculation.
+ *
+ * The threshold logic: a state needs (a) >= 50 prereq entries to have
+ * meaningful coverage, and (b) >= 5 chains of depth >= 3 to have a real
+ * bottleneck story. States without prereqs.json are skipped entirely.
+ */
+import { existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { articles } from "../../../../content/blog/index";
+import { getAllStates } from "../../../../lib/states/registry";
+
+const REPO_ROOT = resolve(__dirname, "../../../..");
+const DISABLED = resolve(REPO_ROOT, ".blog-pipeline/DISABLED");
+const CLUSTER = "prereq-chains-guide";
+const SLICE_OUT_DIR = resolve(REPO_ROOT, ".blog-pipeline/slices/prereq");
+
+type PrereqEntry = [string, { text: string; courses: string[] }];
+
+type Candidate = {
+  triggerSource: "prereq-bottleneck";
+  topic: string;
+  targetReader: string;
+  searchIntentHypothesis: string;
+  articleType: "state-spoke";
+  state: string;
+  cluster: string;
+  nonDuplicateRationale: string;
+  dataSlicePaths: string[];
+  rankScore: number;
+};
+
+type StateStats = {
+  state: string;
+  totalEntries: number;
+  coursesWithPrereqs: number;
+  deepChainCount: number;
+  maxChainDepth: number;
+  topBlockers: Array<{ course: string; transitiveDownstream: number }>;
+  deepestChains: Array<{ leaf: string; depth: number; path: string[] }>;
+};
+
+function readPrereqs(stateSlug: string): PrereqEntry[] | null {
+  const path = resolve(REPO_ROOT, `data/${stateSlug}/prereqs.json`);
+  if (!existsSync(path)) return null;
+  try {
+    const data = JSON.parse(readFileSync(path, "utf-8"));
+    if (Array.isArray(data)) return data as PrereqEntry[];
+    return Object.entries(data).map(([k, v]) => [k, v]) as PrereqEntry[];
+  } catch {
+    return null;
+  }
+}
+
+function buildGraph(entries: PrereqEntry[]): Map<string, Set<string>> {
+  const requires = new Map<string, Set<string>>();
+  for (const [course, spec] of entries) {
+    if (!spec || !Array.isArray(spec.courses)) continue;
+    if (!requires.has(course)) requires.set(course, new Set());
+    for (const p of spec.courses) {
+      requires.get(course)!.add(p);
+    }
+  }
+  return requires;
+}
+
+function chainDepth(
+  course: string,
+  requires: Map<string, Set<string>>,
+  memo: Map<string, number>,
+  visiting: Set<string>,
+): number {
+  if (memo.has(course)) return memo.get(course)!;
+  if (visiting.has(course)) return 0;
+  const prereqs = requires.get(course);
+  if (!prereqs || prereqs.size === 0) {
+    memo.set(course, 0);
+    return 0;
+  }
+  visiting.add(course);
+  let best = 0;
+  for (const p of prereqs) {
+    best = Math.max(best, 1 + chainDepth(p, requires, memo, visiting));
+  }
+  visiting.delete(course);
+  memo.set(course, best);
+  return best;
+}
+
+function deepestPath(
+  course: string,
+  requires: Map<string, Set<string>>,
+  memo: Map<string, string[]>,
+  visiting: Set<string>,
+): string[] {
+  if (memo.has(course)) return memo.get(course)!;
+  if (visiting.has(course)) return [course];
+  const prereqs = requires.get(course);
+  if (!prereqs || prereqs.size === 0) {
+    const leaf = [course];
+    memo.set(course, leaf);
+    return leaf;
+  }
+  visiting.add(course);
+  let best: string[] = [];
+  for (const p of prereqs) {
+    const path = deepestPath(p, requires, memo, visiting);
+    if (path.length > best.length) best = path;
+  }
+  visiting.delete(course);
+  const result = [course, ...best];
+  memo.set(course, result);
+  return result;
+}
+
+function transitiveDownstream(requires: Map<string, Set<string>>): Map<string, number> {
+  const downstream = new Map<string, Set<string>>();
+  const reverse = new Map<string, Set<string>>();
+  for (const [course, prereqs] of requires) {
+    for (const p of prereqs) {
+      if (!reverse.has(p)) reverse.set(p, new Set());
+      reverse.get(p)!.add(course);
+    }
+  }
+  function collect(course: string, seen: Set<string>): Set<string> {
+    if (downstream.has(course)) {
+      for (const c of downstream.get(course)!) seen.add(c);
+      return seen;
+    }
+    const direct = reverse.get(course);
+    if (!direct) return seen;
+    for (const c of direct) {
+      if (!seen.has(c)) {
+        seen.add(c);
+        collect(c, seen);
+      }
+    }
+    return seen;
+  }
+  const result = new Map<string, number>();
+  for (const course of reverse.keys()) {
+    const set = collect(course, new Set());
+    downstream.set(course, set);
+    result.set(course, set.size);
+  }
+  return result;
+}
+
+function computeStats(stateSlug: string): StateStats | null {
+  const entries = readPrereqs(stateSlug);
+  if (!entries || entries.length < 50) return null;
+  const requires = buildGraph(entries);
+  const memo = new Map<string, number>();
+  let deepChainCount = 0;
+  let maxChainDepth = 0;
+  const allDepths: Array<{ course: string; depth: number }> = [];
+  for (const course of requires.keys()) {
+    const d = chainDepth(course, requires, memo, new Set());
+    allDepths.push({ course, depth: d });
+    if (d >= 3) deepChainCount++;
+    if (d > maxChainDepth) maxChainDepth = d;
+  }
+  const downstream = transitiveDownstream(requires);
+  const blockers = Array.from(downstream.entries())
+    .map(([course, n]) => ({ course, transitiveDownstream: n }))
+    .sort((a, b) => b.transitiveDownstream - a.transitiveDownstream)
+    .slice(0, 10);
+  const pathMemo = new Map<string, string[]>();
+  const deepest = allDepths
+    .filter((d) => d.depth >= 3)
+    .sort((a, b) => b.depth - a.depth)
+    .slice(0, 10)
+    .map(({ course, depth }) => ({
+      leaf: course,
+      depth,
+      path: deepestPath(course, requires, pathMemo, new Set()),
+    }));
+  return {
+    state: stateSlug,
+    totalEntries: entries.length,
+    coursesWithPrereqs: requires.size,
+    deepChainCount,
+    maxChainDepth,
+    topBlockers: blockers,
+    deepestChains: deepest,
+  };
+}
+
+function detect(): Candidate[] {
+  const states = getAllStates();
+  const candidates: Candidate[] = [];
+
+  const existingSpokes = articles.filter(
+    (a) => a.cluster === CLUSTER && a.clusterRole === "spoke"
+  );
+  const coveredStates = new Set(
+    existingSpokes.map((s) => s.state).filter((s): s is string => s !== null)
+  );
+
+  mkdirSync(SLICE_OUT_DIR, { recursive: true });
+
+  for (const s of states) {
+    if (coveredStates.has(s.slug)) continue;
+    const stats = computeStats(s.slug);
+    if (!stats) continue;
+    if (stats.deepChainCount < 5) continue;
+
+    const slicePath = resolve(SLICE_OUT_DIR, `${s.slug}.json`);
+    writeFileSync(slicePath, JSON.stringify(stats, null, 2));
+
+    candidates.push({
+      triggerSource: "prereq-bottleneck",
+      topic: `${s.name} community college prereq bottlenecks: state-specific spoke for the prereq-chains hub`,
+      targetReader: `${s.name} community college student trying to plan a 2- or 3-year graduation path who has not yet realized which prereq chains will gate their schedule`,
+      searchIntentHypothesis: `User searching "${s.name.toLowerCase()} community college prerequisites" or "${s.name.toLowerCase()} cc course sequence" wants to know which courses gate downstream classes and how to sequence early-semester registration`,
+      articleType: "state-spoke",
+      state: s.slug,
+      cluster: CLUSTER,
+      nonDuplicateRationale: `Cluster "${CLUSTER}" has ${existingSpokes.length} spoke(s), none for ${s.name}. Detector confirmed ${stats.deepChainCount} chains of depth >= 3 across ${stats.coursesWithPrereqs} courses with prereqs (max depth ${stats.maxChainDepth}).`,
+      dataSlicePaths: [
+        `data/${s.slug}/prereqs.json`,
+        `lib/states/${s.slug}/config.ts`,
+        `.blog-pipeline/slices/prereq/${s.slug}.json`,
+      ],
+      rankScore: stats.deepChainCount * 3 + stats.maxChainDepth * 10 + stats.coursesWithPrereqs,
+    });
+  }
+
+  candidates.sort((a, b) => b.rankScore - a.rankScore);
+  return candidates;
+}
+
+function main() {
+  if (existsSync(DISABLED)) {
+    process.stdout.write(JSON.stringify({ candidates: [], disabled: true }));
+    process.exit(0);
+  }
+  try {
+    const candidates = detect();
+    process.stderr.write(
+      `[detect-prereq-bottlenecks] found ${candidates.length} candidate(s)\n`
+    );
+    process.stdout.write(JSON.stringify({ candidates }, null, 2));
+    process.exit(0);
+  } catch (err) {
+    process.stderr.write(`[detect-prereq-bottlenecks] error: ${String(err)}\n`);
+    process.stdout.write(JSON.stringify({ candidates: [], error: String(err) }));
+    process.exit(1);
+  }
+}
+
+main();

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ next-env.d.ts
 
 # scraper caches (e.g. tmp/scns/crslist-*.txt — re-downloadable, ~80 MB)
 /tmp/
+
+# blog-pipeline regenerable slices (snapshot/cooldown stay; per-state computed slices regenerate)
+.blog-pipeline/slices/

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -564,7 +564,7 @@ export const articles: ArticleMeta[] = [
     clusterRole: "spoke",
   },
 
-  // --- Standalone: Prerequisite chains ---
+  // --- Cluster D: Prereq chains (hub + future state spokes) ---
   {
     slug: "prerequisite-chains-why-four-semester-plans-take-six",
     title:
@@ -576,6 +576,8 @@ export const articles: ArticleMeta[] = [
     state: null,
     author: "Community College Path",
     tags: ["prerequisites", "planning", "two-year-degree", "course-sequence", "developmental"],
+    cluster: "prereq-chains-guide",
+    clusterRole: "hub",
   },
 
   // --- Cluster A spoke: transfer equivalency reading ---


### PR DESCRIPTION
## Summary

First data-driven detector for the blog pipeline. Mines \`data/{state}/prereqs.json\` for every covered state, builds a require/reverse-require graph, and emits a candidate per state where the data supports a real bottleneck story.

This is the start of leveraging the *actual data* the repo collects (50k+ course sections, prereq chains, instructor data, transfer mappings) for article generation, instead of relying solely on registry-shape signals.

## What it does

For each state with \`data/{state}/prereqs.json\`:

1. Build a graph: course → prereq courses
2. Compute chain depth for every course (with cycle detection)
3. Compute transitive downstream count per prereq (\"how many courses does this gate?\")
4. If the state has ≥50 entries AND ≥5 chains of depth ≥3, emit a candidate
5. Write a precomputed slice file at \`.blog-pipeline/slices/prereq/{state}.json\` with: total entries, courses-with-prereqs, deep-chain count, max chain depth, top 10 blocker courses, and the 10 deepest chains with full ancestor paths

The drafter consumes the slice verbatim. Every numeric claim in the article must come from the slice, not LLM speculation.

## What it found on main

\`\`\`
[detect-prereq-bottlenecks] found 16 candidate(s)
 - ga score=6629   (1,732 prereq entries)
 - md score=5760   (2,410 entries, 1,070 deep chains, max depth 14)
 - nc score=4945
 - fl score=2576
 - sc score=2132
 ...
\`\`\`

Maryland slice highlights:
- 14-deep chain: \`SURG 205 ← SURG 200 ← SURG 135 ← ... ← ENGL 100 ← ESOL 100\` (Surgical Tech program)
- Top blockers by transitive downstream: ESOL 100 gates 420 courses, ENG 001 gates 315, ENGL 101 gates 280

This is the kind of data-grounded specificity BRIEF.md asks for and that pure cluster-gap detection can't surface.

## Other changes

- Promoted \`prerequisite-chains-why-four-semester-plans-take-six\` from standalone to hub of the new \`prereq-chains-guide\` cluster, so the new candidates have a hub to anchor against.
- Added \`.blog-pipeline/slices/\` to \`.gitignore\` — regenerable per detector run; \`cooldown.json\` and \`snapshot.json\` stay committed.
- Updated \`SKILL.md\` to document the new detector and the data-driven-detector convention.

## Performance bug fix during development

Initial implementation hung on Maryland because \`deepestPath\` recursed without memoization through OR-branch alternative prereqs (a course with \"MATH 110 OR MATH 111\" as prereq created exponential branching at depth-14 chains). Fixed by adding a shared \`pathMemo\` across the deepest-chains computation. Full pipeline now runs in ~3 seconds for all 22 covered states.

## Test plan

- [x] \`npx tsx .claude/skills/blog-pipeline/scripts/detect-prereq-bottlenecks.ts\` exits 0 within ~3s and returns 16 candidates
- [x] \`.blog-pipeline/slices/prereq/md.json\` exists post-run with valid JSON
- [x] Slice contains the 14-deep Surgical Tech chain (sanity-check known data)
- [x] No infinite recursion on states with cycles or deep OR-alternation
- [x] \`npm run lint\` passes

## Follow-ups (separate PRs)

- Per-college granularity in \`detect-cluster-gaps.ts\` (next PR in this series)
- \`detect-rare-course-by-term.ts\` — find courses offered at only 1-3 colleges per state per session
- \`detect-section-pattern.ts\` — hybrid/online/late-start density per state per term

🤖 Generated with [Claude Code](https://claude.com/claude-code)