### PR TITLE
seo: quick wins from GSC audit + wire GSC into blog pipeline

### DIFF
--- a/.claude/skills/blog-pipeline/SKILL.md
+++ b/.claude/skills/blog-pipeline/SKILL.md
@@ -43,8 +43,16 @@ Run the detectors in parallel. Each returns 0..N candidate briefs. See `referenc
 npx tsx .claude/skills/blog-pipeline/scripts/detect-cluster-gaps.ts > /tmp/blog-candidates-c.json
 npx tsx .claude/skills/blog-pipeline/scripts/detect-data-deltas.ts > /tmp/blog-candidates-a.json
 npx tsx .claude/skills/blog-pipeline/scripts/detect-prereq-bottlenecks.ts > /tmp/blog-candidates-d.json
-# Trigger B (keyword/search) is manual-input for now — see references/triggers.md
+# Trigger B (keyword/search) — see references/triggers.md for CSV + GSC sources
 ```
+
+**GSC refresh (run before every pipeline invocation):** If `~/gsc_token.json` exists, pull fresh Search Console data first — it feeds Trigger B with real click and impression signals:
+
+```bash
+source ~/gsc-venv/bin/activate && python3 ~/gsc_audit.py
+```
+
+This writes `~/gsc_audit_output.json`. The detect stage reads `blog_queries` (impressions with 0 clicks) and `quick_wins` (position 5–20, low CTR) from that file and promotes them as Trigger B candidates. If the script is unavailable or fails, continue without it — the other detectors are unaffected.
 
 A candidate brief is JSON with: `triggerSource`, `topic`, `targetReader`, `searchIntentHypothesis`, `articleType` (`general` | `state-spoke` | `college-spoke` | `hub`), `state` (or `null`), optional `college` (slug), `cluster` (or `null`), `nonDuplicateRationale`, `dataSlicePaths` (file paths whose contents the drafter must read).
 

--- a/.claude/skills/blog-pipeline/references/triggers.md
+++ b/.claude/skills/blog-pipeline/references/triggers.md
@@ -92,9 +92,28 @@ A spoke without underlying data becomes filler. The reader hits "Pennsylvania tr
 
 **Fires when:** external search demand reveals an uncovered topic.
 
-### v1 — manual CSV
+### Source 1 — GSC audit (primary, automated)
 
