### PR TITLE
feat(seo): WebPage + SearchAction on state landing + transfer pages (#319)

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -64,11 +64,40 @@ export default async function HomePage({ params }: Props) {
     ],
   };
 
+  // WebPage + SearchAction. Tells Google that this state landing is a
+  // searchable surface (the course-search hero is the entry point) and
+  // ties it back to the site-wide WebSite/Organization entities declared
+  // in the root layout via @id references.
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": `${siteUrl}/${state}#webpage`,
+    url: `${siteUrl}/${state}`,
+    name: `${config.name} Community College Course Finder`,
+    description: config.branding.tagline,
+    isPartOf: { "@id": `${siteUrl}/#website` },
+    about: { "@id": `${siteUrl}/#organization` },
+    breadcrumb: { "@id": `${siteUrl}/${state}#breadcrumb` },
+    primaryImageOfPage: { "@type": "ImageObject", url: `${siteUrl}/${state}/opengraph-image` },
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${siteUrl}/${state}/courses?q={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  };
+
   return (
     <div>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageLd) }}
       />
       {/* Search section */}
       <section id="search" className="py-16 px-4 sm:px-6 lg:px-8">

--- a/app/[state]/transfer/page.tsx
+++ b/app/[state]/transfer/page.tsx
@@ -71,11 +71,40 @@ export default async function TransferPage({ params }: Props) {
     ],
   };
 
+  // WebPage + SearchAction for the transfer-lookup tool. Tells Google
+  // this state's transfer page is a searchable surface (the receiving
+  // university dropdown + course lookup), and ties back to the site-wide
+  // WebSite/Organization entities declared in the root layout via @id.
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": `${siteUrl}/${state}/transfer#webpage`,
+    url: `${siteUrl}/${state}/transfer`,
+    name: `${config.name} Community College Transfer Course Finder`,
+    description: `Find which ${config.name} community college courses transfer to universities. See direct equivalencies, elective credit, and course availability.`,
+    isPartOf: { "@id": `${siteUrl}/#website` },
+    about: { "@id": `${siteUrl}/#organization` },
+    breadcrumb: { "@id": `${siteUrl}/${state}/transfer#breadcrumb` },
+    primaryImageOfPage: { "@type": "ImageObject", url: `${siteUrl}/${state}/opengraph-image` },
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${siteUrl}/${state}/transfer?course={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  };
+
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageLd) }}
       />
       <Link
         href={`/${state}`}


### PR DESCRIPTION
Continues the #319 tool-page SEO audit. PR #328 added site-wide WebSite + EducationalOrganization at the root layout; this PR adds the per-route WebPage entities for the two highest-traffic tool routes that still only had BreadcrumbList JSON-LD.

## Audit re-pass after #328 merged

| Route | Existing JSON-LD | Gap |
|---|---|---|
| `/[state]/page.tsx` | BreadcrumbList only | Needs WebPage + SearchAction |
| `/[state]/courses/page.tsx` | BreadcrumbList + WebPage + SearchAction | ✅ |
| `/[state]/transfer/page.tsx` | BreadcrumbList only | Needs WebPage + SearchAction |
| `/[state]/about/page.tsx` | FAQPage | ✅ |
| `/[state]/online/page.tsx` | ItemList of CollegeOrUniversity | ✅ |
| `/[state]/colleges/page.tsx` | BreadcrumbList + CollectionPage with itemListElement | ✅ |
| `/[state]/college/[id]/page.tsx` | CollegeOrUniversity + BreadcrumbList | ✅ |
| `/[state]/course/[code]/page.tsx` | Course + CourseInstance + BreadcrumbList | ✅ |
| `/[state]/program/[slug]/page.tsx` | ItemList of CollegeOrUniversity | ✅ |
| `/[state]/subject/[prefix]/page.tsx` | ItemList of Course | ✅ |
| `/[state]/transfer/to/[universitySlug]/page.tsx` | (3 schemas already) | ✅ |

Two real gaps. This PR closes both.

## What changed

### `/[state]/page.tsx`
Adds WebPage with:
- `@id` stable URL for cross-references
- `isPartOf` pointing at the site-wide WebSite (from #328's `@id` of `${SITE}/#website`)
- `about` pointing at the site-wide EducationalOrganization
- `breadcrumb` reference to the existing BreadcrumbList
- `primaryImageOfPage` pointing at the existing per-state OG image
- `SearchAction` with `urlTemplate` `/[state]/courses?q={search_term_string}` — eligible for state-scoped sitelinks search box

### `/[state]/transfer/page.tsx`
Adds WebPage with the same structure plus a transfer-specific SearchAction whose urlTemplate targets `/[state]/transfer?course={search_term_string}`.

Both pages keep their existing BreadcrumbList; the new WebPage is added as a second `<script type="application/ld+json">` tag (Google handles multiple JSON-LD blocks per page natively).

## Why @id linkage matters

The site-wide WebSite + EducationalOrganization in #328 use stable `@id` values (`${SITE}/#website`, `${SITE}/#organization`). This PR's WebPage entities reference those via `isPartOf` and `about` — so Google can build a connected graph of the site's structure rather than treating every page's JSON-LD as isolated.

## What deliberately stayed open

- Per-route `openGraph.*` enrichment — Next.js `metadataBase` + canonical + auto-fallback to `title`/`description` handles this acceptably; the diff cost wasn't worth the marginal value
- Migration of existing inline JSON-LD scripts to the new `JsonLd` component — cosmetic refactor, no SEO benefit
- Per-route OG image overrides — the existing `app/[state]/opengraph-image.tsx` covers all `/[state]/*` routes
- Lighthouse SEO score targets per route type (post-deploy verification, not a code change)
- Search Console verification (post-deploy verification)
- Programmatic per-college / per-course landing pages (tracked in #320)

## Verification

- TypeScript compiles for changed files
- `npm run lint` clean for repo files (one pre-existing scraper warning, unrelated)
- JSON-LD payloads round-trip through `JSON.parse` cleanly
- `@id` URIs match the scheme established by #328's site-wide schema

Manual verification on Vercel preview:
- View source on `/va` — confirm WebPage JSON-LD with SearchAction present alongside the existing BreadcrumbList
- View source on `/va/transfer` — same
- Run Google Rich Results test on both — should validate as WebPage with SearchAction
- After merge, watch Search Console for sitelinks search box appearing per state in 2-4 weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)