### PR TITLE
feat(seo): Course Availability Profile section on per-course pages (#320)

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -8,6 +8,7 @@ import { getAllStates, isValidState, getStateConfig } from "@/lib/states/registr
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getTransferInfo, getUniversities } from "@/lib/transfer";
 import { subjectName } from "@/lib/subjects";
+import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import type { CourseSection } from "@/lib/types";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
@@ -285,11 +286,17 @@ export default async function CoursePage(props: PageProps) {
   // Group by college
   const colleges = groupByCollege(sections, institutions);
 
-  // Mode breakdown across all sections
+  // Mode breakdown across all sections (consumed by the existing pill row)
   const modeBreakdown: Record<string, number> = {};
   for (const s of sections) {
     modeBreakdown[s.mode] = (modeBreakdown[s.mode] || 0) + 1;
   }
+
+  // Course Availability Profile — server-rendered summary that gives the
+  // page substantive unique content per term beyond the section table
+  // (rendered later in this file). Consumed by the JSX block below the
+  // existing transfer-equivalency section.
+  const availabilityProfile = computeCourseAvailabilityProfile(sections);
 
   // Transfer data
   const transferInfo = config.transferSupported
@@ -551,6 +558,151 @@ export default async function CoursePage(props: PageProps) {
                   })}
                 </tbody>
               </table>
+            </div>
+          </section>
+        )}
+
+        {/* Course Availability Profile — server-rendered substantive
+            content per term. Helps long-tail SEO ("[course] online
+            community college", "[course] evening class [state]") and
+            gives users the at-a-glance shape of how this course is
+            offered without having to scroll through every section. */}
+        {availabilityProfile && availabilityProfile.totalSections > 0 && (
+          <section className="mb-8 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+              Availability Profile
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
+              How {prefix} {number} is being offered across {availabilityProfile.collegeCount}{" "}
+              {availabilityProfile.collegeCount === 1 ? "college" : "colleges"}{" "}
+              this term ({availabilityProfile.totalSections}{" "}
+              {availabilityProfile.totalSections === 1 ? "section" : "sections"} total).
+            </p>
+
+            <div className="grid sm:grid-cols-2 gap-6">
+              {/* Format mix */}
+              <div>
+                <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                  Delivery format
+                </h3>
+                <ul className="text-sm text-gray-700 dark:text-slate-300 space-y-1">
+                  {Object.entries(availabilityProfile.modes.counts)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([mode, count]) => (
+                      <li key={mode} className="flex justify-between">
+                        <span className="capitalize">
+                          {mode.replace("-", " ")}
+                        </span>
+                        <span>
+                          <span className="font-medium text-gray-900 dark:text-slate-100">
+                            {count}
+                          </span>{" "}
+                          <span className="text-xs text-gray-500 dark:text-slate-400">
+                            ({availabilityProfile.modes.pcts[mode].toFixed(0)}%)
+                          </span>
+                        </span>
+                      </li>
+                    ))}
+                </ul>
+              </div>
+
+              {/* Time of day */}
+              <div>
+                <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                  When sections meet
+                </h3>
+                <ul className="text-sm text-gray-700 dark:text-slate-300 space-y-1">
+                  {availabilityProfile.timeOfDay.morning > 0 && (
+                    <li className="flex justify-between">
+                      <span>Morning (before noon)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {availabilityProfile.timeOfDay.morning}
+                      </span>
+                    </li>
+                  )}
+                  {availabilityProfile.timeOfDay.afternoon > 0 && (
+                    <li className="flex justify-between">
+                      <span>Afternoon (noon–5 PM)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {availabilityProfile.timeOfDay.afternoon}
+                      </span>
+                    </li>
+                  )}
+                  {availabilityProfile.timeOfDay.evening > 0 && (
+                    <li className="flex justify-between">
+                      <span>Evening (5 PM and after)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {availabilityProfile.timeOfDay.evening}
+                      </span>
+                    </li>
+                  )}
+                  {availabilityProfile.timeOfDay.asynchronous > 0 && (
+                    <li className="flex justify-between">
+                      <span>Asynchronous / TBA</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {availabilityProfile.timeOfDay.asynchronous}
+                      </span>
+                    </li>
+                  )}
+                </ul>
+              </div>
+            </div>
+
+            {/* Start dates + instructor diversity footer */}
+            <div className="mt-6 pt-4 border-t border-gray-100 dark:border-slate-700 grid sm:grid-cols-2 gap-6 text-sm">
+              <div>
+                <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">
+                  Start dates
+                </h3>
+                {availabilityProfile.startDates.distinct > 0 ? (
+                  <p className="text-gray-700 dark:text-slate-300">
+                    Sections begin on{" "}
+                    <span className="font-medium text-gray-900 dark:text-slate-100">
+                      {availabilityProfile.startDates.distinct}
+                    </span>{" "}
+                    distinct date
+                    {availabilityProfile.startDates.distinct === 1 ? "" : "s"}.
+                    {availabilityProfile.startDates.lateStartCount > 0 && (
+                      <>
+                        {" "}
+                        <Link
+                          href={`/${state}/starting-soon`}
+                          className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
+                        >
+                          {availabilityProfile.startDates.lateStartCount}{" "}
+                          late-start
+                        </Link>{" "}
+                        more than two weeks after the term&apos;s earliest start.
+                      </>
+                    )}
+                  </p>
+                ) : (
+                  <p className="text-gray-500 dark:text-slate-400">
+                    Start-date data not available for this term.
+                  </p>
+                )}
+              </div>
+              <div>
+                <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">
+                  Instructor diversity
+                </h3>
+                {availabilityProfile.instructorCount > 0 ? (
+                  <p className="text-gray-700 dark:text-slate-300">
+                    Taught by{" "}
+                    <span className="font-medium text-gray-900 dark:text-slate-100">
+                      {availabilityProfile.instructorCount}
+                    </span>{" "}
+                    distinct instructor
+                    {availabilityProfile.instructorCount === 1 ? "" : "s"}{" "}
+                    across {availabilityProfile.collegeCount}{" "}
+                    {availabilityProfile.collegeCount === 1 ? "college" : "colleges"}.
+                  </p>
+                ) : (
+                  <p className="text-gray-500 dark:text-slate-400">
+                    Instructor assignments not yet published for this term.
+                  </p>
+                )}
+              </div>
             </div>
           </section>
         )}