-For v1, this is fully manual. Drop a file at `.blog-pipeline/keyword-candidates.csv`:
+Before each pipeline run, refresh GSC data:
+
+```bash
+source ~/gsc-venv/bin/activate && python3 ~/gsc_audit.py
+# writes ~/gsc_audit_output.json
+```
+
+Read two sections of the output:
+
+**`blog_queries`** — queries where one of our blog pages already shows up in Google but gets 0 clicks (impressions > 0, clicks = 0). These prove search demand exists and we're close to ranking — a topic refinement or new companion article can capture the traffic.
+
+**`quick_wins`** — queries where a course/college page ranks position 5–20 with low CTR. A blog post explaining the course or concept can lift the entire cluster.
+
+For each entry, synthesize a candidate brief: the `query` becomes the `searchIntentHypothesis`, the page URL informs `state` and `articleType`. Treat `impressions` as a proxy for monthly volume. Apply the same filters as the CSV source (intent ≥ 3, alignment ≥ 3, no near-duplicate against existing posts).
+
+Prioritize `blog_queries` with position < 20 — these are one article away from page 1.
+
+### Source 2 — manual CSV
+
+For topics not yet appearing in GSC, drop a file at `.blog-pipeline/keyword-candidates.csv`:
 
 ```csv
 query,monthly_volume,intent_quality_0_to_5,product_alignment_0_to_5
@@ -105,14 +124,14 @@ query,monthly_volume,intent_quality_0_to_5,product_alignment_0_to_5
 The detector:
 1. Reads the CSV (returns zero candidates if file is missing — that's fine)
 2. Filters to rows where `monthly_volume >= 200`, `intent_quality >= 3`, `product_alignment >= 3`
-3. For each surviving row, runs an embedding-similarity check against existing 33 articles. Reject if cosine similarity > 0.82 against any existing post.
+3. For each surviving row, runs an embedding-similarity check against existing articles. Reject if cosine similarity > 0.82 against any existing post.
 4. Returns surviving rows as candidate briefs
 
 The thresholds are intentional. 200/mo is the floor where ranking is worth the effort. Intent and alignment ≥ 3 filters out vanity traffic — the visitor must plausibly use Community College Path.
 
-### v2 — automated
+### v2 — fully automated
 
-Wire to DataForSEO, Ahrefs MCP, or Google Trends only after the manual flow proves which kinds of queries actually convert to good articles. Premature automation here will fill the pipeline with junk.
+Wire to DataForSEO, Ahrefs MCP, or Google Trends only after the GSC + CSV flow proves which kinds of queries actually convert to good articles. Premature automation here will fill the pipeline with junk.
 
 ### Why this trigger is third-priority
 

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -159,7 +159,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const term = termLabel(currentTerm);
 
   const pageTitle = `${parsed.prefix} ${parsed.number}: ${title} — ${config.name} Community Colleges`;
-  const description = `Find ${parsed.prefix} ${parsed.number} (${title}, ${credits} credits) at ${collegeCount} ${config.systemName} colleges for ${term}. ${sections.length} sections available${onlineCount > 0 ? `, ${onlineCount} online` : ""}. Compare schedules, check seats, and see transfer equivalencies.`;
+  const description = `${parsed.prefix} ${parsed.number} (${title}, ${credits} ${credits === 1 ? "credit" : "credits"}) — ${sections.length} sections at all ${collegeCount} ${config.systemName} colleges for ${term}${onlineCount > 0 ? `, ${onlineCount} online` : ""}. See schedules, open seats, and transfer credit.`;
 
   const canonical = `${process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com"}/${state}/course/${code}`;
 

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -221,9 +221,9 @@ export const articles: ArticleMeta[] = [
   {
     slug: "how-to-find-late-start-community-college-classes",
     title:
-      "How to Find Late-Start Community College Classes Before the Semester Is Lost",
+      "How Late Can You Enroll in Community College? Late-Start Classes Explained",
     description:
-      "Missed the start of the semester? Late-start classes begin weeks later and carry the same credits. Here's how to find them.",
+      "You can enroll days before a late-start section begins — weeks after the main semester started. Here's how to find open sections and what to expect.",
     date: "2026-04-04",
     category: "registration-timing",
     state: null,
@@ -447,9 +447,9 @@ export const articles: ArticleMeta[] = [
   {
     slug: "new-jersey-community-college-transfer-credit-guide",
     title:
-      "How New Jersey Community College Transfer Credit Actually Works: An NJTransfer Student's Guide",
+      "NJTransfer.org Explained: How NJ Community College Transfer Credit Actually Works",
     description:
-      "NJ has 40 receiving institutions — but the same course can be a direct match at Rowan (96%) and worth nothing at Rutgers Engineering (13%). Here's how to navigate it.",
+      "NJTransfer.org shows equivalencies for 40 NJ universities — but the same course can be a direct match at Rowan (96%) and worth nothing at Rutgers Engineering (13%). Here's how to read it.",
     date: "2026-04-12",
     category: "state-system-explainers",
     state: "nj",


### PR DESCRIPTION
## Summary

First pass of SEO quick wins driven by 90 days of real Google Search Console data (2,126 clicks, 76k impressions, Feb–May 2026).

- **Course page descriptions** — fixed "1 credits" grammar bug; reframed to "N sections at all X colleges" so queries that include a specific college name (e.g. "SDV 100 danville community college", 71 impressions, pos 6.9, 0 clicks) see the comprehensiveness signal and click through
- **Late-start blog** — retitled to "How Late Can You Enroll in Community College?" to directly match the query landing at position 10.5 with 0 clicks; description now answers the question in the snippet
- **NJ transfer guide** — leads with "NJTransfer.org Explained" to capture pos-9.5 "njtransfer.org" branded query and pos-18.5 "nj transfer equivalency"
- **Blog pipeline skill** — Stage 1 now runs `gsc_audit.py` before each invocation; Trigger B reads `blog_queries` + `quick_wins` from the output so every future article decision is grounded in actual click/impression data, not just internal gap detection

## Related
- Blog batch backlog: #306

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Course page for `/va/course/sdv-100` shows updated description in `<meta name="description">` and OG tags
- [ ] Blog post titles updated correctly in browser tab
- [ ] Re-run `python3 ~/gsc_audit.py` in 2 weeks and verify CTR improvement on the three targeted pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)