### PR TITLE
feat(seo): @id linkage from programmatic-route schemas to site-wide graph (#319/#320)

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -132,8 +132,13 @@ export default async function CollegeDetailPage(props: PageProps) {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "CollegeOrUniversity",
+    "@id": `${siteUrl}/${state}/college/${institution.id}#college`,
     name: institution.name,
     url: `${siteUrl}/${state}/college/${institution.id}`,
+    // Tie the institution back to the site-wide WebSite + Organization
+    // declared in the root layout so Google can build a connected entity
+    // graph rather than treating each page's schema as isolated.
+    isPartOf: { "@id": `${siteUrl}/#website` },
     parentOrganization: {
       "@type": "EducationalOrganization",
       name: config.systemName,

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -323,8 +323,12 @@ export default async function CoursePage(props: PageProps) {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Course",
+    "@id": `${siteUrl}/${state}/course/${code}#course`,
     name: `${prefix} ${number}: ${courseTitle}`,
     description: `${courseTitle} (${credits} credits) offered at ${colleges.length} ${config.systemName} community colleges.`,
+    // Connect to the site-wide WebSite/Organization graph from the root
+    // layout so Google sees this Course as part of the site, not isolated.
+    isPartOf: { "@id": `${siteUrl}/#website` },
     provider: {
       "@type": "Organization",
       name: config.systemFullName,

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -116,10 +116,14 @@ export default async function ProgramPage(props: PageProps) {
   const itemListLd = {
     "@context": "https://schema.org",
     "@type": "ItemList",
+    "@id": `${url}/${state}/program/${slug}#itemlist`,
     name: `${program.name} programs at ${config.name} community colleges`,
     description: data.program.description,
     numberOfItems: data.colleges.length,
     url: `${url}/${state}/program/${slug}`,
+    // Connect to the site-wide WebSite/Organization graph from the root
+    // layout so Google sees this program list as part of the site.
+    isPartOf: { "@id": `${url}/#website` },
     itemListElement: data.colleges.slice(0, 25).map((c, i) => ({
       "@type": "ListItem",
       position: i + 1,

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -172,10 +172,14 @@ export default async function StateSubjectPage(props: PageProps) {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "ItemList",
+    "@id": `${siteUrl}/${state}/subject/${rawPrefix}#itemlist`,
     name: `${subject} Courses — ${config.systemName}`,
     description: `${sections.length} ${subject} sections across ${collegeCount} ${config.systemName} colleges for ${term}.`,
     numberOfItems: courses.length,
     url: `${siteUrl}/${state}/subject/${rawPrefix}`,
+    // Connect to the site-wide WebSite/Organization graph from the root
+    // layout so Google sees this subject list as part of the site.
+    isPartOf: { "@id": `${siteUrl}/#website` },
     itemListElement: courses.slice(0, 25).map((c, i) => ({
       "@type": "ListItem",
       position: i + 1,


### PR DESCRIPTION
After auditing the four programmatic routes (per-college, per-course, per-program, per-subject), the underlying schema (CollegeOrUniversity, Course, ItemList) was already in place — but isolated. Each page's JSON-LD declared its own entity without referencing the site-wide WebSite + EducationalOrganization that #328 added at the root layout.

This PR adds \`@id\` values to each programmatic route's schema and links them via \`isPartOf\` to the site-wide WebSite. That gives Google a connected entity graph spanning the whole site rather than treating per-page schema as disconnected.

## Routes touched

| Route | Schema | Added |
|---|---|---|
| \`/[state]/college/[id]\` | CollegeOrUniversity | \`@id\` + \`isPartOf\` |
| \`/[state]/course/[code]\` | Course | \`@id\` + \`isPartOf\` |
| \`/[state]/program/[slug]\` | ItemList | \`@id\` + \`isPartOf\` |
| \`/[state]/subject/[prefix]\` | ItemList | \`@id\` + \`isPartOf\` |

\`@id\` URIs follow the pattern \`${SITE}/${state}/...#<role>\` so each entity has a stable identifier. \`isPartOf\` references \`${SITE}/#website\` (the WebSite entity from #328's root-layout graph).

## Why this matters

Google treats JSON-LD with cross-references as a connected entity graph. With \`@id\` linkage:
- The site-wide WebSite (with SearchAction) gets associated with every page
- The EducationalOrganization gets associated with each programmatic page
- Knowledge-graph features can attach to the org instead of being scattered
- Sitelinks, breadcrumbs, and rich-result eligibility are computed against the connected graph

Without \`@id\` linkage, Google sees each page's schema as standalone and has to re-infer relationships. With it, the relationships are explicit.

## What this PR does NOT do

- Add new programmatic routes (the existing routes are functioning and quality-gated; expanding the universe is separate work tracked in #320)
- Migrate inline JSON-LD scripts to the JsonLd component (cosmetic refactor; defer)
- Add structured-data fields not currently sourced (e.g., aggregateRating on CollegeOrUniversity — we don't have rating data)

## Verification

- TypeScript compiles for changed files
- \`npm run lint\` clean for repo files (one pre-existing scraper warning, unrelated)
- All four JSON-LD payloads round-trip through \`JSON.parse\`
- \`@id\` URIs follow the URI scheme established by #328 + #329

## #319 status after this lands

✅ Site-wide WebSite + Org schema (#328)
✅ Root OG image (#328)
✅ ItemList enrichment on /colleges (#328)
✅ JsonLd reusable component (#328)
✅ WebPage + SearchAction on state landing + transfer pages (#329)
✅ \`@id\` linkage from programmatic routes to site graph (this PR)

⏳ **Still open** (post-deploy verification or out of code scope):
- Lighthouse SEO score targets per route type (manual run)
- Search Console verification within 30 days (manual check)
- Migration of existing inline JSON-LD scripts to the JsonLd component (cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)