--- a/lib/course-stats.ts
+++ b/lib/course-stats.ts
@@ -1,0 +1,131 @@
+/**
+ * Compute summary statistics for a single course's sections in a single
+ * term — mode breakdown, start-date diversity, time-of-day distribution,
+ * instructor count. Used by /[state]/course/[code] to render a server-
+ * rendered "Course Availability Profile" section that gives every course
+ * landing page substantive unique content per term.
+ *
+ * Pure transform — no I/O. Mirrors the structure of lib/college-stats.ts
+ * but optimized for the per-course rather than per-college view.
+ */
+import type { CourseSection } from "@/lib/types";
+
+export type CourseAvailabilityProfile = {
+  totalSections: number;
+  collegeCount: number;
+  modes: {
+    counts: Record<string, number>;
+    pcts: Record<string, number>;
+  };
+  startDates: {
+    distinct: number;
+    earliest: string | null;
+    latest: string | null;
+    lateStartCount: number;
+  };
+  timeOfDay: {
+    morning: number; // before 12:00
+    afternoon: number; // 12:00-16:59
+    evening: number; // 17:00+
+    asynchronous: number; // no start_time / TBA
+  };
+  instructorCount: number;
+};
+
+function normalizeTimeBucket(
+  startTime: string | null | undefined
+): "morning" | "afternoon" | "evening" | "asynchronous" {
+  if (!startTime) return "asynchronous";
+  const trimmed = startTime.trim().toUpperCase();
+  if (!trimmed || trimmed === "TBA" || trimmed === "ARR") return "asynchronous";
+
+  // Accept either "09:30 AM" / "9:30 AM" / "09:30" / "0930" / "9:30PM"
+  const ampmMatch = trimmed.match(/^(\d{1,2}):?(\d{2})\s*(AM|PM)?$/);
+  if (!ampmMatch) return "asynchronous";
+
+  let hour = parseInt(ampmMatch[1], 10);
+  const ampm = ampmMatch[3];
+  if (ampm === "PM" && hour < 12) hour += 12;
+  if (ampm === "AM" && hour === 12) hour = 0;
+  if (Number.isNaN(hour) || hour < 0 || hour > 23) return "asynchronous";
+
+  if (hour < 12) return "morning";
+  if (hour < 17) return "afternoon";
+  return "evening";
+}
+
+export function computeCourseAvailabilityProfile(
+  sections: CourseSection[]
+): CourseAvailabilityProfile | null {
+  if (sections.length === 0) return null;
+
+  const collegeSlugs = new Set<string>();
+  for (const s of sections) collegeSlugs.add(s.college_code);
+
+  // Mode breakdown.
+  const counts: Record<string, number> = {};
+  for (const s of sections) {
+    const m = s.mode || "unknown";
+    counts[m] = (counts[m] || 0) + 1;
+  }
+  const pcts: Record<string, number> = {};
+  for (const k of Object.keys(counts)) {
+    pcts[k] = (counts[k] / sections.length) * 100;
+  }
+
+  // Start-date diversity.
+  const startDates = sections
+    .map((s) => s.start_date)
+    .filter((d): d is string => Boolean(d) && d.length === 10);
+  const distinctDates = new Set(startDates);
+  let earliest: string | null = null;
+  let latest: string | null = null;
+  let lateStartCount = 0;
+  if (distinctDates.size > 0) {
+    const sorted = [...distinctDates].sort();
+    earliest = sorted[0];
+    latest = sorted[sorted.length - 1];
+    const cutoffMs = new Date(earliest).getTime() + 14 * 86400_000;
+    for (const d of startDates) {
+      if (new Date(d).getTime() > cutoffMs) lateStartCount++;
+    }
+  }
+
+  // Time-of-day buckets.
+  const timeOfDay = {
+    morning: 0,
+    afternoon: 0,
+    evening: 0,
+    asynchronous: 0,
+  };
+  for (const s of sections) {
+    const bucket = normalizeTimeBucket(s.start_time);
+    timeOfDay[bucket]++;
+  }
+
+  // Instructor diversity. Treat null/empty/"To be Announced" as no
+  // distinct instructor (don't inflate the count with a placeholder).
+  const instructors = new Set<string>();
+  for (const s of sections) {
+    const i = (s.instructor || "").trim();
+    if (!i) continue;
+    if (/^to be announced$/i.test(i)) continue;
+    if (/^tba$/i.test(i)) continue;
+    if (/^staff$/i.test(i)) continue;
+    instructors.add(i.toLowerCase());
+  }
+
+  return {
+    totalSections: sections.length,
+    collegeCount: collegeSlugs.size,
+    modes: { counts, pcts },
+    startDates: {
+      distinct: distinctDates.size,
+      earliest,
+      latest,
+      lateStartCount,
+    },
+    timeOfDay,
+    instructorCount: instructors.size,
+  };
+}


