### PR TITLE
fix(blog-pipeline): resolve SKILL.md merge conflict + update coverage tally

### DIFF
--- a/.claude/skills/blog-pipeline/SKILL.md
+++ b/.claude/skills/blog-pipeline/SKILL.md
@@ -86,21 +86,12 @@ If two candidates tie on cluster-non-saturation, pick the one whose data slice h
 
 `content/blog/BRIEF.md` § "What kinds of articles to create" lists nine theme areas. Audit which themes have ≥ 3 spokes vs. which have 0. Push candidates that fill 0-spoke themes ahead of candidates that pile onto already-covered themes, even when rankScores favor the latter.
 
-<<<<<<< HEAD
-As of 2026-05-10 (update this after each batch):
-- ✅ Heavily covered: transfer confusion (18 spokes), senior waivers (13), session timing (8), audit-at-college (9), prereq sequencing (7 spokes — GA, MD, NC, SC, DE, MA; detector will self-saturate remaining states)
-- ⚠️ Lightly covered: online vs hybrid (1 hub, 0 spokes — detector ready), registration timing / late-start (1 hub, 0 spokes — detector ready)
+As of 2026-05-09 (update this after each batch):
+- ✅ Heavily covered: transfer confusion (18 spokes), senior waivers (13), session timing (8 spokes — MD, TN, MA, NY, NC, VA, CT, SC), audit-at-college (9 college spokes)
+- ⚠️ Lightly covered: prereq sequencing (7 spokes — FL, GA, MD, NC, SC, DE, MA; 9 more states have slice data ready: CT, DC, NH, NY, PA, RI, TN, VA, VT), hybrid-course-density (3 spokes — ME, MD, MA; 5 more states have slices: AL, NC, NY, SC, VA), late-start-by-state (3 spokes — NH, GA, SC; 11 more states have slices: AL, DC, DE, FL, MA, MD, MS, NC, RI, TN, VT)
 - ❌ Zero coverage: cross-college schedule building (BRIEF.md §3), course availability patterns, instructor density, program-level content
 
-The next batches should disproportionately fill the lightly- and zero-covered themes. Run `detect-hybrid-density.ts` and `detect-late-start-density.ts` first; they'll self-filter to states that aren't yet covered.
-=======
-As of 2026-05-10:
-- ✅ Heavily covered: transfer confusion, senior waivers, session timing
-- ⚠️ Lightly covered: prereq sequencing (1 hub, 3 spokes — detector ready), online vs hybrid (1 hub, 0 spokes — detector ready), registration timing / late-start (1 hub, 0 spokes — detector ready), academic calendar (covered via session-timing already)
-- ❌ Zero coverage: cross-college schedule building (BRIEF.md §3), course availability patterns, instructor density, program-level content, mistake-avoidance beyond prereqs
->>>>>>> origin/main
-
-The next batches should disproportionately fill the lightly- and zero-covered themes. That's where the real editorial value sits.
+The next batches should pull from the three lightly-covered clusters — all have detector-ready slice data. Run the detectors; they'll self-filter to states without spokes.
 
 #### Step 2d — Cap any single cluster's share of a batch
 


### PR DESCRIPTION
## Summary

- Resolves unresolved `<<<<<<<` / `>>>>>>>` conflict markers in `SKILL.md` Stage 2c that were left over from concurrent edits during the 2026-05-09 pipeline batches
- Updates the coverage tally to reflect the actual corpus state after PRs #311–#316

## Coverage tally (after merge)

| Cluster | Spokes | Ready to draft |
|---|---|---|
| transfer-credit-guide | 18 | — (saturated for covered states) |
| senior-waivers-guide | 13 | — (saturated for covered states) |
| session-timing-guide | 8 | — (saturated for covered states) |
| audit-at-college-guide | 9 | — |
| prereq-chains-guide | 7 | 9 states with existing slices |
| hybrid-course-density-guide | 3 | 5 states with existing slices |
| late-start-by-state-guide | 3 | 11 states with existing slices |
| cross-college / course-availability / instructor-density | 0 | No detector yet |

## Why this matters

The conflict markers meant SKILL.md was technically broken — any pipeline run would have read malformed instructions in Stage 2c. The stale "0 spokes, detector ready" notes for hybrid and late-start also pointed the pipeline at already-covered ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)