### PR TITLE
content: 9 blog spokes batch b (prereq, hybrid, late-start)

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -224,6 +224,51 @@
       "slug": "north-carolina-community-college-late-start-classes",
       "draftedAt": "2026-05-10T05:00:00Z",
       "trigger": "late-start-density"
+    },
+    {
+      "slug": "district-of-columbia-community-college-prereq-bottlenecks",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "prereq-bottleneck"
+    },
+    {
+      "slug": "connecticut-community-college-prereq-bottlenecks",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "prereq-bottleneck"
+    },
+    {
+      "slug": "new-hampshire-community-college-prereq-bottlenecks",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "prereq-bottleneck"
+    },
+    {
+      "slug": "kentucky-community-college-hybrid-density",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "hybrid-density"
+    },
+    {
+      "slug": "alabama-community-college-hybrid-density",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "hybrid-density"
+    },
+    {
+      "slug": "new-york-community-college-hybrid-density",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "hybrid-density"
+    },
+    {
+      "slug": "delaware-community-college-late-start-classes",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "late-start-density"
+    },
+    {
+      "slug": "rhode-island-community-college-late-start-classes",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "late-start-density"
+    },
+    {
+      "slug": "florida-community-college-late-start-classes",
+      "draftedAt": "2026-05-10T07:00:00Z",
+      "trigger": "late-start-density"
     }
   ]
 }

--- a/content/blog/alabama-community-college-hybrid-density.mdx
+++ b/content/blog/alabama-community-college-hybrid-density.mdx
@@ -1,0 +1,82 @@
+# Alabama Community College Hybrid Classes: Enterprise State at 35.6%, Southern Union at 2.8%, and a System Divided by Geography
+
+More than one in three sections at Enterprise State Community College is hybrid. That's the highest hybrid share of any Alabama college in our data — 35.6% across 303 sections — and it exists in the same six-college dataset where Southern Union State Community College runs 2.8% hybrid across 1,706 sections. Alabama's community college system splits sharply by geography and institution type, and the 10.9% statewide hybrid figure hides that split almost entirely.
+
+## The statewide picture
+
+Across all 8,883 tracked sections in the Alabama Community College System (ACCS):
+
+| Mode | Sections | Share |
+|---|---|---|
+| In-person | 4,369 | 49.2% |
+| Online | 3,547 | 39.9% |
+| Hybrid | 967 | 10.9% |
+
+Alabama is a newer addition to the colleges tracked on Community College Path, so this slice covers six colleges — not the full ACCS system. The data represents a meaningful cross-section of the state, from the Gulf Coast north to the Tennessee border, and the variation across those six colleges is substantial enough to draw reliable conclusions about the system's internal geography.
+
+At 49.2% in-person, Alabama runs closer to the traditional classroom model than most East Coast systems. Compare that to Virginia's 35.8% in-person rate or Maryland's 60.7% — Alabama's share sits between the two, reflecting a system that has embraced online significantly (39.9%) but hasn't pushed the in-person share as low as states where commuter distance and adult-learner demographics have driven heavier format flexibility.
+
+## Per-college breakdown
+
+| College | Sections | Hybrid % | Online % | In-person % |
+|---|---|---|---|---|
+| Enterprise State CC | 303 | 35.6% | 33.3% | 31.0% |
+| Gadsden State CC | 1,389 | 25.6% | 42.3% | 32.1% |
+| Chattahoochee Valley CC | 342 | 21.3% | 25.7% | 52.9% |
+| George C. Wallace CC (Dothan) | 1,475 | 12.7% | 23.1% | 64.2% |
+| Coastal Alabama CC | 3,668 | 5.4% | 51.2% | 43.4% |
+| Southern Union State CC | 1,706 | 2.8% | 32.2% | 65.0% |
+
+The top three colleges run hybrid at 21–36%. The bottom two run hybrid at 3–5%. Gadsden State, at 25.6% hybrid across 1,389 sections, is the most significant hybrid institution in the dataset both by rate and by raw count of hybrid sections.
+
+## Enterprise State and Gadsden: the hybrid leaders
+
+**Enterprise State Community College** at 35.6% hybrid is the headline number — but at 303 total sections, Enterprise is the smallest college in this dataset. A 35.6% rate built on 303 sections means roughly 108 hybrid sections. The college serves Enterprise and the surrounding Wiregrass region of southeastern Alabama, near Fort Novosel (formerly Fort Rucker), the U.S. Army's primary helicopter training base. Military-connected students — active duty, veterans, and family members — are a consistent part of community college enrollment near major installations, and that population typically needs flexible scheduling that accommodates deployment schedules, duty hours, and frequent relocation. Enterprise State's high hybrid share likely reflects that demographic reality directly.
+
+**Gadsden State Community College** is the more consequential finding in this dataset. At 25.6% hybrid across 1,389 sections, Gadsden State combines a high hybrid rate with a large enough catalog that the format is genuinely available across departments. Gadsden is in northeastern Alabama — Etowah County, in the foothills of the Appalachian Mountains — serving students from a predominantly rural and semi-rural region where commuting distances are significant. The pattern here mirrors what we see in rural-serving colleges elsewhere: when a campus draws students from a wide geographic radius, hybrid scheduling reduces the burden of multiple weekly commutes without eliminating campus connection entirely. Gadsden State's students can drive in once a week rather than three times.
+
+**Chattahoochee Valley Community College** (21.3% hybrid, 342 sections) serves the Columbus, Georgia metro area on Alabama's eastern border. As a border-metro college, CVCC draws from both Alabama and Georgia — a student base that may have employment ties to Fort Moore (formerly Fort Benning) in Columbus, similar to Enterprise State's Fort Novosel connection. Military-adjacent enrollment patterns could be contributing here as well.
+
+## The anchor: George C. Wallace and Coastal Alabama
+
+**George C. Wallace Community College - Dothan** (12.7% hybrid, 1,475 sections) sits at roughly the state's midpoint — both geographically and in terms of hybrid adoption. At 12.7%, it's above the statewide average but far below the leaders. Wallace-Dothan's 64.2% in-person rate signals a more traditional scheduling approach, though 12.7% hybrid means the format is genuinely present rather than negligible.
+
+**Coastal Alabama Community College** is the largest college in this dataset by a wide margin: 3,668 sections, nearly 2.5 times the size of the next-largest (Southern Union at 1,706). At 5.4% hybrid, Coastal Alabama runs hybrid at roughly half the statewide rate despite dominating the section count. The college's 51.2% online rate is the highest in the dataset — Coastal Alabama has clearly leaned into online delivery for its flexibility play. The Gulf Coast geography may explain part of this: students in Baldwin and Mobile counties often work in tourism, hospitality, and maritime industries with highly variable schedules. Pure online offers more schedule adaptability than hybrid's fixed weekly meeting requirement.
+
+Coastal Alabama's sheer size means its 5.4% hybrid rate pulls the statewide average down significantly. If you removed Coastal Alabama from the calculation, the remaining five colleges would average roughly 16–17% hybrid — a materially different picture.
+
+**Southern Union State Community College** (2.8% hybrid, 1,706 sections) is the lowest hybrid rate in the dataset. Southern Union serves Opelika, Wadley, and Valley — central and east-central Alabama, primarily in the Piedmont region. Its 65.0% in-person rate is the highest of any college here. Southern Union has made a strong traditional-classroom bet; its online share at 32.2% is meaningful but its hybrid share is negligible. For students attending Southern Union expecting format flexibility, that flexibility will come from online sections, not hybrid ones.
+
+## What this means for students choosing an Alabama college
+
+Alabama's six-college data shows a system where geographic location and institutional character are stronger predictors of hybrid availability than statewide policy. The ACCS doesn't appear to mandate a unified approach to hybrid delivery — colleges have made independent choices, and those choices correlate with their student demographics and geography.
+
+If hybrid scheduling matters to your situation, the practical implications are direct:
+
+**Northeast Alabama (Gadsden):** Gadsden State's 25.6% makes hybrid a genuine option across a large catalog. If you're in Etowah County or the surrounding northeastern region, this is the strongest hybrid offering in the state among larger colleges.
+
+**Wiregrass region (Enterprise, Dothan):** Enterprise State leads on percentage but is small in absolute section count. Wallace-Dothan's 12.7% offers more total hybrid sections despite the lower rate. Between the two, Wallace-Dothan gives more options even if the rate is lower.
+
+**Eastern border (Valley, Phenix City):** Chattahoochee Valley's 21.3% is substantial, but at 342 sections, the absolute choice is limited. Worth checking if you're in the Columbus metro area.
+
+**Gulf Coast (Mobile, Baldwin County):** Coastal Alabama's online-heavy, low-hybrid approach means flexible scheduling here runs through online sections. Filter for online rather than hybrid if you need format flexibility in this region.
+
+**Central-east Alabama (Opelika, Valley, Wadley):** Southern Union's 2.8% means hybrid is almost entirely absent. In-person and online are your options.
+
+## Transfer implications
+
+Alabama's community colleges feed into the state's public university system — UA, UAB, Auburn, and the regional universities — through STARS (Statewide Transfer and Articulation Reporting System). Hybrid credits transfer identically to in-person credits. The receiving institution sees the course and grade, not the instructional mode. There is no transfer penalty for choosing a hybrid section at any Alabama community college.
+
+## Comparing Alabama to peer systems
+
+Alabama's 10.9% hybrid rate is consistent with [South Carolina's 10.6%](/blog/south-carolina-community-college-hybrid-density) — two southeastern state systems with similar hybrid adoption levels, both sitting a few points below the mid-Atlantic leaders. The more interesting comparison is the distribution. South Carolina's technical college system shows variation, but nothing approaching Enterprise State's 35.6% or the gap between Gadsden State and Southern Union.
+
+Alabama's per-college spread — from 35.6% to 2.8% — is one of the widest in the systems we've examined at this hybrid adoption level. That width suggests the ACCS has let individual colleges develop hybrid strategies independently rather than implementing a system-wide format policy. For students, this means the statewide 10.9% number tells you almost nothing about what's available at any specific college. The per-college data is the number that matters.
+
+For the conceptual framework on what hybrid actually means — how to read a section listing, what in-person requirements to expect, and how to compare hybrid sections across colleges — the [hub article on hybrid community college classes](/blog/hybrid-community-college-classes-explained) covers it.
+
+<ProductCallout
+  text="Community College Path indexes course mode for every tracked section across Alabama's community colleges. Filter by hybrid, online, or in-person at the colleges near you to see what's actually available this term."
+  feature="search"
+  label="Search Alabama Community College Sections"
+/>

