### PR TITLE
Blog batch D: 3 late-start spokes (VT, AL, DC) — exhausts detector

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -299,6 +299,21 @@
       "slug": "massachusetts-community-college-late-start-classes",
       "draftedAt": "2026-05-10T09:00:00Z",
       "trigger": "late-start-density"
+    },
+    {
+      "slug": "vermont-community-college-late-start-classes",
+      "draftedAt": "2026-05-10T11:00:00Z",
+      "trigger": "late-start-density"
+    },
+    {
+      "slug": "alabama-community-college-late-start-classes",
+      "draftedAt": "2026-05-10T11:00:00Z",
+      "trigger": "late-start-density"
+    },
+    {
+      "slug": "district-of-columbia-community-college-late-start-classes",
+      "draftedAt": "2026-05-10T11:00:00Z",
+      "trigger": "late-start-density"
     }
   ]
 }

--- a/.claude/skills/blog-pipeline/SKILL.md
+++ b/.claude/skills/blog-pipeline/SKILL.md
@@ -88,7 +88,7 @@ If two candidates tie on cluster-non-saturation, pick the one whose data slice h
 
 As of 2026-05-10 (update this after each batch):
 - ✅ Heavily covered: transfer confusion (18 spokes), senior waivers (13), session timing (8 spokes — MD, TN, MA, NY, NC, VA, CT, SC), audit-at-college (9 college spokes)
-- ⚠️ Lightly covered: prereq sequencing (13 spokes — FL, GA, MD, NC, SC, DE, MA, RI, NY, PA, DC, CT, NH; 3 more states have slice data ready: TN, VA, VT), hybrid-course-density (9 spokes — ME, MD, MA, VA, SC, NC, KY, AL, NY; detector exhausted — no more slice data for covered states), late-start-by-state (9 spokes — NH, GA, SC, TN, MD, NC, DE, RI, FL; 5 more states have slices: MS, VT, AL, DC, MA)
+- ⚠️ Lightly covered: prereq sequencing (16 spokes — FL, GA, MD, NC, SC, DE, MA, RI, NY, PA, DC, CT, NH, TN, VA, VT; detector exhausted — all covered states have spokes), hybrid-course-density (9 spokes — ME, MD, MA, VA, SC, NC, KY, AL, NY; detector exhausted — no more slice data for covered states), late-start-by-state (15 spokes — NH, GA, SC, TN, MD, NC, DE, RI, FL, KY, MS, MA, VT, AL, DC; detector exhausted — all covered states have spokes)
 - ❌ Zero coverage: cross-college schedule building (BRIEF.md §3), course availability patterns, instructor density, program-level content
 
 The next batches should disproportionately fill the lightly- and zero-covered themes. That's where the real editorial value sits.

