### PR TITLE
blog: pipeline batch c — 4 senior-waiver + SC session + 5 VA audit spokes (10 total)

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -89,6 +89,56 @@
       "slug": "tcc-tidewater-community-college-audit-class-guide",
       "draftedAt": "2026-05-09T23:30:00Z",
       "trigger": "cluster-gap"
+    },
+    {
+      "slug": "connecticut-senior-citizens-ct-state-tuition-waiver",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "georgia-senior-citizens-tcsg-tuition-waiver",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "pennsylvania-senior-citizens-community-college-tuition-waiver",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "florida-senior-citizens-fcs-tuition-waiver",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "south-carolina-technical-college-session-timing-guide",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "blue-ridge-community-college-audit-class-guide",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "brightpoint-community-college-audit-class-guide",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "camp-paul-d-camp-community-college-audit-class-guide",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "central-virginia-community-college-audit-class-guide",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
+    },
+    {
+      "slug": "danville-community-college-audit-class-guide",
+      "draftedAt": "2026-05-10T01:00:00Z",
+      "trigger": "cluster-gap"
     }
   ]
 }

--- a/content/blog/blue-ridge-community-college-audit-class-guide.mdx
+++ b/content/blog/blue-ridge-community-college-audit-class-guide.mdx
@@ -1,0 +1,79 @@
+# How to Audit a Class at Blue Ridge Community College: Cost, Application, and Eligibility
+
+Blue Ridge Community College (BRCC) serves the Shenandoah Valley region of Virginia from its main campus in Weyers Cave plus the Augusta and Rockingham education centers. If you live in Augusta, Rockingham, or surrounding counties and want to take a BRCC course without committing to a grade, you're allowed to. BRCC permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The cost depends entirely on whether you qualify for Virginia's senior tuition waiver.
+
+Here's what auditing actually costs at BRCC, who can do it, and the practical step-by-step.
+
+## What auditing means at BRCC
+
+Auditing is enrollment in a BRCC course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is BRCC-specific: what it actually costs, the application process, and the constraints unique to this college and region.
+
+## What it costs
+
+BRCC applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The senior waiver exception** — if you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, BRCC's audit policy notes that auditing is **free** for eligible seniors under Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). Tuition goes to zero; small mandatory fees may still apply.
+
+If you're not eligible for the senior waiver, expect to pay full freight. If you are, BRCC's audit option is a strong deal in the Shenandoah Valley region — particularly given BRCC's strong rural and adult-learner focus.
+
+## Who can audit at BRCC
+
+BRCC's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or live in BRCC's service area to audit. Out-of-state rates apply where relevant, but the option is open.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences and competitive-admission program courses (nursing clinicals, certain allied health) are the most likely to require this; standard lecture courses in liberal arts and business are usually open.
+
+## How to actually enroll as an auditor at BRCC
+
+BRCC's audit process is managed through ordinary course registration plus one extra notification to admissions:
+
+1. **Apply for admission to BRCC** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application.
+2. **Contact BRCC admissions** by email at admissions@brcc.edu (or phone 540-234-9261) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal BRCC enrollment system** when registration opens for the term. Most audit registrations are completed by admissions based on your email request.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before BRCC's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled at BRCC and trying to maintain SAP for federal aid, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term.
+- **Some courses are not auditable.** Clinical placements, internships, capstone courses, and competitive-admission program courses generally cannot be audited. The admissions office will flag these when you ask.
+- **Multiple education centers.** BRCC's main campus is in Weyers Cave with additional Augusta and Rockingham centers. When you contact admissions, be specific about which section and location.
+
+## When auditing at BRCC makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a Shenandoah Valley resident.** The Virginia senior waiver makes auditing essentially free. Try a humanities elective, a foreign language, a course in something you've always meant to study. Low-stakes structured learning.
+- **You're a working adult considering a career change.** BRCC's audit option lets you sample courses in a new field — business, IT, allied health, education — before committing to the full program and the financial commitment that comes with credit enrollment.
+- **You're already credentialed and want a refresh.** A retired teacher auditing an updated education-policy seminar, a working accountant auditing a tax-law update — auditing gives you the structure without unnecessary credit hours.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school, auditing avoids the GPA hit.
+
+## Where BRCC sits compared to other VA community colleges
+
+BRCC's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to peer VCCS colleges (like [Germanna](/blog/germanna-community-college-audit-class-guide), [NOVA](/blog/nova-northern-virginia-community-college-audit-class-guide), [Reynolds](/blog/reynolds-community-college-audit-class-guide), or [TCC](/blog/tcc-tidewater-community-college-audit-class-guide)) are mostly process detail. BRCC's contact is admissions@brcc.edu / 540-234-9261; otherwise the path is the same.
+
+If you're shopping across multiple Virginia community colleges, BRCC's main differentiators are the rural Shenandoah Valley location and adult-learner focus. The catalog leans toward general academics, business, and allied health programs that fit the regional workforce. BRCC also has one of the deeper [VCCS session-timing menus](/blog/virginia-community-college-session-timing-guide) — 48 distinct start dates per term — giving auditors flexible options for fitting a course into a real schedule.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at BRCC across all locations and online, with the admissions contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Blue Ridge Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver. If you're 60+ and a Virginia resident, it's effectively free. If you're not, it's full tuition without any of the credentials or financial-aid eligibility — a real cost for the experience of structured learning without the grade.
+
+Either way, BRCC admissions at admissions@brcc.edu (540-234-9261) is the right first contact. They'll confirm section availability across BRCC's locations, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/brightpoint-community-college-audit-class-guide.mdx
+++ b/content/blog/brightpoint-community-college-audit-class-guide.mdx
@@ -1,0 +1,79 @@
+# How to Audit a Class at Brightpoint Community College: Cost, Application, and Eligibility
+
+Brightpoint Community College — formerly John Tyler Community College, renamed in 2022 — serves the Tri-Cities region south of Richmond from campuses in Chester and Midlothian plus an extensive online catalog. If you live in Chesterfield, Henrico, Petersburg, Hopewell, or surrounding counties and want to take a Brightpoint course without committing to a grade, you're allowed to. Brightpoint permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The cost depends entirely on whether you qualify for Virginia's senior tuition waiver.
+
+Here's what auditing actually costs at Brightpoint, who can do it, and the practical step-by-step.
+
+## What auditing means at Brightpoint
+
+Auditing is enrollment in a Brightpoint course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is Brightpoint-specific: what it actually costs, the application process, and the constraints unique to this college.
+
+## What it costs
+
+Brightpoint applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The senior waiver exception** — if you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, Brightpoint's audit policy notes that auditing is **free** for eligible seniors under Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). Tuition goes to zero; small mandatory fees may still apply.
+
+If you're not eligible for the senior waiver, expect to pay full freight.
+
+## Who can audit at Brightpoint
+
+Brightpoint's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or live in Brightpoint's service area to audit. Out-of-state rates apply where relevant, but the option is open.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences and competitive-admission program courses are the most likely to require this; standard lecture courses are usually open.
+
+## How to actually enroll as an auditor at Brightpoint
+
+Brightpoint's audit process is managed through ordinary course registration plus one extra notification to admissions:
+
+1. **Apply for admission to Brightpoint** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application.
+2. **Contact Brightpoint admissions and records** by email at admissionsandrecords@brightpoint.edu (or phone 804-796-4000) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal Brightpoint enrollment system** when registration opens for the term. Most audit registrations are completed by the admissions and records office based on your email request.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before Brightpoint's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled and trying to maintain SAP for federal aid, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term.
+- **Some courses are not auditable.** Clinical placements, internships, capstone courses, and competitive-admission program courses generally cannot be audited.
+- **Two campuses plus online.** Chester and Midlothian have different course concentrations; the online and hybrid catalog adds another dimension. When you contact admissions and records, be specific about which section.
+
+## When auditing at Brightpoint makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a Tri-Cities or south-of-Richmond resident.** The Virginia senior waiver makes auditing essentially free. Try a humanities elective, a foreign language, a course in something you've always meant to study. Low-stakes structured learning.
+- **You're considering a career change to a Brightpoint program.** Audit one course in the program before committing to the full sequence. Brightpoint's programs span business, IT, allied health, engineering tech, and liberal arts; an audit course gives you a real preview.
+- **You're already credentialed and want a professional refresh.** A retired engineer auditing an updated CAD course, a working accountant auditing a tax-law update — auditing gives you the structure without unnecessary credit hours.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school, auditing avoids the GPA hit.
+
+## Where Brightpoint sits compared to other VA community colleges
+
+Brightpoint's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to peer VCCS colleges (like [Germanna](/blog/germanna-community-college-audit-class-guide), [NOVA](/blog/nova-northern-virginia-community-college-audit-class-guide), [Reynolds](/blog/reynolds-community-college-audit-class-guide), or [TCC](/blog/tcc-tidewater-community-college-audit-class-guide)) are mostly process detail. Brightpoint's contact is admissionsandrecords@brightpoint.edu / 804-796-4000.
+
+If you're shopping across multiple Virginia community colleges, Brightpoint's main differentiators are the Tri-Cities and south-of-Richmond location and program concentrations in business, IT, and allied health. Combined with [VCCS's session-timing menu](/blog/virginia-community-college-session-timing-guide) — Brightpoint runs a strong supply of 8-week and late-start sections — auditors have flexible options for fitting a course into a real schedule.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at Brightpoint across both campuses and online, with the admissions contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Brightpoint Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver. If you're 60+ and a Virginia resident, it's effectively free. If you're not, it's full tuition without any of the credentials or financial-aid eligibility — a real cost for the experience of structured learning without the grade.
+
+Either way, Brightpoint admissions and records at admissionsandrecords@brightpoint.edu (804-796-4000) is the right first contact. They'll confirm section availability across the Chester and Midlothian campuses and the online catalog, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/camp-paul-d-camp-community-college-audit-class-guide.mdx
+++ b/content/blog/camp-paul-d-camp-community-college-audit-class-guide.mdx
@@ -1,0 +1,80 @@
+# How to Audit a Class at Paul D. Camp Community College: Cost, Application, and Eligibility
+
+Paul D. Camp Community College serves the Western Tidewater region of Virginia from campuses in Franklin, Hobbs Hampton Roads (Suffolk), and Smithfield. If you live in Franklin, Suffolk, Smithfield, or surrounding counties and want to take a Camp course without committing to a grade, you're allowed to. Camp permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The cost depends entirely on whether you qualify for Virginia's senior tuition waiver.
+
+Here's what auditing actually costs at Camp, who can do it, and the practical step-by-step.
+
+## What auditing means at Camp
+
+Auditing is enrollment in a Camp course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is Camp-specific: what it actually costs, the application process, and the constraints unique to this college.
+
+## What it costs
+
+Camp applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The senior waiver exception** — if you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, Camp's audit policy notes that auditing is **free** for eligible seniors under Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). Tuition goes to zero; small mandatory fees may still apply.
+
+If you're not eligible for the senior waiver, expect to pay full freight. If you are, Camp's audit option is one of the more accessible deals in the Western Tidewater region — particularly given Camp's smaller-college, adult-learner-friendly profile.
+
+## Who can audit at Camp
+
+Camp's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or live in Camp's service area to audit. Out-of-state rates apply where relevant, but the option is open.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences and certain technical-program courses are the most likely to require this; standard lecture courses are usually open.
+
+## How to actually enroll as an auditor at Camp
+
+Camp's audit process is managed through ordinary course registration plus one extra notification to admissions:
+
+1. **Apply for admission to Camp** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application.
+2. **Contact Camp admissions** by email at info@pdc.edu (or phone 757-569-6700) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal Camp enrollment system** when registration opens for the term. Most audit registrations are completed by admissions based on your email request.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before Camp's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled and trying to maintain SAP for federal aid, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term.
+- **Some courses are not auditable.** Clinical placements, internships, capstone courses, and competitive-admission program courses generally cannot be audited.
+- **Multiple campuses with different course mixes.** Franklin and Hobbs Hampton Roads (Suffolk) campuses each have different course concentrations. When you contact admissions, be specific about which section and location.
+- **Smaller catalog than larger VCCS colleges.** Camp's catalog is narrower than NOVA's or TCC's by design. Some specific courses may only run once a term or once a year — plan ahead.
+
+## When auditing at Camp makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a Western Tidewater or Hampton Roads-adjacent resident.** The Virginia senior waiver makes auditing essentially free. Try a humanities elective, a course in something you've always meant to study.
+- **You prefer smaller class sizes.** Camp's smaller-college profile means many sections have under 20 students — an unusual benefit for an auditor who wants real instructor access and discussion-based learning.
+- **You're considering a career change to a Camp program.** Audit one course in the program before committing to the full sequence. Camp's programs span general academics, business, IT, and several technical workforce paths.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school, auditing avoids the GPA hit.
+
+## Where Camp sits compared to other VA community colleges
+
+Camp's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to peer VCCS colleges (like [Germanna](/blog/germanna-community-college-audit-class-guide), [NOVA](/blog/nova-northern-virginia-community-college-audit-class-guide), [Reynolds](/blog/reynolds-community-college-audit-class-guide), or [TCC](/blog/tcc-tidewater-community-college-audit-class-guide)) are mostly process detail. Camp's contact is info@pdc.edu / 757-569-6700.
+
+If you're shopping across multiple Virginia community colleges, Camp's main differentiators are the smaller scale, the Western Tidewater location bridging rural and Hampton Roads communities, and the more intimate class sizes. The catalog leans toward general academics and a focused set of workforce programs — narrower than the urban VCCS colleges but with more individual instructor attention.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at Camp across all campuses and online, with the admissions contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Paul D. Camp Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver. If you're 60+ and a Virginia resident, it's effectively free. If you're not, it's full tuition without any of the credentials or financial-aid eligibility — a real cost for the experience of structured learning without the grade.
+
+Either way, Camp admissions at info@pdc.edu (757-569-6700) is the right first contact. They'll confirm section availability across the Franklin and Hobbs Hampton Roads campuses, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/central-virginia-community-college-audit-class-guide.mdx
+++ b/content/blog/central-virginia-community-college-audit-class-guide.mdx
@@ -1,0 +1,79 @@
+# How to Audit a Class at Central Virginia Community College: Cost, Application, and Eligibility
+
+Central Virginia Community College (CVCC) serves the Lynchburg region from its main campus in Lynchburg plus the Bedford and Amherst centers. If you live in Lynchburg, Bedford, Amherst, Campbell, Appomattox, or surrounding counties and want to take a CVCC course without committing to a grade, you're allowed to. CVCC permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The cost depends entirely on whether you qualify for Virginia's senior tuition waiver.
+
+Here's what auditing actually costs at CVCC, who can do it, and the practical step-by-step.
+
+## What auditing means at CVCC
+
+Auditing is enrollment in a CVCC course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is CVCC-specific: what it actually costs, the application process, and the constraints unique to this college.
+
+## What it costs
+
+CVCC applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The senior waiver exception** — if you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, CVCC's audit policy notes that auditing is **free** for eligible seniors under Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). Tuition goes to zero; small mandatory fees may still apply.
+
+If you're not eligible for the senior waiver, expect to pay full freight.
+
+## Who can audit at CVCC
+
+CVCC's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or live in CVCC's service area to audit. Out-of-state rates apply where relevant, but the option is open.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences and competitive-admission program courses are the most likely to require this; standard lecture courses are usually open.
+
+## How to actually enroll as an auditor at CVCC
+
+CVCC's audit process is managed through ordinary course registration plus one extra notification to student records:
+
+1. **Apply for admission to CVCC** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application.
+2. **Contact CVCC's student records office** by email at studentrecords@centralvirginia.edu (or phone 434-832-7633) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal CVCC enrollment system** when registration opens for the term. Most audit registrations are completed by student records based on your email request.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before CVCC's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled and trying to maintain SAP for federal aid, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term.
+- **Some courses are not auditable.** Clinical placements, internships, capstone courses, and competitive-admission program courses (CVCC's nursing and allied health programs in particular) generally cannot be audited.
+- **Multiple campuses.** Lynchburg main campus plus Bedford and Amherst centers each have different course concentrations. When you contact student records, be specific about which section and location.
+
+## When auditing at CVCC makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a central Virginia resident.** The Virginia senior waiver makes auditing essentially free. Try a humanities elective, a foreign language, a course in something you've always meant to study.
+- **You're considering a career change.** CVCC's audit option lets you sample courses in a new field — business, IT, allied health, education, engineering tech — before committing to the full program and the financial commitment that comes with credit enrollment.
+- **You're already credentialed and want a refresh.** A retired teacher auditing an updated education course, a working accountant auditing a tax-law update — auditing gives you the structure without unnecessary credit hours.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school, auditing avoids the GPA hit.
+
+## Where CVCC sits compared to other VA community colleges
+
+CVCC's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to peer VCCS colleges (like [Germanna](/blog/germanna-community-college-audit-class-guide), [NOVA](/blog/nova-northern-virginia-community-college-audit-class-guide), [Reynolds](/blog/reynolds-community-college-audit-class-guide), [TCC](/blog/tcc-tidewater-community-college-audit-class-guide), [BRCC](/blog/blue-ridge-community-college-audit-class-guide), or [Brightpoint](/blog/brightpoint-community-college-audit-class-guide)) are mostly process detail. CVCC's contact is studentrecords@centralvirginia.edu / 434-832-7633.
+
+If you're shopping across multiple Virginia community colleges, CVCC's main differentiators are the central Virginia location and program concentrations in business, IT, allied health, and engineering tech. CVCC's catalog is moderate-sized — narrower than NOVA's or TCC's but broader than Camp's. Combined with [VCCS's session-timing menu](/blog/virginia-community-college-session-timing-guide), CVCC offers reasonable flexibility for fitting a course into a real schedule.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at CVCC across all campuses and online, with the student records contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Central Virginia Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver. If you're 60+ and a Virginia resident, it's effectively free. If you're not, it's full tuition without any of the credentials or financial-aid eligibility — a real cost for the experience of structured learning without the grade.
+
+Either way, CVCC student records at studentrecords@centralvirginia.edu (434-832-7633) is the right first contact. They'll confirm section availability across the Lynchburg main campus and Bedford and Amherst centers, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/connecticut-senior-citizens-ct-state-tuition-waiver.mdx
+++ b/content/blog/connecticut-senior-citizens-ct-state-tuition-waiver.mdx
@@ -1,0 +1,88 @@
+# Connecticut Senior Citizens at CT State Community College: How the 62+ Audit Program Actually Works
+
+If you're 62 or older and a Connecticut resident, you can audit courses at any campus of CT State Community College tuition-free under Connecticut General Statutes § 10a-27. The unified-system structure that emerged from the 2023 community college merger means the program runs across all 12 former colleges as a single audit benefit — your eligibility doesn't depend on which campus you pick.
+
+The catch — same as most state senior-audit programs — is in the word "audit." Connecticut's senior tuition waiver doesn't give you credit toward a degree. It gives you a structured seat in a CT State classroom, free of tuition, on a space-available basis.
+
+Here's what the program actually covers, what it doesn't, and how to use it without surprises.
+
+## The basic rule
+
+Under CGS § 10a-27, Connecticut residents aged 62 and older may take courses at public institutions of higher education tuition-free on a space-available basis. At CT State Community College — the unified system that absorbed 12 formerly independent community colleges in 2023 — the program runs as an **audit-only** benefit. You attend lectures, participate in discussion if the instructor allows, but you don't receive a grade or course credit on your transcript.
+
+There's no statutory income test. No retirement test. The hard requirements are (a) age 62+, (b) Connecticut residency, and (c) the section being available when senior registration opens.
+
+The age threshold is two years higher than the most generous regional senior-waiver programs — [Massachusetts at age 60](/blog/massachusetts-senior-citizens-community-college-tuition-waiver), [Maryland at age 60](/blog/maryland-senior-citizens-community-college-tuition-waiver), and [New Jersey at age 65](/blog/new-jersey-senior-citizens-county-college-tuition-waiver) bracket the regional comparison. CT's 62 sits between MA/MD and NJ.
+
+## What the waiver does *not* cover
+
+This is where most surprises come from. The waiver waives tuition. It does not waive:
+
+- **Mandatory student fees.** CT State campuses charge student services fees, technology fees, lab fees for science courses, and similar mandatory charges on top of tuition. For a 3-credit course, fees can run $100–$300 depending on the campus and course type. Tuition is the largest line item but not the only one.
+- **Course materials.** Textbooks, online access codes, and lab supplies aren't covered.
+- **Credit enrollment.** This is the biggest constraint. If you want a course to count toward a degree or appear on your transcript with a grade, you must enroll as a regular credit-paying student. The senior waiver only covers audit.
+- **Continuing-education and workforce courses.** CT State runs separate continuing-education catalogs at most campuses; these typically aren't covered by § 10a-27 even if the audit format is offered.
+
+A useful mental model: the program is for intellectual engagement and structured learning. It's not a path to credentials.
+
+## "Space available" — what it means at CT State
+
+Senior audit registration at CT State campuses opens **after** matriculated students register for the term. That's the law's tradeoff: tuition is free, but you don't displace a paying student.
+
+In practice across the unified system:
+
+- **Popular gen-ed sections fill fastest.** ENG 101, MAT 100, PSY 100. By the time senior registration opens, these are often closed.
+- **Online and asynchronous sections fill across all demographics.** Working students grab them first.
+- **Larger campuses (Gateway, Manchester, Norwalk, Capital, Middlesex)** have the deepest section catalogs but also the most competition for popular sections.
+- **Smaller campuses (Asnuntuck, Quinebaug Valley, Tunxis, Three Rivers, Housatonic, Northwestern, Naugatuck Valley)** have narrower in-person catalogs but the same access to system-wide online and hybrid sections.
+- **Niche electives, morning sections, and 8-week 2nd-half courses** tend to have meaningful availability.
+- **Summer terms** have shorter catalogs but less competition for seats. CT State's [session-timing menu](/blog/connecticut-state-community-college-session-timing-guide) covers when each format runs.
+
+Each CT State campus sets its own senior audit registration date — typically a few days to a week after general registration opens. Email or call the registrar at the campus you're considering and ask exactly when senior auditors can register, plus what one-time paperwork (proof of CT residency, age verification) is needed.
+
+## Practical constraints
+
+A few things worth knowing:
+
+- **You're enrolling at CT State, not at a specific former college.** Since the 2023 merger, CT State is a single accredited institution. Your audit application is to CT State Community College; you pick a campus for in-person sections but can register for online sections offered system-wide.
+- **Registration is per-term, not annual.** Re-register each term you want to audit.
+- **You can't switch from audit to credit mid-term.** Audit status is locked once registration closes.
+- **Some courses are not auditable.** Clinical placements, internships, and certain studio art or competitive-admission program courses generally cannot be audited.
+- **No financial aid for audit.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment.
+
+## Where CT's program compares to neighboring states
+
+Senior tuition waivers exist in [most states with public community colleges](/blog/free-community-college-classes-for-seniors), and Connecticut sits in the middle of the regional spectrum:
+
+- [Massachusetts](/blog/massachusetts-senior-citizens-community-college-tuition-waiver) waives tuition at age 60 and covers credit and audit equally.
+- [Maryland](/blog/maryland-senior-citizens-community-college-tuition-waiver) waives at age 60 with no income cap, covering credit and audit.
+- [New Jersey](/blog/new-jersey-senior-citizens-county-college-tuition-waiver) waives at age 65 but covers credit enrollment, not just audit — making it the most generous for credentials.
+- [New York CUNY](/blog/new-york-cuny-senior-citizens-tuition-waiver) at age 60 is audit-only, structurally similar to CT.
+- [Virginia](/blog/virginia-senior-citizens-community-college-free-tuition) at age 60 covers audit free; credit enrollment requires income below ~$29k.
+
+If you're a Connecticut resident curious about credit-bearing community college, you'd pay regular CT State tuition (which is among the lower in the region); the senior waiver is specifically for audit. If credentials matter and you have flexibility, MA or NJ may have better economics depending on age.
+
+## How to actually enroll
+
+The process is shorter than most people expect:
+
+1. **Pick a CT State campus.** Browse all 12 former-college campuses to compare locations, course offerings, and term schedules.
+2. **Apply as a non-degree senior auditor.** CT State has a streamlined non-degree application — typically online, no transcripts required, completed once. Mention you're applying under CGS § 10a-27 for senior audit.
+3. **Provide proof of CT residency and age** when prompted. Driver's license or state ID usually suffices.
+4. **Wait for senior registration to open.** Each campus publishes the senior registration date for upcoming terms.
+5. **Pick courses with backups.** Have a first choice and at least one fallback. Popular gen-eds may be closed by the time your window opens. [Search CT State courses across all campuses](/ct) to see current sections and seats.
+6. **Pay any remaining fees.** Tuition is zero. Mandatory student fees and course materials are still on you.
+
+<ProductCallout
+  text="Community College Path indexes course offerings across all 12 CT State campuses. Search for a section or browse a campus catalog to see what's running this term."
+  feature="search"
+  label="Search CT State Courses"
+/>
+
+## The bottom line
+
+Connecticut's senior tuition waiver under § 10a-27 is a real benefit with a specific scope: audit-only enrollment at any CT State campus, free of tuition, on a space-available basis for residents 62+. It's the right program if you want structured learning without a credential. It's the wrong program if you want credits toward a degree — for that, regular CT State tuition (or out-of-state alternatives in MA/MD/NJ) is the path.
+
+For audit, CT State's unified system is one of the simpler ways to navigate a senior-waiver program in the region. Apply as non-degree, register after matriculated students, and plan around fees and materials — those don't go to zero, but tuition does.
+
+Either way, the registrar at the CT State campus closest to you is the right first contact. They'll confirm section availability, walk you through one-time residency-and-age verification, and tell you exactly when senior registration opens for the term you want.

--- a/content/blog/danville-community-college-audit-class-guide.mdx
+++ b/content/blog/danville-community-college-audit-class-guide.mdx
@@ -1,0 +1,81 @@
+# How to Audit a Class at Danville Community College: Cost, Application, and Eligibility
+
+Danville Community College (DCC) serves the Southside Virginia region from its main campus in Danville plus the Halifax-South Boston regional site. If you live in Danville, Pittsylvania, Halifax, or surrounding counties and want to take a DCC course without committing to a grade, you're allowed to. DCC permits auditing — sitting in on a class without earning credit, taking exams, or submitting graded coursework. The cost depends entirely on whether you qualify for Virginia's senior tuition waiver.
+
+Here's what auditing actually costs at DCC, who can do it, and the practical step-by-step.
+
+## What auditing means at DCC
+
+Auditing is enrollment in a DCC course where you attend lectures, participate in discussion if you choose, and have access to the instructor — but you don't take exams, don't submit graded work, and don't receive a grade or course credit on your transcript. The course shows on your record as "AU" rather than a letter grade.
+
+The general explainer on what auditing means is in our [hub article on auditing a class](/blog/what-does-audit-a-class-mean). What follows is DCC-specific: what it actually costs, the application process, and the constraints unique to this college and region.
+
+## What it costs
+
+DCC applies the **same tuition and fees to audit students as to credit students**. There is no audit discount in the standard cost model. A 3-credit class that costs roughly $500 in tuition and fees for a credit student costs roughly $500 to audit.
+
+For most non-senior auditors, that price means auditing is a deliberate choice. You're paying real tuition for the experience of sitting in the class without the grade pressure or financial-aid eligibility.
+
+**The senior waiver exception** — if you're 60 or older and meet the residency and income criteria under Va. Code § 23.1-905, DCC's audit policy notes that auditing is **free** for eligible seniors under Virginia's [60+ senior tuition waiver](/blog/virginia-senior-citizens-community-college-free-tuition). Tuition goes to zero; small mandatory fees may still apply.
+
+If you're not eligible for the senior waiver, expect to pay full freight.
+
+## Who can audit at DCC
+
+DCC's posted criteria are open compared to peer institutions:
+
+- **Minimum age 18.** No upper age limit.
+- **Residency not required.** You don't need to be a Virginia resident or live in DCC's service area to audit. Out-of-state rates apply where relevant, but the option is open.
+- **Senior discount available** for residents 60+ — see the waiver detail above.
+- **Instructor approval may be required.** Some instructors require an in-person conversation or written request before approving an auditor. Lab sciences and certain technical-program courses (welding, automotive, HVAC) are the most likely to require this; standard lecture courses are usually open.
+
+## How to actually enroll as an auditor at DCC
+
+DCC's audit process is managed through ordinary course registration plus one extra notification to admissions:
+
+1. **Apply for admission to DCC** if you don't already have a student record. Use the VCCS application portal at apply.vccs.edu. There's no separate "auditor" application.
+2. **Contact DCC admissions** by email at admissions@danville.edu (or phone 434-797-8467) before you register. Tell them which course (course code + section number) and which campus or online section you want to audit. They'll confirm the section is open to auditors and walk you through any instructor-approval step.
+3. **Register through the normal DCC enrollment system** when registration opens for the term. Most audit registrations are completed by admissions based on your email request.
+4. **Pay tuition and fees** by the published deadline. If you're a senior using the waiver, complete the waiver paperwork at the same time. If not, you pay credit-equivalent rates.
+5. **Attend the course.** Once enrolled as an auditor, you can sit in throughout the term. If you change your mind and want to switch to credit (or the reverse), the request must be filed before DCC's add/drop deadline — typically the end of the second week.
+
+## Practical constraints
+
+A few things worth knowing before you commit:
+
+- **Financial aid does not cover audited courses.** Federal aid, state grants, and most scholarships specifically exclude audit enrollment.
+- **Audit courses don't count toward financial-aid satisfactory academic progress.** If you're already enrolled and trying to maintain SAP for federal aid, an audit course doesn't add to your credit total.
+- **Switching audit-to-credit (or credit-to-audit) is a hard deadline.** Miss the add/drop window and your registration is locked in for the term.
+- **Some courses are not auditable.** Clinical placements, internships, capstone courses, and competitive-admission program courses generally cannot be audited.
+- **Multiple campuses.** Danville main campus plus the Halifax-South Boston regional site each have different course concentrations. When you contact admissions, be specific about which section and location.
+- **Smaller catalog than urban VCCS colleges.** DCC's catalog is narrower than NOVA's or TCC's by design. Some specific courses may only run once a term or once a year — plan ahead.
+
+## When auditing at DCC makes sense
+
+A few situations where it works well:
+
+- **You're 60+ and a Southside Virginia resident.** The Virginia senior waiver makes auditing essentially free. Try a humanities elective, a foreign language, a course in something you've always meant to study.
+- **You prefer smaller class sizes.** DCC's smaller-college profile means many sections have under 25 students — an unusual benefit for an auditor who wants real instructor access and discussion-based learning.
+- **You're considering a workforce or technical program career change.** DCC has a strong workforce-program focus (welding, advanced manufacturing, automotive, healthcare). Audit one course in the program area before committing to the full sequence.
+- **You're already credentialed and want a refresh.** A retired skilled tradesperson auditing an updated welding-techniques course, a working healthcare professional auditing a continuing-education topic — auditing gives you the structure without unnecessary credit hours.
+- **You want a class without GPA exposure.** If your GPA matters for scholarships, transfer admissions, or graduate school, auditing avoids the GPA hit.
+
+## Where DCC sits compared to other VA community colleges
+
+DCC's audit policy is typical for the [VCCS system](/va/colleges) — open eligibility, same-cost for non-seniors, free for waiver-eligible seniors, instructor-approval optional. The differences compared to peer VCCS colleges (like [Germanna](/blog/germanna-community-college-audit-class-guide), [NOVA](/blog/nova-northern-virginia-community-college-audit-class-guide), [Reynolds](/blog/reynolds-community-college-audit-class-guide), [TCC](/blog/tcc-tidewater-community-college-audit-class-guide), [BRCC](/blog/blue-ridge-community-college-audit-class-guide), [Brightpoint](/blog/brightpoint-community-college-audit-class-guide), or [CVCC](/blog/central-virginia-community-college-audit-class-guide)) are mostly process detail. DCC's contact is admissions@danville.edu / 434-797-8467.
+
+If you're shopping across multiple Virginia community colleges, DCC's main differentiators are the Southside Virginia location, the smaller-college class sizes, and the strong workforce-program emphasis. The catalog leans toward general academics, healthcare, advanced manufacturing, and skilled trades — narrower than urban VCCS colleges but with focused depth in areas DCC has invested in for the regional workforce.
+
+If you want to know how transfer credits would work afterward, our [Virginia transfer guaranteed-admission explainer](/blog/virginia-community-college-transfer-guaranteed-admission) covers what credit enrollment unlocks vs. audit.
+
+<ProductCallout
+  text="Community College Path lists every audit-eligible course at DCC across all locations and online, with the admissions contact and last-verified policy date."
+  feature="colleges"
+  label="See VA Community Colleges"
+/>
+
+## The bottom line
+
+Auditing at Danville Community College is allowed, the process is straightforward, and the cost depends entirely on the senior waiver. If you're 60+ and a Virginia resident, it's effectively free. If you're not, it's full tuition without any of the credentials or financial-aid eligibility — a real cost for the experience of structured learning without the grade.
+
+Either way, DCC admissions at admissions@danville.edu (434-797-8467) is the right first contact. They'll confirm section availability across the Danville and Halifax-South Boston locations, walk you through any instructor-approval step, and tell you exactly when the add/drop deadline closes for the term you want.

--- a/content/blog/florida-senior-citizens-fcs-tuition-waiver.mdx
+++ b/content/blog/florida-senior-citizens-fcs-tuition-waiver.mdx
@@ -1,0 +1,89 @@
+# Florida Senior Citizens at FCS Colleges: How the 60+ Tuition Waiver Actually Works (And Why Credit Doesn't Count Toward Graduation)
+
+If you're 60 or older and a Florida resident, the Florida College System (FCS) — 28 state colleges spread across the state — must waive tuition and fees on a space-available basis under FL Stat. § 1009.26(4). Florida's program is unusual among regional senior-waiver programs in two ways: it covers fees in addition to tuition (most state programs cover tuition only), but the credit you earn this way **doesn't count toward graduation**.
+
+That second clause is a meaningful constraint that catches many Florida 60+ residents off guard. Here's what the program actually covers, what it doesn't, and how to use it without surprises.
+
+## The basic rule
+
+Under FL Stat. § 1009.26(4), Florida residents aged 60 and older may have tuition and fees waived at FCS institutions for credit courses on a space-available basis. The statute leaves the specific fees waivable up to each college's discretion — most FCS colleges waive both tuition and student fees for senior enrollees, but coverage of lab fees, technology fees, and program-specific fees varies.
+
+The unique constraint: **credit earned this way does not apply toward graduation requirements**. You can attend a credit-bearing course, complete the work, receive a grade, and have the course on your transcript — but it can't be counted toward an associate degree, certificate, or other FCS credential. If you want a credential, you'd need to enroll as a regular fee-paying student.
+
+That makes Florida's program functionally similar to audit-only programs in [North Carolina](/blog/north-carolina-senior-citizens-community-colleges) or [South Carolina](/blog/south-carolina-senior-citizens-technical-colleges) — but with the structural difference that you receive grades and credit hours on your transcript, just not credit hours that satisfy degree requirements.
+
+The hard requirements are (a) age 60+, (b) Florida residency, and (c) the section being available when senior registration opens.
+
+## What the waiver does *not* cover
+
+This is where most surprises come from:
+
+- **Some specific fees.** FCS colleges have discretion over which fees are waived. Most waive student services and technology fees; some don't waive lab fees or specialized program fees. Check with the specific college's admissions office before assuming the full bill goes to zero.
+- **Course materials.** Textbooks, online access codes, and lab supplies aren't covered.
+- **Credit toward an FCS credential.** This is the biggest constraint, and the one most people don't anticipate. Senior-waiver enrollment doesn't count toward an associate degree at the FCS college you're attending.
+- **Continuing-education and workforce training programs.** Some FCS colleges run separate continuing-ed catalogs that may not be covered by the waiver.
+
+A useful mental model: the program is for intellectual engagement and structured learning at low or zero out-of-pocket cost. It's not a path to a credentialed Florida community college degree.
+
+## Where the "doesn't count toward graduation" rule matters most
+
+For some 60+ Florida residents, the no-graduation-credit rule doesn't matter. Examples:
+
+- **Personal enrichment learners.** Auditing or attending courses for the experience of learning, not for the credential.
+- **Career professionals seeking refresh.** Attending courses to update skills (a retired engineer auditing updated CAD courses, a working accountant auditing a tax-law update).
+- **Already-credentialed residents.** Someone with a bachelor's or graduate degree taking community college courses for personal interest — credit-toward-graduation isn't the goal.
+
+For other 60+ Florida residents, the rule does matter. Examples:
+
+- **Residents transitioning to a new career who want a credential.** The waiver provides cost-free coursework but not a credential. To earn a credential, you'd pay regular tuition.
+- **Residents looking to transfer to a Florida public university (UF, FSU, UCF, USF, FIU, etc.).** Florida has a strong [SCNS-based transfer system](/blog/florida-community-college-transfer-credit-guide) — but credit earned under the senior waiver doesn't count toward an associate degree, which means the 2+2 articulation guarantee may not apply. Transfer is still possible, but the path is different.
+
+If credentialed enrollment matters to you, the senior waiver may not be the right vehicle. Pay regular FCS tuition (which is among the lowest in the country) for the credentialed path; use the waiver for non-credentialed structured learning.
+
+## "Space available" — what it actually means at FCS colleges
+
+Senior auditors register **after** matriculated students. In practice across the 28 FCS colleges:
+
+- **Popular gen-ed sections fill fastest.** ENC 1101, MAC 1105, BSC 1010, PSY 2012.
+- **Online and asynchronous sections fill across all demographics.**
+- **Larger urban FCS colleges** (Miami Dade, Valencia, Broward, Palm Beach State, Hillsborough, Tallahassee) publish the deepest catalogs.
+- **Niche electives, morning sections, and second-half-of-semester courses** tend to have meaningful availability.
+- **Summer terms** have shorter catalogs but less competition for seats.
+
+Each FCS college sets its own senior registration date — typically a few days to a week after general registration opens. Email or call the registrar at the college you're considering.
+
+## How Florida's program compares to neighboring states
+
+Senior tuition waivers vary widely across the [hub overview of programs nationally](/blog/free-community-college-classes-for-seniors). FL's program sits in a specific spot in the regional spectrum:
+
+- [Georgia TCSG](/blog/georgia-senior-citizens-tcsg-tuition-waiver) at age 62 covers credit enrollment with the credit counting toward a TCSG credential — a meaningful difference for Georgians who want a degree.
+- [South Carolina](/blog/south-carolina-senior-citizens-technical-colleges) at age 60 is audit-only at SC technical colleges.
+- [North Carolina](/blog/north-carolina-senior-citizens-community-colleges) at age 65 is audit-only at NCCCS colleges.
+- [Tennessee](/blog/tennessee-senior-citizens-tbr-community-colleges) at age 65 covers tuition and most fees at TBR community colleges.
+
+If you're in northern Florida and have flexibility, comparing FL's no-credentials program to GA's credentialed alternative may shift your strategy.
+
+## How to actually enroll
+
+The process is shorter than most people expect:
+
+1. **Pick an FCS college near you.** Florida has 28 FCS state colleges; most have multiple campuses.
+2. **Apply for admission.** FCS colleges have a standard application — typically online, transcripts often not required for senior-waiver enrollment.
+3. **Indicate senior waiver eligibility.** Most FCS colleges ask for proof of FL residency and age.
+4. **Wait for senior registration to open.** Each college publishes the senior registration date for upcoming terms.
+5. **Pick courses with backups.** Have a first choice and at least one fallback. [Search FCS courses across all 28 Florida state colleges](/fl) to see current offerings.
+6. **Pay any remaining fees and buy materials.** Most fees are waived; books and program-specific costs are not.
+
+<ProductCallout
+  text="Community College Path indexes courses across all 28 FCS colleges. Search for a section or browse a college catalog to see what's running this term."
+  feature="search"
+  label="Search Florida College System Courses"
+/>
+
+## The bottom line
+
+Florida's senior tuition waiver under § 1009.26(4) covers more than just tuition — most FCS colleges waive most mandatory fees too — but the credit you earn doesn't count toward an FCS associate degree. That's a real constraint for residents who want a credential, and a non-issue for residents who just want structured learning.
+
+If credentials matter, regular FCS tuition (low even at full price) is the path. If credentials don't matter, the senior waiver is genuinely one of the most cost-effective lifelong-learning programs in the Southeast — tuition and fees waived, just bring your own books.
+
+Either way, the registrar at the FCS college closest to you is the right first contact. They'll confirm waiver eligibility, walk you through residency-and-age verification, clarify which fees their college actually waives, and tell you exactly when senior registration opens for the term you want.

--- a/content/blog/georgia-senior-citizens-tcsg-tuition-waiver.mdx
+++ b/content/blog/georgia-senior-citizens-tcsg-tuition-waiver.mdx
@@ -1,0 +1,83 @@
+# Georgia Senior Citizens at TCSG Technical Colleges: How the 62+ Tuition Waiver Actually Works
+
+If you're 62 or older and a Georgia resident, you can attend classes at any of the 22 colleges in the Technical College System of Georgia (TCSG) with tuition waived under OCGA 20-4-20. Unlike most senior tuition waivers in the Southeast, Georgia's program covers **credit-bearing enrollment** — not just audit — making it one of the more useful programs for residents who want a real credential rather than just structured learning.
+
+The catch is in two places: in the words "space-available" and in what the waiver doesn't cover. Tuition is the largest line item but it's not the entire bill, and senior auditors register after credit-paying students.
+
+Here's what the program actually covers, what it doesn't, and how to use it without surprises.
+
+## The basic rule
+
+Under OCGA 20-4-20, Georgia residents aged 62 and older may attend classes at TCSG technical colleges with tuition waived on a space-available basis. The waiver applies to credit-bearing enrollment — you can earn a grade, credit hours, and credentials — not just audit. That's a meaningful difference from senior-waiver programs in [South Carolina](/blog/south-carolina-senior-citizens-technical-colleges) or [North Carolina](/blog/north-carolina-senior-citizens-community-colleges) where audit is the only option.
+
+There's no statutory income test. No retirement test. The hard requirements are (a) age 62+, (b) Georgia residency, and (c) the section being available when senior registration opens.
+
+The age threshold (62) is two years higher than the most generous regional senior-waiver programs at age 60 — including [Maryland](/blog/maryland-senior-citizens-community-college-tuition-waiver) and [Virginia](/blog/virginia-senior-citizens-community-college-free-tuition) — but Georgia's coverage of credit enrollment puts it ahead of states with lower age thresholds that only cover audit.
+
+## What the waiver does *not* cover
+
+This is where most surprises come from. The waiver waives tuition. It does not waive:
+
+- **Mandatory fees.** TCSG colleges charge student services fees, technology fees, lab fees for technical and allied health courses, and program-specific fees on top of tuition. For a 3-credit course, fees can run $100–$400 depending on the program. Allied health and technical programs (welding, automotive, HVAC, sonography) have higher fee schedules than general academic courses.
+- **Textbooks and course materials.** No relief here. Technical and allied health programs often require costly equipment, uniforms, lab kits, and specialized software — these are typically the largest non-tuition cost.
+- **Some workforce certifications.** Short-term certificate programs and continuing-education sections may run on different cost models. Confirm with the college's admissions office before assuming the waiver applies.
+
+A useful mental model: tuition is roughly 50–70% of the bill at most TCSG colleges. The waiver eliminates that. The rest — fees, books, equipment — is real but typically still a fraction of out-of-pocket cost compared to paying full freight.
+
+## "Space available" — what it actually means at TCSG colleges
+
+Senior waiver students register **after** credit-seeking students who pay full tuition. That's the law's tradeoff: tuition is free, but you're not displacing a paying student.
+
+In practice across the 22 TCSG colleges:
+
+- **Allied health and high-demand technical sections fill fastest.** Nursing, sonography, dental hygiene, welding, HVAC, electrical — all carry waiting lists and competitive admission criteria on top of registration. Senior auditors often can't enter these directly.
+- **General academic and gen-ed sections are more open.** ENGL 1101, MATH 1111, PSY 1010, history surveys — these usually have available seats by the time senior registration opens.
+- **Online and asynchronous sections fill faster than expected** — working students grab them across all demographics.
+- **Niche electives, morning sections, and second-half-of-semester courses** tend to have meaningful availability.
+- **Summer terms** have shorter catalogs but less competition.
+
+Each TCSG college sets its own senior registration date — typically a few days to a week after general registration opens. Email or call the registrar at the college you're considering. Doing this in advance is the single biggest predictor of whether you get the section you want.
+
+## Where the waiver pairs with TCSG's prereq structure
+
+Georgia is unusual among Southeast community college systems in the depth of its program prereq chains — particularly in allied health and technical programs where chains can run 4–6 levels deep before the program's core courses. Senior auditors who try to enter program-specific courses directly often discover they're missing prereqs. Plan around it.
+
+For non-credentialed structured learning, general-academic courses (composition, history, psychology, philosophy, art appreciation) are the simplest entry — minimal prereqs, broad availability, and accessible content.
+
+For credentialed enrollment toward a credential or new career — increasingly common among Georgia 62+ residents — start with the program advisor at the TCSG college early. The waiver makes the tuition zero; the prereq sequencing and program admission decisions are the real path-planning work.
+
+## How to actually enroll
+
+The process is shorter than most people expect:
+
+1. **Pick a TCSG college near you.** Georgia has 22 TCSG colleges spread across the state. Most have multiple campuses.
+2. **Apply for admission.** TCSG colleges have a standard application — typically online, transcripts required only for credit-bearing admission to certain programs.
+3. **Indicate senior waiver eligibility on the application or to admissions.** Some TCSG colleges ask for proof of GA residency and age (driver's license suffices) at application; others verify at first registration.
+4. **Wait for senior registration to open.** Each college publishes the senior registration date for upcoming terms.
+5. **Pick courses with backups.** Have a first choice and at least one fallback. [Search TCSG courses across all 22 Georgia community colleges](/ga) to see current sections and seats.
+6. **Pay any remaining fees and buy materials.** Tuition is zero. Fees, books, and equipment are still on you.
+
+## Where Georgia's program compares to neighboring states
+
+Senior tuition waivers vary widely across the [hub overview of programs nationally](/blog/free-community-college-classes-for-seniors). Georgia's age-62 + credit-eligible structure sits in a specific spot in the regional spectrum:
+
+- [South Carolina](/blog/south-carolina-senior-citizens-technical-colleges) at age 60 is audit-only at SC technical colleges — lower age threshold but less coverage.
+- [North Carolina](/blog/north-carolina-senior-citizens-community-colleges) at age 65 is audit-only at NCCCS colleges.
+- [Florida](/blog/florida-senior-citizens-fcs-tuition-waiver) at age 60 covers credit at FCS but credit earned this way doesn't count toward graduation — so credentials require enrolling at full tuition.
+- [Tennessee](/blog/tennessee-senior-citizens-tbr-community-colleges) at age 65 waives tuition + most fees at TBR community colleges.
+
+If you're a Georgia 62+ resident and credentials matter, GA's combination of credit eligibility + lower fees than fee-heavy MA or NY makes it one of the more practical programs in the Southeast for actually finishing a degree or technical certification.
+
+<ProductCallout
+  text="Community College Path indexes courses across all 22 TCSG colleges. Search for a course or browse a college's catalog to see what's running this term."
+  feature="search"
+  label="Search Georgia TCSG Courses"
+/>
+
+## The bottom line
+
+Georgia's senior tuition waiver under OCGA 20-4-20 is one of the more useful programs in the Southeast: tuition-free at any of the 22 TCSG colleges for residents 62+, with credit-bearing enrollment included rather than audit-only. The age threshold is two years higher than peer states at age 60, but the credit eligibility offsets that for anyone who wants a credential.
+
+Plan around fees and materials — they're real, especially in allied health and technical programs — and around the prereq sequencing that gates many TCSG programs. Use the senior waiver as the tuition reset, then treat program admission and prereq planning as the actual path-finding work.
+
+Either way, the registrar at the TCSG college closest to you is the right first contact. They'll confirm waiver eligibility, walk you through residency-and-age verification, and tell you exactly when senior registration opens for the term you want.

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -866,4 +866,157 @@ export const articles: ArticleMeta[] = [
     cluster: "audit-at-college-guide",
     clusterRole: "spoke",
   },
+
+  // --- Pipeline batch 2026-05-09c: 4 senior-waiver state-spokes + 1 session + 5 audit college-spokes ---
+
+  // Cluster B spokes (senior-waivers): CT, GA, PA, FL
+  {
+    slug: "connecticut-senior-citizens-ct-state-tuition-waiver",
+    title:
+      "Connecticut Senior Citizens at CT State Community College: How the 62+ Audit Program Actually Works",
+    description:
+      "CGS § 10a-27 lets CT residents 62+ audit courses at CT State Community College tuition-free. Here's what's covered, what isn't, and how the unified-system structure affects access.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "ct",
+    author: "Community College Path",
+    tags: ["seniors", "connecticut", "ct-state", "tuition-waiver", "auditing", "audit-only"],
+    cluster: "senior-waivers-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "georgia-senior-citizens-tcsg-tuition-waiver",
+    title:
+      "Georgia Senior Citizens at TCSG Technical Colleges: How the 62+ Tuition Waiver Actually Works",
+    description:
+      "OCGA 20-4-20 waives tuition at all 22 TCSG technical colleges for residents 62+ — covering credit enrollment, not just audit. Here's the credit-eligible structure and how to use it.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "ga",
+    author: "Community College Path",
+    tags: ["seniors", "georgia", "tcsg", "tuition-waiver", "credit-eligible"],
+    cluster: "senior-waivers-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "pennsylvania-senior-citizens-community-college-tuition-waiver",
+    title:
+      "Pennsylvania Senior Citizens at Community Colleges: How the 60+ Audit Program Actually Works",
+    description:
+      "24 P.S. § 19-1908-B lets PA residents 60+ audit community college courses tuition-free. Here's how it works across PA's 14 community colleges and what makes the sponsor-district structure unique.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "pa",
+    author: "Community College Path",
+    tags: ["seniors", "pennsylvania", "tuition-waiver", "auditing", "audit-only"],
+    cluster: "senior-waivers-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "florida-senior-citizens-fcs-tuition-waiver",
+    title:
+      "Florida Senior Citizens at FCS Colleges: How the 60+ Tuition Waiver Actually Works (And Why Credit Doesn't Count Toward Graduation)",
+    description:
+      "FL Stat. § 1009.26(4) waives tuition and fees at all 28 FCS colleges for residents 60+ — but credit earned doesn't count toward an associate degree. Here's what that constraint actually means.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "fl",
+    author: "Community College Path",
+    tags: ["seniors", "florida", "fcs", "tuition-waiver", "fee-waiver"],
+    cluster: "senior-waivers-guide",
+    clusterRole: "spoke",
+  },
+
+  // Cluster C spoke (session-timing): SC
+  {
+    slug: "south-carolina-technical-college-session-timing-guide",
+    title:
+      "South Carolina Technical College Sessions Explained: How SC's 16 Technical Colleges Use 8-Week, Mini-Mester, and Late-Start Formats",
+    description:
+      "Horry-Georgetown publishes 83 distinct start dates per term; Greenville Tech 76. Here's how SC's 16 technical colleges actually structure session length and how to find the right one.",
+    date: "2026-05-09",
+    category: "session-timing",
+    state: "sc",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "south-carolina", "technical-college", "8-week"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+
+  // Cluster E spokes (audit-at-college): BRCC, Brightpoint, Camp, CVCC, DCC
+  {
+    slug: "blue-ridge-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Blue Ridge Community College: Cost, Application, and Eligibility",
+    description:
+      "Blue Ridge Community College in the Shenandoah Valley allows auditing at full credit cost — or free for VA residents 60+. Here's the process across the Weyers Cave campus and education centers.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "brcc",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "brcc", "vccs", "senior-waiver", "shenandoah-valley"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "brightpoint-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Brightpoint Community College: Cost, Application, and Eligibility",
+    description:
+      "Brightpoint Community College (formerly John Tyler) serves the Tri-Cities region with two campuses. Auditing rules, cost (free for seniors), and the application process for the south-of-Richmond auditor.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "brightpoint",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "brightpoint", "vccs", "senior-waiver", "tri-cities"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "camp-paul-d-camp-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Paul D. Camp Community College: Cost, Application, and Eligibility",
+    description:
+      "Paul D. Camp Community College serves Western Tidewater with smaller class sizes and a focused workforce-program catalog. Auditing rules, cost (free for seniors), and how to enroll.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "camp",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "camp", "paul-d-camp", "vccs", "senior-waiver", "western-tidewater"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "central-virginia-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Central Virginia Community College: Cost, Application, and Eligibility",
+    description:
+      "Central Virginia Community College serves the Lynchburg region from main campus plus the Bedford and Amherst centers. Auditing rules, cost (free for seniors), and the application process.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "cvcc",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "cvcc", "vccs", "senior-waiver", "lynchburg"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "danville-community-college-audit-class-guide",
+    title:
+      "How to Audit a Class at Danville Community College: Cost, Application, and Eligibility",
+    description:
+      "Danville Community College serves Southside Virginia with a workforce-program emphasis and smaller class sizes. Auditing rules, cost (free for seniors), and how to enroll.",
+    date: "2026-05-09",
+    category: "senior-waivers",
+    state: "va",
+    college: "dcc",
+    author: "Community College Path",
+    tags: ["auditing", "virginia", "dcc", "danville", "vccs", "senior-waiver", "southside"],
+    cluster: "audit-at-college-guide",
+    clusterRole: "spoke",
+  },
 ];

--- a/content/blog/pennsylvania-senior-citizens-community-college-tuition-waiver.mdx
+++ b/content/blog/pennsylvania-senior-citizens-community-college-tuition-waiver.mdx
@@ -1,0 +1,93 @@
+# Pennsylvania Senior Citizens at Community Colleges: How the 60+ Audit Program Actually Works
+
+If you're 60 or older and a Pennsylvania resident, you can audit courses at any of the state's community colleges tuition-free under 24 P.S. § 19-1908-B. Pennsylvania's senior audit program runs across all 14 community colleges in the state — a system that's structurally diverse, with each community college a separately governed institution rather than part of a unified state system.
+
+The catch — same as most state senior-audit programs — is in the word "audit." Pennsylvania's program is audit-only, meaning structured learning without credit toward a degree.
+
+Here's what the program actually covers, what it doesn't, and how to use it without surprises.
+
+## The basic rule
+
+Under 24 P.S. § 19-1908-B, Pennsylvania residents aged 60 and older may audit courses at community colleges tuition-free on a space-available basis. The program applies across all 14 PA community colleges including the Community College of Philadelphia, Community College of Allegheny County (CCAC), Bucks County, Montgomery County, Delaware County, Harrisburg Area, Westmoreland County, Lehigh Carbon, Northampton, Reading Area, Luzerne County, Pennsylvania Highlands, Butler County, and Lackawanna College.
+
+There's no statutory income test. No retirement test. The hard requirements are (a) age 60+, (b) Pennsylvania residency, and (c) the section being available when senior registration opens.
+
+The age threshold (60) matches the most generous regional senior-waiver programs — including [Maryland](/blog/maryland-senior-citizens-community-college-tuition-waiver), [Virginia](/blog/virginia-senior-citizens-community-college-free-tuition), and [Massachusetts](/blog/massachusetts-senior-citizens-community-college-tuition-waiver). PA's audit-only structure is less generous than MD or MA (both cover credit and audit) but more accessible than [New Jersey's age 65 program](/blog/new-jersey-senior-citizens-county-college-tuition-waiver).
+
+## What the waiver does *not* cover
+
+This is where most surprises come from. The waiver waives tuition. It does not waive:
+
+- **Mandatory fees.** PA community colleges charge student services fees, technology fees, lab fees, and similar mandatory charges on top of tuition. For a 3-credit course, fees can run $80–$300 depending on the college and course type.
+- **Course materials.** Textbooks, online access codes, and lab supplies aren't covered.
+- **Credit enrollment.** This is the biggest constraint. If you want a course to count toward a degree or appear on your transcript with a grade, you must enroll as a regular credit-paying student. The senior waiver only covers audit.
+- **Continuing-education and workforce courses.** PA community colleges run separate continuing-ed catalogs at most campuses; these typically aren't covered by § 19-1908-B even if audit format is offered.
+
+A useful mental model: the program is for intellectual engagement and structured learning. It's not a path to credentials.
+
+## Variability across PA's 14 community colleges
+
+Unlike states with unified community college systems (CT State, CUNY, NCCCS), Pennsylvania's community colleges are individually governed by their local sponsors (counties, cities, or local taxing districts). That means individual college policies vary more than in unified systems:
+
+- **Sponsorship boundaries matter.** PA's community colleges are funded by sponsoring local governments. Residents of the sponsoring district usually pay reduced "in-district" tuition; non-sponsor PA residents pay higher rates. The senior waiver typically applies regardless, but check with your specific college — some may apply the waiver only to in-district residents.
+- **Application processes differ.** The Community College of Philadelphia, CCAC, and other large urban colleges have streamlined senior-audit processes. Smaller rural colleges may require an in-person registrar visit.
+- **Section availability varies.** Larger PA community colleges (CCAC, Bucks, Montgomery County, HACC) publish wider catalogs; smaller colleges have narrower offerings.
+
+If you live in or near multiple PA community college service areas, comparing application processes before choosing is worth a call to each registrar.
+
+## "Space available" — what it actually means at PA community colleges
+
+Senior auditors register **after** matriculated students. Specifically:
+
+- **Popular gen-ed sections fill fastest.** ENG 101, MATH 101, BIO 101, PSY 101.
+- **Online and asynchronous sections fill across all demographics.**
+- **Niche electives, morning sections, and second-half-of-semester courses** tend to have meaningful availability.
+- **Summer terms** have shorter catalogs but less competition.
+
+Each PA community college sets its own senior registration date — typically a few days to a week after general registration opens. Email or call the registrar at the college you're considering and ask exactly when senior auditors can register, plus what one-time paperwork (proof of PA residency, age verification) is needed.
+
+## Practical constraints
+
+A few things worth knowing:
+
+- **Registration is per-term, not annual.** Re-register each term you want to audit.
+- **You can't switch from audit to credit mid-term.** Audit status is locked once registration closes.
+- **Some courses are not auditable.** Clinical placements, internships, and certain studio art or competitive-admission program courses generally cannot be audited.
+- **No financial aid for audit.** Federal aid, state grants (PHEAA), and most scholarships specifically exclude audit enrollment.
+- **Sponsor-district status may matter.** If you're outside your community college's sponsoring district, confirm waiver eligibility at registration.
+
+## Where PA's program compares to neighboring states
+
+Senior tuition waivers vary widely across the [hub overview of programs nationally](/blog/free-community-college-classes-for-seniors). PA sits at the lower end of the regional senior-waiver age threshold (60) but with audit-only structure:
+
+- [Maryland](/blog/maryland-senior-citizens-community-college-tuition-waiver) and [Massachusetts](/blog/massachusetts-senior-citizens-community-college-tuition-waiver) at age 60 cover both audit and credit — more generous than PA.
+- [New York CUNY](/blog/new-york-cuny-senior-citizens-tuition-waiver) at age 60 is also audit-only, structurally similar to PA but limited to NYC.
+- [New Jersey](/blog/new-jersey-senior-citizens-county-college-tuition-waiver) at age 65 covers credit enrollment but at a higher age threshold.
+- [Virginia](/blog/virginia-senior-citizens-community-college-free-tuition) at age 60 covers audit free; credit enrollment requires income below ~$29k.
+
+If you're a PA resident curious about credit-bearing community college, you'd pay regular community college tuition (which varies by sponsor district); the senior waiver is specifically for audit. If credentials matter, the math is different than in MD or MA.
+
+## How to actually enroll
+
+The process is shorter than most people expect:
+
+1. **Pick a PA community college near you.** PA has 14 community colleges; check sponsor-district boundaries to confirm in-district eligibility.
+2. **Apply for admission as a senior auditor.** Most PA community colleges have a streamlined senior-audit application — typically online, no transcripts required.
+3. **Provide proof of PA residency and age** when prompted.
+4. **Wait for senior registration to open.** Each college publishes the senior registration date for upcoming terms.
+5. **Pick courses with backups.** Have a first choice and at least one fallback. [Search Pennsylvania community college courses](/pa) to see current offerings.
+6. **Pay any remaining fees.** Tuition is zero. Mandatory student fees and course materials are still on you.
+
+<ProductCallout
+  text="Community College Path indexes courses across Pennsylvania community colleges. Search for a section or browse a college catalog to see what's running this term."
+  feature="search"
+  label="Search PA Community College Courses"
+/>
+
+## The bottom line
+
+Pennsylvania's senior tuition waiver under § 19-1908-B is a real benefit with a specific scope: audit-only enrollment at any PA community college, free of tuition, on a space-available basis for residents 60+. It's the right program if you want structured learning without a credential. It's the wrong program if you want credits toward a degree — for that, regular community college tuition or relocating to MA/MD for the more generous credit-eligible programs would be the alternatives.
+
+For audit, PA's 14-college structure gives you flexibility in choosing a campus that fits your geography and interests. Apply as non-degree, register after matriculated students, and plan around fees, materials, and sponsor-district eligibility.
+
+Either way, the registrar at the PA community college closest to you is the right first contact. They'll confirm waiver eligibility, walk you through residency-and-age verification, and tell you exactly when senior registration opens for the term you want.

--- a/content/blog/south-carolina-technical-college-session-timing-guide.mdx
+++ b/content/blog/south-carolina-technical-college-session-timing-guide.mdx
@@ -1,0 +1,102 @@
+# South Carolina Technical College Sessions Explained: How SC's 16 Technical Colleges Use 8-Week, Mini-Mester, and Late-Start Formats
+
+Horry-Georgetown Technical College's fall 2026 schedule lists **83 distinct start dates** in a single semester. Greenville Technical has 76. Across the 16 technical colleges of the South Carolina Technical College System, fall 2026 contains 18,817 individual section offerings spread across the entire term.
+
+That puts SC among the most session-flexible community college systems in the Southeast. Most SC technical college students never realize how varied the menu is until they've already enrolled in a section they could have structured better.
+
+Here's how session timing actually works in SC tech colleges, when each format helps, and how to find the right one.
+
+## How SC technical colleges structure session length
+
+The 16 colleges of the South Carolina Technical College System run on the same fall–spring–summer rhythm but with significantly different breadth of session-length options.
+
+**Horry-Georgetown Technical College (HGTC)** is the most session-diverse — 83 distinct start dates in fall 2026. Full-term, both 8-week halves, multiple mini-mesters, late-start sections weekly, and continuing-education sections with their own date stacks.
+
+**Greenville Technical College** at 76 distinct start dates is a close second.
+
+**York Technical College** at 13 distinct start dates is the next tier — strong 8-week and late-start coverage.
+
+The remaining ~13 SC technical colleges (Aiken, Central Carolina, Florence-Darlington, Midlands, Northeastern, Orangeburg-Calhoun, Piedmont, Spartanburg, Tri-County, Trident, Williamsburg, Denmark, Technical College of the Lowcountry) typically run 5–15 distinct start dates per term — full-term-dominant with reliable 8-week and late-start supplements.
+
+If session diversity matters to your schedule, HGTC and Greenville Tech offer the deepest menus. Most other SC technical colleges run reliable but narrower schedules.
+
+## The session formats at SC technical colleges
+
+The general framework lives in our [community college sessions hub](/blog/community-college-sessions-explained); here's the SC translation. Comparable session menus exist at peer state systems — [Maryland community college sessions](/blog/maryland-community-college-session-timing-guide) and [Virginia community college sessions](/blog/virginia-community-college-session-timing-guide) cover the regional alternatives.
+
+**Full-term (15–16 weeks).** SC technical college fall and spring run 15 or 16 weeks plus finals. Every SC technical college runs full-term, and most credit hours are taught in it.
+
+**8-week sessions (Term 1 and Term 2).** Two halves of the term. SC tech colleges publish both halves at most colleges as "Term 1" or "8W1" for the first half and "Term 2" or "8W2" for the second.
+
+**Mini-mester / Mini-session.** Compressed 4–5 week sessions, typically wedged between fall and spring or between spring and summer. HGTC and Greenville Tech have the deepest mini-mester catalogs.
+
+**Late-start sections.** Standard sections beginning a few weeks after the regular term — common at HGTC, where late-start dates appear almost every week of the term.
+
+**Summer sessions.** SC summer typically runs 8–10 weeks total, broken into Summer Term 1 (~5 weeks), Summer Term 2 (~5 weeks), and a full-summer parallel option. Smaller catalogs but reliable gen-ed coverage.
+
+**Continuing-education and workforce sections.** Distinct from credit sections; these run on their own date stacks and typically don't qualify for federal financial aid. Watch the section type when filtering — accidentally registering for a continuing-ed section can mean paying out of pocket without aid coverage.
+
+## Workload math when sessions compress
+
+A 3-credit course is 3 credits regardless of session length. What changes is the weekly load.
+
+- 16-week full-term 3-credit class: roughly 9 hours per week (3 in-class + 6 outside).
+- 8-week Term 1 or Term 2: roughly 18 hours per week for the same content.
+- 4-week mini-session: roughly 36 hours per week — practically a full-time job for a single course.
+
+SC technical college students who try to stack a mini-session course with full-term enrollment are the most common overload-and-drop pattern. The compressed session isn't easier; it's the same total work in less calendar time.
+
+## Practical patterns that work for SC tech college students
+
+**Stack Term 1 + Term 2 to compress a year.** Take ENG 101 in Term 1 of fall, finish, then take ENG 102 in Term 2. You earn 6 credits over the same calendar weeks as one full-term course but never juggle both. HGTC and Greenville Tech have the deepest 8-week catalogs.
+
+**Use mini-session for one focused gen-ed.** Pick something self-contained — a humanities elective, a writing course, a public-speaking course. Don't pair a mini-session with a heavy spring or summer schedule starting immediately after.
+
+**Use late-start sections to recover from a dropped class.** If you withdraw from something in week 3, an 8-week 2nd-half section starting in week 8 or a 12-week late-start can replace the credits.
+
+**Use summer to compress a degree timeline.** SC summer runs are smaller but reliably include the gen-ed core. One summer course shifts your graduation date roughly a third of a semester earlier.
+
+**If you're at a smaller SC tech college, build around the full-term calendar.** The 13 mid-tier and smaller SC tech colleges publish narrower session menus. Plan a full-term-default schedule and supplement with the 1–3 8-week sections each term offers.
+
+If you're not sure how to fit sessions to your weekly availability, our [schedule-building guide](/blog/how-to-build-community-college-schedule) walks through the mechanics.
+
+## How to find sessions on SC tech college search tools
+
+SC technical colleges use a mix of registration platforms — Banner, Colleague, and PeopleSoft depending on the college.
+
+1. **Look at the start date column, not just the course code.** ENG 101 at HGTC runs in 8+ different sessions per fall. Course code is identical; only dates differ.
+2. **Filter by start date range.** Want a Term 2 section? Filter by start dates in mid-October. Mini-session typically late December or early May. Late-start: anything starting after the second week of term.
+3. **Check the part-of-term codes.** SC tech colleges use codes like "1" (full term), "8W1"/"8W2" (8-week halves), "5W1"/"5W2" (5-week summer halves), "MM" (mini-session). Reading these saves you from accidentally registering for a session that doesn't fit.
+4. **Filter for credit vs. continuing-education sections.** SC tech colleges publish both in some search interfaces. Continuing-ed sections don't qualify for federal financial aid.
+
+[Search South Carolina technical college courses](/sc) to see what's actually open at the college you're considering, and [browse all 16 SC technical colleges](/sc/colleges) to compare offerings.
+
+## Transfer credit and session length
+
+A common worry: do credits earned in compressed sessions transfer the same as full-term credits within SC's 2+2 framework or out to four-year institutions?
+
+Yes. The [SC technical college transfer pathway](/blog/south-carolina-technical-college-transfer) treats credits earned in 8-week, mini-session, and summer sections identically to full-term credits — transcript records the course, credits, and grade with no session-length notation. Receiving universities don't track session length and rarely ask. If a course transfers full-term, it transfers compressed.
+
+That's the strongest argument for using session diversity: no penalty for compressing a degree timeline using shorter sessions, and a real penalty (lost time, momentum, financial-aid SAP issues) for stretching a degree out longer than necessary.
+
+<ProductCallout
+  text="Community College Path indexes section-level data including start dates and session formats across all 16 SC technical colleges. Filter for 8-week, late-start, or mini-session sections without scrolling through each college's full schedule."
+  feature="search"
+  label="Search SC Sections by Start Date"
+/>
+
+## Common SC-specific mistakes
+
+- **Assuming all SC tech colleges have the same menu.** They don't. HGTC's 83-distinct-start-date schedule is unusual; smaller SC tech colleges run 5–15. Plan around your actual college's offerings.
+- **Mixing a mini-session with a full-term overload.** A mini-session course is essentially a full-time commitment for those weeks. Adding it to 12 credits of full-term work usually means dropping something.
+- **Late-registering for Term 2 without checking prereq chain status.** If a Term 2 course requires the Term 1 version, you can't take both simultaneously to "catch up." Read the prereq before you register — our [prereq chains explainer](/blog/prerequisite-chains-why-four-semester-plans-take-six) covers how to spot this.
+- **Confusing credit and continuing-education sections.** SC tech colleges publish both in the same search interface at some campuses. Continuing-ed doesn't qualify for federal financial aid. Filter carefully.
+- **Skipping summer because "I want a break."** A break is fine — just understand that one summer course shifts your graduation a full term earlier; declining is a real cost.
+
+## The bottom line
+
+South Carolina's technical college session menu is wider than most students realize and varies dramatically across the 16 colleges. Full-term is the default; 8-week halves, mini-sessions, late-start, and summer terms are the levers that compress a degree timeline. HGTC and Greenville Tech offer the deepest menus; smaller SC tech colleges run leaner but reliable schedules.
+
+Use the menu deliberately. Look at start dates first. Watch the workload math when sessions compress. Treat 8-week stacking and summer terms as the main compression strategies, not heroic full-term overloads.
+
+The faster you understand which sessions exist at your SC tech college, the more options you actually have when life shifts mid-term.


### PR DESCRIPTION
## Pipeline run summary

Third batch this week. Detectors surfaced 120 candidates; this PR ships the next 10 in rankScore order.

| Type | Count | Cluster |
|---|---|---|
| state-spoke (senior-waiver) | 4 | senior-waivers-guide |
| state-spoke (session-timing) | 1 | session-timing-guide |
| college-spoke (audit-at-college) | 5 | audit-at-college-guide |
| **Total** | **10** | |

After this batch:
- senior-waivers-guide: 9 → 13 spokes (added CT, GA, PA, FL)
- session-timing-guide: 7 → 8 spokes (added SC)
- audit-at-college-guide: 4 → 9 spokes (added BRCC, Brightpoint, Camp, CVCC, DCC)

## Articles

### Senior-waiver state-spokes (4)

| Slug | Words | Statute / age |
|---|---|---|
| `connecticut-senior-citizens-ct-state-tuition-waiver` | 1280 | CGS § 10a-27, age 62, audit-only |
| `georgia-senior-citizens-tcsg-tuition-waiver` | 1242 | OCGA 20-4-20, age 62, **credit-eligible** (unusual for the region) |
| `pennsylvania-senior-citizens-community-college-tuition-waiver` | 1232 | 24 P.S. § 19-1908-B, age 60, audit-only |
| `florida-senior-citizens-fcs-tuition-waiver` | 1210 | FL Stat. § 1009.26(4), age 60, tuition+fees waived but **credit doesn't count toward graduation** |

### Session-timing state-spoke (1)

| Slug | Words | Anchor |
|---|---|---|
| `south-carolina-technical-college-session-timing-guide` | 1456 | HGTC 83, Greenville Tech 76 distinct start dates; 18,817 sections across 16 SC tech colleges |

### Audit-at-college college-spokes (5, all VA, sourced verbatim from `data/va/institutions.json#<college>.audit_policy`)

| Slug | Words | College | Region | Contact |
|---|---|---|---|---|
| `blue-ridge-community-college-audit-class-guide` | 1259 | BRCC | Shenandoah Valley | admissions@brcc.edu |
| `brightpoint-community-college-audit-class-guide` | 1220 | Brightpoint (formerly John Tyler) | Tri-Cities/south of Richmond | admissionsandrecords@brightpoint.edu |
| `camp-paul-d-camp-community-college-audit-class-guide` | 1248 | Paul D. Camp | Western Tidewater | info@pdc.edu |
| `central-virginia-community-college-audit-class-guide` | 1215 | CVCC | Lynchburg | studentrecords@centralvirginia.edu |
| `danville-community-college-audit-class-guide` | 1258 | DCC | Southside Virginia | admissions@danville.edu |

## Quality gates

| Gate | All 10 |
|---|---|
| G1 word count | ✅ all in range |
| G2 internal links | ✅ |
| G3 banned phrases | ✅ |
| G4 embedding similarity | ⚠️ skipped (no embeddings API in worktree) |
| G5 npm run build | ⚠️ Vercel preview is the real G5; lint passes 0 errors |
| G6 BRIEF.md output block | ✅ |

### Pre-load-siblings rule applied

Per the new `feedback_blog_pipeline_preload_siblings.md` memory rule, each draft included 2+ sibling-cluster links from the start. This batch hit only one round-2 issue: the 4 senior-waiver state-spokes linked siblings but missed the hub itself (`/blog/free-community-college-classes-for-seniors`). Resolved with one-line edits in each comparison section.

The takeaway: pre-loading siblings worked, but G2 also requires a hub link explicitly when a hub exists. Should consider extending the memory rule to cover both hub + sibling pre-loading.

## Reviewer guidance

- **Senior-waiver state-spokes** share a common structure (basic rule → what's not covered → space-available → comparisons → process → bottom line). Read CT as the template, then check state-specific accuracy for GA/PA/FL.
- **GA's program is the unusual one** in this batch — it's age 62 + credit-eligible, which puts it above SC/NC/VA audit-only programs in usefulness despite the higher age threshold. Worth verifying.
- **FL's program is also unusual** — tuition + fees waived but credit doesn't count toward an FCS associate degree. That constraint affects how the article frames usefulness for credential-seekers vs lifelong-learners.
- **5 audit college-spokes** share a common structure (cost → eligibility → process → constraints → comparisons → bottom line). Each carries the audit_policy fields verbatim from `data/va/institutions.json`.
- **SC session-timing** parallels MD/TN/MA/NY/NC/VA/CT session-timing posts.

## Reviewer checklist

- [ ] Spot-check 1–2 state-spokes for fluff
- [ ] Verify statutes (CGS § 10a-27, OCGA 20-4-20, 24 P.S. § 19-1908-B, FL Stat. § 1009.26(4))
- [ ] Verify audit_policy contact emails / phone numbers (`data/va/institutions.json`)
- [ ] Verify SC start-date counts (`data/sc/courses/horry-georgetown/2026FA.json`, `greenville/2026FA.json`)
- [ ] Click internal links across the batch
- [ ] Confirm StateToolsCTA renders for state-spokes on Vercel preview
- [ ] Most have annual review-cadence flag — add calendar reminders

## Next batch preview

Top remaining candidates by rankScore after this batch lands:
- GA prereq-bottleneck (still in queue from initial gate-fail; pending redraft with no Top-N headlines and full link density)
- NH/PA session-timing (need course data first; PA still has none)
- ~12 more VA audit college-spokes
- 57 NC audit college-spokes (untapped, biggest single source of templated articles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)