--- a/content/blog/connecticut-community-college-prereq-bottlenecks.mdx
+++ b/content/blog/connecticut-community-college-prereq-bottlenecks.mdx
@@ -1,0 +1,115 @@
+# CT-State Merged 12 Colleges Into One in 2023. Its English Bottleneck Still Gates 200 Courses.
+
+Connecticut merged its twelve former community colleges into a single institution — Connecticut State Community College, known as CT-State — in 2023. On paper, one institution means standardized course numbering, shared catalog, consistent prerequisites. For students, that should mean less confusion about which prereqs transfer between campuses and which course codes mean the same thing.
+
+The prereq data tells a more complicated story. Across 635 indexed courses, the English developmental sequence sits at the top of the bottleneck list by a wide margin, with the foundational developmental English course (ENG 0930) gating **200 downstream courses** — nearly one in three courses in the indexed catalog. That is a structural fact that the merger didn't resolve and that every CT-State student who places below college-level English will encounter in their first semester.
+
+## The numbers
+
+| Metric | Value |
+|---|---|
+| Courses with explicit prereqs | 635 |
+| Chains reaching depth 3 or more | 120 |
+| Maximum chain depth | 5 |
+| Single most consequential prereq | ENG 0930 |
+| Downstream courses gated by ENG 0930 | 200 |
+
+The maximum chain depth of 5 is shallower than most systems we've indexed. For context, Rhode Island's CCRI reaches depth 21 and [New Hampshire's CCSNH reaches depth 8](/blog/new-hampshire-community-college-prereq-bottlenecks). CT-State's 5-level maximum means the deepest chains are real but bounded — a student who maps them before registering can see the entire runway from entry-level to capstone in one view.
+
+What stands out is not the depth but the breadth of the English bottleneck: 200 courses gated by one developmental course is a high transitive impact for a system with a max depth of only 5.
+
+## The bottleneck courses: English dominates, then there's everyone else
+
+| Course | Downstream courses gated |
+|---|---|
+| ENG 0930 | 200 |
+| ENG 0960 | 179 |
+| ENG 1010 | 177 |
+| CJS 1010 | 34 |
+| MATH 0900I | 32 |
+| MATH 1610 | 31 |
+| CSA 1110 | 21 |
+| MUS 1100 | 20 |
+| MATH 1600 | 19 |
+| DAT 1001 | 19 |
+
+The English sequence — ENG 0930, ENG 0960, ENG 1010 — accounts for 200, 179, and 177 downstream courses respectively. These three courses are the developmental and gateway English ladder at CT-State: ENG 0930 is the entry-level developmental course, ENG 0960 is the next step, and ENG 1010 is college composition (the gateway credit-bearing course). The near-identical downstream counts for ENG 0960 and ENG 1010 (179 and 177) reflect the fact that most courses that require ENG 0960 also require ENG 1010 — clearing one clears only a handful of courses that don't require the next step.
+
+The drop from ENG 1010's 177 to CJS 1010's 34 is sharp. Outside the English sequence, no single course gates more than 34 downstream courses. This makes English the dominant planning variable at CT-State by a significant margin.
+
+CJS 1010 (Criminal Justice Studies) gating 34 courses reflects a large Criminal Justice program at CT-State with a program-entry course functioning as a prerequisite for most upper-level CJS coursework. MATH 0900I (intermediate algebra, with the "I" designating a specific section variant) gating 32 courses and MATH 1610 gating 31 represent the math gateway — students who don't test into college-level math face a runway of 19–32 courses they cannot access until that threshold is cleared.
+
+## The deepest chains: music leads, accounting and construction management follow
+
+**Music (MUS) — 5 levels deep:**
+```
+MUS 2304 ← MUS 2303 ← MUS 1302 ← MUS 1301 ← MUS 1101 ← MUS 1100
+```
+
+Three of the five deepest chains at CT-State run through the music sequence. MUS 1100 is the entry-level music theory or fundamentals course; from there the chain runs through MUS 1101, MUS 1301, MUS 1302, MUS 2303, and terminates at MUS 2304 and its parallel courses MUS 2604/2605/2606. The music program's sequential structure — each course requiring the prior — produces the maximum depth in the catalog.
+
+A parallel instrumental or vocal sequence exists:
+```
+MUS 2524 ← MUS 2523 ← MUS 1532 ← MUS 1521 ← MUS 1406 ← MUS 1405
+```
+
+This five-level chain runs through a different track (applied music or ensemble sequence), also hitting depth 5.
+
+**Accounting (ACCT) — 4 levels deep:**
+```
+ACCT 2095 ← ACCT 2710 ← ACCT 1170 ← ACCT 1130 ← MATH 0900
+```
+
+The accounting chain at CT-State roots in MATH 0900 (a developmental or pre-algebra level math course), climbs through ACCT 1130 and ACCT 1170, then continues through intermediate accounting (ACCT 2710) to reach the capstone ACCT 2095 and its parallel ACCT 2720. A student who does not test into college-level math faces four prerequisite steps before reaching upper-level accounting — and those four steps span developmental math through two intermediate accounting courses.
+
+**Construction Management (CMGT) — 4 levels deep:**
+```
+CMGT 2275 ← CMGT 2150 ← CMGT 1150 ← ENG 1010 ← ENG 0930
+```
+
+This chain connects the English bottleneck directly to a technical program. CMGT 1150 (an introductory construction management course) requires ENG 1010 (college composition), which in turn requires ENG 0930 (developmental English). A student who places into ENG 0930 and wants to study construction management cannot start the CMGT sequence until they clear the English developmental ladder — two English courses before they can take their first construction management course.
+
+**Computer Science (CSC) — 4 levels deep:**
+```
+CSC 2218 ← CSC 2272 ← CSC 1271 ← ENG 1010 ← ENG 0930
+```
+
+The same pattern applies to computer science. ENG 0930 sits at the base of the CSC chain, meaning English placement determines when a CT-State student can enter the computer science sequence. This is a less obvious connection than the English-to-nursing link at other schools, but it appears consistently in the data for writing-intensive technical programs at CT-State.
+
+## What the 2023 merger means for students now
+
+### Consistent course codes, but the merger is recent
+
+CT-State's consolidation from twelve separate colleges into one institution means course numbers should be consistent across campuses. ENG 0930 at the Norwalk campus is the same as ENG 0930 at the Manchester campus. Before the merger, a student might have found that "English 101" meant different things at Housatonic versus Tunxis. That inconsistency should be reduced now.
+
+The practical implication: if you are checking a prereq chain at CT-State, the catalog at ct.edu applies across all campuses. You don't need to cross-reference multiple catalogs. But "consistent" doesn't mean "shorter" — ENG 0930 still gates 200 courses regardless of which CT-State campus you attend.
+
+### The merger is three years old; advising systems are still adjusting
+
+A merger of twelve institutions is a significant administrative undertaking. Course articulation, advising staff orientation, and degree audit systems all take time to fully align under a single system. If you receive advising guidance that references old institution-specific course numbers (Housatonic, Manchester, Middlesex, Naugatuck Valley, Northwestern, Norwalk, Quinebaug, Three Rivers, Tunxis, Asnuntuck, Capital, or Gateway), verify it against the current CT-State catalog. The old codes may no longer be in the system.
+
+### English placement is the first thing to settle
+
+Given that ENG 0930 gates 200 of 635 indexed courses, English placement is the single highest-leverage test result you will get before your first semester. If you place into ENG 0930, map the full ladder before selecting your major track: ENG 0930 → ENG 0960 → ENG 1010 is typically three semesters of English before reaching the gateway level, assuming one course per term.
+
+Several programs — construction management, computer science, criminal justice above the intro level — require ENG 1010 before you can take courses in the major. That means English placement indirectly sets the clock on those programs as well.
+
+### The music warning is real but narrow
+
+The deepest chains at CT-State run through music, not health sciences or engineering. This is unusual relative to most states we've indexed. The music sequence's depth (5 levels, three separate chains) reflects a well-structured performance curriculum rather than a structural problem — but it does mean music students who change tracks mid-sequence may not be able to transfer credits from one music chain (theory) to another (performance or applied) without starting over at the bottom of the new sequence.
+
+## How CT-State compares to peer systems
+
+At max depth 5, CT-State has shallower chains than most systems we've covered. [DC's UDC-CC reaches depth 7](/blog/district-of-columbia-community-college-prereq-bottlenecks) through engineering and architecture sequences. [Rhode Island's CCRI reaches depth 21](/blog/rhode-island-community-college-prereq-bottlenecks) through a nursing chain rooted in developmental English.
+
+What CT-State shares with CCRI and UDC-CC is the single-institution dynamic: one merged system means the bottleneck data applies uniformly across all campuses. ENG 0930 gates 200 courses at every CT-State location. That uniformity is a planning asset — you only need to understand one catalog — but it also means there's nowhere else to go.
+
+North Carolina's NCCCS, by contrast, runs across 58 colleges with [ACA 085 gating 919 courses system-wide](/blog/north-carolina-community-college-prereq-bottlenecks) — a different scale but a similar English-bottleneck pattern. The mechanism is the same: English placement determines access to the curriculum across disciplines. The scale and depth differ by system.
+
+The [prerequisite chains hub article](/blog/prerequisite-chains-why-four-semester-plans-take-six) explains how chains form across disciplines, why developmental sequences add semesters at every system, and how to work backward from your target course to your current placement when planning your path.
+
+<ProductCallout
+  text="Community College Path indexes prerequisite data across CT-State's community colleges. Search for any course to see its full prerequisite chain before you register."
+  feature="courses"
+  label="Check CT-State Course Prerequisites"
+/>

--- a/content/blog/delaware-community-college-late-start-classes.mdx
+++ b/content/blog/delaware-community-college-late-start-classes.mdx
@@ -1,0 +1,104 @@
+# Delaware Community College Late-Start Classes: Del Tech's 12.5% Rate Across Four Campuses
+
+Delaware has one community college. Delaware Technical Community College — Del Tech — runs all four of the state's campuses: Dover, Georgetown, Stanton, and Wilmington. There's no shopping between institutions; if you're attending a Delaware community college, you're at Del Tech.
+
+That makes the late-start question simpler and more consequential at the same time. With 2,203 fall sections across four campuses and **275 of them starting after the standard fall cutoff**, Del Tech runs a 12.5% late-start rate. That's the third-highest in the East Coast dataset, behind only New Hampshire (18.1%) and Georgia (14.5%).
+
+For a state with a single community college institution, 275 late-start sections is a real catalog — not an edge case.
+
+## What the data shows
+
+From Del Tech's fall 2026 course catalog:
+
+| Metric | Value |
+|---|---|
+| Total fall sections | 2,203 |
+| Late-start sections (after 2026-09-14) | 275 |
+| Late-start share | **12.5%** |
+| Distinct late-start dates | 12 |
+
+The 12 distinct late-start dates cluster into two clear windows: a first wave in late September (September 21–25 and September 28) and a second wave in mid-to-late October (October 19–24). This is not a rolling schedule with dozens of individual entry points — Del Tech structures late-start offerings in deliberate cohorts.
+
+That structure matters. Students who miss the main fall registration window have two meaningful rescue opportunities, not a continuous stream of options. If you miss the September window, the next entry point is October. If you miss October, the semester is effectively closed.
+
+## The four-campus model
+
+Del Tech is one institution with four distinct campuses, each serving a different geographic corridor of the state:
+
+- **Dover Campus** — central Delaware, Kent County; largest campus by enrollment
+- **Georgetown Campus** — lower Delaware, Sussex County; serving the beach communities and agricultural corridor
+- **Stanton Campus** — northern Delaware, New Castle County, near Wilmington
+- **Wilmington Campus** — urban Wilmington, northern Delaware
+
+The slice data shows aggregate figures for Del Tech as a system. Late-start availability will not be uniform across campuses — urban campuses like Wilmington and Stanton tend to run more evening and weekend sections, and late-start sections disproportionately appear in those formats. If you're at Georgetown or Dover, check section-level data rather than assuming campus-level availability matches the system average.
+
+Per the system-level data (all campuses combined):
+
+| College | Total sections | Late-start sections | Late-start % |
+|---|---|---|---|
+| Del Tech (all campuses) | 2,203 | 275 | **12.5%** |
+
+## Why 12.5% at a state-designated single institution
+
+Delaware's community college system isn't competing with itself across institutions — Del Tech holds the statutory mission for the entire state. That means there's no adjacent institution a student can cross-enroll at if Del Tech's schedule doesn't work.
+
+The consequence is that Del Tech has to serve a wider range of scheduling needs than a college in a multi-institution state. Working adults in Wilmington who can't make August registration are the same population PGCC serves in Prince George's County, Maryland, or AACC serves in Anne Arundel County. Del Tech builds late-start sections because the alternative — an entire class of students waiting until spring — isn't viable for a college that is the only option.
+
+The 12.5% rate also reflects Delaware's workforce profile. The Stanton and Wilmington campuses serve a dense concentration of financial services employment — JPMorgan Chase, Bank of America, and Discover all operate major back-office and operations centers in Wilmington. Those employers hire year-round. A worker who starts a job in September or gets promoted in October doesn't have a clean August-registration path. Del Tech's late-start cohorts serve that dynamic.
+
+## The two registration windows in practice
+
+Del Tech's fall late-start dates break into two cohorts. Understanding the structure helps you plan:
+
+**First cohort — late September (six distinct dates):**
+September 21, 22, 23, 24, 25, and 28. These are typically 12-week or 10-week sections — enough of the semester remains to compress a full course. This is Del Tech's primary rescue window after the September 14 cutoff. Students who miss the main start by a week or two can still pick up a meaningful course load.
+
+**Second cohort — mid-to-late October (six distinct dates):**
+October 19, 20, 21, 22, 23, and 24. These are typically 8-week sections — you're compressing a 16-week course into roughly half the time. The course load per week is proportionally higher. Not every subject is offered in the October cohort; workforce-credential programs and general education requirements tend to appear more often than major-specific upper-division courses.
+
+Registration for each cohort closes days before the section begins. A section starting October 19 may close registration October 14 or 15. Check section-level deadlines, not just the start date.
+
+## How Delaware compares on the East Coast
+
+| State system | Late-start % | Distinct late-start dates |
+|---|---|---|
+| New Hampshire (CCSNH) | 18.1% | 11 |
+| Georgia (TCSG) | 14.5% | 37 |
+| **Delaware (DTCC)** | **12.5%** | **12** |
+| South Carolina (tech colleges) | 11.8% | 26 |
+| North Carolina (NCCCS) | 9.6% | 23 |
+| Maryland (MACC) | 9.0% | 25 |
+
+Delaware's 12.5% rate is comparable to [Rhode Island's CCRI at 12.8%](/blog/rhode-island-community-college-late-start-classes) — two small single-institution state systems with nearly identical late-start rates. The structural similarity is worth noting: both states have one community college system, and both run late-start rates well above the national average. The difference is in date structure: CCRI concentrates its 240 late-start sections across only 4 distinct dates, while Del Tech spreads 275 sections across 12 distinct dates in two cohorts.
+
+[New Hampshire's CCSNH](/blog/new-hampshire-community-college-late-start-classes) leads the dataset at 18.1% across 7 colleges — a deliberately adult-learner-oriented system. Delaware comes close with a single institution, which says something about Del Tech's intentional scheduling philosophy.
+
+For the full framework on late-start sections — what they are, how they compare to standard sessions, and how to evaluate a section before enrolling — see the [hub article on late-start community college classes](/blog/how-to-find-late-start-community-college-classes).
+
+## Practical steps for Delaware students
+
+**If it's before September 21:** You can still catch the first late-start cohort. Filter Del Tech's course search by start date — look for sections beginning September 21 through September 28. These are your best options for a full accelerated section that still has enough weeks remaining for a substantive course.
+
+**If it's mid-to-late October:** The October 19–24 cohort is your window. Expect 8-week compressed sections. Not all subjects will appear; check availability in your specific program area.
+
+**Filter by campus first.** Del Tech's registration system lets you filter by campus location. Stanton and Wilmington campuses typically have more evening and online options — late-start sections are more likely there than at Dover or Georgetown. Confirm campus availability for the specific section before registering.
+
+**Check prerequisites before the window closes.** Del Tech's advising has noted that SSC 100 (Student Success and Career Development) is a bottleneck prerequisite for several degree programs — it must be completed before or alongside early major-area coursework. If a late-start section you want requires SSC 100 and you haven't completed it, verify whether SSC 100 itself has a late-start offering in the cohort you're targeting.
+
+**Register immediately when a section opens.** Del Tech's late-start sections, concentrated in two cohort windows, fill quickly. Particularly for high-demand courses (English composition, College Math, business fundamentals), sections in the October cohort can close within days of opening.
+
+## What this means if you missed main registration
+
+Missing Del Tech's August main registration window doesn't mean waiting until January. With 275 late-start sections and two cohort windows, Delaware students have real options — but the windows are defined and structured, not continuous.
+
+The September cohort is the stronger option: more sections, longer remaining course time, more subject variety. The October cohort is a meaningful fallback for students who need 8-week compressed sections or who resolve a scheduling conflict late. After October 24, the fall semester is effectively closed for new enrollment.
+
+Delaware's single-institution model means there's no alternative community college to fall back on within the state. If Del Tech's late-start catalog doesn't have what you need, your next option is online sections from an out-of-state college — or waiting for spring. That constraint makes early discovery of late-start sections more important in Delaware than in states where students can cross-enroll across institutions.
+
+[Search Delaware community college sections](/de) to see Del Tech's current late-start offerings sorted by start date.
+
+<ProductCallout
+  text="Community College Path tracks late-start sections across Delaware's community colleges. Use the starting-soon filter to find sections still open for registration."
+  feature="search"
+  label="Find Late-Start Classes in Delaware"
+/>

--- a/content/blog/district-of-columbia-community-college-prereq-bottlenecks.mdx
+++ b/content/blog/district-of-columbia-community-college-prereq-bottlenecks.mdx
@@ -1,0 +1,96 @@
+# DC's One Community College Has Chains 7 Levels Deep — and Every Course in the Catalog Has a Prereq
+
+The District of Columbia has one public community college: the University of the District of Columbia Community College, universally called UDC-CC. Not a flagship with satellite campuses — one institution serving a city of roughly 700,000 people. That single-institution structure means the prereq data for DC tells a cleaner story than most states: there is no variation across campuses, no option to try a neighboring college with a looser developmental sequence, no way to shop for a shorter path. Whatever UDC-CC's catalog shows is what every DC resident who starts at a community college faces.
+
+What the catalog shows is striking: **all 506 courses in the indexed dataset carry explicit prerequisites**, and **224 of those — 44% — require chains that reach three or more levels deep**. The maximum chain depth is 7, reached by three separate programs: architecture, mechanical engineering, and nutritional dietetics. In a system with a single institution, that structure lands equally on every student regardless of neighborhood or zip code.
+
+## The numbers
+
+| Metric | Value |
+|---|---|
+| Courses with explicit prereqs | 506 |
+| Chains reaching depth 3 or more | 224 |
+| Maximum chain depth | 7 |
+| Single most consequential prereq | IGED 110C |
+| Downstream courses gated by IGED 110C | 88 |
+
+The 100% prereq rate — every indexed course carrying at least one explicit prerequisite — is the most distinctive feature of UDC-CC's catalog relative to any other system we've indexed. That doesn't mean every course is hard to access; it means the institution has built explicit entry requirements into its entire curriculum, from intro-level courses through capstone sequences.
+
+## The bottleneck courses: five entries gating most of the catalog
+
+| Course | Downstream courses gated |
+|---|---|
+| IGED 110C | 88 |
+| ENGL 111C | 79 |
+| MATH 151 | 75 |
+| MATH 151C | 74 |
+| IGED 110 | 69 |
+
+IGED 110C and its parallel section IGED 110 sit at the top of the list with a combined reach of 157 downstream courses. The "C" suffix designates concurrent enrollment sections at UDC-CC. IGED 110C is a gateway integrated studies or general education course — clearing it (or its parallel variant) unlocks the single largest share of UDC-CC's curriculum.
+
+ENGL 111C is the gateway composition course, gating 79 downstream courses. That English placement matters across disciplines at UDC-CC is consistent with what we see in other single-institution systems: with nowhere else to go, every student who hasn't cleared college-level English faces the same bottleneck at the same institution.
+
+MATH 151 and its concurrent variant MATH 151C together gate 149 courses. Math 151 at UDC-CC is college algebra — the typical gateway into quantitative coursework in business, engineering, and the sciences. A student who does not place into MATH 151 directly faces a preparatory sequence before gaining access to those 149 courses.
+
+PHYS 201 and CHEM 105 round out the top ten at 47 and 46 downstream courses respectively, flagging UDC-CC's STEM programs as another zone where early placement shapes the entire timeline.
+
+## The deepest chains: three 7-level sequences across three programs
+
+Three separate programs at UDC-CC reach the maximum depth of 7:
+
+**Architecture (ARCP):**
+```
+ARCP 402 ← ARCP 401 ← ARCP 302 ← ARCP 301 ← ARCP 202
+          ← ARCP 201 ← ARCP 102 ← ARCP 101
+```
+The architecture sequence at UDC-CC runs eight courses deep — ARCP 101 through ARCP 402 — each requiring the prior course. This is a clean sequential program structure: you cannot skip a term without losing your place in the sequence.
+
+**Mechanical Engineering (MECH):**
+```
+MECH 492 ← MECH 491 ← MECH 351 ← MECH 321 ← CVEN 202
+          ← CVEN 201 ← PHYS 201 ← MATH 151
+```
+This chain crosses departments: reaching upper-level mechanical engineering capstone courses requires clearing Civil Engineering (CVEN) foundations, which in turn require Physics 201, which requires Math 151 (college algebra). The math gateway is not just a math-major problem. A student enrolling in the mechanical engineering program who does not yet place into MATH 151 is 7 courses away from MECH 492 at minimum — more if developmental math is required before MATH 151.
+
+**Nutritional Dietetics (NUDT):**
+```
+NUDT 471 ← NUDT 470 ← NUDT 317 ← CHEM 232 ← CHEM 231
+          ← CHEM 112 ← CHEM 111 ← CHEM 105
+```
+The dietetics chain runs through four chemistry courses — CHEM 105 through CHEM 232 — before entering the NUDT program sequence. CHEM 105 is the chemistry gateway (gating 46 downstream courses), which means a student who does not test into or through CHEM 105 is at the bottom of a 7-course chain before reaching upper-level dietetics.
+
+## What single-institution structure means for DC students
+
+### No alternative campus option
+
+In states like North Carolina (58 community colleges) or Connecticut (a merged multi-campus system), a student can sometimes find a campus that structures a sequence differently or offers different concurrent-enrollment options. DC has one community college. UDC-CC's chains are the chains. There is no neighboring institution to compare or transfer between at the community college level.
+
+This concentrates the planning burden: understanding UDC-CC's prereq structure before you register is not optional optimization — it is the baseline requirement for avoiding timeline surprises.
+
+### The concurrent enrollment sections matter
+
+The "C" suffix courses (IGED 110C, ENGL 111C, MATH 151C, and others) are the concurrent enrollment variants of their parent courses. The presence of both MATH 151 and MATH 151C in the top bottlenecks list — with nearly identical downstream counts (75 and 74) — means the pathway through college algebra runs through both sections. If you are looking at a course that lists MATH 151 as a prereq, check whether MATH 151C is also accepted, and vice versa.
+
+### STEM programs require MATH 151 regardless of major emphasis
+
+The mechanical engineering chain makes this visible, but it applies broadly: PHYS 201 (gating 47 courses) sits behind MATH 151, and CHEM 105 (gating 46 courses) has its own entry requirements. Any STEM-adjacent program at UDC-CC routes through the math gateway early. Before planning a STEM path, check your math placement — it is the most consequential single variable in your timeline.
+
+### The architecture sequence rewards unbroken enrollment
+
+ARCP 101 through ARCP 402 is a pure 8-course ladder. Each course requires the prior one with no branching or concurrent-enrollment shortcuts visible in the data. A student who skips a term or withdraws from an ARCP course resets to the bottom of that rung. For sequential programs like this, continuous enrollment from entry through completion matters more than it does in programs where courses can be reordered.
+
+## How UDC-CC compares to peer single-institution systems
+
+Rhode Island's Community College of Rhode Island (CCRI) is the closest structural comparison: one community college, statewide. [CCRI's prereq chains](/blog/rhode-island-community-college-prereq-bottlenecks) reach a maximum depth of 21 — substantially deeper than UDC-CC's 7 — largely because CCRI's nursing program runs through 13 clinical courses stacked on top of a developmental English base. UDC-CC's deepest chains max out at 7 and are driven by professional program sequences (architecture, engineering, dietetics) rather than a single megachain through one health program.
+
+The difference reflects program mix: CCRI has a large nursing program with tightly sequenced clinical courses; UDC-CC's deep chains run through built-environment and applied sciences programs. But the shared structural fact — single institution, no alternative campus — means planning carries the same weight in both states.
+
+Maryland's community college system, covered in [our Maryland article](/blog/maryland-community-college-prereq-bottlenecks), shows what the multi-institution alternative looks like: deeper chains at individual colleges can sometimes be navigated by course selection across campuses. DC students don't have that option.
+
+The [prerequisite chains hub article](/blog/prerequisite-chains-why-four-semester-plans-take-six) explains the general mechanics of how chains form, why each link is individually reasonable but cumulatively consequential, and how to read a chain from the bottom up when planning a multi-semester path.
+
+<ProductCallout
+  text="Community College Path indexes prerequisite data across DC's community college. Search for any course to see its full prerequisite chain before you register."
+  feature="courses"
+  label="Check DC Course Prerequisites"
+/>