### PR DESCRIPTION
Mirrors the per-college Course Offering Profile from #331, scoped to \`/[state]/course/[code]\`. Per-course pages already had rich JSON-LD, section listings, transfer equivalencies, and prereq metadata — but the substantive narrative content was thin and most data was buried in the section table.

## What this adds

A server-rendered "Availability Profile" section between the transfer equivalencies and the per-college section table. For each course in each state, it surfaces:

- **Delivery format** — in-person / online / hybrid / zoom with section counts and percentages
- **Time of day** — morning (before noon), afternoon (noon–5 PM), evening (5 PM+), asynchronous/TBA
- **Start dates** — distinct count + late-start count linking to \`/[state]/starting-soon\`
- **Instructor diversity** — distinct instructor count across colleges (filters out "TBA", "Staff", "To be Announced" placeholders)

Computed inline from the \`sections\` array already loaded by the page. No new I/O. Helper lives in \`lib/course-stats.ts\` as a pure transform mirroring \`lib/college-stats.ts\`.

## Real-data verification

ENG 101 at Germanna Community College, Summer 2026:

| Metric | Value |
|---|---|
| Total sections | 36 |
| In-person | 12 |
| Online | 24 |
| Morning (before noon) | 7 |
| Afternoon (noon–5 PM) | 3 |
| Evening (5 PM+) | 2 |
| Asynchronous / TBA | 24 |
| Distinct start dates | 4 |
| Distinct instructors | 18 |

Across thousands of (state, course) pages × seasonal terms, that's substantial new indexable content per page.

## Why this matters

1. **Long-tail SEO matching** — searches like "ENG 101 evening community college va" or "BIO 101 online community college md" can now match on profile content
2. **At-a-glance shape** — users see how a course is offered without scrolling through every section
3. **Differentiation** — generic course-info aggregators don't have term-current per-college mode/time/instructor breakdowns

## Verification

- TypeScript compiles for changed files
- \`npm run lint\` clean for repo files (one pre-existing scraper warning, unrelated)
- Real-data computation tested against \`data/va/courses/gcc/2026SU.json\` — output matches expected counts
- One React unescaped-entity error fixed during iteration (\`'\` → \`&apos;\`)

## What this PR does NOT do

- Add similar profiles to \`/[state]/program/[slug]\` or \`/[state]/subject/[prefix]\` (these already have rich ItemList content)
- Surface availability comparisons across terms (would require loading multi-term data — current per-term snapshot is enough for v1)
- Add structured-data fields for the new content (defer)

## #320 status after this lands

✅ Per-college landing pages with substantive content (#331)
✅ Per-course landing pages with substantive content (this PR)
⏳ Per-program enrichment (lower priority — already gated by qualifies(), already has ItemList content)
⏳ Per-subject enrichment (already has ItemList content)
⏳ Internal linking from blog → programmatic pages (separate work)
⏳ Search Console verification within 60 days (post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)