### PR TITLE
feat(seo): site-wide WebSite/Org JSON-LD + root OG image + /colleges ItemList (#319)

### DIFF
--- a/app/colleges/page.tsx
+++ b/app/colleges/page.tsx
@@ -107,13 +107,36 @@ export default async function AllCollegesPage() {
     ],
   };
 
+  // Build itemListElement entries for every college we cover. Listing
+  // each college explicitly gives Google a structured entry per item
+  // rather than just a count — important for sitelinks and for
+  // appearing in itemList-aware result types (rich results, knowledge
+  // panels, etc.).
+  const collegeListItems = stateData.flatMap((s, stateIdx) =>
+    s.institutions.map((inst, instIdx) => ({
+      "@type": "ListItem",
+      position:
+        stateData
+          .slice(0, stateIdx)
+          .reduce((sum, st) => sum + st.institutions.length, 0) +
+        instIdx +
+        1,
+      url: `${siteUrl}/${s.slug}/college/${inst.id}`,
+      name: inst.name,
+    }))
+  );
+
   const collectionLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     name: "All Community Colleges",
     description: `Browse ${totalColleges} community colleges across ${states.length} states.`,
     url: `${siteUrl}/colleges`,
-    numberOfItems: totalColleges,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: totalColleges,
+      itemListElement: collegeListItems,
+    },
   };
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import AdSenseScript from "@/components/AdSenseScript";
 import ThemeProvider from "@/components/ThemeProvider";
 import AuthProvider from "@/components/AuthProvider";
 import LoginModal from "@/components/auth/LoginModal";
+import JsonLd from "@/components/JsonLd";
 import { getAllStates } from "@/lib/states/registry";
 import "./globals.css";
 
