### PR TITLE
blog: pipeline batch b — 10 spokes (6 session-timing + NY senior + 3 audit-college)

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -39,6 +39,56 @@
       "slug": "germanna-community-college-audit-class-guide",
       "draftedAt": "2026-05-09T22:30:00Z",
       "trigger": "cluster-gap"
+    },
+    {
+      "slug": "tennessee-community-college-session-timing-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "massachusetts-community-college-session-timing-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "new-york-cuny-community-college-session-timing-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "north-carolina-community-college-session-timing-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "virginia-community-college-session-timing-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "connecticut-state-community-college-session-timing-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "new-york-cuny-senior-citizens-tuition-waiver",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "nova-northern-virginia-community-college-audit-class-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "reynolds-community-college-audit-class-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "tcc-tidewater-community-college-audit-class-guide",
+      "draftedAt": "2026-05-09T23:30:00Z",
+      "trigger": "cluster-gap"
     }
   ]
 }

--- a/content/blog/connecticut-state-community-college-session-timing-guide.mdx
+++ b/content/blog/connecticut-state-community-college-session-timing-guide.mdx
@@ -1,0 +1,97 @@
+# Connecticut State Community College Sessions Explained: How CT State's Unified System Uses 8-Week, Late-Start, and Summer Formats
+
+Connecticut is unusual among East Coast states. The 12 community colleges that used to operate independently (Asnuntuck, Capital, Gateway, Housatonic, Manchester, Middlesex, Naugatuck Valley, Northwestern, Norwalk, Quinebaug Valley, Three Rivers, Tunxis) merged in 2023 into a single accredited institution: **Connecticut State Community College**, with each former college now operating as a campus of the unified system.
+
+That structural change matters for session timing. CT State's fall 2026 schedule lists **55 distinct start dates** across all 12 campuses combined. With a single accreditation, students enrolled at one campus can register for sections at other campuses without inter-college transfer paperwork. The catalog you have access to is the entire system's catalog, not just one campus's.
+
+Here's how session timing actually works in CT State, when each format helps, and how to find the right one.
+
+## How CT State's unified system structures session length
+
+Across all 12 campuses, CT State's fall 2026 contains 12,713 individual section offerings. Because the system is now a single institution, the session-format menu is unified — what's offered at one campus is, in principle, available to students system-wide, subject to mode (in-person sections require physical access; online sections don't).
+
+In practice, the larger campuses — Gateway (New Haven), Manchester, Norwalk, Capital (Hartford), Middlesex — publish the deepest section catalogs. The smaller campuses (Asnuntuck, Quinebaug Valley, Tunxis, Three Rivers, Housatonic, Northwestern, Naugatuck Valley) typically have narrower in-person catalogs but the same access to system-wide online and hybrid sections.
+
+If you're choosing a CT State campus to enroll in, the difference matters less than it would in a non-unified system — your enrollment is in CT State as a whole, and your effective catalog is system-wide.
+
+## The session formats at CT State
+
+The general framework lives in our [community college sessions hub](/blog/community-college-sessions-explained); here's the CT State translation.
+
+**Full-term (15 weeks).** CT State fall and spring both run 15 weeks plus finals. This is dominant — typically 70–85% of credit sections.
+
+**8-week sessions (Session A and Session B).** Two halves of the term. CT State publishes both halves as "Session A" or "8W-A" for the first half and "Session B" or "8W-B" for the second.
+
+**Late-start sections.** Standard sections beginning a few weeks after the regular term — often a 12-week section starting in mid- or late September.
+
+**Mini-sessions / Intersession.** Compressed sessions wedged between fall and spring or between spring and summer. CT State runs a January intersession at most campuses; some campuses also run a Maymester between spring and summer.
+
+**Summer sessions.** CT State summer typically runs 10 weeks total, broken into Summer Session A (~5 weeks), Summer Session B (~5 weeks), and a full-summer 10-week parallel option. Smaller catalogs but reliable gen-ed coverage.
+
+**Workforce / continuing-education sections.** Distinct from credit sections; these run on their own date stacks and typically don't qualify for federal financial aid. Watch the section type when filtering.
+
+## Workload math when sessions compress
+
+A 3-credit course is 3 credits regardless of session length. What changes is the weekly load.
+
+- 15-week full-term 3-credit class: roughly 9 hours per week (3 in-class + 6 outside).
+- 8-week Session A or Session B: roughly 18 hours per week for the same content.
+- 4-week intersession: roughly 36 hours per week — practically a full-time job for a single course.
+- 5-week summer session: roughly 22 hours per week.
+
+CT State students who try to stack a January intersession course with a regular spring schedule that begins two weeks later are the most common overload-and-drop pattern. The compressed session isn't easier; it's the same total work in less calendar time.
+
+## Practical patterns that work for CT State students
+
+**Stack Session A + Session B to compress a year.** Take ENG 101 in Session A of fall, finish it, then take ENG 102 in Session B. You earn 6 credits over the same calendar weeks as one full-term course but never juggle both. The larger CT State campuses (Gateway, Manchester, Norwalk) have the deepest 8-week catalogs.
+
+**Use system-wide enrollment to expand your catalog.** Because CT State is a single institution, a student enrolled at Asnuntuck (a smaller campus) can register for an online or hybrid section based at Gateway without transfer paperwork. The unified accreditation is genuinely useful for session flexibility — your effective catalog is system-wide.
+
+**Use January intersession for one focused gen-ed.** Pick something self-contained — a humanities elective, a writing-intensive course. Don't pair it with a heavy spring schedule starting just after the intersession ends.
+
+**Use summer to compress a degree timeline.** CT State summer runs cover the gen-ed core. One summer course shifts your graduation date roughly a third of a semester earlier; two summer courses can shift it a full term.
+
+**Use late-start sections to recover from a dropped class.** If you withdraw from something in week 3, a Session B 8-week section starting in week 8 or a late-start 12-week section can replace the credits.
+
+If you're not sure how to fit sessions to your weekly availability, our [schedule-building guide](/blog/how-to-build-community-college-schedule) walks through the mechanics. The [hybrid format primer](/blog/hybrid-community-college-classes-explained) covers in-person/online/hybrid format choice. For a regional comparison, [Maryland community college sessions](/blog/maryland-community-college-session-timing-guide) covers MD's session menu without the unified-system advantage CT State has — useful contrast for understanding what unification gains you.
+
+## How to find sessions on CT State search tools
+
+CT State uses Banner across all campuses, with a unified registration system that lets you search across all 12 campuses simultaneously.
+
+1. **Look at the start date column, not just the course code.** ENG 101 at CT State runs in 8–10 different sessions per fall — across multiple campuses, in multiple formats. Course code is identical; campus, mode, and date differ.
+2. **Filter by start date range.** Want a Session B section? Filter for start dates in mid-October. Intersession typically late December or early January. Late-start: anything starting after the second week of term.
+3. **Filter by campus and mode.** If you need in-person classes at a specific campus, filter to that campus first. If you can attend online or hybrid sections from anywhere, drop the campus filter and search system-wide.
+4. **Check the part-of-term codes.** Banner uses codes like "1" (full term), "8WA"/"8WB" (8-week halves), "5WA"/"5WB" (5-week summer halves), "MM" (mini-mester). Reading these saves you from accidentally registering for a session that doesn't fit.
+
+[Search CT State courses across all 12 campuses](/ct) to see what's actually open, and learn more about the unified system in our [CT State system guide](/blog/connecticut-ct-state-unified-system-guide).
+
+## Transfer credit and session length
+
+A common worry: do credits earned in compressed sessions transfer the same as full-term credits within CT or to out-of-state four-years?
+
+Yes. The CT State articulation framework treats credits earned in 8-week, intersession, and summer sections identically to full-term credits. The transcript records the course, credits, and grade with no session-length notation. CSCU senior institutions (Central, Eastern, Southern, Western Connecticut State) and out-of-state receivers don't track session length and rarely ask. If a course transfers full-term, it transfers compressed.
+
+That's the strongest argument for using session diversity: no penalty for compressing a degree timeline, real penalty (lost time, momentum, financial-aid SAP issues) for stretching a degree out longer than necessary.
+
+<ProductCallout
+  text="Community College Path indexes section-level data including start dates and session formats across all 12 CT State campuses. Filter for 8-week, late-start, or summer sections without scrolling through Banner's full schedule."
+  feature="search"
+  label="Search CT State Sections by Start Date"
+/>
+
+## Common CT-specific mistakes
+
+- **Treating CT State campuses as separate institutions.** They aren't. Since the 2023 merger, CT State is a single accredited institution. You can register across campuses without transfer paperwork — use that.
+- **Mixing a January intersession with the start of spring.** Intersession ends roughly when spring begins. Many students underestimate the recovery week and start spring already burned out.
+- **Late-registering for Session B without checking prereq chain status.** If a Session B course requires the Session A version, you can't take both simultaneously to "catch up." Read the prereq before you register — our [prereq chains explainer](/blog/prerequisite-chains-why-four-semester-plans-take-six) covers how to spot this.
+- **Confusing credit and continuing-education sections.** CT State publishes both in the same search interface. Continuing-ed sections don't qualify for federal financial aid. Filter carefully.
+- **Skipping summer because "I want a break."** A break is fine — just understand that one summer course shifts your graduation a full term earlier; declining is a real cost.
+
+## The bottom line
+
+CT State's unified-system structure makes it unusual among East Coast community college systems — your enrollment gives you access to the entire 12-campus catalog, and session diversity is meaningful (55 distinct start dates per term across the system). Full-term dominates; 8-week halves, January intersession, and summer terms are the supplementary levers.
+
+Use what's available. Look at start dates first. Watch the workload math when sessions compress. Treat 8-week stacking and summer terms as the main compression strategies, not heroic full-term overloads.
+
+The faster you understand the unified-system advantage and CT State's actual schedule shape, the more flexibility you have when life shifts mid-term.

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -715,4 +715,155 @@ export const articles: ArticleMeta[] = [
     cluster: "audit-at-college-guide",
     clusterRole: "spoke",
   },
+
+  // --- Pipeline batch 2026-05-09b: 7 state-spokes + 3 college-spokes ---
+
+  // Cluster C spokes (session-timing): TN, MA, NY, NC, VA, CT
+  {
+    slug: "tennessee-community-college-session-timing-guide",
+    title:
+      "Tennessee Community College Sessions Explained: How TBR's 12 Colleges Use 8-Week, Mini-Mester, and Late-Start Formats",
+    description:
+      "Northeast State publishes 62 distinct start dates per term. Here's how TBR's 12 community colleges actually structure session length, when each format helps, and how to find the right one before you register.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: "tn",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "tennessee", "tbr", "8-week", "wintermester"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "massachusetts-community-college-session-timing-guide",
+    title:
+      "Massachusetts Community College Sessions Explained: How MassCC's 15 Colleges Use Full-Term, 8-Week, and Summer Formats",
+    description:
+      "MassCC runs leaner session menus than peer states. Here's how the 15 colleges structure session length, when each format helps, and where Middlesex and Greenfield offer the deepest options.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: "ma",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "massachusetts", "masscc", "8-week", "intersession"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "new-york-cuny-community-college-session-timing-guide",
+    title:
+      "New York CUNY Community College Sessions Explained: How the 7 CUNY-CC Colleges Use 8-Week, Winter, and Summer Formats",
+    description:
+      "CUNY's 7 community colleges run a centrally synchronized session menu — narrower than peer systems but with a unique cross-campus enrollment advantage in winter and summer terms.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: "ny",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "new-york", "cuny", "8-week", "winter-session"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "north-carolina-community-college-session-timing-guide",
+    title:
+      "North Carolina Community College Sessions Explained: How NCCCS's 58 Colleges Use 8-Week, Mini-Mester, and Late-Start Formats",
+    description:
+      "Central Piedmont alone publishes 49 distinct start dates per term. Here's how NCCCS's 58 community colleges actually structure session length, when each format helps, and how to find the right one.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: "nc",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "north-carolina", "ncccs", "8-week", "mini-session"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "virginia-community-college-session-timing-guide",
+    title:
+      "Virginia Community College Sessions Explained: How VCCS's 23 Colleges Use 8-Week, Dynamic, and Late-Start Formats",
+    description:
+      "TCC publishes 74 distinct start dates per term. Here's how VCCS's 23 community colleges actually structure session length, including the dynamic-dated sections unique to Virginia.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: "va",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "virginia", "vccs", "8-week", "dynamic-dated"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "connecticut-state-community-college-session-timing-guide",
+    title:
+      "Connecticut State Community College Sessions Explained: How CT State's Unified System Uses 8-Week, Late-Start, and Summer Formats",
+    description:
+      "CT State's 2023 merger created a unified 12-campus system with shared accreditation. Here's how that affects session diversity and cross-campus enrollment for 8-week, intersession, and summer formats.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: "ct",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "connecticut", "ct-state", "8-week", "unified-system"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+
+  // Cluster B spoke: NY senior waivers
+  {
+    slug: "new-york-cuny-senior-citizens-tuition-waiver",
+    title:
+      "New York CUNY Senior Citizens at Community Colleges: How the 60+ Audit Program Actually Works",
+    description:
+      "N.Y. Education Law § 6304(5) waives tuition for residents 60+ at all 7 CUNY community colleges — but only for audit enrollment, not credit. Here's what's covered and how it compares to nearby states.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "ny",
+    author: "Community College Path",
+    tags: ["seniors", "new-york", "cuny", "tuition-waiver", "auditing", "audit-only"],
+    cluster: "senior-waivers-guide",
+    clusterRole: "spoke",
+  },
+
+  // Cluster E spokes (audit-at-college): NOVA, Reynolds, TCC
+  {
+    slug: "nova-northern-virginia-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Northern Virginia Community College: Cost, Application, and Eligibility",
+    description:
+      "NOVA, Virginia's largest community college, allows auditing at full credit cost — or free for VA residents 60+. Here's the process across NOVA's six campuses and online catalog.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "nova",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "nova", "vccs", "senior-waiver", "northern-virginia"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "reynolds-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Reynolds Community College: Cost, Application, and Eligibility",
+    description:
+      "Reynolds Community College in central Virginia allows auditing at full credit cost — or free for VA residents 60+. Here's the process across the three Richmond-area campuses.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "reynolds",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "reynolds", "vccs", "senior-waiver", "richmond"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "tcc-tidewater-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Tidewater Community College: Cost, Application, and Eligibility",
+    description:
+      "TCC serves Hampton Roads with four campuses and a heavy military-affiliated student body. Auditing rules, cost (free for seniors), and important notes for military and veteran auditors.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "tcc",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "tcc", "tidewater", "vccs", "senior-waiver", "hampton-roads"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
 ];

--- a/content/blog/massachusetts-community-college-session-timing-guide.mdx
+++ b/content/blog/massachusetts-community-college-session-timing-guide.mdx
@@ -1,0 +1,97 @@
+# Massachusetts Community College Sessions Explained: How MassCC's 15 Colleges Use Full-Term, 8-Week, and Summer Formats
+
+Massachusetts community colleges run leaner session menus than peer states. Where AACC in Maryland publishes 93 distinct start dates per term and Northeast State in Tennessee publishes 62, MassCC's most session-diverse colleges — Middlesex (18 distinct start dates) and Greenfield (17) — sit closer to the bottom of regional charts. Most of MassCC's 5,333 fall 2026 sections start on or near the standard full-term date.
+
+That's not a flaw, it's a system characteristic. MassCC's 15 community colleges have historically built around the 15-week semester with a small set of supplementary 8-week and summer options. The flexibility is real but narrower than students transferring from Maryland or Tennessee expect.
+
+Here's what session timing actually looks like across MassCC, when each format helps, and how to find the right one before you register.
+
+## How MassCC colleges structure session length
+
+The 15 colleges of the Massachusetts Community College system run on a similar fall–spring–summer rhythm but with notably different breadth of session-length options.
+
+**Middlesex Community College** is the most session-diverse — 18 distinct start dates in fall 2026. Full-term, two 8-week halves, late-start sections, mini-mesters, and a handful of self-paced workforce sections.
+
+**Greenfield Community College** at 17 distinct start dates and **Holyoke Community College** at 7 round out the top of the diversity chart.
+
+The other 12 MassCC colleges — Bunker Hill, Bristol, Cape Cod, Massasoit, MassBay, Mt. Wachusett, North Shore, Northern Essex, Quinsigamond, Roxbury, Springfield Tech, and Berkshire — typically run 2–6 distinct start dates per term. Mostly full-term-dominant with a small number of 8-week and summer additions.
+
+If session flexibility is critical to your schedule, Middlesex and Greenfield offer the deepest menus. Most other MassCC colleges run a narrow but reliable schedule built around the standard semester.
+
+## The session formats you'll see at MassCC colleges
+
+The general framework lives in our [community college sessions hub](/blog/community-college-sessions-explained); here's the MassCC-specific translation.
+
+**Full-term (15 weeks).** MassCC fall and spring both run 15 weeks plus finals. This is the dominant format at every MassCC college — typically 75–90% of credit sections.
+
+**8-week sessions (Session 1, Session 2).** Two halves of the term. At MassCC colleges that publish them, you'll see "Session 1" or "8W1" for the first half and "Session 2" or "8W2" for the second. Same content, half the calendar weeks; meeting frequency or duration doubles.
+
+**Mini-mester / Intersession.** Compressed 2–4 week sessions. Most MassCC colleges run a January intersession between fall and spring. Course content from a 3-credit class delivered in a few weeks of intensive meetings.
+
+**Late-start sections.** Standard sections that begin a few weeks after the regular term — often a 12-week section that starts mid-September instead of late August.
+
+**Summer sessions.** MassCC summer typically runs 8–10 weeks total, broken into Summer I, Summer II, and a full-summer parallel option. Smaller catalogs but reliable gen-ed coverage.
+
+## Workload math when sessions compress
+
+A 3-credit course is 3 credits regardless of session length. What changes is the weekly load.
+
+- 15-week full-term 3-credit class: roughly 9 hours per week.
+- 8-week Session 1 or Session 2: roughly 18 hours per week for the same content.
+- 4-week January intersession: roughly 36 hours per week — practically a full-time job for a single course.
+
+MassCC students who try to stack a January intersession with a regular spring schedule that begins two weeks later are the most common overload-and-drop pattern. The compressed session isn't easier; it's the same total work in less calendar time.
+
+## Practical patterns that work for MassCC students
+
+A few sequencing moves work consistently:
+
+**Stack Session 1 + Session 2 to compress a year.** Take ENG 101 in Session 1 of fall, finish it, then take ENG 102 in Session 2. You earn 6 credits over the same calendar weeks as one full-term course but never juggle both simultaneously. Middlesex and Greenfield have the deepest 8-week catalogs to support this.
+
+**Use January intersession for one focused gen-ed.** Pick a humanities elective, a writing-intensive course, or something self-contained. Don't pair it with a heavy spring schedule starting just after the intersession ends.
+
+**Use summer to compress a degree timeline.** MassCC summer runs are smaller but reliably include the gen-ed core. One summer course can shift your graduation date roughly a third of a semester earlier.
+
+**If you're at a smaller MassCC college, build around the full-term calendar.** Cape Cod, Mt. Wachusett, and Berkshire publish narrow session menus. Plan a full-term-default schedule and supplement with the 1–2 8-week sections each term offers.
+
+If you're not sure how to fit sessions to your weekly availability, our [schedule-building guide](/blog/how-to-build-community-college-schedule) walks through it. The [hybrid format primer](/blog/hybrid-community-college-classes-explained) covers in-person vs. online vs. hybrid format choice. For a comparison with a deeper-menu state system, [Maryland community college sessions](/blog/maryland-community-college-session-timing-guide) shows what 8-week and mini-mester look like in a system where AACC alone publishes 93 distinct start dates per term.
+
+## How to find sessions on MassCC college search tools
+
+This is where most practical confusion lives.
+
+1. **Look at the start date column, not just the course code.** ENG 101 at Middlesex runs in 5–6 different sessions per fall. Course code is identical; only dates differ.
+2. **Filter by start date range.** Want a Session 2 section? Filter for start dates in mid-October. Intersession typically late December or early January. Late-start: anything starting after the second week of term.
+3. **Check separate registration deadlines per session.** Session 2 and intersession sections each have their own registration cutoffs. Missing the main-term deadline doesn't mean you've missed everything.
+4. **Read section notes for hybrid/online format.** MassCC colleges have shifted significantly toward hybrid and online formats since 2020 — many sections that look "in person" by location are actually 50%+ online.
+
+[Search Massachusetts community college courses](/ma) to see what's actually open at the MassCC college you're considering, and [browse all 15 MassCC colleges](/ma/colleges) to compare offerings.
+
+## Transfer credit and session length
+
+A common worry: do credits earned in compressed sessions transfer the same as full-term credits?
+
+Yes. The [MassTransfer system](/ma/transfer) treats credits earned in 8-week, intersession, and summer sessions identically to full-term credits. The transcript records the course, credits, and grade — receiving institutions (UMass system, state universities, private four-years) don't track session length. If a course transfers full-term, it transfers compressed.
+
+That's the strongest argument for session diversity: no penalty for compressing a degree timeline using shorter sessions, and a real penalty (lost time, lost momentum, financial-aid satisfactory-academic-progress issues) for stretching a degree out longer than necessary.
+
+<ProductCallout
+  text="Community College Path indexes section-level data including start dates and session formats across all 15 MassCC colleges, so you can filter for 8-week, late-start, or intersession sections without scrolling through each college's full schedule."
+  feature="search"
+  label="Search MA Sections by Start Date"
+/>
+
+## Common Massachusetts-specific mistakes
+
+- **Assuming MassCC sessions match what you saw at another state's CC.** MassCC's session menu is meaningfully narrower than Maryland's or Tennessee's. Don't expect Middlesex's 18 distinct start dates as the system norm.
+- **Overlapping January intersession with the start of spring.** Intersession ends roughly when spring begins. Many students underestimate the recovery week and start spring already burned out.
+- **Late-registering for Session 2 without checking prereq chain status.** If a Session 2 course requires the Session 1 version, you can't take both simultaneously to "catch up." Read the prereq before you register — our [prereq chains explainer](/blog/prerequisite-chains-why-four-semester-plans-take-six) covers how to spot this in advance.
+- **Skipping summer because "I want a break."** A break is fine — just understand that one summer course shifts your graduation a full term earlier; declining is a real cost.
+
+## The bottom line
+
+Massachusetts community colleges run a leaner session menu than peer states. Full-term dominates; 8-week halves, January intersession, and summer sub-sessions are the supplementary levers. Middlesex and Greenfield offer the deepest schedules; smaller MassCC colleges run reliable but narrow menus.
+
+Use what's available. Look at start dates first. Watch the workload math when sessions compress. Stack 8-week sections and summer terms to compress a degree — not heroic full-term overloads.
+
+The faster you understand your MassCC college's actual schedule shape, the more options you have when life shifts mid-term.

--- a/content/blog/new-york-cuny-community-college-session-timing-guide.mdx
+++ b/content/blog/new-york-cuny-community-college-session-timing-guide.mdx
@@ -1,0 +1,98 @@
+# New York CUNY Community College Sessions Explained: How the 7 CUNY-CC Colleges Use 8-Week, Winter, and Summer Formats
+
+CUNY's 7 community colleges run on the New York City rhythm — fall, spring, winter intersession, and a multi-session summer — but with surprisingly compressed session diversity compared to peer state systems. Queensborough Community College's fall 2026 schedule lists 17 distinct start dates. Hostos has 13. BMCC has 8. The remaining four CUNY community colleges (Bronx, Kingsborough, LaGuardia, Guttman) typically run 2–6 distinct start dates per term.
+
+That's a deliberate system characteristic, not a flaw. CUNY is built around a tightly synchronized academic calendar across all 25 campuses (7 CCs + 11 senior colleges + 7 graduate/professional schools), and that synchronization keeps session variation narrower than at less-coordinated state systems. The flexibility you have is real but works differently than what students transferring from suburban or rural community colleges expect.
+
+Here's how session timing actually works at CUNY-CC, when each format helps, and how to find the right one.
+
+## How CUNY community colleges structure session length
+
+Across CUNY's 7 community colleges, fall 2026 contains 5,775 individual section offerings.
+
+**Queensborough** is the most session-diverse — 17 distinct start dates in fall 2026. Full-term, both 8-week halves, late-start sections, and a handful of mini-mester offerings.
+
+**Hostos** at 13 distinct start dates and **Borough of Manhattan (BMCC)** at 8 round out the top of the diversity chart.
+
+**Bronx, Kingsborough, LaGuardia, and Guttman** typically run 2–6 distinct start dates per term. Mostly full-term-dominant with a small number of 8-week and summer additions. Guttman in particular has the most synchronized schedule of the seven — its degree pathways are explicitly built around the standard semester calendar.
+
+If session flexibility matters to your schedule, Queensborough and Hostos offer the deepest menus. Most other CUNY-CC campuses run a narrow but reliable schedule built around the standard 15-week semester.
+
+## The session formats at CUNY community colleges
+
+The general framework lives in our [community college sessions hub](/blog/community-college-sessions-explained); here's the CUNY-CC-specific translation.
+
+**Full-term (15 weeks).** CUNY fall and spring both run 15 weeks plus finals. This is dominant — typically 80–90% of credit sections.
+
+**8-week sessions ("Session 1" and "Session 2").** Two halves of the term. CUNY publishes both halves at most colleges. Same content, half the calendar weeks; meeting frequency or duration doubles.
+
+**Winter session.** A 3-week intensive between fall and spring, running roughly January 2–22 at most CUNY-CC campuses. CUNY's winter session is centrally administered and the catalog is shared across the system — students at one CUNY-CC can sometimes register for winter session courses at another, expanding the catalog meaningfully.
+
+**Late-start sections.** Standard sections that begin a few weeks after the regular term, often a 12-week section starting in mid- or late September.
+
+**Summer sessions.** CUNY summer is structured as Summer 1 (~6 weeks, June–July), Summer 2 (~6 weeks, July–August), and a full-summer 12-week parallel option. Like winter, summer is centrally administered with cross-campus enrollment available.
+
+## Workload math when sessions compress
+
+A 3-credit course is 3 credits regardless of session length. What changes is the weekly load.
+
+- 15-week full-term 3-credit class: roughly 9 hours per week.
+- 8-week Session 1 or Session 2: roughly 18 hours per week for the same content.
+- 3-week Winter session: roughly 45 hours per week — a full-time-plus commitment for a single course.
+- 6-week Summer 1: roughly 22 hours per week.
+
+CUNY students who try to stack a winter-session course with a regular spring schedule that begins two weeks later are the most common overload-and-drop pattern. Three weeks of intensive study followed immediately by a full spring load is brutal; plan a recovery week.
+
+## Practical patterns that work for CUNY-CC students
+
+**Stack Session 1 + Session 2 to compress a year.** Take ENG 101 in Session 1 of fall, finish, then take ENG 102 in Session 2. You earn 6 credits over the same calendar weeks as one full-term course but never juggle both. Queensborough and Hostos have the deepest 8-week catalogs to support this.
+
+**Use winter session for one focused gen-ed.** CUNY's 3-week winter session is intense but bounded. Pick something self-contained — a humanities elective, a public speaking course. Don't pair it with a heavy spring schedule starting just after winter ends.
+
+**Use summer to compress a degree timeline.** CUNY summer runs cover the gen-ed core. One summer course can shift your graduation date roughly a third of a semester earlier; two summer courses across Summer 1 and Summer 2 can shift it a full term.
+
+**Take advantage of cross-campus enrollment in winter and summer.** Winter and summer courses at CUNY are shared across community and senior campuses. Students at BMCC can register for a section running at Hunter or City College if it fits their needs. This is unusual flexibility — most state systems don't allow it.
+
+**If you're at a smaller CUNY-CC campus, build around the full-term calendar.** Guttman, LaGuardia, and Kingsborough publish narrower session menus. Plan a full-term-default schedule and use winter/summer for compression rather than mid-term session stacks.
+
+If you're not sure how to fit sessions to your weekly availability, our [schedule-building guide](/blog/how-to-build-community-college-schedule) covers the mechanics. The [hybrid format primer](/blog/hybrid-community-college-classes-explained) covers in-person/online/hybrid format choice. For a regional comparison, [Maryland community college sessions](/blog/maryland-community-college-session-timing-guide) covers a system where Anne Arundel CC publishes 93 distinct start dates per term — useful contrast for thinking about CUNY's narrower-but-cross-campus model.
+
+## How to find sessions on CUNY college search tools
+
+CUNY uses the centralized CUNYfirst registration system across all 7 community colleges. To find specific sessions:
+
+1. **Look at the start date column, not just the course code.** ENG 101 at Queensborough runs in 5–6 different sessions per fall. Course code is identical; only dates differ.
+2. **Filter by start date range.** Want a Session 2 section? Filter for start dates in mid-October. Winter session is the first three weeks of January. Late-start: anything starting after the second week of term.
+3. **Check the part-of-term codes.** CUNYfirst uses codes like "1" (full term), "5W1"/"5W2" (5-week halves of summer), "8W1"/"8W2" (8-week halves of fall/spring), "3WW" (3-week winter). Reading these saves you from accidentally registering for a session that doesn't fit.
+4. **Watch for cross-campus winter and summer offerings.** CUNYfirst lets you search across colleges for these terms, expanding your effective catalog.
+
+[Search CUNY community college courses](/ny) to see what's actually open at the campus you're considering, and [browse all 7 CUNY community colleges](/ny/colleges) to compare offerings.
+
+## Transfer credit and session length
+
+A common worry: do credits earned in compressed sessions transfer the same as full-term credits inside CUNY or to SUNY/private four-years?
+
+Yes, both ways. The [CUNY transfer pathway](/ny/transfer) treats credits earned in 8-week, winter, and summer sessions identically to full-term credits — transcript records the course, credits, and grade with no session-length notation. SUNY and private receivers don't track session length and rarely ask. If a course transfers full-term, it transfers compressed.
+
+That's the strongest argument for using session diversity: no penalty for compressing a degree timeline, real penalty (lost time, momentum, financial-aid SAP issues) for stretching it out.
+
+<ProductCallout
+  text="Community College Path indexes section-level data including start dates and session formats across all 7 CUNY community colleges. Filter for 8-week, winter, or late-start sections without scrolling through CUNYfirst's full schedule."
+  feature="search"
+  label="Search CUNY Sections by Start Date"
+/>
+
+## Common CUNY-specific mistakes
+
+- **Underestimating winter session intensity.** CUNY's winter session runs 3 weeks for a full 3-credit course — roughly 45 hours of weekly work. Pick one course, focus, recover before spring.
+- **Missing the cross-campus enrollment option.** Many CUNY-CC students don't realize winter and summer offerings can be taken at any CUNY campus. If your home college doesn't offer the section you need, check Hunter, Brooklyn, or Lehman before assuming you're stuck.
+- **Late-registering for Session 2 without checking prereq chain status.** If a Session 2 course requires the Session 1 version, you can't take both simultaneously to "catch up." Read the prereq before you register — our [prereq chains explainer](/blog/prerequisite-chains-why-four-semester-plans-take-six) covers how to spot this.
+- **Skipping summer because "I want a break."** A break is fine — just understand that one summer course shifts your graduation a full term earlier; declining is a real cost.
+
+## The bottom line
+
+CUNY community colleges run a narrower session menu than peer state systems but with one unique advantage — cross-campus enrollment in winter and summer that effectively expands your catalog past your home college. Full-term dominates; 8-week halves, 3-week winter session, and Summer 1/2 are the supplementary levers.
+
+Use what's available. Look at start dates first. Watch the workload math when sessions compress, especially in winter. Treat 8-week stacking, winter session, and summer terms as the main compression strategies — not heroic full-term overloads.
+
+The faster you understand your CUNY-CC's actual schedule shape and the cross-campus options, the more flexibility you have when life shifts mid-term.

--- a/content/blog/new-york-cuny-senior-citizens-tuition-waiver.mdx
+++ b/content/blog/new-york-cuny-senior-citizens-tuition-waiver.mdx
@@ -1,0 +1,85 @@
+# New York CUNY Senior Citizens at Community Colleges: How the 60+ Audit Program Actually Works
+
+If you're 60 or older and a New York State resident, every CUNY community college is required by state law to let you audit credit courses tuition-free. The program runs under N.Y. Education Law § 6304(5) — one of the cleaner senior citizen audit provisions in the country in terms of statute, and one of the more constrained in terms of what it actually delivers.
+
+The catch — and it's a meaningful one — is in the word "audit." CUNY's senior tuition waiver does not give you credit. It gives you a seat in the classroom. Whether that's what you wanted depends on why you're enrolling.
+
+Here's what the CUNY senior audit program actually covers, what it doesn't, and how to use it without surprises.
+
+## The basic rule
+
+Under N.Y. Education Law § 6304(5), New York State residents aged 60 and older may audit undergraduate credit courses at CUNY community colleges on a space-available basis, with tuition waived. The program applies across CUNY's 7 community colleges: Borough of Manhattan, Bronx, Hostos, Kingsborough, LaGuardia, Queensborough, and Guttman.
+
+The waiver is for **auditing only**. You can attend lectures, participate in discussion if the instructor allows, and submit work if you choose, but you do not earn course credit, you do not receive a grade, and the course does not count toward a degree or certificate. On your transcript, the course (if recorded at all) shows as "AU" or as a non-credit notation.
+
+There's no statutory income test for community-college audit enrollment under § 6304(5). There's no retirement test. The hard requirements are (a) age 60+, (b) New York State residency, and (c) the section being available when senior registration opens.
+
+## What the waiver does *not* cover
+
+This is where most surprises come from. The waiver waives tuition. It does not waive:
+
+- **Mandatory student fees.** CUNY community colleges charge student activity fees, technology fees, lab fees for science courses, and similar mandatory charges on top of tuition. For a 3-credit course, fees can run $100–$300 depending on the college and course type. Tuition is the largest line item but not the only one.
+- **Course materials.** Textbooks, online access codes, and lab supplies are not part of the waiver. CUNY operates a textbook-access program at some colleges that reduces these costs, but they aren't eliminated.
+- **Credit enrollment.** This is the biggest constraint. If you want a course to count toward a degree or appear on your transcript with a grade, you must enroll as a regular credit-paying student — the senior waiver only covers the audit option.
+- **Degree-seeking enrollment.** The audit program is not a path to a CUNY associate degree. To earn a credential, you'd need to apply as a matriculated student and pay regular community-college tuition (which CUNY discounts for seniors via a separate provision, but not to zero).
+
+A useful mental model: the waiver is for intellectual engagement and structured learning. It is not a path to credentials. If you want the credential, this isn't the program.
+
+## "Space available" — what it actually means at CUNY-CC
+
+Senior audit registration at CUNY community colleges typically opens **after** matriculated students register for the term. That's the law's tradeoff: tuition is free, but you don't displace a paying student.
+
+In practice across CUNY's 7 community colleges:
+
+- **Popular gen-ed sections fill fastest.** ENG 101, MAT 100, PSY 100, HIS 100 — anything that satisfies a transfer requirement to CUNY senior colleges. By the time senior registration opens, these are often closed.
+- **Online and asynchronous sections fill across all demographics.** Working students grab them first.
+- **CUNY's larger urban colleges** (BMCC, LaGuardia, Queensborough) tend to have the most section variety, but also the most competition for popular gen-eds.
+- **Niche electives, morning sections, and second-half-of-semester courses** tend to have meaningful availability.
+- **Summer terms** have shorter catalogs but less competition for seats.
+
+Each CUNY community college sets its own senior audit registration date — typically a few days to a week after general registration opens. Call or email the registrar at the college you're considering and ask exactly when senior auditors can register, and what one-time paperwork (proof of NY residency, age verification) they need before that first registration. Doing this in advance is the single biggest predictor of whether you get the section you want.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **You must be a matriculated or non-degree CUNY enrollee to use the waiver.** Most colleges admit senior auditors as "non-degree" students with a streamlined application — short form, no transcripts required. The application is one-time; once you have a CUNY ID, future term enrollments are simpler.
+- **Registration is per-term, not annual.** You re-register each term you want to audit. Senior registration windows close on the same dates as regular registration; missing the deadline means waiting for the next term.
+- **You can't switch from audit to credit mid-term.** Once registered as an auditor, that's the status for the term. Changing requires re-registration in a future term.
+- **Some courses are not auditable.** Clinical placements, internships, certain studio art courses, and competitive-admission program courses (nursing clinical sequences, dental hygiene practica) generally cannot be audited. The registrar will flag these when you ask.
+
+## Where CUNY's senior waiver compares to neighboring states
+
+Senior tuition waivers exist in [several states with meaningfully different rules](/blog/free-community-college-classes-for-seniors), and CUNY's audit-only design sits at a specific point in the spectrum.
+
+- **New Jersey** ([detailed waiver guide](/blog/new-jersey-senior-citizens-county-college-tuition-waiver)) waives tuition for residents 65+ at all 18 county colleges, and importantly covers **credit enrollment**, not just audit. NJ seniors can earn community college credits tuition-free; NY seniors at CUNY-CC cannot.
+- **Maryland** ([guide here](/blog/maryland-senior-citizens-community-college-tuition-waiver)) covers both audit and credit at age 60 with no income cap. Stronger than NY's program for anyone seeking a credential.
+- **Virginia** ([guide here](/blog/virginia-senior-citizens-community-college-free-tuition)) at age 60 covers audit free regardless of income; credit enrollment requires income below ~$29k. NY's audit-only structure is similar to VA's audit branch.
+- **Massachusetts** at age 60 covers credit and audit at MassCC colleges tuition-free with no income cap — more generous than NY for credit-seekers.
+
+If you're a New York State resident curious about credit-bearing community college without paying full tuition: at CUNY, you'd pay regular CC tuition (which is among the lower in the country); the senior waiver is specifically for the audit-only option. If credentials matter, the math is different than in NJ or MD.
+
+## How to actually enroll
+
+The process is shorter than most people expect:
+
+1. **Pick a CUNY community college near you.** [Browse all 7 CUNY community colleges](/ny/colleges) to compare locations, course offerings, and term schedules.
+2. **Apply as a non-degree senior auditor.** Each CUNY-CC has a simple non-degree application — typically online, no transcripts required, completed once. Mention you're applying under § 6304(5) for senior audit.
+3. **Provide proof of NY residency and age** when prompted. Driver's license or state ID usually suffices.
+4. **Wait for senior registration to open.** Each college publishes the senior registration date for upcoming terms. Senior auditors register after matriculated students.
+5. **Pick courses with backups.** Have a first choice and at least one fallback. Popular gen-eds may be closed by the time your window opens. [Search CUNY community college courses](/ny) to see current sections and seats.
+6. **Pay any remaining fees.** Tuition is zero. Mandatory student fees, lab fees, and materials are still on you.
+
+<ProductCallout
+  text="Community College Path indexes course offerings across all 7 CUNY community colleges. Search for a course or browse a college's catalog to see exactly which sections are running this term."
+  feature="search"
+  label="Search CUNY Community College Courses"
+/>
+
+## The bottom line
+
+CUNY's senior tuition waiver is a real benefit with a specific scope: audit-only enrollment at any of the 7 community colleges, free of tuition, on a space-available basis for residents 60+. It's the right program if you want structured learning without a credential. It's the wrong program if you want credits toward a CUNY degree.
+
+If credit matters, look at the Tuition Assistance Program (TAP) for matriculated CUNY students, or compare the credit-bearing senior waivers in neighboring states (NJ, MA, MD) to see whether crossing a state line changes the math for you.
+
+For audit, CUNY's program is one of the simpler statutes to navigate in the region. Apply as non-degree, register after matriculated students, and plan around fees and materials — those don't go to zero, but tuition does.

--- a/content/blog/north-carolina-community-college-session-timing-guide.mdx
+++ b/content/blog/north-carolina-community-college-session-timing-guide.mdx
@@ -1,0 +1,102 @@
+# North Carolina Community College Sessions Explained: How NCCCS's 58 Colleges Use 8-Week, Mini-Mester, and Late-Start Formats
+
+Across the 58 colleges of the North Carolina Community College System (NCCCS), fall 2026 contains 53,631 individual section offerings — the largest single-semester catalog of any community college system in the Southeast. Central Piedmont Community College alone publishes **49 distinct start dates** in a single term. Martin CC has 34. Guilford Technical has 31. The next several colleges sit in the 20–30 range.
+
+NCCCS's session menu is wider than any peer state's, partly because the system itself is the largest by college count, and partly because NC has historically built its community college system around adult learners and workforce flexibility. Most NCCCS students never realize how varied the menu is until they've committed to a schedule that wastes the option value.
+
+Here's how session timing actually works across NCCCS, when each format helps, and how to find the right one.
+
+## How NCCCS colleges structure session length
+
+The 58 colleges of NCCCS run on the same fall–spring–summer rhythm but with significantly different breadth of session-length options.
+
+**Central Piedmont Community College (Charlotte)** is the most session-diverse — 49 distinct start dates in fall 2026. Full-term, both 8-week halves, multiple mini-mesters, late-start sections weekly, and continuing-education sections with their own date stacks.
+
+**Martin Community College** at 34 distinct start dates and **Guilford Technical** at 31 are the next tier. Both publish deep 8-week and late-start coverage.
+
+The mid-tier — Wake Tech, Forsyth Tech, Cape Fear, Pitt, Fayetteville Tech, Caldwell, Davidson-Davie — typically run 15–25 distinct start dates per term. Strong 8-week halves, reliable mini-mester offerings, late-start sections most weeks of the term.
+
+The smaller and rural NCCCS colleges (~30 of the 58) tend toward leaner schedules — typically 5–12 distinct start dates per term. Still meaningful flexibility, just narrower than the urban colleges.
+
+If session diversity matters to your schedule, Central Piedmont, Martin, and Guilford Technical offer the deepest menus. Most rural NCCCS colleges run a narrower but still reliable schedule built around 15-week terms with 8-week and mini-mester supplements.
+
+## The session formats at NCCCS colleges
+
+The general framework lives in our [community college sessions hub](/blog/community-college-sessions-explained); here's the NCCCS-specific translation.
+
+**Full-term (16 weeks).** NCCCS fall and spring run 16 weeks plus finals — slightly longer than peer systems. Every NCCCS college runs full-term, and most credit hours are taught in it.
+
+**8-week sessions (Term 1 and Term 2).** Two halves of the term. NCCCS publishes both halves at most colleges as "Term 1" or "8W1" for the first half and "Term 2" or "8W2" for the second.
+
+**Mini-mester / Mini-session.** Compressed 4–5 week sessions, typically wedged between fall and spring or between spring and summer. NCCCS calls these "mini-sessions" or "Maymester" depending on the college; Central Piedmont's mini-session catalog is particularly deep.
+
+**Late-start sections.** Standard sections beginning a few weeks after the regular term. NCCCS has the country's most aggressive late-start approach — Central Piedmont publishes new late-start dates almost every week of the term, and Martin CC's structure is similar.
+
+**Summer sessions.** NCCCS summer typically runs 8–10 weeks total, broken into multiple parallel sub-sessions — Summer Term 1, Summer Term 2, full-summer, and 4-week intensives. Smaller catalogs than fall/spring but reliable gen-ed coverage.
+
+**Continuing education and workforce sections.** Distinct from credit sections; these run on their own date stacks (often 6, 8, or 12 weeks) and are not part of the credit catalog. Watch the section type when filtering — accidentally registering for a continuing-education section can mean paying out of pocket without financial-aid coverage.
+
+## Workload math when sessions compress
+
+A 3-credit course is 3 credits regardless of session length. What changes is the weekly load.
+
+- 16-week full-term 3-credit class: roughly 9 hours per week (3 in-class + 6 outside).
+- 8-week Term 1 or Term 2: roughly 18 hours per week for the same content.
+- 4-week mini-session: roughly 36 hours per week — practically a full-time job for a single course.
+
+NCCCS students who try to stack a mini-session course with full-term enrollment are the most common overload-and-drop pattern. The compressed session isn't easier; it's the same total work in less calendar time.
+
+## Practical patterns that work for NCCCS students
+
+**Stack Term 1 + Term 2 to compress a year.** Take ENG 111 in Term 1 of fall, finish, then take ENG 112 in Term 2. You earn 6 credits over the same calendar weeks as one full-term course but never juggle both. Central Piedmont, Martin, and Guilford Tech have the deepest 8-week catalogs.
+
+**Use mini-session for one focused gen-ed.** Pick something self-contained — a humanities elective, a writing-intensive course, a public-speaking course. Don't pair a mini-session with a heavy spring or summer schedule starting immediately after.
+
+**Use late-start sections to recover from a dropped class.** If you withdraw from something in week 3, an 8-week 2nd-half section starting in week 8 or a 12-week late-start can replace the credits. Central Piedmont and Martin have the deepest late-start catalogs in the state.
+
+**Use summer to compress a degree timeline.** NCCCS summer runs are smaller but reliably include the gen-ed core. One summer course shifts your graduation date roughly a third of a semester earlier; two summer courses can shift it a full term.
+
+**If you're at a smaller NCCCS college, build around the full-term calendar.** Rural NCCCS colleges publish narrower session menus. Plan a full-term-default schedule and supplement with the 1–3 8-week sections each term offers.
+
+If you're not sure how to fit sessions to your weekly availability, our [schedule-building guide](/blog/how-to-build-community-college-schedule) walks through the mechanics. The [hybrid format primer](/blog/hybrid-community-college-classes-explained) covers in-person/online/hybrid format choice. For a peer-state comparison, [Maryland community college sessions](/blog/maryland-community-college-session-timing-guide) covers MD's 16-college lineup — narrower than NCCCS but built on similar 8-week and mini-session patterns.
+
+## How to find sessions on NCCCS college search tools
+
+NCCCS uses Colleague-based registration systems at most colleges, with Self-Service or Banner at others. To find specific sessions:
+
+1. **Look at the start date column, not just the course code.** ENG 111 at Central Piedmont runs in 8+ different sessions per fall. Course code is identical; only dates differ.
+2. **Filter by start date range.** Want a Term 2 section? Filter by start dates in mid-October. Mini-session typically late December or early May. Late-start: anything starting after the second week of term.
+3. **Check the section type filter.** NCCCS colleges publish credit and continuing-education sections in the same search interface at some campuses. Filter to "credit" sections only unless you specifically want continuing-ed.
+4. **Watch for separate registration deadlines.** Term 2, mini-session, and late-start sections each have their own registration cutoffs. Missing the main-term deadline doesn't mean you've missed everything.
+
+[Search North Carolina community college courses by start date and college](/nc) to see what's actually open at the NCCCS campus you're considering, and [browse all 58 NCCCS colleges](/nc/colleges) to compare offerings.
+
+## Transfer credit and session length
+
+A common worry: do credits earned in compressed sessions transfer the same as full-term credits within the NC Comprehensive Articulation Agreement (CAA) or out of state?
+
+Yes. The [NC CAA](/blog/north-carolina-community-college-unc-transfer-caa) treats credits earned in 8-week, mini-session, and summer sections identically to full-term credits — transcript records the course, credits, and grade with no session-length notation. UNC system receivers and private four-years don't track session length and rarely ask. If a course transfers full-term, it transfers compressed.
+
+That's the strongest argument for using session diversity: no penalty for compressing a degree timeline using shorter sessions, and a real penalty (lost time, momentum, financial-aid SAP issues) for stretching a degree out longer than necessary.
+
+<ProductCallout
+  text="Community College Path indexes section-level data including start dates and session formats across all 58 NCCCS colleges. Filter for 8-week, late-start, or mini-session sections without scrolling through each college's full schedule."
+  feature="search"
+  label="Search NC Sections by Start Date"
+/>
+
+## Common NCCCS-specific mistakes
+
+- **Assuming all NCCCS colleges have the same menu.** They don't. Central Piedmont's 49-distinct-start-date schedule is unusual; many rural NCCCS colleges run 5–12. Plan around your actual college's offerings.
+- **Mixing a mini-session with a full-term overload.** A mini-session course is essentially a full-time commitment for those weeks. Adding it to 12 credits of full-term work usually means dropping something.
+- **Late-registering for Term 2 without checking prereq chain status.** If a Term 2 course requires the Term 1 version, you can't take both simultaneously to "catch up." Read the prereq before you register — our [prereq chains explainer](/blog/prerequisite-chains-why-four-semester-plans-take-six) covers how to spot this.
+- **Confusing credit and continuing-education sections.** NCCCS publishes both in the same search interface at many colleges. Continuing-ed sections don't qualify for federal financial aid and don't count toward an associate degree. Filter carefully.
+- **Skipping summer because "I want a break."** A break is fine — just understand that one summer course shifts your graduation a full term earlier; declining is a real cost.
+
+## The bottom line
+
+NCCCS runs the largest community college session menu in the Southeast and varies dramatically across the 58 colleges. Full-term is the default; 8-week halves, mini-sessions, late-start, and summer terms are the levers that compress a degree timeline. Central Piedmont, Martin, and Guilford Tech offer the deepest menus; rural colleges run leaner but reliable schedules.
+
+Use the menu deliberately. Look at start dates first. Watch the workload math when sessions compress. Treat 8-week stacking and summer terms as the main compression strategies, not heroic full-term overloads.
+
+The faster you understand which sessions exist at your NCCCS college, the more options you actually have when life shifts mid-term.

--- a/content/blog/nova-northern-virginia-community-college-audit-class-guide.mdx
+++ b/content/blog/nova-northern-virginia-community-college-audit-class-guide.mdx
@@ -1,0 +1,79 @@
+# How to Audit a Class at Northern Virginia Community College: Cost, Application, and Eligibility
+
+Northern Virginia Community College (NOVA) is the largest college in Virginia by enrollment — over 70,000 students across six campuses (Alexandria, Annandale, Loudoun, Manassas, Medical Education Campus, Woodbridge) plus an extensive online catalog. If you live in the DC metro area and want to take a NOVA course without committing to a grade, you're allowed to. NOVA's policy permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The catch is that the cost depends entirely on whether you qualify for Virginia's senior tuition waiver.
+
+Here's what auditing actually costs at NOVA, who can do it, and the practical step-by-step.
+
+## What auditing means at NOVA
+
+Auditing is enrollment in a NOVA course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is NOVA-specific: what it actually costs, the application process, and the constraints unique to this college.
+
+## What it costs
+
+NOVA applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The exception** — and it's a meaningful one — is Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). If you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, NOVA's audit policy notes that auditing is **free** for eligible seniors. The waiver covers tuition; you may still owe small mandatory fees depending on the term, but the tuition line goes to zero.
+
+If you're not eligible for the senior waiver, expect to pay full freight. If you are, NOVA's audit option is one of the most generous deals in higher education in the DC metro area — particularly given NOVA's catalog breadth.
+
+## Who can audit
+
+NOVA's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or a NOVA service-area resident to audit. Out-of-state rates apply where relevant, but the option is open to anyone.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences, clinical placements at the Medical Education Campus, and competitive-admission program courses are the most likely to require this; standard lecture courses in liberal arts and business are usually open.
+
+## How to actually enroll as an auditor at NOVA
+
+NOVA's audit process is managed through ordinary course registration plus one extra notification to admissions. Here's the sequence:
+
+1. **Apply for admission to NOVA** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application — you apply as a regular student.
+2. **Contact NOVA admissions** by email at admissions@nvcc.edu (or phone 703-323-3000) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal NOVA enrollment system** when registration opens for the term. Most audit registrations are completed by admissions based on your email request, but some terms require you to register through the student portal and then submit a separate audit-status form before the add/drop deadline.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before NOVA's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment. If you're considering auditing as a way to "test the waters" before committing financially, the math may not work — you're paying out of pocket.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled at NOVA and trying to maintain SAP for federal aid, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term. The deadline is usually around two weeks after the term starts.
+- **Some courses are not auditable.** Clinical placements at the Medical Education Campus, internships, capstone courses, and specific competitive-admission program courses (nursing clinical, dental hygiene practica, allied health practica) generally cannot be audited. The admissions office will flag these when you ask.
+- **Six campuses and extensive online catalog.** When you contact admissions, be specific about which section you want. NOVA's catalog includes sections at every campus plus online and hybrid sections; a course code alone doesn't pin down location and mode.
+
+## When auditing at NOVA makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a DC metro resident.** The Virginia senior waiver makes auditing essentially free, and NOVA's catalog is one of the largest in Virginia. Try a foreign language, a humanities seminar, a survey course in something you've always meant to learn. Low-stakes, structured intellectual engagement.
+- **You're considering a NOVA degree program and want a no-pressure preview.** Audit one course in the program before you commit to the full sequence. NOVA's programs span business, IT, allied health, engineering tech, liberal arts, and the arts; an audit course gives you a real preview before enrolling.
+- **You're already credentialed and want professional refresh.** A retired engineer auditing an updated CAD course, a working accountant auditing a tax-law update — auditing gives you the structure of a class without unnecessary credit hours.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school applications, auditing a course you find interesting but risky avoids the GPA hit.
+
+## Where NOVA sits compared to other VA community colleges
+
+NOVA's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to other VCCS colleges are mostly process detail. Compared to [Germanna Community College](/blog/germanna-community-college-audit-class-guide) and other VCCS colleges, NOVA's process is similar in shape — apply via VCCS, email admissions, register, pay or apply waiver — but at NOVA you also pick a campus and mode at registration time.
+
+If you're shopping across multiple Virginia community colleges, NOVA's catalog breadth is the main differentiator. Six campuses and a deep online catalog means almost any subject is available, often in multiple format and time options.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at NOVA across all six campuses and online, with the registrar contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Northern Virginia Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver. If you're 60+ and a Virginia resident, it's effectively free. If you're not, it's full tuition without any of the credentials or financial-aid eligibility — a real cost for the experience of structured learning without the grade.
+
+Either way, NOVA admissions at admissions@nvcc.edu (703-323-3000) is the right first contact. They'll confirm section availability across NOVA's six campuses and online catalog, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/reynolds-community-college-audit-class-guide.mdx
+++ b/content/blog/reynolds-community-college-audit-class-guide.mdx
@@ -1,0 +1,81 @@
+# How to Audit a Class at Reynolds Community College: Cost, Application, and Eligibility
+
+Reynolds Community College is the public community college serving the Richmond metro area — three campuses (Downtown, Parham Road, Goochland) plus an online catalog that's grown substantially since 2020. If you live in central Virginia and want to take a Reynolds course without committing to a grade, you're allowed to. Reynolds permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The cost depends entirely on whether you qualify for Virginia's senior tuition waiver.
+
+Here's what auditing actually costs at Reynolds, who can do it, and the practical step-by-step.
+
+## What auditing means at Reynolds
+
+Auditing is enrollment in a Reynolds course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is Reynolds-specific: what it actually costs, the application process, and the constraints unique to this college.
+
+## What it costs
+
+Reynolds applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The exception** — and it's a meaningful one — is Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). If you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, Reynolds's audit policy notes that auditing is **free** for eligible seniors. The waiver covers tuition; you may still owe small mandatory fees depending on the term, but the tuition line goes to zero.
+
+If you're not eligible for the senior waiver, expect to pay full freight. If you are, Reynolds's audit option is one of the most accessible deals for adult learners in the Richmond metro area.
+
+## Who can audit at Reynolds
+
+Reynolds's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or live in the Richmond service area to audit. Out-of-state rates apply where relevant, but the option is open.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences and competitive-admission program courses (nursing clinicals, allied health practica) are the most likely to require this; lecture courses in liberal arts and business are usually open.
+
+Reynolds enrolls a meaningful proportion of working adults and career-changers — which means the auditor profile in many sections is itself diverse. Don't be surprised to find other auditors in classes you join.
+
+## How to actually enroll as an auditor at Reynolds
+
+Reynolds's audit process is managed through ordinary course registration plus one extra notification to admissions. Here's the sequence:
+
+1. **Apply for admission to Reynolds** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application — you apply as a regular student.
+2. **Contact Reynolds admissions** by email at admissions@reynolds.edu (or phone 804-371-3000) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal Reynolds enrollment system** when registration opens for the term. Most audit registrations are completed by admissions based on your email request; some terms require you to register through the student portal and then submit a separate audit-status form before the add/drop deadline.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before Reynolds's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment. If you're considering auditing as a way to "test the waters" before committing financially, the math may not work — you're paying out of pocket.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled at Reynolds and trying to maintain SAP for federal aid, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term. The deadline is usually around two weeks after the term starts.
+- **Some courses are not auditable.** Clinical placements, internships, capstone courses, and specific competitive-admission program courses generally cannot be audited. The admissions office will flag these when you ask.
+- **Three campuses with different course mixes.** When you contact admissions, be specific about which section. Downtown, Parham Road, and Goochland each have different course concentrations; online and hybrid sections add another dimension.
+
+## When auditing at Reynolds makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a central Virginia resident.** The Virginia senior waiver makes auditing essentially free at Reynolds. Try a humanities elective, a foreign language, a course in something you've always meant to study. Low-stakes structured learning.
+- **You're a working adult considering a career change.** Reynolds's audit option lets you sample courses in a new field — accounting, IT, healthcare administration, paralegal — before committing to the full program and the financial-aid commitment that comes with credit enrollment.
+- **You're already credentialed and want a refresh.** A retired teacher auditing an education-policy seminar, a working accountant auditing a tax-law update — auditing gives you the structure without unnecessary credit hours.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school, auditing a course you find interesting but risky avoids the GPA hit.
+
+## Where Reynolds sits compared to other VA community colleges
+
+Reynolds's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to peer VCCS colleges (like [Germanna](/blog/germanna-community-college-audit-class-guide)) are mostly process detail. Reynolds's contact is admissions@reynolds.edu / 804-371-3000; otherwise the path is the same.
+
+If you're shopping across multiple Virginia community colleges, Reynolds's central Virginia location and adult-learner emphasis are the main differentiators. The catalog leans toward business, IT, allied health, and liberal arts, with growing online and hybrid coverage.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at Reynolds across all three campuses and online, with the admissions contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Reynolds Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver. If you're 60+ and a Virginia resident, it's effectively free. If you're not, it's full tuition without any of the credentials or financial-aid eligibility — a real cost for the experience of structured learning without the grade.
+
+Either way, Reynolds admissions at admissions@reynolds.edu (804-371-3000) is the right first contact. They'll confirm section availability across the three campuses and the online catalog, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/tcc-tidewater-community-college-audit-class-guide.mdx
+++ b/content/blog/tcc-tidewater-community-college-audit-class-guide.mdx
@@ -1,0 +1,81 @@
+# How to Audit a Class at Tidewater Community College: Cost, Application, and Eligibility
+
+Tidewater Community College (TCC) serves the Hampton Roads region of Virginia — four campuses (Chesapeake, Norfolk, Portsmouth, Virginia Beach) plus a substantial online catalog. The region has a heavy military presence (Naval Station Norfolk, JEB Little Creek, Naval Air Station Oceana, Joint Base Langley-Eustis), and TCC's student body reflects that — active-duty service members, military spouses, veterans, and military-affiliated dependents make up a significant share of enrollment.
+
+If you live in Hampton Roads and want to take a TCC course without committing to a grade, you're allowed to. TCC permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The cost depends entirely on whether you qualify for Virginia's senior tuition waiver or military-related programs.
+
+Here's what auditing actually costs at TCC, who can do it, and the practical step-by-step.
+
+## What auditing means at TCC
+
+Auditing is enrollment in a TCC course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is TCC-specific: what it actually costs, the application process, and the constraints unique to this college and region.
+
+## What it costs
+
+TCC applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior, non-military-affiliated auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The senior waiver exception** — if you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, TCC's audit policy notes that auditing is **free** for eligible seniors under Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). Tuition goes to zero; small mandatory fees may still apply.
+
+**Military and veteran considerations** — auditing is generally not eligible for military tuition assistance (TA), GI Bill benefits, or VA education programs. Those benefits are designed for credit-bearing enrollment toward a credential. If you want military or veteran benefits to cover your courses, you need to enroll for credit, not audit. The exception is some spouse-and-dependent benefits programs that may have different rules — check with TCC's military and veterans support office before assuming.
+
+## Who can audit at TCC
+
+TCC's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or live in the Hampton Roads service area to audit. Out-of-state rates apply where relevant, but the option is open.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences and competitive-admission program courses are the most likely to require this; standard lecture courses are usually open.
+
+## How to actually enroll as an auditor at TCC
+
+TCC's audit process is managed through ordinary course registration plus one extra notification to admissions. Here's the sequence:
+
+1. **Apply for admission to TCC** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application — you apply as a regular student.
+2. **Contact TCC admissions** by email at admissions@tcc.edu (or phone 757-822-1122) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal TCC enrollment system** when registration opens for the term. Most audit registrations are completed by admissions based on your email request; some terms require you to register through the student portal and then submit a separate audit-status form before the add/drop deadline.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before TCC's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, military TA, GI Bill, and most scholarships specifically exclude audit enrollment.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled at TCC and trying to maintain SAP for federal aid or VA benefits, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term. The deadline is usually around two weeks after the term starts.
+- **Some courses are not auditable.** Clinical placements, internships, capstone courses, and competitive-admission program courses (nursing clinical, dental hygiene, allied health practica) generally cannot be audited. The admissions office will flag these when you ask.
+- **Four campuses with different course mixes.** When you contact admissions, be specific about which section. Chesapeake, Norfolk, Portsmouth, and Virginia Beach each have different course concentrations; online and hybrid sections add another dimension. TCC's [session-timing menu](/blog/virginia-community-college-session-timing-guide) is also among the deepest in VCCS — 74 distinct start dates per term — so timing options are plentiful.
+
+## When auditing at TCC makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a Hampton Roads resident.** The Virginia senior waiver makes auditing essentially free, and TCC's catalog is the largest in southeastern Virginia. Try a humanities elective, a foreign language, a course in something you've always meant to study. Low-stakes structured learning.
+- **You're a military spouse or dependent waiting to use a transferred benefit.** If your benefit eligibility hasn't started yet but you want to begin coursework, auditing a few sections gives you exposure without committing the benefit allocation. Switch to credit when the benefit becomes available.
+- **You're already credentialed and want a refresh.** A retired sailor auditing a maritime-history course, a working IT professional auditing an updated cybersecurity class — auditing gives you the structure without unnecessary credit hours.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school applications, auditing a course you find interesting but risky avoids the GPA hit.
+
+## Where TCC sits compared to other VA community colleges
+
+TCC's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to peer VCCS colleges (like [Germanna](/blog/germanna-community-college-audit-class-guide) or [NOVA](/blog/nova-northern-virginia-community-college-audit-class-guide)) are mostly process detail. TCC's contact is admissions@tcc.edu / 757-822-1122; otherwise the path is the same.
+
+If you're shopping across multiple Virginia community colleges, TCC's main differentiators are catalog depth, deep session-timing menu (74 distinct start dates per term in fall 2026), and proximity to the Hampton Roads military installations. The military-affiliated student support is among the most developed in the VCCS system, even though military benefits don't cover audit enrollment.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at TCC across all four campuses and online, with the admissions contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Tidewater Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver and your benefit eligibility. If you're 60+ and a Virginia resident, it's effectively free. If you're not — including military and veteran auditors — it's full tuition without any of the credentials, financial-aid coverage, or military-benefit eligibility that credit enrollment provides.
+
+Either way, TCC admissions at admissions@tcc.edu (757-822-1122) is the right first contact. They'll confirm section availability across the four campuses and the online catalog, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/tennessee-community-college-session-timing-guide.mdx
+++ b/content/blog/tennessee-community-college-session-timing-guide.mdx
@@ -1,0 +1,102 @@
+# Tennessee Community College Sessions Explained: How TBR's 12 Colleges Use 8-Week, Mini-Mester, and Late-Start Formats
+
+Northeast State Community College's fall 2026 schedule lists **62 distinct start dates** in a single semester. That's not 62 sections — that's 62 different days a section can begin. Cleveland State has 28. Volunteer State has 25. Across the 12 colleges of the Tennessee Board of Regents (TBR), fall 2026 contains 33,074 individual section offerings spread across the entire term.
+
+The 16-week semester is the default at every TBR college, but it's surrounded by 8-week halves, mini-mesters, late-start sections, and summer sub-sessions. Most Tennessee community college students never realize how varied the menu is until they've already committed to a schedule that wastes the option value.
+
+Here's how session timing actually works in TBR, when each format helps, and how to find the right one before you register.
+
+## How TBR colleges structure session length
+
+TBR's 12 community colleges all run on the same fall–spring–summer rhythm, but the breadth of session-length options varies meaningfully across the system.
+
+**Northeast State (Blountville)** is the most session-diverse — 62 distinct start dates in fall 2026 alone. Full term, both 8-week halves, multiple mini-mesters, late-start sections weekly, and short-cycle workforce courses with their own date stacks.
+
+**Cleveland State** at 28 distinct start dates and **Volunteer State** at 25 are the next tier — strong 8-week, mini-mester, and rolling late-start coverage.
+
+**Pellissippi State, Chattanooga State, Roane State, and Walters State** typically run 10–20 distinct start dates per term — full term plus reliable 8-week splits and a handful of late-start sections.
+
+The smaller and rural TBR colleges (Columbia State, Dyersburg State, Jackson State, Motlow State, Nashville State, Southwest TN) tend toward leaner schedules — typically 5–12 distinct start dates per term. Still meaningful flexibility, just narrower than the urban colleges.
+
+If session diversity matters to your schedule, the colleges with deeper menus (Northeast State, Cleveland State, Volunteer State) make it easier than colleges with 3–6 distinct start dates.
+
+## The session formats you'll see at TBR colleges
+
+The general framework for these formats lives in our [community college sessions hub](/blog/community-college-sessions-explained); here's how each translates to TBR specifically.
+
+**Full-term (15 weeks).** TBR fall and spring both run 15 weeks plus finals. Every TBR college runs full-term, and most credit hours are taught in it.
+
+**8-week (Term A and Term B).** TBR formally publishes both halves at most colleges as "Term A" (first half) and "Term B" (second half). Each term has its own registration deadline, drop dates, and finals.
+
+**Mini-mester / Maymester / Wintermester.** Compressed 2–4 week sessions. Wintermester runs in early January at most TBR colleges; Maymester runs in mid-May after spring finals. Course content from a 3-credit class delivered in a few weeks of intensive meetings.
+
+**Late-start sections.** Standard sections that begin after the main term has started — often Term B sections dressed up, but sometimes 12-week sections that begin a few weeks into the regular semester.
+
+**Summer sessions.** TBR summer typically runs 10 weeks total, broken into Summer I (first 5 weeks), Summer II (second 5 weeks), and a full-summer 10-week option. Smaller catalogs but reliable gen-eds.
+
+**Dual-enrollment sections.** TBR has unusually large dual-enrollment programs — high-school students taking community college classes for joint credit. These run as a parallel session structure, often on the high school's calendar rather than the college's. If you're a non-dual-enrollment student, watch the section notes — dual-enrollment sections may not be open to general registration.
+
+## Workload math when sessions compress
+
+A 3-credit course is 3 credits regardless of session length. What changes is the weekly load.
+
+- 15-week full-term 3-credit class: roughly 9 hours per week (3 in-class + 6 outside).
+- 8-week Term A or Term B: roughly 18 hours per week for the same content.
+- 4-week Wintermester or Maymester: roughly 36 hours per week — practically a full-time job for a single course.
+
+Tennessee TBR students who try to stack a Maymester course with an existing summer enrollment are the most common overload-and-drop pattern. The compressed session isn't easier; it's the same total work in less calendar time.
+
+## Practical patterns that work
+
+A few sequencing moves work consistently for TBR students:
+
+**Stack Term A and Term B back-to-back.** Take Course A in Term A, finish it, then take Course B in Term B. You earn 6 credits over the same calendar weeks as one full-term course but never juggle both simultaneously. Most TBR colleges design ENGL 1010 + ENGL 1020, MATH 1530 + a follow-on, and US History pairs around exactly this pattern.
+
+**Use Wintermester for one focused course.** Pick something self-contained — a humanities elective, a public speaking course, a single-semester writing course. Don't pair it with a heavy spring schedule starting two weeks later.
+
+**Use summer to compress a degree.** TBR summer runs are smaller but reliably include the gen-ed core. One summer course shifts your graduation roughly a third of a semester earlier; two summer courses can shift it a full term.
+
+**Watch for late-start gen-eds when you withdraw mid-term.** If you drop a class in week 3 or 4, a Term B section starting in week 8 can replace those credits. Northeast State, Cleveland State, and Volunteer State publish the deepest late-start catalogs in TBR.
+
+If you're not sure how to fit sessions to your weekly availability, our [schedule-building guide](/blog/how-to-build-community-college-schedule) walks through the format-and-timing decisions, and the [hybrid format primer](/blog/hybrid-community-college-classes-explained) covers the in-person/online/hybrid dimension. Comparable session menus exist at peer state systems — [Maryland community college sessions](/blog/maryland-community-college-session-timing-guide) covers MD's 16-college lineup if you're considering a cross-state comparison.
+
+## How to find sessions on TBR college search tools
+
+This is where most practical confusion lives. TBR community college schedule tools surface "courses" but session-length information is buried in the date column.
+
+1. **Look at the start date column, not just the course code.** ENGL 1010 at Northeast State runs in 8+ different sessions per fall — full-term, both 8-week halves, multiple late-start variants. Course code is identical; only dates differ.
+2. **Filter by start date range.** Want a Term B section? Filter by start dates in mid-October. Wintermester typically late December or early January. Late-start: anything starting after the second week of term.
+3. **Check separate registration deadlines per session.** Term B and Wintermester sections each have their own registration cutoffs. Missing the main-term deadline doesn't necessarily mean you've missed everything.
+4. **Watch the part-of-term codes.** TBR colleges use codes like "1" (full term), "1A" (Term A), "1B" (Term B), "MM" (Mini-mester), "DE" (Dual Enrollment). Reading these saves you from accidentally registering for a section that doesn't fit your schedule.
+
+[Search Tennessee community college courses](/tn) to see what's actually open at the TBR college you're considering, and [browse all 12 TBR community colleges](/tn/colleges) to compare offerings.
+
+## Where session length and transfer credit intersect
+
+A common worry: do credits earned in compressed sessions transfer the same as full-term credits inside Tennessee or out of state?
+
+Yes, both ways. The [Tennessee Transfer Pathway](/tn/transfer) treats credits earned in 8-week, mini-mester, and summer sessions identically to full-term credits — transcript records the course, credits, and grade with no session-length notation. Receiving universities (UT system, TBR universities, private four-years) don't track session length and rarely ask. If a course transfers full-term, it transfers compressed.
+
+That's the strongest argument for session diversity: there's no penalty for compressing a degree timeline using shorter sessions, and there's a real penalty (lost time, lost momentum, financial-aid issues) for stretching a degree out.
+
+<ProductCallout
+  text="Community College Path indexes section-level data including start dates and session formats across all 12 TBR community colleges, so you can filter for 8-week, late-start, or Wintermester sections without scrolling through a college's full schedule."
+  feature="search"
+  label="Search TN Sections by Start Date"
+/>
+
+## Common Tennessee-specific mistakes
+
+- **Assuming all TBR colleges offer the same menu.** They don't. Northeast State's 62-distinct-start-date schedule is unusual; smaller TBR colleges run 5–12. Plan around your actual college's offerings.
+- **Overlapping Wintermester with the start of spring.** Wintermester ends roughly when spring begins. Many students underestimate the recovery week and start spring already burned out.
+- **Mixing a Maymester with summer enrollment.** Maymester typically runs the first half of May; if you also enroll in Summer I starting late May, you have approximately zero break between intense terms. Pick one.
+- **Accidentally registering for a dual-enrollment section.** Dual-enrollment sections at TBR colleges follow the high-school calendar and may not match the college's term dates. Read section notes before registering.
+- **Skipping summer because "I want a break."** A break is fine — just understand that one summer course can move your graduation a full term earlier; declining it is a real choice with a real cost.
+
+## The bottom line
+
+TBR's session menu is wider than most students realize and varies dramatically across the 12 colleges. Full-term is the default; 8-week (Term A/B), Wintermester, Maymester, and summer sub-sessions are the levers that compress a degree timeline.
+
+Use the menu deliberately. Look at start dates first. Watch the workload math when sessions compress. Treat 8-week stacking and summer terms as the main compression strategies — not heroic full-term overloads.
+
+The faster you understand which sessions exist at your TBR college, the more options you actually have when life shifts mid-term.

--- a/content/blog/virginia-community-college-session-timing-guide.mdx
+++ b/content/blog/virginia-community-college-session-timing-guide.mdx
@@ -1,0 +1,101 @@
+# Virginia Community College Sessions Explained: How VCCS's 23 Colleges Use 8-Week, Dynamic, and Late-Start Formats
+
+Tidewater Community College's fall 2026 schedule lists **74 distinct start dates** in a single semester. New River CC has 50. Blue Ridge CC has 48. Across the 23 colleges of the Virginia Community College System (VCCS), fall 2026 contains 26,236 individual section offerings spread across the entire term.
+
+VCCS has built one of the more session-flexible community college systems on the East Coast — the result of a deliberate adult-learner strategy and the system's heavy investment in dynamic-dated sections that can begin almost any week of the term. Most VCCS students never realize how varied the menu is until they've already enrolled in a section they could have structured better.
+
+Here's how session timing actually works in VCCS, when each format helps, and how to find the right one before you register.
+
+## How VCCS colleges structure session length
+
+The 23 colleges of VCCS run on the same fall–spring–summer rhythm but with significantly different breadth of session-length options.
+
+**Tidewater Community College (TCC)** is the most session-diverse — 74 distinct start dates in fall 2026 alone. Full-term, both 8-week halves, multiple sub-terms (12-week, 10-week), late-start sections weekly, and dynamic-dated workforce courses with their own date stacks.
+
+**New River CC (NRCC)** at 50 distinct start dates and **Blue Ridge CC (BRCC)** at 48 round out the top of the chart. Both publish deep 8-week and late-start coverage.
+
+The mid-tier — Northern Virginia (NOVA), Reynolds, John Tyler/Brightpoint, Central Virginia (CVCC), Germanna, Piedmont Virginia (PVCC) — typically run 20–40 distinct start dates per term. Strong 8-week coverage, reliable late-start sections most weeks of the term.
+
+The smaller and rural VCCS colleges typically run 8–18 distinct start dates per term. Still meaningful flexibility, just narrower than the urban colleges.
+
+If session diversity matters to your schedule, TCC, NRCC, and BRCC offer the deepest menus. Most other VCCS colleges run wide enough schedules that the standard sessions you'd want (8-week halves, mini-mester, summer) are reliably available.
+
+## The session formats at VCCS colleges
+
+The general framework lives in our [community college sessions hub](/blog/community-college-sessions-explained); here's the VCCS-specific translation.
+
+**Full-term (15 weeks).** VCCS fall and spring both run 15 weeks plus finals. Every VCCS college runs full-term, and most credit hours are taught in it.
+
+**8-week sessions (Session 1 and Session 2).** Two halves of the term. VCCS publishes both halves at most colleges as "8W1" or "Session 1" for the first half and "8W2" or "Session 2" for the second.
+
+**Dynamic-dated sections.** A VCCS hallmark — sections that begin on rolling dates rather than fixed session boundaries. These are common at TCC, NRCC, and BRCC. A dynamic section might run 14 weeks but start in week 3 of the term, or run 9 weeks starting mid-October. The course content and credits are unchanged; the calendar is shifted.
+
+**Late-start sections.** Standard sections beginning a few weeks after the regular term — often dynamic sections relabeled.
+
+**Summer sessions.** VCCS summer typically runs 10 weeks total, broken into Summer Term 1 (5 weeks), Summer Term 2 (5 weeks), and a full-summer 10-week parallel option. Smaller catalogs but reliable gen-ed coverage.
+
+**Workforce credit sections.** VCCS has a meaningful workforce-credit catalog (FastForward, certifications) that runs on its own date stacks. These can be credit-bearing and qualify for financial aid; check the section type before registering.
+
+## Workload math when sessions compress
+
+A 3-credit course is 3 credits regardless of session length. What changes is the weekly load.
+
+- 15-week full-term 3-credit class: roughly 9 hours per week (3 in-class + 6 outside).
+- 8-week Session 1 or Session 2: roughly 18 hours per week for the same content.
+- 4-week intensive (rare in VCCS, more common in summer): roughly 36 hours per week.
+- 12-week dynamic-dated section: similar to full-term, just shifted in calendar — workload is roughly 11 hours per week.
+
+VCCS students who try to stack a Session 1 course with a dynamic-dated 14-week section starting in week 3 are the most common overload-and-drop pattern. The compressed sections aren't easier; they're the same total work in less calendar time.
+
+## Practical patterns that work for VCCS students
+
+**Stack Session 1 + Session 2 to compress a year.** Take ENG 111 in Session 1 of fall, finish, then take ENG 112 in Session 2. You earn 6 credits over the same calendar weeks as one full-term course but never juggle both. TCC, NRCC, and BRCC have the deepest 8-week catalogs.
+
+**Use dynamic-dated sections when life forces a non-standard start.** If you can't enroll until week 3, a dynamic section that starts week 4 and runs 12 weeks gives you a full course without compressed workload. TCC publishes the deepest dynamic-dated catalog.
+
+**Use summer to compress a degree timeline.** VCCS summer runs are smaller but reliably include the gen-ed core. One summer course shifts your graduation date roughly a third of a semester earlier; two summer courses can shift it a full term.
+
+**Use late-start sections to recover from a dropped class.** If you withdraw from something in week 3, an 8-week Session 2 or a dynamic-dated 10-week section starting in week 6 can replace the credits.
+
+If you're not sure how to fit sessions to your weekly availability, our [schedule-building guide](/blog/how-to-build-community-college-schedule) walks through the mechanics. The [hybrid format primer](/blog/hybrid-community-college-classes-explained) covers in-person/online/hybrid format choice. If you're transferring out, the [VA guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers how compressed-session credits flow through the GAA. For a regional comparison, [Maryland community college sessions](/blog/maryland-community-college-session-timing-guide) covers MD's 16-college session menu — useful if you're choosing between VCCS and Maryland community colleges.
+
+## How to find sessions on VCCS college search tools
+
+VCCS uses PeopleSoft Campus Solutions across all 23 colleges. To find specific sessions:
+
+1. **Look at the start date column, not just the course code.** ENG 111 at TCC runs in 10+ different sessions per fall. Course code is identical; only dates differ.
+2. **Filter by start date range.** Want a Session 2 section? Filter for start dates in mid-October. Late-start: anything starting after the second week of term. Dynamic-dated sections: filter for non-standard start dates.
+3. **Check the part-of-term codes.** VCCS uses codes like "1" (full term), "8W1"/"8W2" (8-week halves), "DYN" (dynamic-dated), "5W1"/"5W2" (summer 5-week halves). Reading these saves you from accidentally registering for a session that doesn't fit.
+4. **Filter for credit vs. workforce.** VCCS publishes workforce-credit and continuing-education sections alongside credit sections at some colleges. Make sure you know which type you're enrolling in.
+
+[Search Virginia community college courses by start date and college](/va) to see what's actually open at the VCCS campus you're considering, and [browse all 23 VCCS colleges](/va/colleges) to compare offerings.
+
+## Transfer credit and session length
+
+A common worry: do credits earned in compressed sessions transfer the same as full-term credits within VCCS or out to four-year institutions?
+
+Yes. The [Virginia Guaranteed Admission Agreement](/blog/virginia-community-college-transfer-guaranteed-admission) and standard VCCS articulation treat credits earned in 8-week, dynamic, summer, and workforce-credit sections identically to full-term credits. The transcript records the course, credits, and grade with no session-length notation. Receiving universities (UVA, Virginia Tech, JMU, William & Mary, GMU, Old Dominion, VCU, ODU, etc.) don't track session length and rarely ask.
+
+That's the strongest argument for using session diversity: no penalty for compressing a degree timeline using shorter sessions, and a real penalty (lost time, momentum, financial-aid SAP issues) for stretching a degree out.
+
+<ProductCallout
+  text="Community College Path indexes section-level data including start dates and session formats across all 23 VCCS colleges. Filter for 8-week, late-start, dynamic-dated, or summer sections without scrolling through each college's full schedule."
+  feature="search"
+  label="Search VA Sections by Start Date"
+/>
+
+## Common VCCS-specific mistakes
+
+- **Assuming all VCCS colleges have the same menu.** They don't. TCC's 74-distinct-start-date schedule is unusual; smaller VCCS colleges run 8–18. Plan around your actual college's offerings.
+- **Stacking dynamic-dated sections that overlap.** A dynamic section starting week 3 plus a Session 1 ending week 8 creates a 5-week overlap. Read the dates before you register, not after.
+- **Late-registering for Session 2 without checking prereq chain status.** If a Session 2 course requires the Session 1 version, you can't take both simultaneously to "catch up." Read the prereq before you register — our [prereq chains explainer](/blog/prerequisite-chains-why-four-semester-plans-take-six) covers how to spot this in advance.
+- **Confusing credit, workforce-credit, and continuing-education sections.** VCCS publishes all three in the same search interface at some colleges. Workforce-credit qualifies for federal aid; continuing-ed often doesn't. Filter carefully.
+- **Skipping summer because "I want a break."** A break is fine — just understand that one summer course shifts your graduation a full term earlier; declining is a real cost.
+
+## The bottom line
+
+VCCS's session menu is wider than most students realize and varies dramatically across the 23 colleges. Full-term is the default; 8-week halves, dynamic-dated sections, late-start, and summer terms are the levers that compress a degree timeline. TCC, NRCC, and BRCC offer the deepest menus; smaller colleges run leaner but reliable schedules.
+
+Use the menu deliberately. Look at start dates first. Watch the workload math when sessions compress. Treat 8-week stacking, dynamic-dated sections, and summer terms as the main compression strategies, not heroic full-term overloads.
+
+The faster you understand which sessions exist at your VCCS college, the more options you actually have when life shifts mid-term.


### PR DESCRIPTION
## Pipeline run summary

Second batch from this week's pipeline. Detectors surfaced 132 candidates; this PR ships the next 10 in rankScore order, grouped by article type for review efficiency.

| Type | Count | Cluster |
|---|---|---|
| state-spoke (session-timing) | 6 | session-timing-guide |
| state-spoke (senior-waiver) | 1 | senior-waivers-guide |
| college-spoke (audit-at-college) | 3 | audit-at-college-guide |
| **Total** | **10** | |

After this batch:
- session-timing-guide: 1 → 7 spokes (MD, TN, MA, NY, NC, VA, CT)
- audit-at-college-guide: 1 → 4 spokes (Germanna, NOVA, Reynolds, TCC)
- senior-waivers-guide: gains NY (audit-only under § 6304(5))

## Articles

### Session-timing spokes (6, all sourced from real per-college start-date counts)

| Slug | Words | Anchor data |
|---|---|---|
| `tennessee-community-college-session-timing-guide` | 1471 | Northeast State 62 distinct start dates, 33,074 sections across 12 TBR colleges |
| `massachusetts-community-college-session-timing-guide` | 1331 | Middlesex 18, Greenfield 17 distinct start dates; 5,333 sections; MassCC's narrower-menu reality |
| `new-york-cuny-community-college-session-timing-guide` | 1443 | Queensborough 17, Hostos 13, BMCC 8; 5,775 sections; cross-campus winter/summer enrollment |
| `north-carolina-community-college-session-timing-guide` | 1557 | Central Piedmont 49, Martin 34, Guilford Tech 31; 53,631 sections; largest community college session catalog in the Southeast |
| `virginia-community-college-session-timing-guide` | 1518 | TCC 74, NRCC 50, BRCC 48; 26,236 sections; dynamic-dated VCCS sections |
| `connecticut-state-community-college-session-timing-guide` | 1491 | 55 distinct start dates system-wide; 12,713 sections; unified-system cross-campus enrollment after 2023 merger |

### Senior-waiver spoke (1)

| Slug | Words | Anchor |
|---|---|---|
| `new-york-cuny-senior-citizens-tuition-waiver` | 1420 | N.Y. Education Law § 6304(5); audit-only program at 7 CUNY-CCs; comparison to NJ/MD/MA/VA waivers |

### Audit-at-college spokes (3, sourced verbatim from `data/va/institutions.json#<college>.audit_policy`)

| Slug | Words | College | Contact |
|---|---|---|---|
| `nova-northern-virginia-community-college-audit-class-guide` | 1408 | NOVA | admissions@nvcc.edu |
| `reynolds-community-college-audit-class-guide` | 1354 | Reynolds | admissions@reynolds.edu |
| `tcc-tidewater-community-college-audit-class-guide` | 1432 | TCC | admissions@tcc.edu |

## Quality gates

| Gate | All 10 |
|---|---|
| G1 word count | ✅ all in range (state-spoke 1000–1800, college-spoke 800–1500) |
| G2 internal links | ✅ |
| G3 banned phrases | ✅ |
| G4 embedding similarity | ⚠️ skipped (no embeddings API in worktree) |
| G5 npm run build | ⚠️ worktree env can't reach Supabase; lint passes 0 errors |
| G6 BRIEF.md output block | ✅ |

### Iterative gate process

Round 1: the 6 session-timing spokes failed G2 ("spoke does not link to any sibling spoke") because none referenced the existing Maryland session-timing post. Round 2: added a one-sentence cross-state comparison link in each, all 10 then passed.

## Reviewer guidance

- The 6 session-timing posts share a structure (per-state distinct-start-date table → format menu → workload math → patterns → search-tool tips → transfer-credit note → mistakes → bottom line). Read MD as the template if you haven't already, then skim the 6 for state-specific accuracy.
- The 3 audit-at-college posts share a structure (audit definition → cost → eligibility → process steps → constraints → when it makes sense → comparison to peer VCCS colleges). Read Germanna as the template, then verify the campus-and-contact-specific details for NOVA/Reynolds/TCC against `data/va/institutions.json`.
- The NY senior-waiver is a standalone — read on its own merits.

## Reviewer checklist

- [ ] Spot-check 1–2 session-timing posts for fluff
- [ ] Verify per-state distinct-start-date counts cited (data/{state}/courses/)
- [ ] Verify audit_policy contact emails / phone numbers (data/va/institutions.json)
- [ ] Click internal links across the batch
- [ ] Confirm StateToolsCTA renders for state-spokes on Vercel preview
- [ ] If review-cadence flag is true (most are annual), add calendar reminders

## Next batch preview

After this lands, top remaining candidates by rankScore:
- GA senior-waiver state-spoke (still in queue after earlier prereq-bottleneck gate-fail)
- Remaining VA audit college-spokes (~18: BRCC, Brightpoint, CAMP, CVCC, etc.)
- NC audit college-spokes (~57)
- Remaining state-spokes for thinner clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)