--- a/content/blog/alabama-community-college-late-start-classes.mdx
+++ b/content/blog/alabama-community-college-late-start-classes.mdx
@@ -1,0 +1,104 @@
+# Alabama Community College Late-Start Classes: 5.3% Rate, 6 Colleges, 16 Distinct Dates
+
+Alabama's community college system — the Alabama Community College System (ACCS) — includes dozens of colleges statewide. The late-start dataset for fall 2026 covers 6 colleges in the ACCS, representing 4,424 sections. Of those, **236 sections start after the standard fall cutoff**, giving the covered colleges a **5.3% late-start rate** across 16 distinct late-start dates.
+
+That 5.3% is below the East Coast average of approximately 8.5%. But aggregate percentages mask significant variation across colleges — and within Alabama, the college-level spread is wide enough that your options depend heavily on which specific institution you're attending.
+
+For context on what late-start sections are and how they compare to full-term coursework, see the [hub article on late-start community college classes](/blog/how-to-find-late-start-community-college-classes).
+
+## System-level summary
+
+| Metric | Value |
+|---|---|
+| Total fall sections (covered colleges) | 4,424 |
+| Late-start sections | 236 |
+| Late-start share | **5.3%** |
+| Distinct late-start dates | 16 |
+| Colleges in dataset | 6 |
+
+Sixteen distinct late-start dates across a single fall semester is meaningful calendar flexibility. That's more distinct entry points than Delaware (12), Vermont (8), or Rhode Island (4), despite Alabama's lower overall percentage. The dates spread from mid-September through late November, creating a long tail of entry opportunities even as the semester advances.
+
+## Per-college breakdown
+
+The 5.3% system average is pulled down by the largest colleges in the dataset. The highest late-start rates belong to two smaller colleges:
+
+| College | Total sections | Late-start sections | Late-start % |
+|---|---|---|---|
+| Chattahoochee Valley Community College | 197 | 19 | **9.6%** |
+| Enterprise State Community College | 303 | 29 | **9.6%** |
+| Southern Union State Community College | 650 | 41 | 6.3% |
+| Coastal Alabama Community College | 1,505 | 75 | 5.0% |
+| Gadsden State Community College | 865 | 41 | 4.7% |
+| George C. Wallace Community College – Dothan | 904 | 31 | 3.4% |
+
+Chattahoochee Valley (CVCC) and Enterprise State both run 9.6% late-start rates — nearly double the system average and above the East Coast 8.5% baseline. For students at those colleges, late-start flexibility is comparable to Maryland or Tennessee. For students at Wallace–Dothan (3.4%), the late-start catalog is thinner.
+
+Two important caveats: CVCC's 9.6% applies to just 197 total sections, so 19 late-start sections is a small absolute number. Enterprise State's 29 late-start sections out of 303 is more meaningful by volume. Both are substantially smaller institutions than Coastal Alabama or Gadsden State.
+
+## The 16 late-start dates
+
+Alabama's 16 distinct late-start dates in fall 2026:
+
+**September wave (4 dates):** September 18, 21, 23, 25
+**October cluster (9 dates):** October 12, 13, 15, 16, 17, 23, 26, 29, 30
+**November tail (3 dates):** November 6, 13, 30
+
+The September wave (September 18–25) is the primary rescue window after the standard fall cutoff. Sections beginning here likely run 10–12 weeks, providing the most course time remaining in the fall semester. These are your best options for full-course-equivalent coverage if you missed the main start.
+
+The October cluster is the largest concentration of dates. Nine entry points across October give students who missed September's window multiple fallback options. Expect 8-week compressed formats by mid-October. Not all subjects will appear at every date — workforce credentials and general education courses show up more frequently in compressed formats than major-specific program coursework.
+
+The November tail is specialized territory. Sections beginning November 6, 13, or especially November 30 are very compressed — a section starting November 30 in a semester ending mid-December runs perhaps 2–3 weeks. These serve specific purposes: skills modules, professional development units, lab completions, or short-format certifications. They're not the right entry point for a student trying to recover a missed standard course.
+
+## Why 5.3% is below average — and what drives it
+
+The East Coast average of 8.5% is pulled up by systems like New Hampshire (18.1%), Georgia (14.5%), and Delaware (12.5%). These are systems where late-start sections are a deliberate scheduling philosophy, not an exception.
+
+Alabama's 5.3% reflects a different default. The larger ACCS colleges — Coastal Alabama (1,505 sections, 5.0%), Gadsden State (865 sections, 4.7%), and Wallace–Dothan (904 sections, 3.4%) — run below the system average or at it. These are institutions where the main fall registration window is the primary enrollment event, and late-start sections supplement rather than define the catalog.
+
+The smaller colleges (CVCC and Enterprise State) run above the system average, which suggests size and mission play a role. Smaller colleges serving more concentrated regional populations — and therefore less able to sustain multiple full-term sections of every course — may rely on late-start compressed formats to keep courses viable when enrollment doesn't support a full 16-week section.
+
+## Connection to hybrid scheduling
+
+Alabama's hybrid course density also varies by college in ways that interact with late-start availability. The [Alabama hybrid density analysis](/blog/alabama-community-college-hybrid-density) found that colleges running more hybrid sections tend to have more scheduling flexibility overall — hybrid formats require less physical facility time and can more easily accommodate compressed calendars.
+
+Enterprise State and Chattahoochee Valley, the two colleges with the highest late-start rates (9.6% each), are worth checking against the hybrid data. Colleges where hybrid is common tend to be the same colleges where late-start is more accessible, because both reflect an institutional flexibility around non-standard scheduling. If you're looking for a late-start section in a hybrid format — the most flexible combination — Enterprise State and CVCC are your best starting points in the Alabama dataset.
+
+## How Alabama compares
+
+| State system | Late-start % | Distinct late-start dates |
+|---|---|---|
+| New Hampshire (CCSNH) | 18.1% | 11 |
+| [Delaware (DTCC)](/blog/delaware-community-college-late-start-classes) | 12.5% | 12 |
+| Tennessee (TBR) | 7.8% | 28 |
+| **Alabama (ACCS, 6 colleges)** | **5.3%** | **16** |
+| Connecticut (CT State) | 4.0% | 14 |
+
+Alabama's 5.3% puts it closer to the lower end of the East Coast dataset. Tennessee, which shares the Southeast region, runs 7.8% with 28 distinct dates across its TBR system — a notably higher rate and more date diversity. For a student with schedule flexibility to attend any ACCS college, 16 distinct dates offers more entry point options than Tennessee's 28 might suggest at any individual institution, but Tennessee's system-wide availability is higher.
+
+For a broader look at how late-start scheduling functions in the Southeast, the [Maryland community college late-start analysis](/blog/maryland-community-college-late-start-classes) covers a system with similar size and workforce orientation running a 9.0% rate — a useful comparison for understanding what's achievable at the system level.
+
+## Practical steps for Alabama students
+
+**Know your college's rate before assuming the system average applies to you.** If you're at Chattahoochee Valley or Enterprise State (9.6%), your situation is more flexible than the 5.3% system average implies. If you're at Wallace–Dothan (3.4%), you have fewer options and should check availability earlier.
+
+**Prioritize the September 18–25 window.** The four September dates are your best opportunity for a substantive late-start course with meaningful remaining course time. Sections opening in this window will be 10-12 week formats and will have the broadest subject availability.
+
+**October is viable, not ideal.** The nine October dates give you fallback options, but expect 8-week compressed formats and a narrower subject menu. High-demand courses — English composition, College Math, introductory business — are the most likely to appear. Specialized program-track courses are less reliably offered in this window.
+
+**Registration closes before the section begins.** A section starting October 13 at Gadsden State may close registration by October 8 or 9. ACCS colleges don't have a uniform system-wide cutoff — check section-level deadlines in the course catalog.
+
+**If no late-start section fits:** With 16 distinct dates and 6 colleges in the dataset, the November 6 and November 13 dates are your last practical options for a standard compressed course. November 30 is extremely compressed and should only be considered for short-format skills or professional development modules.
+
+## What the 5.3% means in practice
+
+Alabama's below-average late-start rate means the system is less forgiving of missed main registration windows than New Hampshire, Georgia, Delaware, or Maryland. The practical implication: if you're an Alabama community college student who missed the August main registration window, act quickly. The September wave is your primary window, and 236 late-start sections spread across 6 colleges means individual colleges may have only a handful of sections in each subject area.
+
+The 16 distinct dates soften this somewhat — if September fills up or doesn't have what you need, October provides multiple additional entry points. But the absolute section count (236 across 6 colleges, roughly 40 per college on average) means the late-start catalog at any individual college is not large.
+
+At Enterprise State and CVCC, where 9.6% rates apply to smaller catalogs, the late-start options are proportionally strong but absolutely small. Twenty-nine sections at Enterprise State is a real menu, but not every subject will be available. Plan around what's actually offered rather than assuming your first-choice course will appear in the late-start catalog.
+
+<ProductCallout
+  text="Community College Path tracks late-start sections across Alabama's community colleges. Use the starting-soon filter to find sections still open for registration."
+  feature="search"
+  label="Find Late-Start Classes in Alabama"
+/>

