### PR TITLE
feat(seo): Availability Snapshot on per-program + per-subject pages (#320)

### DIFF
--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -22,6 +22,7 @@ import {
   PROGRAMS,
 } from "@/lib/programs";
 import { loadProgramAcrossColleges, checkCourseAvailability } from "@/lib/programs/requirements";
+import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import ProgramRequirements from "@/components/ProgramRequirements";
 
@@ -135,6 +136,11 @@ export default async function ProgramPage(props: PageProps) {
     })),
   };
 
+  // Program Availability Snapshot — server-rendered substantive content
+  // pulled from the same flatSections that loadProgramData has already
+  // aggregated. Same helper used by /[state]/course/[code] for consistency.
+  const programProfile = computeCourseAvailabilityProfile(data.flatSections);
+
   // Other programs offered in this state (for cross-linking footer)
   const otherProgramSlugs = PROGRAMS.filter((p) => p.slug !== slug).map(
     (p) => p.slug
@@ -224,6 +230,148 @@ export default async function ProgramPage(props: PageProps) {
             </table>
           </div>
         </section>
+
+        {/* Program Availability Snapshot — server-rendered substantive
+            content per term. Helps long-tail SEO ("[program] online
+            community college [state]", "[program] evening sections").
+            Computed inline from data.flatSections — no extra I/O. */}
+        {programProfile && programProfile.totalSections > 0 && (
+          <section className="mb-10 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+              {program.name} Availability Snapshot
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
+              How {program.name.toLowerCase()} sections are being offered
+              across {programProfile.collegeCount}{" "}
+              {programProfile.collegeCount === 1 ? "college" : "colleges"} in{" "}
+              {config.name} this term ({programProfile.totalSections}{" "}
+              {programProfile.totalSections === 1 ? "section" : "sections"}{" "}
+              total).
+            </p>
+
+            <div className="grid sm:grid-cols-2 gap-6">
+              <div>
+                <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                  Delivery format
+                </h3>
+                <ul className="text-sm text-gray-700 dark:text-slate-300 space-y-1">
+                  {Object.entries(programProfile.modes.counts)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([mode, count]) => (
+                      <li key={mode} className="flex justify-between">
+                        <span className="capitalize">
+                          {mode.replace("-", " ")}
+                        </span>
+                        <span>
+                          <span className="font-medium text-gray-900 dark:text-slate-100">
+                            {count}
+                          </span>{" "}
+                          <span className="text-xs text-gray-500 dark:text-slate-400">
+                            ({programProfile.modes.pcts[mode].toFixed(0)}%)
+                          </span>
+                        </span>
+                      </li>
+                    ))}
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                  When sections meet
+                </h3>
+                <ul className="text-sm text-gray-700 dark:text-slate-300 space-y-1">
+                  {programProfile.timeOfDay.morning > 0 && (
+                    <li className="flex justify-between">
+                      <span>Morning (before noon)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {programProfile.timeOfDay.morning}
+                      </span>
+                    </li>
+                  )}
+                  {programProfile.timeOfDay.afternoon > 0 && (
+                    <li className="flex justify-between">
+                      <span>Afternoon (noon&ndash;5 PM)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {programProfile.timeOfDay.afternoon}
+                      </span>
+                    </li>
+                  )}
+                  {programProfile.timeOfDay.evening > 0 && (
+                    <li className="flex justify-between">
+                      <span>Evening (5 PM and after)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {programProfile.timeOfDay.evening}
+                      </span>
+                    </li>
+                  )}
+                  {programProfile.timeOfDay.asynchronous > 0 && (
+                    <li className="flex justify-between">
+                      <span>Asynchronous / TBA</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {programProfile.timeOfDay.asynchronous}
+                      </span>
+                    </li>
+                  )}
+                </ul>
+              </div>
+            </div>
+
+            {(programProfile.startDates.distinct > 0 ||
+              programProfile.instructorCount > 0) && (
+              <div className="mt-6 pt-4 border-t border-gray-100 dark:border-slate-700 grid sm:grid-cols-2 gap-6 text-sm">
+                {programProfile.startDates.distinct > 0 && (
+                  <div>
+                    <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">
+                      Start dates
+                    </h3>
+                    <p className="text-gray-700 dark:text-slate-300">
+                      Sections begin on{" "}
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {programProfile.startDates.distinct}
+                      </span>{" "}
+                      distinct date
+                      {programProfile.startDates.distinct === 1 ? "" : "s"}.
+                      {programProfile.startDates.lateStartCount > 0 && (
+                        <>
+                          {" "}
+                          <Link
+                            href={`/${state}/starting-soon`}
+                            className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
+                          >
+                            {programProfile.startDates.lateStartCount}{" "}
+                            late-start
+                          </Link>{" "}
+                          more than two weeks after the term&apos;s earliest
+                          start.
+                        </>
+                      )}
+                    </p>
+                  </div>
+                )}
+                {programProfile.instructorCount > 0 && (
+                  <div>
+                    <h3 className="font-medium text-gray-900 dark:text-slate-100 mb-1">
+                      Instructor diversity
+                    </h3>
+                    <p className="text-gray-700 dark:text-slate-300">
+                      Taught by{" "}
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {programProfile.instructorCount}
+                      </span>{" "}
+                      distinct instructor
+                      {programProfile.instructorCount === 1 ? "" : "s"} across{" "}
+                      {programProfile.collegeCount}{" "}
+                      {programProfile.collegeCount === 1
+                        ? "college"
+                        : "colleges"}
+                      .
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+        )}
 
         <ProgramRequirements
           state={state}

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -17,6 +17,7 @@ import { getCurrentTerm, termLabel } from "@/lib/terms";
 import { isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { subjectName } from "@/lib/subjects";
+import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
 import type { CourseSection } from "@/lib/types";
@@ -160,6 +161,12 @@ export default async function StateSubjectPage(props: PageProps) {
   const hybridCount = sections.filter((s) => s.mode === "hybrid").length;
   const inPersonCount = sections.filter((s) => s.mode === "in-person").length;
   const term = termLabel(currentTerm);
+
+  // Subject Availability Snapshot — server-rendered substantive content
+  // pulled from the same sections already loaded for the course list.
+  // Same helper used by /[state]/course/[code] and /[state]/program/[slug]
+  // for consistency.
+  const subjectProfile = computeCourseAvailabilityProfile(sections);
 
   // Other subjects for browse links — distinct prefix scan, not full catalog
   const allSubjects = (await getDistinctSubjects(currentTerm, state)).filter(
@@ -309,6 +316,110 @@ export default async function StateSubjectPage(props: PageProps) {
             </span>
           )}
         </div>
+
+        {/* Subject Availability Snapshot — server-rendered substantive
+            content per term. Helps long-tail SEO ("[subject] online
+            community college [state]", "[subject] evening sections").
+            Computed inline from sections — no extra I/O. */}
+        {subjectProfile && subjectProfile.totalSections > 0 && (
+          <section className="mb-8 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+              {subject} Availability Snapshot
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
+              How {subject.toLowerCase()} sections are being offered across{" "}
+              {subjectProfile.collegeCount}{" "}
+              {subjectProfile.collegeCount === 1 ? "college" : "colleges"} in{" "}
+              {config.name} this term ({subjectProfile.totalSections}{" "}
+              {subjectProfile.totalSections === 1 ? "section" : "sections"}{" "}
+              total).
+            </p>
+
+            <div className="grid sm:grid-cols-2 gap-6">
+              <div>
+                <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                  When sections meet
+                </h3>
+                <ul className="text-sm text-gray-700 dark:text-slate-300 space-y-1">
+                  {subjectProfile.timeOfDay.morning > 0 && (
+                    <li className="flex justify-between">
+                      <span>Morning (before noon)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {subjectProfile.timeOfDay.morning}
+                      </span>
+                    </li>
+                  )}
+                  {subjectProfile.timeOfDay.afternoon > 0 && (
+                    <li className="flex justify-between">
+                      <span>Afternoon (noon&ndash;5 PM)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {subjectProfile.timeOfDay.afternoon}
+                      </span>
+                    </li>
+                  )}
+                  {subjectProfile.timeOfDay.evening > 0 && (
+                    <li className="flex justify-between">
+                      <span>Evening (5 PM and after)</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {subjectProfile.timeOfDay.evening}
+                      </span>
+                    </li>
+                  )}
+                  {subjectProfile.timeOfDay.asynchronous > 0 && (
+                    <li className="flex justify-between">
+                      <span>Asynchronous / TBA</span>
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {subjectProfile.timeOfDay.asynchronous}
+                      </span>
+                    </li>
+                  )}
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-medium text-gray-900 dark:text-slate-100 mb-2">
+                  Start dates &amp; instructors
+                </h3>
+                <div className="text-sm text-gray-700 dark:text-slate-300 space-y-2">
+                  {subjectProfile.startDates.distinct > 0 && (
+                    <p>
+                      Sections begin on{" "}
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {subjectProfile.startDates.distinct}
+                      </span>{" "}
+                      distinct date
+                      {subjectProfile.startDates.distinct === 1 ? "" : "s"}
+                      {subjectProfile.startDates.lateStartCount > 0 && (
+                        <>
+                          ,{" "}
+                          <Link
+                            href={`/${state}/starting-soon`}
+                            className="font-medium text-teal-600 dark:text-teal-400 hover:text-teal-700 dark:hover:text-teal-300"
+                          >
+                            {subjectProfile.startDates.lateStartCount}{" "}
+                            late-start
+                          </Link>
+                        </>
+                      )}
+                      .
+                    </p>
+                  )}
+                  {subjectProfile.instructorCount > 0 && (
+                    <p>
+                      Taught by{" "}
+                      <span className="font-medium text-gray-900 dark:text-slate-100">
+                        {subjectProfile.instructorCount}
+                      </span>{" "}
+                      distinct instructor
+                      {subjectProfile.instructorCount === 1 ? "" : "s"} across
+                      the state.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* Course table */}
         <section className="mb-8">

--- a/lib/programs/index.ts
+++ b/lib/programs/index.ts
@@ -38,6 +38,12 @@ export type ProgramData = {
   totalColleges: number;
   totalOnline: number;
   colleges: ProgramCollegeRow[];
+  // Flattened sections across all matched prefixes for the program. Used
+  // by the per-program landing page to compute an availability profile
+  // (mode mix, time-of-day, start dates, instructor diversity) without
+  // re-loading. Already in scope inside loadProgramData; returning it
+  // here saves the page from a second round of Supabase calls.
+  flatSections: CourseSection[];
   // Sample of representative courses for an ItemList block.
   sampleCourses: {
     prefix: string;
@@ -143,6 +149,7 @@ export async function loadProgramData(
     totalOnline: all.filter((s) => s.mode === "online" || s.mode === "zoom")
       .length,
     colleges,
+    flatSections: all,
     sampleCourses,
   };
 }


### PR DESCRIPTION
Completes the per-programmatic-route content enrichment series after #331 (per-college) and #332 (per-course). Per-program and per-subject pages already had ItemList JSON-LD + per-college tables, but lacked the substantive narrative content that helps with long-tail SEO.

## What this adds

A server-rendered "Availability Snapshot" section on both route types using the same \`computeCourseAvailabilityProfile\` helper from \`lib/course-stats.ts\` (introduced in #332). Single helper, three consumer pages — keeps the format consistent across the corpus.

### \`/[state]/program/[slug]\` — Program Availability Snapshot
Rendered between the colleges-table and the \`ProgramRequirements\` component. Shows:
- Delivery format mix (in-person / online / hybrid / zoom) with counts and percentages
- Time of day (morning before noon / afternoon noon-5 PM / evening 5 PM+ / asynchronous)
- Start dates + late-start link to \`/[state]/starting-soon\`
- Instructor diversity count

### \`/[state]/subject/[prefix]\` — Subject Availability Snapshot
Rendered between the existing mode-pill row and the course table. Slightly slimmer layout (no separate format-mix column since the pills above it already show that), focused on time-of-day and start-dates/instructors as the most useful new info.

## Implementation note: \`flatSections\` on \`ProgramData\`

\`lib/programs/index.ts\` extended with one new field on \`ProgramData\`: \`flatSections: CourseSection[]\`. The function already loads sections via \`loadCoursesBySubject\` for each matched prefix; returning the flat array adds zero extra I/O. Used by the per-program page to compute the snapshot without re-querying.

## Verification

- TypeScript compiles for all changed files
- \`npm run lint\` clean for repo files (one pre-existing scraper warning, unrelated)
- Both pages compute the snapshot from data already in scope — no additional Supabase queries
- React entities escaped properly (\`&ndash;\` for en-dash, \`&amp;\` for ampersand, \`&apos;\` for apostrophe)

## Why this matters for #320

- Adds 100-150 words of unique data-grounded content per program page and per subject page
- Across ~22 programs × multiple states + ~50-100 subjects × multiple states, that's substantial new indexable content
- Long-tail queries like "nursing programs Maryland community college evening" or "ENG online community college va" can now match on snapshot content
- Keeps consistency with the per-college (#331) and per-course (#332) profiles for a unified browsing experience

## #320 status after this lands

✅ Per-college landing pages with substantive content (#331)
✅ Per-course landing pages with substantive content (#332)
✅ Blog → programmatic crawl-discovery (#333)
✅ Per-program + per-subject Availability Snapshot (this PR)
⏳ Auto-detect college/course mentions in MDX prose (separate work — would require careful MDX transformation)
⏳ Search Console verification within 60 days (post-deploy)

The four major programmatic route types now each have substantive server-rendered content beyond their schema. The crawl-discovery loop from blog → programmatic is wired up. What's left is post-deploy verification and one more potential lever (auto-detection of entity mentions in blog prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)