### PR TITLE
fix(blog-pipeline): tighten G1 wordCount JSX-strip regex

### DIFF
--- a/.claude/skills/blog-pipeline/scripts/quality-gates.ts
+++ b/.claude/skills/blog-pipeline/scripts/quality-gates.ts
@@ -48,10 +48,13 @@ const TOOL_LINK_PATTERNS = [
 ];
 
 function wordCount(mdx: string): number {
-  // Strip frontmatter and JSX tags before counting
+  // Strip frontmatter and JSX tags before counting. The JSX regex requires
+  // the tag start with `<` (or `</`) immediately followed by a letter, so
+  // bare `<` characters in prose ("< 7% hybrid") and tables don't trigger
+  // a greedy multi-line match that swallows real article content.
   const body = mdx
     .replace(/^---[\s\S]*?---/, "")
-    .replace(/<[^>]+>/g, " ")
+    .replace(/<\/?[A-Za-z][^>]*>/g, " ")
     .replace(/```[\s\S]*?```/g, " ");
   return body.trim().split(/\s+/).filter(Boolean).length;
 }


### PR DESCRIPTION
## Summary

One-line regex fix to the G1 quality gate. Eliminates the bare-\`<\` gotcha that surfaced in PR #314.

## The bug

\`wordCount\` in \`quality-gates.ts\` strips JSX with \`/<[^>]+>/g\` before counting words. The character class \`[^>]\` matches anything that isn't \`>\` — including newlines — so a bare \`<\` in prose or tables matches greedily across multiple lines until it finds the next \`>\` elsewhere in the file (commonly the closing \`>\` of a real JSX tag).

A bare \`<\` in an article (\"under < 7% hybrid\", \"students < 60\", etc.) silently consumes hundreds of words from the count, dropping the gate-reported word count to a fraction of reality and triggering false G1 fails.

Hit this during the 2026-05-10 hybrid-density batch on the MD article: gate reported 447 words against an actual 1522, blocking a clean draft until I rewrote \`< 7%\` as \"under 7%\".

## The fix

\`\`\`diff
- .replace(/<[^>]+>/g, " ")
+ .replace(/<\/?[A-Za-z][^>]*>/g, " ")
\`\`\`

Require the \`<\` (or \`</\`) to be immediately followed by a letter. JSX tags must start with a letter (or \`/\`), so this still strips real JSX correctly, including multi-line JSX. Bare \`<\` followed by space, digit, or punctuation no longer matches.

## Verification

| Test | Old result | New result |
|---|---|---|
| Bare \`<\` in prose (\"...< 7%...JSX tag later...\") | 9 words (bug) | 16 words (fixed) |
| Multi-line JSX (\`<ProductCallout\\n  text=...\\n/>\`) | 4 words | 4 words (no regression) |
| Real corpus MD article | 1549 | 1549 (no regression) |
| Real corpus hub article | 1845 | 1845 (no regression) |

## Test plan

- [x] Synthetic test: bare \`<\` in prose now counts correctly
- [x] Synthetic test: multi-line JSX still strips correctly
- [x] Real corpus regression: existing articles unchanged

## Related

Removed the \`feedback_blog_pipeline_avoid_lt_in_prose.md\` memory entry I added yesterday as a workaround — now obsolete since the regex is fixed at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)