--- a/content/blog/district-of-columbia-community-college-late-start-classes.mdx
+++ b/content/blog/district-of-columbia-community-college-late-start-classes.mdx
@@ -1,0 +1,100 @@
+# DC Community College Late-Start Classes: UDC-CC's 5.6% Rate and 6 Entry Points
+
+The District of Columbia has one community college. UDC Community College — the community college division of the University of the District of Columbia — is the only public two-year institution in DC. There's no cross-town alternative, no second institution to check if the first doesn't work.
+
+Fall 2026 data: 1,054 sections, 59 late-start sections, a **5.6% late-start rate**, and exactly 6 distinct late-start dates.
+
+That's a small dataset by any measure. Acknowledging that upfront matters here, because small numbers shift quickly. A single canceled section or a newly added block is a larger percentage of 59 late-start sections than it would be in a system running hundreds. The framework below is based on what the data shows — and where the data is thin, this article says so.
+
+For the broader context on late-start community college sections and how to evaluate them, see the [hub article on late-start community college classes](/blog/how-to-find-late-start-community-college-classes).
+
+## What the data shows
+
+| Metric | Value |
+|---|---|
+| Total fall sections | 1,054 |
+| Late-start sections (after 2026-09-14) | 59 |
+| Late-start share | **5.6%** |
+| Distinct late-start dates | 6 |
+| Institutions in dataset | 1 |
+
+Fifty-nine late-start sections is a real but constrained catalog. For comparison, Delaware's Del Tech runs 275 late-start sections across a similar single-institution structure; Rhode Island's CCRI runs 240. UDC-CC's 59 sections represent a meaningfully smaller late-start menu — enough to have real options in some subject areas, but not enough to guarantee your specific program's courses will appear.
+
+## The 6 late-start dates
+
+UDC-CC's 6 distinct late-start dates in fall 2026:
+
+- **September 22**
+- **September 26**
+- **September 28**
+- **October 22**
+- **December 3**
+- **December 15**
+
+These dates form a distinctive three-part structure rather than a continuous distribution.
+
+**September cluster (three dates, September 22–28):** This is the primary late-start window. Three dates within a week give students who missed the main fall start a tight but meaningful rescue opportunity. Sections here are likely 10-week or 12-week compressed formats with enough remaining course time for substantive coverage. This is where most of UDC-CC's 59 late-start sections will be concentrated.
+
+**October 22 (single date):** One entry point in mid-October, roughly halfway through the semester. Sections starting here would run approximately 8 weeks — compressed but workable for general education requirements and skills-based coursework. The single date means no fallback if October 22 doesn't have what you need.
+
+**December cluster (December 3 and December 15):** Two very late dates, well into what many institutions would consider finals territory. These are specialized short-format sections — skills modules, professional development units, or condensed workshops rather than standard course sections. A section beginning December 15 in a semester that may end in mid-to-late December is running perhaps 1–2 weeks. These are not general-purpose course options and shouldn't be treated as rescue windows for missed standard courses.
+
+## Single-institution DC context
+
+UDC-CC's position is structurally similar to Del Tech in Delaware or CCRI in Rhode Island — a single community college serving a geographically bounded jurisdiction. But DC's situation has additional layers.
+
+**The enrollment base.** UDC-CC serves a predominantly working-adult population in an urban environment with substantial year-round employment turnover. DC's employment patterns — federal government, hospitality, healthcare, professional services — involve workers changing roles, returning to school, or picking up credentials mid-year. The 59 late-start sections reflect a real institutional attempt to serve that population, even if the numbers are smaller than comparable single-institution states.
+
+**Limited alternatives.** For a DC resident who needs a community college course and UDC-CC doesn't have it in a late-start format, the in-state option doesn't exist. Community colleges in Prince George's County (PGCC) and Northern Virginia (NOVA) are geographically close and theoretically accessible for some DC residents, but they're out-of-state for tuition purposes. This raises the cost of the fallback option significantly.
+
+**Campus geography.** UDC-CC operates primarily at the main UDC campus on Connecticut Avenue NW in upper northwest DC, with some programming at other locations. Late-start section availability at specific sites will vary. Online sections within the 59 late-start total may be the most accessible for students across different DC neighborhoods.
+
+## Prerequisites and late-start timing
+
+For DC students planning around specific programs, prerequisite chains are worth checking before committing to a late-start registration. The [DC community college prerequisite bottlenecks analysis](/blog/district-of-columbia-community-college-prereq-bottlenecks) identifies which UDC-CC programs have the tightest prerequisite requirements — the courses and sequences where a late-start registration in October or November doesn't give you enough runway to resolve a missing prerequisite before the semester ends.
+
+In a catalog of 59 late-start sections, subjects with complex prerequisites will appear in the late-start catalog less frequently than introductory or standalone courses. Check availability at the section level rather than assuming a course's late-start availability from the program catalog.
+
+## How DC compares
+
+DC's 5.6% is below the East Coast average but not dramatically so. The more telling number is the 6 distinct dates and 59 total sections — the scale constraint rather than the percentage.
+
+| State system | Late-start % | Distinct late-start dates |
+|---|---|---|
+| [Delaware (DTCC)](/blog/delaware-community-college-late-start-classes) | 12.5% | 12 |
+| Rhode Island (CCRI) | 12.8% | 4 |
+| **DC (UDC-CC)** | **5.6%** | **6** |
+| Vermont (VTSU/CCV) | 6.8% | 8 |
+| Connecticut (CT State) | 4.0% | 14 |
+
+The Rhode Island comparison is instructive from a single-institution perspective. CCRI runs a 12.8% late-start rate with only 4 distinct dates — the inverse of DC's 6 dates at 5.6%. Rhode Island has higher total late-start volume; DC has slightly more calendar flexibility. Both are small single-institution systems where late-start availability is real but constrained by the scale of the institution itself.
+
+Delaware's Del Tech at 12.5% and 12 dates is the closest structural parallel at a different scale — one institution, one state, substantially higher late-start investment. The gap between Del Tech's 275 late-start sections and UDC-CC's 59 is the practical difference for students.
+
+## Practical steps for DC students
+
+**The September 22–28 window is your primary option.** If you missed UDC-CC's main fall registration window, the three September dates are your best opportunity for a late-start course with substantive remaining course time. Check the catalog in early September — registration for September 22 sections will close around September 17 or 18.
+
+**October 22 is a single fallback.** If the September window doesn't work, October 22 is your next option. One date means you're working with whatever is offered that day — not a menu of choices. Check availability for your specific program area before counting on this window.
+
+**December 3 and December 15 are not general-purpose options.** These dates are appropriate for short-format modules, skills units, or specific circumstances. If a standard course section appears at these dates, it will be extremely compressed. Evaluate the remaining course time before registering.
+
+**Check section-level registration deadlines.** UDC-CC's course catalog will show last-day-to-add dates at the section level. Don't assume the section start date is the registration deadline. For a September 26 section, registration may close September 21.
+
+**Financial aid and late enrollment.** If you're adding a late-start section to maintain financial aid eligibility or full-time enrollment status, verify the census date for the late-start section with UDC-CC's financial aid office. Late-start sections have different census dates than full-term sections, and the timing affects how and when your enrollment status is calculated.
+
+**Consider online sections.** With 59 late-start sections across a single urban campus, online sections within the late-start catalog offer the most scheduling flexibility. If you're working a variable schedule or have location constraints, prioritize online late-start sections in the September cluster first.
+
+## What the 5.6% means in DC
+
+UDC-CC's late-start catalog is real — 59 sections gives students genuine options — but it's the smallest late-start menu in the single-institution comparisons. The September 22–28 cluster is where most of those options live, and it's a short window: registration for the September 22 date closes before the weekend.
+
+For a DC community college student who missed the main fall registration window, the practical advice is simple: move quickly. The September cluster is your strongest window, it closes fast, and the subject selection within 59 total late-start sections is narrower than what students at larger single-institution systems like Del Tech or CCRI have access to.
+
+The October 22 date is a meaningful fallback, but it's one date with limited section counts — not a second wave comparable to what you'd find in Maryland or Tennessee. After October 22, the fall semester is functionally closed for standard late-start enrollment.
+
+<ProductCallout
+  text="Community College Path tracks late-start sections across DC's community colleges. Use the starting-soon filter to find sections still open for registration."
+  feature="search"
+  label="Find Late-Start Classes in DC"
+/>

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -1567,4 +1567,46 @@ export const articles: ArticleMeta[] = [
     cluster: "late-start-by-state-guide",
     clusterRole: "spoke",
   },