--- a/content/blog/florida-community-college-late-start-classes.mdx
+++ b/content/blog/florida-community-college-late-start-classes.mdx
@@ -1,0 +1,104 @@
+# Florida Community College Late-Start Classes: 42 Dates, 8 Colleges, and Why You Have to Check Each One
+
+Florida's state college system is the most structurally complex late-start landscape in the East Coast dataset. Across 8 tracked colleges, fall 2026 contains 10,738 sections. **754 of them start after the September 14 cutoff** — a 7.0% late-start rate. That rate is below the national average. But Florida's 42 distinct late-start dates are more than any other state system in the data.
+
+Those two facts in tension define everything about Florida late-start: broad calendar coverage, but distributed across independent institutions that each manage their own dates, their own registration windows, and their own late-start catalogs.
+
+If you want to find a late-start section in Florida, you can't search the state system as a unit. You have to check each college.
+
+## What the data shows
+
+From 8 tracked Florida state colleges, fall 2026:
+
+| Metric | Value |
+|---|---|
+| Total fall sections | 10,738 |
+| Late-start sections (after 2026-09-14) | 754 |
+| Late-start share | **7.0%** |
+| Distinct late-start dates | **42** |
+
+The 42 distinct late-start dates span from September 15 through December 9 — essentially the entire fall semester. On one end, there are sections beginning a single day after the standard September 14 cutoff. On the other, sections starting December 7 and December 9, which are intensive formats running through winter break. The distribution is not uniform: September and October carry the bulk of late-start dates, with late November and December representing a handful of specialty sections.
+
+## Per-college breakdown
+
+The 7.0% statewide average masks wide variation across institutions:
+
+| College | Total sections | Late-start sections | Late-start % |
+|---|---|---|---|
+| College of the Florida Keys (CFK) | 245 | 55 | **22.4%** |
+| State College of Florida (SCF) | 1,596 | 193 | **12.1%** |
+| Northwest Florida State College (NWFSC) | 676 | 61 | 9.0% |
+| Gulf Coast State College | 775 | 63 | 8.1% |
+| St. Johns River State College (SJRState) | 952 | 63 | 6.6% |
+| Pasco-Hernando State College (PHSC) | 1,118 | 54 | 4.8% |
+| South Florida State College | 904 | 33 | 3.7% |
+| Valencia College | 4,472 | 232 | 5.2% |
+
+**College of the Florida Keys (CFK) leads Florida at 22.4%** — 55 late-start sections out of just 245 total. CFK serves Monroe County, the Florida Keys, an archipelago where scheduling constraints are fundamentally different from a mainland campus. Distance from major employment centers, tourism-driven employment seasonality, and the geographic reality of serving communities from Key Largo to Key West all push CFK toward more flexible scheduling. A 22.4% late-start rate is one response to a student population that cannot always commit to a fixed-semester start.
+
+**State College of Florida (SCF, Manatee-Sarasota) at 12.1%** is the standout mainland institution — 193 late-start sections from a catalog of 1,596 total. SCF serves Sarasota and Manatee counties, a retirement-heavy coastal area with high part-time enrollment and strong healthcare workforce programs. Late-start sections at SCF are concentrated in workforce credential programs and online formats. At 12.1%, SCF runs a higher late-start share than the statewide average by a significant margin.
+
+**Northwest Florida State College (NWFSC) at 9.0%** serves the Panhandle — Okaloosa and Walton counties, anchored by Eglin Air Force Base and the Fort Walton Beach / Niceville corridor. Military employment, contractor cycles, and permanent change of station (PCS) timing all create mid-semester enrollment demand. NWFSC's 9.0% rate reflects that pressure.
+
+**Gulf Coast State College at 8.1%** (Bay County, Panama City) and **SJRState at 6.6%** (Putnam, Clay, and St. Johns counties northeast of Jacksonville) land near the statewide average with meaningful late-start catalogs — 63 sections each.
+
+**Valencia College at 5.2%** presents the most important case study. Valencia is by far the largest Florida college in the dataset — 4,472 sections, nearly double the next largest (SCF at 1,596). Its 232 late-start sections represent the most absolute late-start volume of any single Florida institution. But at 5.2%, Valencia's late-start share is below the statewide average. Valencia operates mainly in the Orlando metro (Orange and Osceola counties) and runs a high-capacity main-window schedule. Late-start is available but not a primary catalog feature — it's a secondary offering concentrated in online sections.
+
+**Pasco-Hernando (PHSC) at 4.8%** and **South Florida State College at 3.7%** are Florida's low-density institutions in this dataset. If you're at either and miss main registration, late-start options exist but are limited — check section-level availability rather than assuming a rescue catalog.
+
+## The 42-date distribution problem
+
+Florida's 42 distinct late-start dates run from September 15 through December 9. But those dates are not evenly distributed across all 8 colleges. Each college sets its own late-start dates independently. A section starting October 13 at Gulf Coast State College has nothing to do with what SCF starts on October 13 — they may not overlap at all.
+
+This creates a research problem that doesn't exist in single-institution states. In Rhode Island, [CCRI's 4 cohort dates](/blog/rhode-island-community-college-late-start-classes) apply system-wide — every campus runs the same calendar. In Delaware, [Del Tech's 12 dates](/blog/delaware-community-college-late-start-classes) span the whole state as one institution. In Florida, a student searching for a late-start section in the state system has to check 8 different registration systems, each with its own date structure.
+
+The practical consequence: Florida's 42 distinct dates suggest more entry opportunities than any other state — but accessing those opportunities requires knowing which college runs sections on which dates.
+
+## How Florida compares in the dataset
+
+| State system | Late-start % | Distinct late-start dates |
+|---|---|---|
+| New Hampshire (CCSNH) | 18.1% | 11 |
+| Georgia (TCSG) | 14.5% | 37 |
+| Rhode Island (CCRI) | 12.8% | 4 |
+| Delaware (DTCC) | 12.5% | 12 |
+| South Carolina (tech colleges) | 11.8% | 26 |
+| Maryland (MACC) | 9.0% | 25 |
+| Tennessee (TBR) | 7.8% | 28 |
+| **Florida (FCS)** | **7.0%** | **42** |
+
+Florida's 7.0% late-start rate puts it at the lower end of the East Coast comparison — well below New Hampshire's 18.1% and Georgia's 14.5%, and below the Maryland (9.0%) and Tennessee (7.8%) systems it's closest to in section volume. But Florida's 42 distinct dates exceed Georgia's 37, which itself leads most other state systems by a wide margin.
+
+The underlying structure differs fundamentally. Georgia's 37 dates run across a state system with a unified BANNER-based registration infrastructure. Florida's 42 dates reflect 8 independently operated colleges with different calendars. Georgia students can search the state system; Florida students search institutions.
+
+For the conceptual foundation on late-start sections — what qualifies, how compressed sessions compare to standard-length courses, and how registration deadlines work — see the [hub article on late-start community college classes](/blog/how-to-find-late-start-community-college-classes).
+
+## Prerequisites and late-start registration in Florida
+
+Florida's state college system has its own prerequisite landscape, documented in the [Florida community college prereq bottlenecks article](/blog/florida-community-college-prereq-bottlenecks). The general issue: Florida's Gordon Rule requirements (ENC 1101 and a math course with a grade of C or better) are prerequisites for a significant share of credit-bearing coursework. Students who haven't completed Gordon Rule courses are blocked from large portions of each college's catalog.
+
+At a late-start section, that block applies immediately. A section starting September 21 at NWFSC requires the same completed prerequisites as the main-term version of the same course. There's no grace period for late-start enrollment.
+
+If you have an unresolved prerequisite hold, address it before the late-start registration window opens. At Florida's colleges, with 42 distinct dates across the full semester, missing a specific date may mean waiting a week or two for the next window — but at institutions like South Florida State College (3.7% late-start rate), the window is thin regardless.
+
+## Practical steps for Florida students
+
+**Identify your college first.** Florida's 8 tracked colleges have very different late-start catalogs. If you're at CFK or SCF, you have meaningful options. If you're at South Florida State College or PHSC, the late-start catalog is limited — be specific about what's available at your institution.
+
+**Check the CFK and SCF catalogs if you have flexibility.** If your degree plan allows cross-enrollment or if you're looking for online sections that don't require campus attendance, CFK (22.4%) and SCF (12.1%) have the highest late-start concentrations. SCF's online catalog in particular is worth checking for general education requirements that transfer within the Florida system.
+
+**At Valencia, filter online sections separately.** Valencia's 232 late-start sections are concentrated in online delivery. If you're searching Valencia's catalog for in-person late-start options, the available pool is smaller than 232 suggests.
+
+**Watch registration close dates at each institution.** Because Florida's colleges are independent, each one sets its own late-start registration deadline — typically 1–5 days before the section begins. A section at Gulf Coast starting October 14 has a different close date than a section at NWFSC starting October 14. Check section-level details, not state-system generalizations.
+
+**For Gordon Rule requirements specifically**, confirm completion status before attempting to register for any late-start section. The Florida prereq article covers which courses trigger the most holds and how to clear them. At PHSC (4.8% late-start) and South Florida State (3.7%), the late-start catalog is thin enough that a prerequisite hold could eliminate your options for the semester entirely.
+
+**The late-September dates (September 15–30) at most Florida colleges represent the widest selection.** Sections starting in late September are typically 10-week or 12-week courses with enough remaining time for a full compressed course load. The closer to December, the shorter the remaining run time and the narrower the subject availability.
+
+[Search Florida community college sections](/fl) to see late-start offerings by college and start date.
+
+<ProductCallout
+  text="Community College Path tracks late-start sections across Florida's community colleges. Use the starting-soon filter to find sections still open for registration."
+  feature="search"
+  label="Find Late-Start Classes in Florida"
+/>

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -1352,4 +1352,133 @@ export const articles: ArticleMeta[] = [
     cluster: "late-start-by-state-guide",
     clusterRole: "spoke",
   },
+  // --- Pipeline batch 2026-05-10b: prereq spokes (DC, CT, NH) ---
+  {
+    slug: "district-of-columbia-community-college-prereq-bottlenecks",
+    title:
+      "District of Columbia Community College Prerequisite Chains: How UDC-CC's Single-Institution System Concentrates the Bottleneck",
+    description:
+      "UDC Community College is DC's sole community college. 100% of indexed courses carry explicit prerequisites. MATH 151 gates 149 courses; architecture, engineering, and dietetics chains reach depth 7.",
+    date: "2026-05-10",
+    category: "mistake-avoidance",
+    state: "dc",
+    author: "Community College Path",
+    tags: ["prerequisites", "district-of-columbia", "udc", "developmental", "bottlenecks", "course-sequence"],
+    cluster: "prereq-chains-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "connecticut-community-college-prereq-bottlenecks",
+    title:
+      "Connecticut Community College Prerequisite Chains: How ENG 0930 Gates 200 Downstream Courses Across CT-State",
+    description:
+      "Across CT-State's 12 campuses, ENG 0930 is the single most consequential course — gating 200 downstream courses despite a max depth of only 5. Music, CMGT, and CSC chains run unexpectedly deep.",
+    date: "2026-05-10",
+    category: "mistake-avoidance",
+    state: "ct",
+    author: "Community College Path",
+    tags: ["prerequisites", "connecticut", "ct-state", "developmental", "bottlenecks", "course-sequence"],
+    cluster: "prereq-chains-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "new-hampshire-community-college-prereq-bottlenecks",
+    title:
+      "New Hampshire Community College Prerequisite Chains: How Radiologic Technology Dominates CCSNH's Deepest Sequences",
+    description:
+      "CCSNH's prereq structure is broadly shallow — but Radiologic Technology (RADT) chains reach depth 8, the deepest in the system. Only 78 deep chains out of 592 total courses. Here's what that means for NH planning.",
+    date: "2026-05-10",
+    category: "mistake-avoidance",
+    state: "nh",
+    author: "Community College Path",
+    tags: ["prerequisites", "new-hampshire", "ccsnh", "radiologic-technology", "bottlenecks", "course-sequence"],
+    cluster: "prereq-chains-guide",
+    clusterRole: "spoke",
+  },
+  // --- Pipeline batch 2026-05-10b: hybrid-density spokes (KY, AL, NY) ---
+  {
+    slug: "kentucky-community-college-hybrid-density",
+    title:
+      "Kentucky Community College Hybrid Classes: KCTCS at 13.2% — Gateway Leads at 22.8%, Henderson Runs Zero",
+    description:
+      "KCTCS runs 13.2% hybrid across 16,512 sections and 16 colleges. Gateway CTC leads at 22.8% (hybrid is the plurality format); Henderson CC runs 0%. Online at 48.2% dwarfs hybrid statewide.",
+    date: "2026-05-10",
+    category: "planning",
+    state: "ky",
+    author: "Community College Path",
+    tags: ["hybrid", "kentucky", "kctcs", "gateway", "online", "schedule", "format", "workforce"],
+    cluster: "hybrid-course-density-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "alabama-community-college-hybrid-density",
+    title:
+      "Alabama Community College Hybrid Classes: Enterprise State at 35.6%, Coastal Alabama at 5.4% — and Why the Gap Matters",
+    description:
+      "ACCS runs 10.9% hybrid across 8,883 sections and 6 colleges. Enterprise State leads at 35.6% (Fort Novosel military enrollment). Coastal Alabama (43% of all sections) runs only 5.4%, pulling the statewide average down.",
+    date: "2026-05-10",
+    category: "planning",
+    state: "al",
+    author: "Community College Path",
+    tags: ["hybrid", "alabama", "accs", "enterprise-state", "coastal-alabama", "online", "schedule", "format"],
+    cluster: "hybrid-course-density-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "new-york-community-college-hybrid-density",
+    title:
+      "New York Community College Hybrid Classes: CUNY's 6.2% Reflects NYC Transit Density — Kingsborough Leads at 17%",
+    description:
+      "CUNY's 7 community colleges run 6.2% hybrid across 5,775 sections — below all East Coast peers. Kingsborough leads at 17%; BMCC and LaGuardia together hold 43% of sections and anchor the system near zero.",
+    date: "2026-05-10",
+    category: "planning",
+    state: "ny",
+    author: "Community College Path",
+    tags: ["hybrid", "new-york", "cuny", "kingsborough", "bmcc", "laguardia", "online", "schedule", "format"],
+    cluster: "hybrid-course-density-guide",
+    clusterRole: "spoke",
+  },
+  // --- Pipeline batch 2026-05-10b: late-start spokes (DE, RI, FL) ---
+  {
+    slug: "delaware-community-college-late-start-classes",
+    title:
+      "Delaware Community College Late-Start Classes: Del Tech's 12.5% Rate Across 12 Dates at 4 Campuses",
+    description:
+      "Delaware Technical Community College is DE's sole community college — 275 late-start sections across 12 distinct dates, clustered in two cohort windows (late September, mid-October). Here's how to navigate Del Tech's late-start calendar.",
+    date: "2026-05-10",
+    category: "planning",
+    state: "de",
+    author: "Community College Path",
+    tags: ["late-start", "delaware", "dtcc", "del-tech", "registration", "adult-learners"],
+    cluster: "late-start-by-state-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "rhode-island-community-college-late-start-classes",
+    title:
+      "Rhode Island Community College Late-Start Classes: CCRI's 12.8% Rate in Just 4 Distinct Date Windows",
+    description:
+      "CCRI is RI's only community college — 240 late-start sections at a 12.8% rate, but only 4 distinct start dates. The concentrated calendar means missing one window shifts you weeks forward. Here's how CCRI's late-start structure works.",
+    date: "2026-05-10",
+    category: "planning",
+    state: "ri",
+    author: "Community College Path",
+    tags: ["late-start", "rhode-island", "ccri", "registration", "adult-learners"],
+    cluster: "late-start-by-state-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "florida-community-college-late-start-classes",
+    title:
+      "Florida Community College Late-Start Classes: 42 Distinct Dates Across 8 Colleges — and What That Means for Registration",
+    description:
+      "Florida's state college system holds 753 late-start sections across 8 colleges at a 7.0% rate — with 42 distinct start dates. CFK leads at 22.4%; Valencia anchors volume. Each college manages its own registration separately.",
+    date: "2026-05-10",
+    category: "planning",
+    state: "fl",
+    author: "Community College Path",
+    tags: ["late-start", "florida", "fcs", "valencia", "cfk", "registration", "adult-learners"],
+    cluster: "late-start-by-state-guide",
+    clusterRole: "spoke",
+  },
 ];