@@ -51,6 +52,43 @@ export const metadata: Metadata = {
   },
 };
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
+
+// Site-wide JSON-LD: WebSite (with sitelink search action), and an
+// EducationalOrganization that aggregates the state systems we cover.
+// Lives in the root layout so it appears on every page; per-route pages
+// can layer additional structured data on top (CollegeOrUniversity,
+// ItemList, BreadcrumbList, etc.).
+const siteJsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#website`,
+      url: SITE_URL,
+      name: "Community College Path",
+      description: `Search courses, plan transfers, and build schedules across ${_totalColleges}+ community colleges in ${_states.length} states.`,
+      potentialAction: {
+        "@type": "SearchAction",
+        target: {
+          "@type": "EntryPoint",
+          urlTemplate: `${SITE_URL}/colleges?q={search_term_string}`,
+        },
+        "query-input": "required name=search_term_string",
+      },
+    },
+    {
+      "@type": "EducationalOrganization",
+      "@id": `${SITE_URL}/#organization`,
+      url: SITE_URL,
+      name: "Community College Path",
+      description: `An independent guide to ${_totalColleges}+ community colleges across ${_states.length} U.S. states. Free course finder, transfer lookup, and schedule planning tools for community college students.`,
+      sameAs: [],
+    },
+  ],
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -63,6 +101,7 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col bg-white dark:bg-slate-900 text-gray-900 dark:text-slate-100">
+        <JsonLd data={siteJsonLd} />
         <ThemeProvider>
           <AuthProvider>
             <GoogleAnalytics />

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,112 @@
+import { ImageResponse } from "next/og";
+import { getAllStates } from "@/lib/states/registry";
+
+export const runtime = "nodejs";
+export const alt = "Community College Path — Community College Course Finder";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Root-level Open Graph image for /, /colleges, /blog index, and any
+// route that doesn't define its own opengraph-image.tsx. Per-state and
+// per-college overrides live deeper in the app/ tree (see
+// app/[state]/opengraph-image.tsx and app/[state]/college/[id]/opengraph-image.tsx).
+
+export default async function Image() {
+  const states = getAllStates();
+  const totalColleges = states.reduce((sum, s) => sum + s.collegeCount, 0);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          width: "100%",
+          height: "100%",
+          backgroundColor: "#f0fdfa",
+          padding: "60px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "white",
+            borderRadius: "24px",
+            border: "2px solid #99f6e4",
+            padding: "60px 80px",
+            width: "100%",
+            height: "100%",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "16px",
+              marginBottom: "32px",
+            }}
+          >
+            <div
+              style={{
+                width: "64px",
+                height: "64px",
+                backgroundColor: "#0d9488",
+                borderRadius: "14px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "white",
+                fontSize: "30px",
+                fontWeight: 700,
+              }}
+            >
+              CCP
+            </div>
+            <span
+              style={{
+                fontSize: "36px",
+                fontWeight: 700,
+                color: "#0d9488",
+              }}
+            >
+              Community College Path
+            </span>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: "56px",
+              fontWeight: 800,
+              color: "#0f172a",
+              textAlign: "center",
+              lineHeight: 1.1,
+              marginBottom: "24px",
+              letterSpacing: "-0.02em",
+            }}
+          >
+            Find courses, plan transfers
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: "30px",
+              color: "#475569",
+              textAlign: "center",
+              maxWidth: "900px",
+              lineHeight: 1.4,
+            }}
+          >
+            {totalColleges}+ community colleges across {states.length} states.
+            Course search, transfer lookup, schedule builder.
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,21 @@
+/**
+ * Server component that emits a JSON-LD <script> tag with the given
+ * structured-data payload. Centralises the pattern used across the app
+ * so we serialize and stringify consistently.
+ *
+ * Usage:
+ *   <JsonLd data={{ "@context": "https://schema.org", "@type": "WebSite", ... }} />
+ *
+ * Multiple JSON-LD blocks per page are fine (and recommended for
+ * separating concerns — e.g. one for WebSite, one for ItemList).
+ */
+type JsonLdData = Record<string, unknown> | Record<string, unknown>[];
+
+export default function JsonLd({ data }: { data: JsonLdData }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
Addresses three of the gaps from the tool-page SEO audit in #319. Scoped tightly to the highest-leverage additions; the rest of #319's checklist stays open.

## What the audit found

After surveying \`app/\`, the existing SEO posture is in better shape than I expected:

- ✅ Sitemap is comprehensive (multi-file index covering core, colleges, college-subjects, courses, state-subjects, transfer, instructors, programs, blog)
- ✅ Most state-tool routes have \`generateMetadata\` with title, description, canonical
- ✅ Interactive tools (\`/results\`, \`/plan\`, \`/schedule\`, \`/starting-soon\`) correctly use \`robots: { index: false }\`
- ✅ JSON-LD already exists on \`/[state]\` (BreadcrumbList), \`/[state]/colleges\` (BreadcrumbList + CollectionPage with itemListElement), \`/[state]/college/[id]\` (CollegeOrUniversity + BreadcrumbList), \`/[state]/transfer/to/[universitySlug]\`, and several others
- ✅ Per-state and per-college OG image generators exist (\`app/[state]/opengraph-image.tsx\`, \`app/[state]/college/[id]/opengraph-image.tsx\`)
- ✅ Root layout sets metadataBase, openGraph type/siteName/locale, Twitter card, robots config

## Real gaps this PR fixes

1. **No site-wide WebSite + Organization JSON-LD.** Google uses these to render sitelinks search boxes and to establish the site's organizational identity for knowledge-graph features. Pages had per-route schemas but no umbrella that ties them together.

2. **No root-level OG image.** \`/\`, \`/colleges\`, \`/blog\` index, and any route without its own \`opengraph-image.tsx\` had no preview image. Per-state and per-college routes were covered by their own image generators; root was not.

3. **\`/colleges\` had numberOfItems but no itemListElement.** Google could see "this is a collection of 200+ things" but not what those things were. ItemList enrichment makes the collection structurally legible.

## What this PR adds

### 1. Site-wide JSON-LD (root layout)

\`app/layout.tsx\` now emits a \`@graph\` payload with two entities:

- **WebSite** with a \`SearchAction\` (\`urlTemplate: /colleges?q={search_term_string}\`) — eligible for the Google sitelinks search box
- **EducationalOrganization** describing the site as an independent guide to 200+ community colleges across 24 states

Both entities have stable \`@id\` values (\`#website\`, \`#organization\`) so per-route structured data can reference them via \`@id\` instead of re-declaring.

### 2. Root \`opengraph-image.tsx\`

1200x630 OG image generator covering all root-level routes. Brand colors, shows total-colleges and total-states counts dynamically from the registry.

Per-segment overrides still apply: \`/[state]/*\` routes get the state-specific image; \`/[state]/college/[id]\` gets the college-specific image. This is the global fallback.

### 3. \`/colleges\` ItemList enrichment

Existing \`CollectionPage\` JSON-LD now includes \`mainEntity: { @type: ItemList, itemListElement: [...] }\` with one \`ListItem\` per college (200+ entries). Each carries \`url\` and \`name\`. Position field reflects the sorted-by-state ordering on the page.

### 4. Reusable \`JsonLd\` component

\`components/JsonLd.tsx\` — small server component that wraps the \`dangerouslySetInnerHTML\` JSON.stringify pattern. Used in the root layout; future pages should adopt this. Existing inline scripts on \`/[state]/*\` pages were left as-is to keep this PR scoped.

## Verification

- \`npm run lint\` — clean for changed files (pre-existing scraper warnings unrelated)
- TypeScript compiles for all changed files
- JSON-LD payload round-trips through \`JSON.parse\` cleanly
- \`@id\` values are stable URIs so other structured data can cross-reference

Manual verification on the Vercel preview deploy:
- View source on / — confirm \`@graph\` JSON-LD present with WebSite + EducationalOrganization
- Run Google Rich Results test on /
- View source on /colleges — confirm itemListElement is populated
- Verify root OG image renders at \`/opengraph-image\`
- Verify per-state and per-college OG images still render (no regression)

## What #319 still has open

- Per-route openGraph.url enrichment (Next.js falls back via metadataBase + canonical, so this is acceptable but could be more explicit)
- Migration of existing inline JSON-LD scripts to the new JsonLd component
- Lighthouse SEO score targets per route type
- Search Console verification that newly indexed routes show up within 30 days
- Programmatic per-college / per-course landing pages (tracked separately in #320)

🤖 Generated with [Claude Code](https://claude.com/claude-code)