+  {
+    slug: "vermont-community-college-late-start-classes",
+    title:
+      "Vermont Community College Late-Start Classes: 6.8% Rate Across a Single Unified System",
+    description:
+      "Vermont State University runs the state's only community college track. Fall 2026 data: 112 late-start sections, 6.8% rate, 8 distinct dates from mid-September through early November.",
+    date: "2026-05-10",
+    category: "registration-timing",
+    state: "vt",
+    author: "Community College Path",
+    tags: ["late-start", "vermont", "vtsu", "ccv", "registration", "adult-learners"],
+    cluster: "late-start-by-state-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "alabama-community-college-late-start-classes",
+    title:
+      "Alabama Community College Late-Start Classes: 5.3% Rate, 6 Colleges, 16 Distinct Dates",
+    description:
+      "ACCS fall 2026 data across 6 colleges: 236 late-start sections at 5.3%. Chattahoochee Valley and Enterprise State lead at 9.6% each; Wallace–Dothan trails at 3.4%. Sixteen distinct entry points from September through November.",
+    date: "2026-05-10",
+    category: "registration-timing",
+    state: "al",
+    author: "Community College Path",
+    tags: ["late-start", "alabama", "accs", "enterprise-state", "coastal-alabama", "registration", "adult-learners"],
+    cluster: "late-start-by-state-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "district-of-columbia-community-college-late-start-classes",
+    title:
+      "DC Community College Late-Start Classes: UDC-CC's 5.6% Rate and 6 Entry Points",
+    description:
+      "UDC Community College is DC's only public two-year institution. Fall 2026: 59 late-start sections, 5.6% rate, 6 distinct dates — including a tight September 22–28 rescue window and two December short-format dates.",
+    date: "2026-05-10",
+    category: "registration-timing",
+    state: "dc",
+    author: "Community College Path",
+    tags: ["late-start", "district-of-columbia", "udc-cc", "registration", "adult-learners"],
+    cluster: "late-start-by-state-guide",
+    clusterRole: "spoke",
+  },
 ];