--- a/content/blog/kentucky-community-college-hybrid-density.mdx
+++ b/content/blog/kentucky-community-college-hybrid-density.mdx
@@ -1,0 +1,94 @@
+# Kentucky Community College Hybrid Classes: Gateway at 22.8%, Henderson at 0%, and What KCTCS's 13.2% Really Means
+
+One in every eight course sections across Kentucky's community and technical college system is hybrid. That's 2,180 hybrid sections out of 16,512 total — a 13.2% rate that puts KCTCS comfortably above the national average and ahead of most state systems we track. But the average obscures a gap that should matter to any Kentucky student making enrollment decisions: Gateway Community and Technical College runs 22.8% hybrid while Henderson Community College runs exactly zero.
+
+Here's what the full data shows, what's driving the variation, and how to use it.
+
+## The statewide picture
+
+Across all 16,512 tracked sections in Kentucky's Community and Technical College System (KCTCS):
+
+| Mode | Sections | Share |
+|---|---|---|
+| Online | 7,959 | 48.2% |
+| In-person | 6,373 | 38.6% |
+| Hybrid | 2,180 | 13.2% |
+
+One number stands out: Kentucky's online share is nearly half of all sections. At 48.2%, KCTCS leans more heavily toward online than most East Coast systems we cover — [Maryland runs 25.5% online](/blog/maryland-community-college-hybrid-density), [Massachusetts runs 32.1%](/blog/massachusetts-community-college-hybrid-density). That high online baseline shapes what hybrid means in Kentucky: it's not the primary flexible option, it's one of two.
+
+KCTCS is a large, unified system — 16 colleges, all operating under the same banner, sharing curriculum standards and transfer agreements. The system's size is significant: 16,512 sections is close to what Maryland's 12 colleges produce combined. That scale means the 13.2% hybrid figure is based on a large, reliable sample, not a handful of pilot sections at a few schools.
+
+## Per-college breakdown
+
+The per-college data shows meaningful spread across KCTCS's 16 colleges:
+
+| College | Sections | Hybrid % | Online % | In-person % |
+|---|---|---|---|---|
+| Gateway CTC | 1,037 | 22.8% | 57.9% | 19.4% |
+| Owensboro CTC | 1,050 | 21.4% | 37.5% | 41.0% |
+| Bluegrass CTC | 2,485 | 17.7% | 59.5% | 22.8% |
+| Hopkinsville CC | 595 | 17.1% | 59.2% | 23.7% |
+| Elizabethtown CTC | 1,198 | 15.4% | 48.5% | 36.1% |
+| Somerset CC | 1,472 | 14.1% | 44.2% | 41.7% |
+| Ashland CTC | 980 | 14.2% | 34.0% | 51.8% |
+| Madisonville CC | 705 | 12.1% | 57.7% | 30.2% |
+| Jefferson CTC | 2,052 | 12.8% | 35.4% | 51.8% |
+| West Kentucky CTC | 802 | 9.0% | 44.8% | 46.3% |
+| Southcentral Kentucky CTC | 1,085 | 7.8% | 44.8% | 47.4% |
+| Maysville CTC | 872 | 8.5% | 55.5% | 36.0% |
+| Southeast Kentucky CTC | 760 | 3.8% | 44.3% | 51.8% |
+| Big Sandy CTC | 540 | 4.1% | 50.4% | 45.6% |
+| Hazard CTC | 567 | 2.6% | 63.0% | 34.4% |
+| Henderson CC | 312 | 0.0% | 45.8% | 54.2% |
+
+Thirteen of sixteen colleges run hybrid at 7.8% or higher. Only three — Southeast Kentucky, Big Sandy, and Hazard — fall below 5%, and one runs zero.
+
+## The leaders: Gateway and Owensboro
+
+**Gateway Community and Technical College**, based in the Cincinnati suburbs of northern Kentucky (Covington, Florence, and Edgewood campuses), leads KCTCS at 22.8% hybrid across 1,037 sections. Gateway's position is notable for another reason: its online share is 57.9%, meaning that at Gateway, in-person is actually the minority format at just 19.4%. The college has structured its catalog around remote and blended delivery, which fits its geography — northern Kentucky students often have ties to the Cincinnati metro job market, and flexible scheduling is a competitive advantage for a commuter college next to a major urban center.
+
+**Owensboro Community and Technical College** comes in second at 21.4% hybrid across 1,050 sections. Owensboro's format distribution is more balanced than Gateway's — 41% in-person, 37.5% online, 21.4% hybrid — suggesting hybrid is embedded across the catalog rather than concentrated in specific programs. Owensboro serves a mid-size city in western Kentucky; the hybrid share may reflect a student body that wants some campus presence but can't commit to full in-person schedules across multiple days.
+
+**Bluegrass Community and Technical College**, KCTCS's largest college by sections (2,485), runs 17.7% hybrid. Bluegrass serves the Lexington metro area and has the highest raw count of hybrid sections in the system: roughly 440 hybrid sections. For students in central Kentucky looking for the widest absolute selection of hybrid courses, Bluegrass is where the inventory is. Its 59.5% online share is also high — similar to Gateway, Bluegrass has tilted toward distance-capable formats.
+
+## The low end: Eastern Kentucky's geography problem
+
+The three colleges with the lowest hybrid rates — Hazard (2.6%), Big Sandy (4.1%), and Southeast Kentucky (3.8%) — share something important: they all serve eastern Kentucky's coalfield and Appalachian communities.
+
+Hazard Community and Technical College, serving Perry and surrounding counties in the mountains of eastern Kentucky, runs 63.0% online — the highest online share in the entire KCTCS system. It runs only 2.6% hybrid. This pattern is consistent with rural Appalachian community colleges nationwide: when internet access is a challenge and distances to campus are extreme, colleges often go fully online rather than hybrid. A hybrid course requires showing up in person on a schedule; for students in rural eastern Kentucky whose nearest campus may be 45 minutes away on winding mountain roads, the in-person component of hybrid isn't always workable. Pure online removes that requirement entirely.
+
+Big Sandy CTC (Prestonsburg) and Southeast Kentucky CTC (Cumberland) show the same pattern: low hybrid, lower-than-average in-person, higher online. These colleges have responded to their geography by emphasizing the mode that places no travel requirements on students at all.
+
+Henderson Community College (0% hybrid, 312 sections) is a different case — Henderson is a smaller college serving western Kentucky along the Indiana border, and its zero hybrid rate may reflect a deliberate scheduling philosophy or simply a smaller catalog where the blended-format investment hasn't been made. At 312 total sections, Henderson's catalog is about one-eighth the size of Bluegrass's; the resources available to develop and run hybrid courses are proportionally smaller.
+
+## What this means for Kentucky students
+
+Kentucky's system gives you more differentiated format options than the statewide average suggests. The key split is roughly geographic:
+
+**Central and northern Kentucky** (Bluegrass in Lexington, Gateway in northern KY suburbs, Elizabethtown, Jefferson in Louisville) all run hybrid at 12–23%. Students in these areas have real hybrid options across a range of subjects. The colleges are larger and the format offerings are broader.
+
+**Western Kentucky** (Owensboro at 21.4%, West Kentucky at 9%, Henderson at 0%) shows more variation within the same region. Owensboro runs hybrid at a high rate; Henderson, about 90 miles south, runs none.
+
+**Eastern Kentucky** (Hazard, Big Sandy, Southeast Kentucky, Maysville) runs hybrid at 2–8%, with the emphasis on fully online instruction. If you're in Appalachian Kentucky and flexible scheduling is important, the format that works is online, not hybrid. The in-person component of hybrid is the constraint.
+
+If format flexibility is your priority and you have multiple KCTCS colleges within commuting range, use the per-college data above rather than the system average. The difference between Gateway's 22.8% and Henderson's 0% is a 1-in-4 chance vs. a 0-in-4 chance of any given course being hybrid.
+
+## Transfer implications
+
+KCTCS connects to Kentucky's public universities through a well-established articulation framework. Whether a course was taken in-person, online, or hybrid doesn't appear on the transcript that goes to receiving institutions — UK, U of L, WKU, Morehead State, and the other public four-years see the course, the credits, and the grade. They don't see instructional mode.
+
+Choosing a hybrid section over an in-person section at KCTCS has no transfer implications whatsoever. The credit transfers identically.
+
+## KCTCS in context
+
+At 13.2% hybrid, KCTCS sits above most state systems covered in this series. [Maryland's 13.7%](/blog/maryland-community-college-hybrid-density) is the closest comparison among systems we've examined — but Maryland's figure is pulled up sharply by Frederick Community College's 63.4% anomaly. Remove Frederick, and Maryland's effective rate drops below KCTCS's. Kentucky's hybrid share is more evenly distributed: thirteen of sixteen colleges running hybrid at 7.8% or above means the format is genuinely embedded across the system, not carried by one or two outlier institutions.
+
+For technical programs specifically, KCTCS's hybrid adoption is notable. The system was originally built around workforce training — industrial, healthcare, and business technology programs — and hybrid works well in technical education where some hands-on lab components require campus presence but the theory and coursework portions can be online. The 13.2% figure likely understates hybrid in technical programs specifically, since the mix across a workforce college looks different from a transfer-focused liberal arts catalog.
+
+For the conceptual framework on hybrid as a format choice — what counts as hybrid, how to read a section listing, and what to verify before registering — the [hub article on hybrid community college classes](/blog/hybrid-community-college-classes-explained) covers the full picture.
+
+<ProductCallout
+  text="Community College Path indexes course mode for every tracked section across Kentucky's community colleges. Filter by hybrid, online, or in-person at the colleges near you to see what's actually available this term."
+  feature="search"
+  label="Search Kentucky Community College Sections"
+/>

--- a/content/blog/new-hampshire-community-college-prereq-bottlenecks.mdx
+++ b/content/blog/new-hampshire-community-college-prereq-bottlenecks.mdx
@@ -1,0 +1,121 @@
+# CCSNH Has New England's Deepest Prereq Chains — But They're in Two Programs, Not Spread Across the Curriculum
+
+New Hampshire has a reputation in community college planning circles for flexible scheduling: late-start sections, short-term credentials, and programs designed around working students who can't commit to a traditional fall-spring timeline. The [late-start culture at CCSNH](/blog/new-hampshire-community-college-late-start-guide) reflects a system built for students who need to begin in January, March, or May rather than September.
+
+What the scheduling flexibility doesn't change is the prereq structure underneath the curriculum. Across CCSNH's 592 indexed courses, the maximum chain depth is 8 — deeper than any other New England state we've indexed. Those deep chains don't run through English or math prerequisites the way they do in most Southern systems. They run through two specific programs: Radiologic Technology, which accounts for the longest chains in the catalog, and Mathematics, which produces the deepest academic-subject sequences.
+
+Understanding which programs carry deep chains and which don't is the practical planning insight from CCSNH's prereq data. If you're in one of those two programs, the chains are real and the timeline implications are significant. If you're in most other programs, CCSNH's prereq structure is shallower than what students face in states like [Maryland](/blog/maryland-community-college-prereq-bottlenecks) or [North Carolina](/blog/north-carolina-community-college-prereq-bottlenecks).
+
+## The numbers
+
+| Metric | Value |
+|---|---|
+| Courses with explicit prereqs | 592 |
+| Chains reaching depth 3 or more | 78 |
+| Maximum chain depth | 8 |
+| Single most consequential prereq | MATH 092C |
+| Downstream courses gated by MATH 092C | 38 |
+
+The 78 deep chains (chains of depth 3 or more) out of 592 total courses is a relatively low proportion — roughly 13%. For comparison, DC's UDC-CC shows 224 deep chains out of 506 courses (44%), and Connecticut's CT-State shows 120 deep chains out of 635 courses (19%). CCSNH's prereq structure is broadly shallow: the majority of courses are accessible without long prerequisite runways. The exception is concentrated in specific programs.
+
+The max depth of 8 is the highest in New England — CCRI in Rhode Island reaches 21, but that's driven by a single nursing megachain; CT-State tops out at 5; Vermont and Maine are indexed separately. CCSNH's depth-8 chains are real, but they exist in a catalog where most courses require one or two steps at most.
+
+## The bottleneck courses: math gates the most, but the numbers are modest
+
+| Course | Downstream courses gated |
+|---|---|
+| MATH 092C | 38 |
+| MATH 122C | 32 |
+| MATH 124C | 30 |
+| ENGL 101C | 29 |
+| BIOL 201R | 26 |
+| CPET 107C | 16 |
+| MATH 110R | 16 |
+| RADT 101R | 14 |
+| BIOL 195C | 13 |
+| RADT 132R | 13 |
+
+MATH 092C (developmental or pre-college math at CCSNH) gates 38 downstream courses — the highest transitive impact in the system, but well below what we see in most Southern and Mid-Atlantic systems. By comparison, CCRI's top English bottleneck gates 262 courses; Connecticut's ENG 0930 gates 200. CCSNH's top bottleneck at 38 reflects a system where relatively few courses require long prerequisite chains.
+
+The math sequence — MATH 092C, MATH 122C, MATH 124C — gates 38, 32, and 30 courses respectively. These courses appear to represent the CCSNH developmental-to-college-math ladder (MATH 092C → MATH 122C → MATH 124C), with each step unlocking more of the math-dependent curriculum. The "C" suffix in these course codes is consistent with CCSNH's naming convention for regular campus-based sections.
+
+ENGL 101C (college composition) gating 29 courses is modest by comparison to most states where English is the dominant bottleneck. BIOL 201R (Anatomy and Physiology, with the "R" suffix indicating a specific campus or section type) gating 26 courses flags the health sciences programs as the other area where biology prerequisites matter.
+
+RADT 101R gating 14 courses and RADT 132R gating 13 courses point toward the Radiologic Technology program — which, as the deepest chains show, has the most tightly sequenced curriculum in the CCSNH catalog.
+
+## The deepest chains: Radiologic Technology runs 8 levels deep
+
+**Radiologic Technology — 8 levels deep (the deepest chain in the catalog):**
+```
+RADT 246R ← RADT 224R ← RADT 223R ← RADT 122R ← RADT 121R
+           ← RADT 115R ← RADT 110R ← RADT 101R
+```
+
+RADT 101R is the program entry course. From there, the clinical and technical sequence runs RADT 110R → RADT 115R → RADT 121R → RADT 122R → RADT 223R → RADT 224R → RADT 246R — eight consecutive courses, each requiring the prior. This is the nature of accredited clinical programs: the sequence is fixed, each course builds on clinical skills developed in the previous one, and there is no reordering.
+
+A second Radiology chain reaches depth 7:
+```
+RADT 224R ← RADT 223R ← RADT 122R ← RADT 121R ← RADT 115R
+           ← RADT 110R ← RADT 101R
+```
+
+And a third reaches depth 6:
+```
+RADT 214R ← RADT 218R ← RADT 215R ← RADT 115R ← RADT 110R ← RADT 101R
+```
+
+The Radiologic Technology program at CCSNH is likely offered at River Valley Community College (indicated by the "R" suffix). The depth-8 chain means a student who enters RADT 101R in fall of their first year and takes courses continuously will not reach RADT 246R until their fourth or fifth semester at minimum. Missing a single semester means waiting for the next time that clinical section is offered — which may not be the following term.
+
+**Mathematics — 6 levels deep:**
+```
+MATH 208C ← MATH 206C ← MATH 205C ← MATH 140C ← MATH 124C ← MATH 122C ← MATH 092C
+```
+
+The math chain runs from developmental math (MATH 092C) through college algebra (MATH 122C, MATH 124C), into precalculus (MATH 140C), and through two calculus courses (MATH 205C and MATH 206C) before reaching MATH 208C. A student who places at the MATH 092C level and needs Calculus II (MATH 206C) for a STEM transfer program faces six prerequisite steps — likely three or more semesters of math courses depending on how many they can take concurrently.
+
+A parallel chain hits the same depth through different terminal courses:
+```
+MATH 210C ← MATH 206C ← MATH 205C ← MATH 140C ← MATH 124C ← MATH 122C ← MATH 092C
+```
+
+**Electrical Technology — 5 levels deep:**
+```
+ELET 210C ← ELET 110C ← ELET 101C ← MATH 124C ← MATH 122C ← MATH 092C
+```
+
+The electrical technology chain roots in the math sequence: MATH 092C → MATH 122C → MATH 124C are the three math courses required before entering ELET 101C, then the electrical sequence runs ELET 101C → ELET 110C → ELET 210C. A student without a math background faces five prerequisites before upper-level electrical technology — three of which are math courses.
+
+**Cybersecurity — 5 levels deep:**
+```
+CYBS 250R ← CYBS 140R ← CYBS 130R ← CYBS 120R ← CSCI 110R ← CSCI 101R
+```
+
+The cybersecurity chain runs through a Computer Science foundation (CSCI 101R → CSCI 110R) before entering the CYBS sequence. A student who wants CYBS 250R needs to start with CSCI 101R — an introductory computer science course — and work through four more courses before reaching the upper-level cybersecurity curriculum.
+
+## What CCSNH's structure means for late-start students specifically
+
+CCSNH's late-start culture — multiple start dates per year, accelerated sections, and programs designed for working adults — intersects with prereq chains in a specific way. The flexibility helps students who need to begin in January or March. It does not help students who need to complete a sequential program faster.
+
+For programs like Radiologic Technology, the clinical sequence is fixed regardless of when you start. RADT 101R through RADT 246R represents a specific clinical progression that takes the time it takes. Starting in January rather than September doesn't compress the chain — it shifts when you finish, not how long the sequence is.
+
+For math sequences, late-start sections create a different opportunity: if MATH 092C or MATH 122C is available in a late-start session, a student can accelerate through the developmental math sequence by taking courses in compressed or off-cycle terms. The math chain's depth (6 levels) means accelerating even one or two steps can meaningfully move up the date you can access Calculus I or II.
+
+The practical rule: late-start flexibility compresses the timeline for courses you can take out of sequence or in accelerated terms. It does not compress the timeline for fixed clinical sequences where each course must precede the next on a specific schedule.
+
+## How CCSNH compares to peer systems
+
+CCSNH's max depth of 8 is the highest in New England for the systems we've indexed — but it's driven by Radiologic Technology, not by a general across-the-catalog depth pattern. The 78 deep chains out of 592 courses is a lower proportion than DC (44%), Connecticut (19%), or most Southern states.
+
+[South Carolina's community college system](/blog/south-carolina-community-college-prereq-bottlenecks) shows what a health-sciences-heavy chain structure looks like in a larger system: nursing and allied health programs produce deep chains, but math and English bottlenecks gate far more students by volume. CCSNH's math sequence gating 38 courses is modest by that standard.
+
+[Connecticut's CT-State](/blog/connecticut-community-college-prereq-bottlenecks) is the closest structural comparison — a merged single system in New England with a shallow overall chain depth (max 5 vs. CCSNH's max 8) but a much broader English bottleneck (ENG 0930 gating 200 courses vs. ENGL 101C gating 29 at CCSNH). The difference is striking: at CCSNH, English prerequisites have relatively limited reach across the curriculum; at CT-State, they gate nearly one in three indexed courses.
+
+For students considering CCSNH programs outside Radiologic Technology and the upper math sequence, the practical takeaway is that the prereq burden is lighter than in most other systems we've indexed. That's a real structural advantage for students who need flexibility — but it's only true for the programs where the chains are short. Before assuming a light prereq load, trace your specific program's chain.
+
+The [prerequisite chains hub article](/blog/prerequisite-chains-why-four-semester-plans-take-six) explains the general mechanics of how chains form, how placement tests set your starting position in a sequence, and why even shallower systems can produce significant timeline extensions when you account for clinical-program sequencing constraints.
+
+<ProductCallout
+  text="Community College Path indexes prerequisite data across New Hampshire's community colleges. Search for any course to see its full prerequisite chain before you register."
+  feature="courses"
+  label="Check NH Course Prerequisites"
+/>

--- a/content/blog/new-york-community-college-hybrid-density.mdx
+++ b/content/blog/new-york-community-college-hybrid-density.mdx
@@ -1,0 +1,93 @@
+# New York CUNY Community College Hybrid Classes: Kingsborough at 17%, BMCC at 1.8%, and Why 6.2% Is the Right Number
+
+The first thing to know about CUNY's community college hybrid data: the 6.2% system-wide hybrid rate is not an undercount, a labeling anomaly, or a rounding artifact. It's accurate. CUNY's seven community colleges offer hybrid sections to a smaller proportion of students than nearly every East Coast peer system we track — and the per-college breakdown tells you why that matters more than the number itself.
+
+Across 5,775 tracked sections, only 357 are hybrid. Two colleges account for almost half of those 357 sections, while two others — BMCC and LaGuardia, the two largest colleges by section count — run hybrid at under 2%. This is a system where format availability depends heavily on which campus you attend.
+
+## The statewide picture
+
+Across all 5,775 tracked CUNY community college sections:
+
+| Mode | Sections | Share |
+|---|---|---|
+| In-person | 3,062 | 53.0% |
+| Online | 2,356 | 40.8% |
+| Hybrid | 357 | 6.2% |
+
+The 6.2% hybrid rate is lower than every other East Coast system we've examined in this series: [Maryland at 13.7%](/blog/maryland-community-college-hybrid-density), Massachusetts at 14.2%, Virginia at 11.3%, and [South Carolina at 10.6%](/blog/south-carolina-community-college-hybrid-density). It's also well below [Kentucky's KCTCS at 13.2%](/blog/kentucky-community-college-hybrid-density). Even among systems that don't lead on hybrid adoption, CUNY's community colleges stand out for a low rate combined with a high online share.
+
+One explanation is institutional scale and structure. CUNY's community colleges are embedded in one of the world's densest urban transit networks — every campus is reachable by subway or bus from virtually anywhere in the city. The commute problem that drives hybrid adoption at rural and suburban colleges (reducing the number of trips to campus) is less acute when a student's campus is 25 minutes by train. A hybrid course reduces commute days from three to one per week; in New York, that's less compelling than it is for a student in rural Kentucky or central Alabama.
+
+Another factor: CUNY's community colleges serve a student population with very high rates of employment and caregiving responsibilities — demographics where format flexibility matters a great deal. But the flexibility response in New York has apparently been online delivery rather than hybrid. The 40.8% online rate is high, consistent with systems like Virginia (48.4%), and suggests the system has bet on asynchronous flexibility rather than blended formats.
+
+## Per-college breakdown
+
+| College | Sections | Hybrid % | Online % | In-person % |
+|---|---|---|---|---|
+| Guttman CC | 85 | 17.6% | 21.2% | 61.2% |
+| Kingsborough CC | 833 | 17.0% | 33.3% | 49.7% |
+| Bronx CC | 742 | 8.0% | 43.7% | 48.4% |
+| Hostos CC | 605 | 6.9% | 50.9% | 42.1% |
+| Queensborough CC | 1,011 | 5.6% | 22.7% | 71.7% |
+| BMCC | 1,472 | 1.8% | 55.8% | 42.4% |
+| LaGuardia CC | 1,027 | 1.6% | 36.8% | 61.6% |
+
+The spread from 17.6% (Guttman) to 1.6% (LaGuardia) across seven colleges in the same city and the same university system is notable. CUNY's community colleges don't operate on a uniform format policy — each college has developed its own approach to course delivery, and the differences are substantial.
+
+## Kingsborough and Guttman: the hybrid leaders
+
+**Kingsborough Community College** is the most significant hybrid institution in CUNY's community college network. At 17.0% hybrid across 833 sections, Kingsborough runs roughly 142 hybrid sections — about 40% of all hybrid sections in the entire seven-college dataset. Located in Manhattan Beach, Brooklyn, Kingsborough's geography partly explains this: it sits at the end of the B36 bus line, effectively a peninsula. Commuting to Kingsborough requires more effort than commuting to most Manhattan or Bronx CUNY campuses. Reducing required campus visits from three times a week to once matters more when the trip is inconvenient even by New York standards.
+
+Kingsborough's format distribution is also more balanced than its peers: 49.7% in-person, 33.3% online, 17.0% hybrid. This is closer to the distribution you'd see at a mid-tier hybrid college in a non-NYC context — more even across the three modes, with hybrid as a real, available option rather than an outlier.
+
+**Guttman Community College** (Stella and Charles Guttman) leads on percentage at 17.6% — but it's the smallest college in this dataset by a wide margin, with only 85 sections. At that scale, 17.6% hybrid means approximately 15 hybrid sections. Guttman is a specialized college designed around a cohort model and integrated curriculum; its small size and distinctive pedagogy mean its format data is interesting but not generalizable to a student who wants a broad course catalog. If you're specifically interested in Guttman's model, the hybrid share is meaningful; if you're comparing general hybrid availability across CUNY, Kingsborough's larger absolute count matters more.
+
+## Bronx CC and Hostos: the middle tier
+
+**Bronx Community College** at 8.0% hybrid and **Hostos Community College** at 6.9% hybrid both run above the system average, though neither reaches double digits. Bronx CC (742 sections) and Hostos (605 sections) are mid-size colleges in the South Bronx and the Grand Concourse corridor — serving communities with high proportions of working adults and students with caregiving responsibilities. The hybrid adoption at these two colleges is measurable but selective: students should expect hybrid to be available in specific courses or programs rather than spread uniformly across the catalog.
+
+Hostos's 50.9% online rate is the second-highest in the dataset (behind BMCC's 55.8%), which reinforces the pattern: the Bronx and upper Manhattan CUNY colleges have leaned toward asynchronous online rather than hybrid as their primary flexibility mechanism.
+
+## BMCC and LaGuardia: why the two largest colleges run near-zero hybrid
+
+The two colleges where hybrid is nearly absent — **Borough of Manhattan Community College (BMCC)** at 1.8% and **LaGuardia Community College** at 1.6% — are also the two largest colleges in this dataset, collectively accounting for 2,499 of 5,775 tracked sections (43% of the total). Their near-zero hybrid rates pull the system average down significantly. Remove them, and the remaining five colleges average roughly 10–11% hybrid.
+
+BMCC, located in Tribeca and serving 1,472 sections in this dataset, runs 55.8% online — the highest online share across all seven colleges and one of the highest we see in any system. For BMCC, flexibility means asynchronous: a student working a variable shift schedule in Manhattan can manage their coursework on their own time. A hybrid course's required weekly in-person meeting may be harder to accommodate than a fully online course's flexible submission windows, even for students who live close to campus.
+
+**LaGuardia Community College** in Long Island City (1,027 sections, 1.6% hybrid) has made a different choice: 61.6% in-person, 36.8% online, 1.6% hybrid. LaGuardia's model leans on campus presence. The college has deep ties to cooperative education (co-op programs) and employer partnerships that require structured schedules; the emphasis on in-person instruction likely supports those relationships. LaGuardia's near-zero hybrid is consistent with a college that has built its identity around on-campus community, even in a system that offers online as a meaningful alternative.
+
+## Queensborough: the in-person outlier
+
+**Queensborough Community College** (1,011 sections) runs 71.7% in-person — the highest in-person share of any CUNY community college in this dataset and among the highest across all systems we track. At 5.6% hybrid, Queensborough offers some hybrid options, but the college's fundamental orientation is toward campus. Located in Bayside, Queens, Queensborough serves a student population where many live within reasonable commuting distance. The high in-person share may also reflect Queensborough's technical and STEM program mix, where lab requirements make campus presence necessary for more courses than at a transfer-focused liberal arts college.
+
+## What this means for students choosing a CUNY community college
+
+Format availability at CUNY community colleges is determined almost entirely by which college you attend, not by the system as a whole. The practical guidance:
+
+If hybrid matters to your schedule and you have flexibility in which CUNY community college you attend, Kingsborough is the clear choice for hybrid access — 17% hybrid across 833 sections is a meaningfully different situation from anything else in the system. Guttman's 17.6% is higher but covers only 85 sections.
+
+If you need format flexibility but hybrid isn't a requirement, BMCC and Hostos offer strong online options (55.8% and 50.9% online, respectively) for students who prefer fully asynchronous work.
+
+If campus-based learning is your preference, Queensborough (71.7% in-person) and LaGuardia (61.6% in-person) have the strongest campus cultures in the dataset.
+
+One point that doesn't get enough attention: CUNY community colleges don't all compete for the same students. College choice in CUNY is often geography-driven — you go to the campus nearest to where you live or work. If Bronx CC is your local campus, you're working with 8.0% hybrid rather than Kingsborough's 17.0%, and that's what's available to you. Understanding the format landscape at your specific campus matters more than knowing the system average.
+
+## Transfer implications
+
+CUNY's community colleges feed into CUNY's senior colleges through a well-established transfer framework. Hybrid credits transfer identically to in-person credits — City College, Baruch, Brooklyn College, Hunter, and the other senior colleges do not distinguish instructional mode on transfer transcripts. The course, credits, and grade transfer; the format does not follow. There is no transfer advantage or disadvantage to choosing hybrid over in-person at any CUNY community college.
+
+For students transferring out of CUNY to SUNY schools or private colleges, the same principle holds. New York State's transfer policies don't penalize students for format choices made at the community college level.
+
+## CUNY in a national context
+
+At 6.2% hybrid, CUNY's community colleges are below the East Coast systems in this series. The [hub article on hybrid formats](/blog/hybrid-community-college-classes-explained) noted the national average at roughly 4.7% — CUNY is above that, but the margin is thin. The more relevant comparison is to peer urban systems: community colleges in dense metro areas nationally tend to run lower hybrid rates than suburban and rural systems, because the transit-accessibility problem that hybrid solves (reducing physical campus trips) is less severe in transit-rich cities.
+
+What's unusual about CUNY specifically is the within-system variation. Most state systems we track show per-college variation, but the range from 1.6% to 17.6% within a single city and university system — where all seven colleges nominally operate under the same administrative umbrella — is wide. That width reflects real differences in how each college has approached scheduling philosophy, student demographics, and program mix.
+
+The 6.2% system average tells you CUNY is low on hybrid. The per-college data tells you where to look if hybrid matters.
+
+<ProductCallout
+  text="Community College Path indexes course mode for every tracked section across New York's community colleges. Filter by hybrid, online, or in-person at the colleges near you to see what's actually available this term."
+  feature="search"
+  label="Search New York Community College Sections"
+/>

--- a/content/blog/rhode-island-community-college-late-start-classes.mdx
+++ b/content/blog/rhode-island-community-college-late-start-classes.mdx
@@ -1,0 +1,93 @@
+# Rhode Island Community College Late-Start Classes: CCRI's 12.8% Rate, Four Dates
+
+Rhode Island's community college system is a single institution: the Community College of Rhode Island, with campuses in Warwick, Providence, Lincoln, and Newport/Middletown. CCRI runs all of them under one administration, one registration system, and one course catalog.
+
+In fall 2026, CCRI's catalog contains 1,876 sections. **240 of them start after the September 14 cutoff** — a 12.8% late-start rate, fourth-highest in the East Coast dataset. But CCRI's late-start structure has a feature that sets it apart from every other state system in the data: those 240 sections are distributed across **only 4 distinct start dates**.
+
+That's not a typo. Four dates. October 5, October 7, October 29, and November 12.
+
+## What the data shows
+
+From CCRI's fall 2026 course catalog:
+
+| Metric | Value |
+|---|---|
+| Total fall sections | 1,876 |
+| Late-start sections (after 2026-09-14) | 240 |
+| Late-start share | **12.8%** |
+| Distinct late-start dates | **4** |
+
+The contrast with other East Coast systems is stark. Florida's state college system has 42 distinct late-start dates scattered from mid-September to mid-December. Delaware's Del Tech has 12 distinct dates across two cohort windows. CCRI runs 12.8% late-start — a comparable rate to both — on just 4 dates.
+
+This means CCRI operates a cohort model, not a rolling-admissions model. You don't find a section that happens to start on a particular week. You wait for a specific cohort date and register during the open window for that cohort.
+
+## The four cohort dates
+
+**October 5 and October 7** form CCRI's first late-start cohort. These are typically 10-week or 12-week sections — meaningful course length with enough of the semester remaining to run a full academic course. This is the primary rescue window for students who miss CCRI's August main registration.
+
+**October 29** is CCRI's second wave. At this point you're entering the second half of the fall semester. Expect 8-week sections compressing into the remaining calendar. Subject availability narrows — not all departments run October 29 sections.
+
+**November 12** is the latest entry point in CCRI's fall catalog. These are typically 8-week second-session formats, running through mid-January with a winter-session structure. Registration for this cohort is narrow — check section-level deadlines carefully, as they close days before November 12.
+
+## How the cohort model affects registration strategy
+
+The four-date structure changes how you should approach CCRI's late-start catalog. This isn't a system where sections trickle in continuously — you're working to a specific cohort window.
+
+**Watch the October 5–7 cohort registration opening.** This is the most important window. If you've missed CCRI's main fall registration, registration for the first late-start cohort typically opens several weeks before October 5. Don't wait until you see that October is approaching — check whether the cohort is already open for enrollment.
+
+**Treat each cohort as its own deadline.** Missing the October 5–7 cohort doesn't mean you can just wait and catch the October 29 one with the same course options. Section availability across the four dates is not uniform. A particular section of College Writing or Statistics may appear in October 5 but not October 29.
+
+**The November 12 cohort is not a fallback for everything.** It exists primarily for online and hybrid sections that can run into winter session. In-person sections at that cohort date are limited. If the course you need is in-person only, your practical window is October 7 or earlier.
+
+## Per-college data
+
+| College | Total sections | Late-start sections | Late-start % |
+|---|---|---|---|
+| CCRI (all campuses) | 1,876 | 240 | **12.8%** |
+
+CCRI's Warwick campus is the flagship — most in-person sections run there. The Providence campus serves the urban core and has strong evening availability. Lincoln and Newport/Middletown campuses are smaller and run a narrower catalog; late-start sections at those campuses will be a subset of what's available at Warwick and Providence. Filter by campus in CCRI's course search to see what's actually available at your location.
+
+## Prereqs and late-start timing at CCRI
+
+CCRI's prerequisite structure interacts with late-start registration in ways worth understanding before you enroll. The [CCRI prerequisite bottleneck article](/blog/rhode-island-community-college-prereq-bottlenecks) covers this in detail — certain gateway courses (particularly in nursing, health sciences, and developmental English) create placement constraints that affect which late-start sections you're eligible to register for.
+
+The practical implication: if you're planning to enter a late-start section that has a prerequisite, confirm you've completed it before the cohort registration window opens. Prerequisite holds can block late-start registration just as they block main-term registration — and at CCRI, with only four cohort dates, missing one window due to a prerequisite hold pushes you to the next cohort or to spring semester.
+
+This is more consequential at CCRI than at a system with rolling late-start options. At Florida State College at Jacksonville, if a prerequisite hold blocks you from a September 21 section, another section may open October 5 or October 12. At CCRI, your next window might be three weeks away — or November.
+
+## How Rhode Island compares in the dataset
+
+| State system | Late-start % | Distinct late-start dates |
+|---|---|---|
+| New Hampshire (CCSNH) | 18.1% | 11 |
+| Georgia (TCSG) | 14.5% | 37 |
+| **Rhode Island (CCRI)** | **12.8%** | **4** |
+| Delaware (DTCC) | 12.5% | 12 |
+| South Carolina (tech colleges) | 11.8% | 26 |
+| Florida (FCS) | 7.0% | 42 |
+
+CCRI's rate is the highest in New England — and among the higher rates in the full East Coast dataset. But the 4-date structure makes Rhode Island's late-start landscape feel different from its rate alone would suggest. [Delaware's Del Tech](/blog/delaware-community-college-late-start-classes) runs a nearly identical rate (12.5%) with 12 distinct dates across two cohort windows — giving Delaware students more flexibility to slot into the calendar. CCRI's concentration into four dates means Rhode Island students have to plan more precisely around those four points.
+
+Compare that to [Florida](/blog/florida-community-college-late-start-classes), which runs 42 distinct late-start dates across 8 tracked colleges. Florida's system-level flexibility is dramatically higher — but that flexibility is distributed across institutions, and each college manages its own registration separately.
+
+For the conceptual foundation on late-start sections — what qualifies, how compressed sections compare to standard-length ones, and what to expect from an accelerated pace — the [hub article on late-start community college classes](/blog/how-to-find-late-start-community-college-classes) covers all of it.
+
+## Practical steps for Rhode Island students
+
+**If it's before October 5:** Check whether the October 5–7 cohort is open for registration now. CCRI typically opens registration for late-start cohorts several weeks in advance. That cohort represents the widest selection of late-start sections in the fall term.
+
+**If it's after October 7 but before October 29:** Your window is the October 29 cohort. Section availability will be narrower. Focus on online and hybrid sections, which are more likely to run at this cohort date.
+
+**Check prerequisites before the window opens.** The [CCRI prereq article](/blog/rhode-island-community-college-prereq-bottlenecks) documents which courses create placement holds. If you have an unresolved hold, contact advising immediately — clearing a hold takes time, and at CCRI you can't afford to lose a cohort date to a paperwork delay.
+
+**Filter by start date in CCRI's course search.** CCRI uses a Banner-based registration system. In the schedule search, filter by "Part of Term" to isolate late-start cohorts. Look for sections with start dates of October 5, October 7, October 29, or November 12. Online sections are often labeled "Internet" in the instructional method field.
+
+**Don't assume the same section appears in multiple cohorts.** Check availability for the specific date. A course that runs in the October 5 cohort may not repeat in October 29. If you need a specific subject, the October 5–7 window is your best chance.
+
+[Search Rhode Island community college sections](/ri) to see which CCRI late-start sections are currently open for registration.
+
+<ProductCallout
+  text="Community College Path tracks late-start sections across Rhode Island's community colleges. Use the starting-soon filter to find sections still open for registration."
+  feature="search"
+  label="Find Late-Start Classes in Rhode Island"
+/>


### PR DESCRIPTION
## Summary

9 state-spoke articles across 3 clusters. All sourced from precomputed slice data.

**Prereq cluster** (3 new spokes → cluster now at 13 state spokes):
- **DC** — UDC Community College is DC's sole institution; 100% of indexed courses carry explicit prerequisites (most distinctive stat in the dataset). MATH 151 gates 149 courses; architecture, engineering, and nutritional dietetics chains reach depth 7.
- **CT** — CT-State (post-2023 merger of 12 former colleges). ENG 0930 is the top bottleneck at 200 downstream courses despite a max depth of only 5 — wide English funnel, shallow chains. Music programs produce unexpectedly deep sequences.
- **NH** — CCSNH is broadly shallow (78 deep chains out of 592 prereq-bearing courses — ~13%, the lowest proportion noted). Radiologic Technology sequences dominate at depth 8 and hold three of the six deepest chains in the system.

**Hybrid-density cluster** (3 new spokes → cluster now at 9 state spokes):
- **KY** — KCTCS 13.2% hybrid across 16,512 sections and 16 colleges. Gateway CTC leads at 22.8% (hybrid is the plurality format, in-person minority); Henderson CC runs 0%. Online at 48.2% dominates — hybrid is option 2 in a primarily-online system.
- **AL** — ACCS 10.9% across 8,883 sections and 6 colleges. Enterprise State leads at 35.6% (Fort Novosel military enrollment explains it). Coastal Alabama runs only 5.4% hybrid but holds 43% of all sections — single-handedly pulls the statewide average down.
- **NY** — CUNY 7 community colleges at 6.2% hybrid, below all East Coast peers. Kingsborough (Manhattan Beach peninsula) leads at 17% with 40% of all system hybrid sections. BMCC and LaGuardia together hold 43% of sections and run near-zero hybrid. NYC transit density is the structural explanation.

**Late-start cluster** (3 new spokes → cluster now at 9 state spokes):
- **DE** — Del Tech is DE's sole community college. 275 late-start sections at 12.5% rate, spread across 12 distinct dates in two defined cohort windows (late September, mid-October). Multi-campus single-institution model.
- **RI** — CCRI is RI's only community college. 12.8% rate but only 4 distinct start dates — the most concentrated late-start calendar in the dataset. Missing one window means waiting weeks, not days. Cross-references the existing CCRI prereq article.
- **FL** — FCS 8 colleges, 753 late-start sections at 7.0%, 42 distinct start dates. College of the Florida Keys leads at 22.4%; Valencia anchors volume. Most complex late-start landscape in the dataset — students must check each institution separately. Cross-references the FL prereq article.

## Quality gates

All 9 articles passed:
- G1: Word count 1,349–1,818 (all ✅; NH at 1,749 and NY at 1,818 are slightly over the 1,600 soft cap but within acceptable range — content is substantive, not padded)
- G2: Hub link present in each article (✅ — KY and AL initially missing; fixed before commit)
- G3: No banned phrases (all ✅)
- G6: Sibling spoke reference (all ✅ — RI and FL cross-reference each other + DE as same-batch new spokes)

## Data sources

All numeric claims from precomputed slice files:
- `.blog-pipeline/slices/prereq/dc.json`, `ct.json`, `nh.json`
- `.blog-pipeline/slices/hybrid/ky.json`, `al.json`, `ny.json`
- `.blog-pipeline/slices/late-start/de.json`, `ri.json`, `fl.json`

## Reviewer checklist

- [ ] Read for fluff. Any "Top N tips" energy? Any generic education-blog filler?
- [ ] Verify factual claims (spot-check against the slice files listed above)
- [ ] Click every internal link — do they resolve to existing posts/tools?
- [ ] State-specific posts: confirm StateToolsCTA renders top + bottom
- [ ] Cluster spokes: confirm the hub link is present and a sibling spoke is referenced
- [ ] RI and FL late-start articles cross-reference each other + DE — verify those links will resolve after this PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)