### PR TITLE
seo: fix zero-click blog posts — better titles, descriptions, and class-times content

### DIFF
--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -277,9 +277,9 @@ export const articles: ArticleMeta[] = [
   {
     slug: "when-do-community-college-schedules-go-live",
     title:
-      "When Do Community College Class Schedules Usually Go Live?",
+      "Community College Class Schedules: Typical Times and When They Go Live",
     description:
-      "Course schedules typically post 2–4 months before the semester. Here's the general timeline and how to plan before the schedule drops.",
+      "Most community college classes run in morning (8–noon), afternoon (noon–5pm), or evening (5–9:30pm) blocks. Here's what to expect for class times — and when the schedule for next semester posts.",
     date: "2026-04-04",
     category: "registration-timing",
     state: null,
@@ -447,9 +447,9 @@ export const articles: ArticleMeta[] = [
   {
     slug: "new-jersey-community-college-transfer-credit-guide",
     title:
-      "NJTransfer.org Explained: How NJ Community College Transfer Credit Actually Works",
+      "NJ Community College Transfer Credits: Where Your Courses Go at Rutgers, Rowan & 38 More Schools",
     description:
-      "NJTransfer.org shows equivalencies for 40 NJ universities — but the same course can be a direct match at Rowan (96%) and worth nothing at Rutgers Engineering (13%). Here's how to read it.",
+      "NJTransfer.org publishes course equivalencies for every NJ community college at 40 four-year schools. Here's which universities accept the most credits — and why the same course counts at Rowan but not at Rutgers Engineering.",
     date: "2026-04-12",
     category: "state-system-explainers",
     state: "nj",

--- a/content/blog/new-jersey-community-college-transfer-credit-guide.mdx
+++ b/content/blog/new-jersey-community-college-transfer-credit-guide.mdx
@@ -1,4 +1,4 @@
-# How New Jersey Community College Transfer Credit Actually Works: An NJTransfer Student's Guide
+# NJ Community College Transfer Credits: Where Your Courses Go at Rutgers, Rowan & 38 More Schools
 
 New Jersey has 18 county colleges and over 40 four-year institutions that accept their credits — but the same community college course can be a direct match at Rowan, worth nothing at Rutgers Engineering, and somewhere in between at Seton Hall. NJTransfer.org publishes these outcomes, but the sheer volume of data makes it hard to see the patterns that matter most.
 

--- a/content/blog/when-do-community-college-schedules-go-live.mdx
+++ b/content/blog/when-do-community-college-schedules-go-live.mdx
@@ -1,10 +1,27 @@
-# When Do Community College Class Schedules Usually Go Live?
+# Community College Class Schedules: Typical Times and When They Go Live
 
-You're ready to plan your next semester. You pull up the course catalog. It still shows last semester's classes.
+You want to know two things: what times do community college classes actually meet, and when does the schedule for next semester come out?
 
-When does the new schedule come out? The answer depends on your state, your college, and the term — and it's rarely published as clearly as you'd like.
+Both answers depend on your college — but there are reliable patterns across most schools.
 
-## The general pattern
+## Typical community college class times
+
+Community college schedules are built around three main blocks:
+
+**Morning sessions (8:00 am – 12:00 pm)**
+The most popular block. Most in-person sections run here — both 50-minute MWF formats and 75-minute TTh formats. An 8:00 am or 9:00 am start is common for high-demand courses like English composition, math, and science lectures. Labs frequently run 9:00 am–12:00 pm.
+
+**Afternoon sessions (12:00 pm – 5:00 pm)**
+A mix of lecture and lab sections. Lighter than the morning but still busy. Common start times: 12:30 pm, 1:00 pm, 2:30 pm. This block suits students who work mornings or have childcare in the early hours.
+
+**Evening sessions (5:00 pm – 9:30 pm)**
+Designed for working adults. Classes typically start at 5:30 pm, 6:00 pm, or 6:30 pm and meet once or twice a week in longer sessions (1.5–3 hours). Workforce programs, professional certifications, and some gen-eds run heavily in this block.
+
+**Online and hybrid sections** don't have fixed meeting times — you complete work asynchronously on your own schedule, with some hybrid sections meeting on campus once a week.
+
+Most colleges also offer **Saturday morning sections** (typically 9:00 am–12:00 pm) and occasional weekend intensives, though coverage varies widely.
+
+## The general pattern for when schedules go live
 
 Most community colleges publish course schedules **4 to 8 weeks before registration opens**, and registration itself typically opens **2 to 4 months before the semester starts**.
 


### PR DESCRIPTION
## Summary

- **NJ transfer guide** (56 impressions, 0 clicks): rewrote title and description to lead with destination schools and what students can look up, replacing a confusing stat-first framing that ranked but never converted
- **Schedules guide** (7 impressions at position 1–5, 0 clicks): article was ranking for "typical class start times community college" but had no content answering that query — added a full "Typical community college class times" section covering morning/afternoon/evening/online blocks, and retitled to match

Both changes are driven by live GSC data showing pages with real impressions and zero clicks — a metadata/content mismatch, not a ranking problem.

## What changed

| File | Change |
|---|---|
| `content/blog/index.ts` | Updated `title` and `description` for 2 articles |
| `new-jersey-community-college-transfer-credit-guide.mdx` | Updated `#` h1 to match new title |
| `when-do-community-college-schedules-go-live.mdx` | New intro + "Typical class times" section; updated `#` h1 |

## Test plan

- [x] Both pages render in local dev with correct new titles in `<title>` tag and `<h1>`
- [x] Schedules page now contains morning/afternoon/evening block content matching search intent
- [x] No other blog posts touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)