--- a/content/blog/vermont-community-college-late-start-classes.mdx
+++ b/content/blog/vermont-community-college-late-start-classes.mdx
@@ -1,0 +1,101 @@
+# Vermont Community College Late-Start Classes: 6.8% Rate Across a Single Unified System
+
+Vermont restructured its public higher education system in 2022. Vermont State University absorbed the former Community College of Vermont and several other institutions into a single unified entity. For students looking for late-start classes in Vermont, this means one institution — Vermont State University — runs everything, with CCV (Community College of Vermont) now operating as the community college division within that structure.
+
+The architecture matters because it shapes what's possible. There's no shopping between institutions. If you're looking for a Vermont community college class, you're in VTSU's catalog, specifically the CCV-track sections.
+
+Fall 2026 data: 1,656 sections, 112 late-start sections, a **6.8% late-start rate**, and 8 distinct late-start dates spread from mid-September through early November.
+
+For the full framework on what late-start sections are, how they compare to full-term courses, and how to evaluate a compressed section before committing — see the [hub article on late-start community college classes](/blog/how-to-find-late-start-community-college-classes).
+
+## What the data shows
+
+| Metric | Value |
+|---|---|
+| Total fall sections | 1,656 |
+| Late-start sections (after 2026-09-14) | 112 |
+| Late-start share | **6.8%** |
+| Distinct late-start dates | 8 |
+
+Vermont's 6.8% is below the East Coast average of 8.5%. Eight distinct late-start dates gives students a reasonable spread of entry windows — but the limited total (112 sections out of 1,656) means the available subjects are not uniformly distributed across those dates. Some dates will have a handful of sections; others will have more.
+
+## The 8 late-start dates and what they mean
+
+Vermont's 8 distinct late-start dates in fall 2026 are:
+
+- September 17
+- September 28
+- October 4
+- October 19
+- October 22
+- October 26
+- November 1
+- November 9
+
+These fall into two rough phases:
+
+**Early window (September 17 – October 4):** Three dates, likely 10-week and 12-week compressed sections. These are your best options if you missed the main fall start — enough of the semester remains for a substantive course at a manageable pace.
+
+**Mid-to-late October through November window:** Five dates across five weeks. Sections here are shorter compressed formats, likely 8-week or less. The coursework intensity per week will be higher. Not all subjects will appear this late in the term — expect general education requirements and skills-based coursework more often than specialized program-track courses.
+
+The November 9 date is notable. A section beginning November 9 in a fall semester is compressed into perhaps 6–7 weeks if finals run into mid-December. These are intensive formats meant for specific use cases — students who need to recover a single credit, pick up a corequisite, or complete a short-format skills module. They're not general-purpose rescue courses.
+
+## Single-institution context
+
+Vermont's merger into Vermont State University simplified some things and constrained others. Before 2022, CCV operated across approximately 12 community learning centers statewide. That geographic distribution hasn't disappeared — VTSU continues to serve students in Burlington, Montpelier, Winooski, St. Johnsbury, and other locations. But the scheduling and catalog operate under a single administrative system.
+
+For late-start purposes, this means:
+
+- No institutional alternatives within the state. If a section you need isn't in VTSU's catalog, there's no second community college to check.
+- Section availability at specific locations will vary. CCV's historically distributed model means some late-start sections may be online-only or tied to specific learning center sites. Filter by delivery format and location when searching.
+- Vermont's rural geography makes online sections especially relevant. Students in Vermont's Northeast Kingdom or rural Central Vermont have fewer commuting options than urban community college students. The 112 late-start sections likely skew toward online delivery.
+
+## How Vermont compares
+
+Vermont's 6.8% sits in the middle of the East Coast dataset — above Connecticut (4.0%) and New York CUNY (2.8%), but well below the leading states.
+
+| State system | Late-start % | Distinct late-start dates |
+|---|---|---|
+| New Hampshire (CCSNH) | 18.1% | 11 |
+| Delaware (DTCC) | 12.5% | 12 |
+| [Rhode Island (CCRI)](/blog/rhode-island-community-college-late-start-classes) | 12.8% | 4 |
+| **Vermont (VTSU/CCV)** | **6.8%** | **8** |
+| Connecticut (CT State) | 4.0% | 14 |
+
+The comparison with Rhode Island is instructive. CCRI is also a single-institution state community college system, and it runs a 12.8% late-start rate — nearly double Vermont's 6.8% — but concentrates those sections across only 4 distinct dates. Vermont's 8 dates give students more calendar flexibility; Rhode Island's higher percentage means more total sections to choose from.
+
+Delaware's Del Tech runs 12.5% across 12 distinct dates and offers a useful structural parallel. Like Vermont, it's a single community college institution serving an entire state. Del Tech's [late-start rate and date count are both substantially higher](/blog/delaware-community-college-late-start-classes), suggesting that Vermont's current 6.8% reflects scheduling choices that could shift — not a hard structural ceiling.
+
+## Vermont prerequisites and late-start timing
+
+If you're planning around specific programs, prerequisite completion matters more in a compressed late-start format than in a full-term section. An 8-week section starting October 19 with a prerequisite doesn't give you much runway to resolve a missing prerequisite before the add/drop deadline.
+
+Check the [Vermont community college prerequisite bottlenecks analysis](/blog/vermont-community-college-prereq-bottlenecks) before registering for a late-start section in a program with prerequisite chains. The programs with the most prerequisite dependencies are the ones where a wrong registration move in October costs you the most time.
+
+## Practical steps for Vermont students
+
+**If it's before September 17:** You can still catch the first late-start wave. Search VTSU's catalog for sections with start dates of September 17. These will have the most favorable remaining course length.
+
+**If it's between September 17 and October 4:** The September 28 and October 4 dates are live. These are likely 8-10 week sections. Check delivery format — if you're outside a major population center, prioritize online sections.
+
+**If it's mid-October or later:** Look at the October 19–26 cluster and the early November dates. Expect shorter compressed formats with higher weekly workloads. Evaluate whether the subject area has sections at those dates — not all of the 112 late-start sections will be distributed evenly.
+
+**Verify registration deadlines individually.** VTSU's system will show last-day-to-add dates at the section level. A section starting October 19 may close registration by October 14 or 15. Don't assume the date shown is the registration deadline.
+
+**Financial aid timing.** Late-start sections have different census dates than full-term sections. If you're adding a late-start section to an existing schedule to maintain full-time status for financial aid purposes, confirm with the financial aid office that the census date for the new section aligns with what they need to process your enrollment status.
+
+## What this means if you missed main registration
+
+Vermont's 6.8% rate and 112 late-start sections mean the system offers real options — but the catalog is smaller than what students in New Hampshire or Delaware can access. With 8 distinct dates, there's reasonable calendar flexibility, but you're working with a limited subject pool at each entry point.
+
+The single-institution structure means there's no fallback within Vermont. If VTSU's late-start catalog doesn't have what you need, your practical alternatives are online sections from out-of-state community colleges or waiting for spring registration.
+
+For most Vermont students who missed the main fall registration window by a week or two, the September 17 or September 28 entry points are the best options. They preserve the most course time, give the highest chance of the subject you need being offered, and set the most sustainable pace for compressed coursework.
+
+After October 4, the remaining dates are shorter formats suited to specific circumstances rather than general course recovery.
+
+<ProductCallout
+  text="Community College Path tracks late-start sections across Vermont's community colleges. Use the starting-soon filter to find sections still open for registration."
+  feature="search"
+  label="Find Late-Start Classes in Vermont"
+/>


