### PR TITLE
feat(seo): Course Offering Profile section on per-college pages (#320)

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -15,6 +15,8 @@ import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { getAllStates } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getTopInstructors } from "@/lib/instructors";
+import { computeOfferingProfile } from "@/lib/college-stats";
+import { subjectName } from "@/lib/subjects";
 import type { CourseSection } from "@/lib/types";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
@@ -124,6 +126,16 @@ export default async function CollegeDetailPage(props: PageProps) {
   // so the map stays the same regardless of which term the client picks.
   // Targeted Supabase query instead of loading the whole state catalog.
   const transferLookup = await buildTransferLookupForCourses(union, state);
+
+  // Course Offering Profile — server-side computed stats from the
+  // most-recent term's sections. Surfaces mode breakdown, start-date
+  // diversity, and top subject prefixes so the per-college page has
+  // substantive unique content beyond the standard course catalog
+  // (which is rendered client-side and not seen by Googlebot until JS
+  // runs). Computed inline from data already in scope, no extra I/O.
+  const offeringProfile = computeOfferingProfile(
+    coursesByTerm[defaultTerm] ?? []
+  );
 
   const systemCollegeCoursesUrl = config.collegeCoursesUrl(collegeSlug);
 
@@ -391,6 +403,117 @@ export default async function CollegeDetailPage(props: PageProps) {
           </div>
         </details>
       </section>
+
+      {/* Course Offering Profile — server-rendered summary of this term's
+          mode breakdown, start-date diversity, and top subjects. Gives
+          Googlebot substantive unique content per-college that doesn't
+          require running the client-side course catalog component. */}
+      {offeringProfile && offeringProfile.total > 0 && (
+        <section className="mt-8 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+            Course Offering Profile
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
+            What {institution.name} is offering for{" "}
+            {defaultTerm.toUpperCase()} — {offeringProfile.total} sections
+            across {Object.keys(offeringProfile.modes.modes).length} delivery
+            modes.
+          </p>
+
+          <div className="grid sm:grid-cols-2 gap-6">
+            {/* Format mix */}
+            <div>
+              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                Format mix
+              </h3>
+              <ul className="text-sm text-gray-700 dark:text-slate-300 space-y-1">
+                {Object.entries(offeringProfile.modes.modes)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([mode, count]) => (
+                    <li key={mode} className="flex justify-between">
+                      <span className="capitalize">
+                        {mode.replace("-", " ")}
+                      </span>
+                      <span>
+                        <span className="font-medium text-gray-900 dark:text-slate-100">
+                          {count}
+                        </span>{" "}
+                        <span className="text-xs text-gray-500 dark:text-slate-400">
+                          ({offeringProfile.modes.modePcts[mode].toFixed(0)}
+                          %)
+                        </span>
+                      </span>
+                    </li>
+                  ))}
+              </ul>
+            </div>
+
+            {/* Section start dates */}
+            <div>
+              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                Section start dates
+              </h3>
+              {offeringProfile.distinctStartDates > 0 ? (
+                <p className="text-sm text-gray-700 dark:text-slate-300">
+                  Sections begin on{" "}
+                  <span className="font-medium text-gray-900 dark:text-slate-100">
+                    {offeringProfile.distinctStartDates}
+                  </span>{" "}
+                  distinct date
+                  {offeringProfile.distinctStartDates === 1 ? "" : "s"} this
+                  term.
+                  {offeringProfile.lateStartCount > 0 && (
+                    <>
+                      {" "}
+                      <Link
+                        href={`/${state}/starting-soon`}
+                        className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
+                      >
+                        {offeringProfile.lateStartCount} late-start sections
+                      </Link>{" "}
+                      begin more than two weeks after the term starts.
+                    </>
+                  )}
+                </p>
+              ) : (
+                <p className="text-sm text-gray-500 dark:text-slate-400">
+                  Start-date data not available for this term.
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Top subjects */}
+          {offeringProfile.topSubjects.length > 0 && (
+            <div className="mt-6 pt-4 border-t border-gray-100 dark:border-slate-700">
+              <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                Most-offered subjects this term
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {offeringProfile.topSubjects.map((s) => {
+                  const label = subjectName(s.prefix);
+                  const display =
+                    label && label !== s.prefix
+                      ? `${label} (${s.prefix})`
+                      : s.prefix;
+                  return (
+                    <Link
+                      key={s.prefix}
+                      href={`/${state}/college/${id}/courses/${s.prefix.toLowerCase()}`}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-900 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-slate-300 hover:border-teal-300 dark:hover:border-teal-700 hover:text-teal-700 dark:hover:text-teal-400 transition-colors"
+                    >
+                      <span>{display}</span>
+                      <span className="text-gray-400 dark:text-slate-500">
+                        {s.sections}
+                      </span>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </section>
+      )}
 
       {/* In-page ad (well after main content per AdSense policy) */}
       <div className="mt-8">

--- a/lib/college-stats.ts
+++ b/lib/college-stats.ts
@@ -1,0 +1,99 @@
+/**
+ * Compute summary statistics for a college's course offerings in a single
+ * term — mode breakdown, start-date diversity, top subject prefixes. Used
+ * by the per-college landing page to render a "Course Offering Profile"
+ * section that gives the page substantive unique content beyond the
+ * standard course catalog.
+ *
+ * The input is a CourseSection[] already loaded by the page (the `union`
+ * across terms or a single term), so this is a pure transform — no I/O.
+ */
+import type { CourseSection } from "@/lib/types";
+
+export type ModeBreakdown = {
+  total: number;
+  modes: Record<string, number>;
+  modePcts: Record<string, number>;
+};
+
+export type CollegeOfferingProfile = {
+  total: number;
+  modes: ModeBreakdown;
+  distinctStartDates: number;
+  earliestStartDate: string | null;
+  latestStartDate: string | null;
+  /**
+   * Sections starting more than 14 days after the term's earliest start
+   * date — a heuristic for "late-start" availability without needing the
+   * canonical fall/spring start-date table. If the earliest date is
+   * 2026-08-31 and a section starts on 2026-10-15, it counts as
+   * late-start (45 days after).
+   */
+  lateStartCount: number;
+  topSubjects: Array<{ prefix: string; sections: number }>;
+};
+
+export function computeOfferingProfile(
+  sections: CourseSection[]
+): CollegeOfferingProfile | null {
+  if (sections.length === 0) return null;
+
+  // Mode breakdown — only count sections with a known mode field. The
+  // schema constrains this to in-person | online | hybrid | zoom, but
+  // be defensive about empty/unknown values.
+  const modes: Record<string, number> = {};
+  for (const s of sections) {
+    const m = s.mode || "unknown";
+    modes[m] = (modes[m] || 0) + 1;
+  }
+  const modePcts: Record<string, number> = {};
+  for (const k of Object.keys(modes)) {
+    modePcts[k] = (modes[k] / sections.length) * 100;
+  }
+
+  // Start-date diversity. Filter out null/empty start_date values; some
+  // scrapers emit empty strings for TBA sections.
+  const startDates = sections
+    .map((s) => s.start_date)
+    .filter((d): d is string => Boolean(d) && d.length === 10);
+  const distinctDates = new Set(startDates);
+
+  let earliestStartDate: string | null = null;
+  let latestStartDate: string | null = null;
+  let lateStartCount = 0;
+
+  if (distinctDates.size > 0) {
+    const sorted = [...distinctDates].sort();
+    earliestStartDate = sorted[0];
+    latestStartDate = sorted[sorted.length - 1];
+
+    // Late-start: section starts > 14 days after the earliest.
+    const earliestMs = new Date(earliestStartDate).getTime();
+    const cutoffMs = earliestMs + 14 * 86400_000;
+    for (const d of startDates) {
+      const ms = new Date(d).getTime();
+      if (ms > cutoffMs) lateStartCount++;
+    }
+  }
+
+  // Top subject prefixes by section count.
+  const subjects: Record<string, number> = {};
+  for (const s of sections) {
+    if (!s.course_prefix) continue;
+    subjects[s.course_prefix] = (subjects[s.course_prefix] || 0) + 1;
+  }
+  const topSubjects = Object.entries(subjects)
+    .map(([prefix, count]) => ({ prefix, sections: count }))
+    .sort((a, b) => b.sections - a.sections)
+    .slice(0, 5);
+
+  return {
+    total: sections.length,
+    modes: { total: sections.length, modes, modePcts },
+    distinctStartDates: distinctDates.size,
+    earliestStartDate,
+    latestStartDate,
+    lateStartCount,
+    topSubjects,
+  };
+}


### PR DESCRIPTION
First content-enrichment pass on programmatic per-college landing pages. Per-college pages already had rich infrastructure (course catalog, audit policy, JSON-LD, OG image) but most of the substantive content was rendered client-side by \`CollegeTermSection\` — meaning Googlebot's initial fetch saw mostly chrome and a loading state.

## What this adds

A server-rendered "Course Offering Profile" section on every \`/[state]/college/[id]\` page:

- **Format mix** (in-person / online / hybrid / zoom) with section counts and percentages
- **Distinct start dates** this term + late-start section count linking to the \`/starting-soon\` tool
- **Top 5 most-offered subject prefixes** linking to per-subject pages (\`/[state]/college/[id]/courses/[prefix]\`)

Computed inline from the courses already loaded for the page (the \`defaultTerm\` slice of \`coursesByTerm\`). No new I/O. Helper lives in \`lib/college-stats.ts\` as a pure transform for testability and reuse.

## Real-data verification

Germanna Community College (VA), 2026 Summer term:

| Metric | Value |
|---|---|
| Total sections | 335 |
| Online | 248 (74%) |
| In-person | 69 (21%) |
| Zoom | 18 (5%) |
| Distinct start dates | 15 |
| Late-start sections | 92 |
| Top subjects | BIO (36), ENG (36), MTH (34), BUS (21), SDV (19) |

Each metric is real, computed from the same data that powers the live course catalog.

## Why this matters for SEO and revenue (#320)

1. **Substantive unique content per college** — each of 200+ college pages now has 100-200 words of data-grounded content beyond the standard college-detail chrome. Google rewards substantial unique content.
2. **Long-tail query matching** — searches like "Germanna online courses summer" or "VCCS hybrid availability" can match on the offering-profile content.
3. **Internal links to per-subject pages** — pushes PageRank to existing programmatic routes that need crawl budget.
4. **Differentiation from generic aggregators** — Google has a reason to surface this page over a generic college-info aggregator that doesn't have term-current data.

## Verification

- TypeScript compiles
- \`npm run lint\` clean for repo files (one pre-existing scraper warning, unrelated)
- Real-data computation tested against \`data/va/courses/gcc/2026SU.json\` — output matches expected percentages

## What this PR does NOT do

- Compute prereq blockers per college (needs prereq-graph filtering — separate work)
- Add similar profiles to \`/[state]/course/[code]\` or other programmatic routes (this PR is scoped to college pages)
- Surface hybrid/late-start historical density comparisons (would require slice-file integration; the current per-term snapshot is enough for v1)
- Add structured-data fields for the new content (would require defining a custom schema — defer)

## Sequencing relative to #320 checklist

- ✅ Per-college landing page generator with substantive content
- ⏳ Per-course landing page generator (already exists, separate enrichment work)
- ⏳ Per-program landing page generator (already exists, gated)
- ⏳ Internal linking from blog to programmatic pages (separate work)
- ⏳ Sitemap integration (already in place)
- ⏳ Search Console verification within 60 days (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)