### PR DESCRIPTION
## Summary

Final batch for the late-start-by-state-guide cluster — 3 state spokes that exhaust the late-start detector across all currently covered states:

- **Vermont** (`vermont-community-college-late-start-classes`) — VTSU/CCV unified system; 6.8%, 8 dates, 1,304 words. Single-institution context; compares to RI (4 dates) and DE (12 dates).
- **Alabama** (`alabama-community-college-late-start-classes`) — ACCS 6 colleges; 5.3%, 16 dates, 1,548 words. CVCC and Enterprise State at 9.6% each; Wallace–Dothan at 3.4%.
- **DC** (`district-of-columbia-community-college-late-start-classes`) — UDC-CC sole institution; 5.6%, 6 dates, 1,470 words. Tight September 22–28 rescue window; two December short-format dates flagged explicitly.

All three detectors (prereq-bottleneck, hybrid-density, late-start-density) are now fully exhausted for covered states. Next pipeline run will signal: time to build a new cluster or add new states.

## Quality gates

| Article | G1 (≥700w) | G2 (hub link) | G3 (no banned phrases) | G6 (sibling ref) |
|---|---|---|---|---|
| Vermont | ✅ 1,304 | ✅ | ✅ | ✅ |
| Alabama | ✅ 1,548 | ✅ | ✅ | ✅ |
| DC | ✅ 1,470 | ✅ | ✅ | ✅ |

## Reviewer checklist
- [ ] Read for fluff. Any "Top N tips" energy? Any generic education-blog filler?
- [ ] Verify factual claims (cite the data slice paths the drafter used)
- [ ] Click every internal link — do they resolve to existing posts/tools?
- [ ] State-specific posts: confirm StateToolsCTA renders top + bottom
- [ ] Cluster spokes: confirm the hub link is present and a sibling spoke is referenced
- [ ] If review-cadence flag is true, add a calendar reminder for annual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)