### PR TITLE
Add course-availability spokes: VA, TN, SC (batch 2)

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -330,5 +330,8 @@
       "draftedAt": "2026-05-10T13:00:00Z",
       "trigger": "course-scarcity"
     }
-  ]
+  ],
+  "virginia-community-college-course-availability": "2026-05-11T03:29:31.895173Z",
+  "tennessee-community-college-course-availability": "2026-05-11T03:29:31.895173Z",
+  "south-carolina-technical-college-course-availability": "2026-05-11T03:29:31.895173Z"
 }

--- a/content/blog/georgia-community-college-course-availability.mdx
+++ b/content/blog/georgia-community-college-course-availability.mdx
@@ -86,7 +86,7 @@ TCSG's full coverage breakdown:
 | Universal (≥80% of colleges) | 174 | 11% |
 | Common (50–79%) | 249 | 15.8% |
 | Selective (25–49%) | 353 | 22.4% |
-| Scarce (<25%, ≥3 sections) | 695 | 44.1% |
+| Scarce (&lt;25%, ≥3 sections) | 695 | 44.1% |
 | Point-source (1 college, ≥5 sections) | 105 | 6.7% |
 
 The 776 multiChoice courses — where a student can pick from 5 or more different TCSG colleges — give some geographic flexibility for roughly a third of the catalog. But the 50.8% overall scarcity ratio means that for a student entering a specialized program, half the courses they'll need are likely to have limited options on where to take them.

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -126,6 +126,69 @@ export const articles: ArticleMeta[] = [
     cluster: "course-availability-guide",
     clusterRole: "spoke",
   },
+  {
+    slug: "virginia-community-college-course-availability",
+    title:
+      "Virginia VCCS Course Availability: Which Courses Are at All 23 Colleges and Which Are at One",
+    description:
+      "VCCS's 23-college system has a 68.6% scarcity ratio — lower than NC's 78.9% but still meaning 2 in 3 courses concentrate at fewer than 25% of campuses. NOVA and TCC each hold 5 exclusive programs; veterinary technology and architecture are entirely scarce statewide.",
+    date: "2026-05-10",
+    category: "registration-timing",
+    state: "va",
+    author: "Community College Path",
+    tags: [
+      "course-availability",
+      "registration",
+      "virginia",
+      "vccs",
+      "anchor-campus",
+      "schedule-planning",
+    ],
+    cluster: "course-availability-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "tennessee-community-college-course-availability",
+    title:
+      "Tennessee Community College Course Availability: 251 Point-Source Courses, Three Regional Anchors, and the Best Scarcity Ratio in the Southeast",
+    description:
+      "Tennessee's TBR system has the best scarcity ratio of any southeastern system in this cluster — but 19.5% of its catalog (251 courses) is available at exactly one campus. Here's how gen-ed breadth and specialized concentration coexist across 12 colleges.",
+    date: "2026-05-10",
+    category: "registration-timing",
+    state: "tn",
+    author: "Community College Path",
+    tags: [
+      "course-availability",
+      "registration",
+      "tennessee",
+      "tbr",
+      "anchor-campus",
+      "schedule-planning",
+    ],
+    cluster: "course-availability-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "south-carolina-technical-college-course-availability",
+    title:
+      "South Carolina Technical College Course Availability: Tri-County Holds 40% of All Exclusive Programs",
+    description:
+      "SCTCS has only 21 universal courses (1.7% of the catalog) — the lowest of any state in the cluster. Tri-County Technical College holds 43 exclusive point-source courses, 40% of all concentrated programs in a 14-college system. Nursing concentrates at Horry-Georgetown; auto body repair (ABR) is 100% scarce statewide.",
+    date: "2026-05-10",
+    category: "registration-timing",
+    state: "sc",
+    author: "Community College Path",
+    tags: [
+      "course-availability",
+      "registration",
+      "south-carolina",
+      "sctcs",
+      "anchor-campus",
+      "schedule-planning",
+    ],
+    cluster: "course-availability-guide",
+    clusterRole: "spoke",
+  },
 
   // --- Cluster A: Transfer credit confusion (hub + spokes) ---
   {

--- a/content/blog/kentucky-community-college-course-availability.mdx
+++ b/content/blog/kentucky-community-college-course-availability.mdx
@@ -76,7 +76,7 @@ KCTCS's full breakdown:
 | Universal (≥80% of colleges) | 127 | 10.5% |
 | Common (50–79%) | 218 | 18.1% |
 | Selective (25–49%) | 326 | 27% |
-| Scarce (<25%, ≥3 sections) | 454 | 37.6% |
+| Scarce (&lt;25%, ≥3 sections) | 454 | 37.6% |
 | Point-source (1 college, ≥5 sections) | 82 | 6.8% |
 
 The 568 multiChoice courses — where a student can pick from 5 or more KCTCS colleges — give real flexibility for a significant portion of the catalog. That figure is lower than NC's 1,015 (for a 55-college system) but the proportion, across a 16-college system, is comparable.

--- a/content/blog/south-carolina-technical-college-course-availability.mdx
+++ b/content/blog/south-carolina-technical-college-course-availability.mdx
@@ -1,0 +1,141 @@
+# South Carolina Technical College Course Availability: Tri-County Holds 40% of All Exclusive Programs
+
+South Carolina's Technical College System — SCTCS — runs 16 colleges statewide, with 14 providing section data across the 2026FA, 2026SP, and 2026SU terms: 18,817 sections, 2,194 unique course IDs, scarcity ratio of 70.4%. More than two-thirds of SCTCS's catalog is available at fewer than 25% of the system's colleges.
+
+That ratio places South Carolina above Georgia's TCSG (50.8%) and Kentucky's KCTCS (44.4%), though below North Carolina's 78.9%. But the number that defines SCTCS's distribution more than any other: Tri-County Technical College, serving Anderson, Oconee, and Pickens counties in the Upstate, holds 43 exclusive point-source courses — 40.2% of every exclusively held program in a 14-college system. One campus is the gatekeeper for nearly half of SC's most concentrated coursework.
+
+For the framework behind how community college catalogs divide into universal, scarce, and point-source tiers — and what to do when your course falls in the scarce half — see the [course availability hub article](/blog/which-community-college-courses-are-hard-to-find).
+
+## The universal tier: only 21 courses qualify
+
+At 80% threshold, only 21 courses in the entire SCTCS catalog qualify as universal — 1.7% of the catalog, the lowest of any state in this cluster. [North Carolina](/blog/north-carolina-community-college-course-availability) has 57 universal courses (3.1%). [Georgia's TCSG](/blog/georgia-community-college-course-availability) has 174 (11%). [Kentucky's KCTCS](/blog/kentucky-community-college-course-availability) has 127 (10.5%).
+
+Top universal courses by section count:
+
+| Course | Colleges | Sections |
+|---|---|---|
+| ENG-101 English Composition I | 13 (92.9%) | 593 |
+| ENG-102 English Composition II | 14 (100%) | 388 |
+| PSY-201 General Psychology | 12 (85.7%) | 431 |
+| BIO-210 Anatomy and Physiology I | 14 (100%) | 338 |
+| MAT-120 Probability & Statistics | 13 (92.9%) | 331 |
+| BIO-211 Anatomy and Physiology II | 14 (100%) | 230 |
+| BIO-101 Biological Science I | 12 (85.7%) | 228 |
+| MAT-110 College Algebra | 12 (85.7%) | 195 |
+| SOC-101 Introduction to Sociology | 12 (85.7%) | 195 |
+| BIO-225 Microbiology | 13 (92.9%) | 129 |
+
+Even ENG-101 — the foundational composition course — appears at only 13 of 14 colleges. For context, North Carolina's ENG-111 runs at all 55 NC colleges with 1,973 sections. South Carolina's equivalent has a gap at the campus level.
+
+The practical implication: before assuming your gen-ed requirement is covered at your home campus, check. York Technical College in Rock Hill — with only 6 of the 21 universal courses — shows why. Most SCTCS colleges carry all 21; York TC is an outlier that matters specifically for students in York County near Charlotte.
+
+## Tri-County Technical College: 40% of all exclusive programs
+
+The distribution of concentrated courses across SCTCS's 14 colleges is the most striking structural fact in the data:
+
+| College | Exclusive Courses | Share of Point-Source | Total Sections |
+|---|---|---|---|
+| Tri-County Technical College | 43 | 40.2% | 3,469 |
+| Horry-Georgetown Technical College | 20 | 18.7% | 3,439 |
+| Greenville Technical College | 14 | 13.1% | 3,563 |
+| Trident Technical College | 8 | 7.5% | 1,106 |
+| Piedmont Technical College | 7 | 6.5% | 2,861 |
+
+Tri-County's 43 exclusive courses represent a concentration that's remarkable even in the context of anchor-campus patterns in other states. Georgia's Central Georgia Technical College holds 43 exclusive courses in a 20-college system — impressive enough to be the defining fact in the [Georgia course availability article](/blog/georgia-community-college-course-availability). Tri-County holds the same number in a 14-college system.
+
+The Upstate economy explains this. Tri-County's service area sits adjacent to the BMW plant in Greer and Michelin North America's US headquarters, with dense automotive supply-chain manufacturing throughout Anderson, Oconee, and Pickens counties. The college's mechatronics, manufacturing technology, and industrial electronics programs are built around those employer partnerships — partnerships that don't replicate at campuses in the Lowcountry or Midlands without the same industrial base.
+
+The top point-source courses at Tri-County tell that story directly:
+
+| Course | College | Sections |
+|---|---|---|
+| MEC-120 Sensors and Instrumentation | Tri-County TC | 27 |
+| MEC-113 Solid State Devices | Tri-County TC | 20 |
+| MEC-112 Digital Controls | Tri-County TC | 20 |
+| MEC-201 AC/DC Drives | Tri-County TC | 18 |
+| SFT-109 Lifetime Fitness and Wellness | Tri-County TC | 19 |
+
+MEC-120, MEC-113, MEC-112, and MEC-201 are all mechatronics and industrial electronics courses — core courses in a manufacturing technology sequence. These aren't available anywhere else in South Carolina. If you're pursuing a mechatronics or industrial electronics program and you're not in Anderson, Oconee, or Pickens county, Tri-County is where those courses are.
+
+## Nursing concentration at Horry-Georgetown: Myrtle Beach or nowhere
+
+Horry-Georgetown Technical College serves the Myrtle Beach metro and the Grand Strand coast. It holds 20 exclusive point-source courses — the second-largest concentration in the system. Within that group, nursing courses stand out:
+
+| Course | College | Sections |
+|---|---|---|
+| NUR-150 Chronic Health Problems | Horry-Georgetown TC | 45 |
+| NUR-217 Trends and Issues in Nursing | Horry-Georgetown TC | 23 |
+| AHS-175 Multi-Skilled Clinical Prac | Horry-Georgetown TC | 16 |
+
+NUR-150 (Chronic Health Problems) and NUR-217 (Trends and Issues in Nursing) are point-source courses with no presence at any other SCTCS college. With 45 sections, NUR-150 is one of the highest-section-count point-source courses in the system.
+
+This reflects what drives nursing program distribution everywhere: clinical partnerships. Horry-Georgetown has placement agreements with Grand Strand Medical Center and other Myrtle Beach-area facilities that campuses inland cannot replicate. A nursing student at Midlands TC in Columbia will find no equivalent for these NUR courses at their home campus.
+
+## Auto Body Repair: 15 courses, every one scarce
+
+The ABR prefix — South Carolina's Auto Body Repair program — has 15 courses in the catalog and every one is scarce. Not one appears at even 25% of the system's colleges, making automotive trades the most fragmented program in SCTCS by depth.
+
+Other entirely scarce prefixes include BCT (Building Construction Technology, 6 courses), BKP (Brickmasonry/Plastering, 6 courses), CET (6 courses), and DHM (Dental Hygiene Management, 12 courses).
+
+For any of these programs, confirm the full sequence exists at your campus before enrolling. A campus without ABR in its catalog cannot complete an auto body program, even if it offers other automotive coursework.
+
+## Per-college data: size isn't the same as breadth
+
+South Carolina's 14 colleges vary dramatically in both size and catalog depth:
+
+| College | Sections | Unique Courses | Exclusive | Universal |
+|---|---|---|---|---|
+| Greenville Technical College | 3,563 | 555 | 14 | 21 |
+| Tri-County Technical College | 3,469 | 434 | 43 | 21 |
+| Horry-Georgetown Technical College | 3,439 | 535 | 20 | 21 |
+| Piedmont Technical College | 2,861 | 440 | 7 | — |
+| Trident Technical College | 1,106 | 376 | 8 | — |
+| Midlands Technical College | 846 | 265 | 6 | — |
+| Spartanburg Community College | 822 | 229 | 3 | — |
+| Florence-Darlington Technical College | 707 | 253 | 0 | — |
+| Aiken Technical College | 542 | 201 | 0 | — |
+| Lowcountry Technical College | 375 | 141 | 1 | — |
+| Central Carolina Technical College | 368 | 138 | 2 | — |
+| York Technical College | 354 | 165 | 2 | 6 |
+| Denmark Technical College | 294 | 130 | 1 | — |
+| Orangeburg-Calhoun Technical College | 71 | 40 | 0 | — |
+
+Two patterns stand out.
+
+Orangeburg-Calhoun TC has the smallest footprint: 71 sections and 40 unique courses. Denmark TC (the next-smallest) has 294 sections and 130 courses. Students in Orangeburg County face the tightest access constraints in the system and should plan on online sections or commuting to Midlands TC for most program sequences.
+
+York TC in Rock Hill has only 6 of the 21 universal courses — nearly every other SCTCS campus carries all 21. Students in York County should verify gen-ed coverage at their home campus before building a transfer-track schedule.
+
+## Coverage distribution
+
+SCTCS's full breakdown across 2,194 course IDs:
+
+| Tier | Courses | Share |
+|---|---|---|
+| Universal (≥80% of colleges) | 21 | 1.7% |
+| Common (50–79%) | 96 | 7.7% |
+| Selective (25–49%) | 253 | 20.3% |
+| Scarce (&lt;25%, ≥3 sections) | 771 | 61.8% |
+| Point-source (1 college, ≥5 sections) | 107 | 8.6% |
+
+The scarce + point-source combined total is 878 courses — 70.4% of the catalog. The 249 multi-choice courses (where students can choose from 5 or more SCTCS colleges) represent just 11.4% of the catalog. The vast majority of courses require a specific campus or a very limited set of options.
+
+## What to check before choosing an SCTCS college
+
+**For manufacturing and industrial trades:** Tri-County is the statewide anchor for mechatronics, industrial electronics, and manufacturing technology. If your program includes MEC-prefix courses, confirm whether they exist at your campus or exclusively at Tri-County before enrolling.
+
+**For nursing programs:** Identify which campuses in your region hold NUR-prefix courses. Horry-Georgetown is the dominant nursing anchor on the Grand Strand. Greenville TC and Tri-County hold the largest catalogs in the Upstate with clinical program depth.
+
+**For automotive and construction trades:** Verify the full ABR or BCT course sequence at your campus — not just whether "automotive" appears as a program area. A campus that offers part of the sequence may not offer all of it.
+
+**For students at smaller colleges:** Orangeburg-Calhoun TC's 71 sections mean online sections or commuting to Midlands TC will likely be necessary for any multi-course program sequence. The SCTCS [colleges directory](/sc/colleges) shows what each campus offers.
+
+**For gen-ed and transfer courses:** The 21 universal courses are available at most campuses — but check your specific campus. York TC's 6 universal courses are a concrete reminder that system-wide universal coverage isn't the same as campus-level coverage.
+
+The 1.7% universal rate means that for 98.3% of SCTCS's catalog, the right question before registering is not "does the system offer this?" but "does my campus offer this?" That distinction defines the entire planning process in SC.
+
+<ProductCallout
+  text="Community College Path indexes South Carolina technical college sections across all 14 SCTCS colleges. Search any course to see which campuses offer it this term."
+  feature="courses"
+  label="Search SC Courses Across All 14 SCTCS Colleges"
+/>

--- a/content/blog/tennessee-community-college-course-availability.mdx
+++ b/content/blog/tennessee-community-college-course-availability.mdx
@@ -1,0 +1,111 @@
+# Tennessee Community College Course Availability: 251 Point-Source Courses, Three Regional Anchors, and the Best Scarcity Ratio in the Southeast
+
+Among the five southeastern systems covered in this cluster, Tennessee's TBR system has the most favorable scarcity ratio: 60%. That means 40% of the catalog — 1,032 courses — is available at four or more of the state's 12 colleges. But underneath that favorable headline is a bifurcated system worth understanding before you register.
+
+Tennessee also has 251 point-source courses — courses with 5 or more sections concentrated at exactly one college. That 19.5% of the catalog is the highest point-source proportion of any system in this cluster. North Carolina, with 55 colleges, has only 31 point-source courses. Tennessee, with 12, has 251. The two numbers — 60% scarcity ratio and 19.5% point-source rate — coexist because TBR's system is bifurcated: transfer-prep and gen-ed courses share broadly, while specialized programs concentrate tightly.
+
+For the framework behind how community college catalogs split into universal vs. concentrated tiers — and what to do when your course falls in the scarce half — see the [course availability hub article](/blog/which-community-college-courses-are-hard-to-find).
+
+## The universal tier: 143 courses at every TBR campus
+
+Of Tennessee's 2,582 unique course IDs, 143 (11.1%) are universal — available at all 12 TBR colleges. That's a stronger universal share than Virginia's 4.3% or South Carolina's 1.7%, and comparable to Georgia's TCSG (11%). The top of the universal list:
+
+| Course | Colleges | Sections |
+|---|---|---|
+| ENGL-1010 Composition 1 | 12 | 1,391 |
+| MATH-1530 Introductory Statistics | 12 | 978 |
+| ENGL-1020 Composition 2 | 12 | 964 |
+| COMM-2025 Fundamentals of Communication | 12 | 863 |
+| PSYC-1030 Introduction to Psychology | 12 | 685 |
+| BIOL-2010 Human Anatomy Phys 1 Lect/Lab | 12 | 648 |
+| HIST-2010 Early United States History | 12 | 522 |
+| HIST-2020 Modern United States History | 12 | 496 |
+| BIOL-2020 Human Anatomy Phys 2 Lect/Lab | 12 | 481 |
+| MUS-1030 Introduction to Music | 12 | 455 |
+
+BIOL-2010 and BIOL-2020 — the A&P sequence — at every TBR campus signals the same commitment to healthcare workforce access that distinguishes [Kentucky's KCTCS system](/blog/kentucky-community-college-course-availability). A nursing or allied health student in rural Tennessee can complete the foundational A&P sequence at their home campus without traveling to a regional hub. With 648 and 481 sections respectively, these are not thin offerings.
+
+The 1,391 sections of ENGL-1010 across all 12 colleges is the highest section count of any single course in the TBR catalog. TBR also has 340 multi-choice courses — courses where a student can pick from five or more different colleges.
+
+## The point-source tier: 251 courses at exactly one campus
+
+The 251 point-source courses — 19.5% of the catalog — are primarily college-success and developmental education courses, not workforce trades.
+
+| Course | College | Sections |
+|---|---|---|
+| COLL-1000 First Year Seminar - Exploratory | Pellissippi State | 128 |
+| NSCC-1010 First Year Experience | Nashville State | 109 |
+| COLS-101 C-State College Success | Columbia State | 80 |
+| COL-1030 College to Career Navigation | Jackson State | 73 |
+| ENGL-0815 Writing Support | Nashville State | 70 |
+| READ-0815 Reading Support | Nashville State | 61 |
+| MATH-0835 Statistics Support | Nashville State | 63 |
+| ACAD-1100 Academic Success Seminar | Southwest Tennessee | 59 |
+| BIOL-1030 Essentials of Biology | Volunteer State | 54 |
+| CHEM-1030 Fundamentals of Chemistry | Volunteer State | 52 |
+
+The top of the point-source list is dominated by First Year Experience programs — COLL-1000, NSCC-1010, COLS-101, COL-1030, ACAD-1100 — each built by a specific campus under its own course code. These are institution-specific orientation programs designed to be campus-specific. There is no expectation that a student would substitute Columbia State's COLS-101 for Pellissippi's COLL-1000 — they're enrollment requirements at specific colleges, not transferable credits. The high point-source count in Tennessee reflects a system where individual campuses have invested in their own student-success identity, not fragmented industrial programs.
+
+The developmental education courses at Nashville State — ENGL-0815, READ-0815, MATH-0835 — reflect a distinct administrative structure. Other TBR colleges may offer developmental support under different numbering or through corequisite models that don't generate separate course IDs.
+
+## Three regional anchor campuses
+
+TBR's exclusive course concentration distributes across three anchor campuses serving distinct geographic regions:
+
+| College | Exclusive Courses | Total Sections | Total Unique Courses |
+|---|---|---|---|
+| Pellissippi State (Knoxville) | 49 | 4,163 | 427 |
+| Northeast State (Tri-Cities) | 43 | 3,209 | 412 |
+| Chattanooga State | 42 | 4,698 | 563 |
+
+Pellissippi State holds 49 exclusive courses — the most of any TBR college. Northeast State serves the Tri-Cities area (Johnson City, Kingsport, Bristol) with 43 exclusive courses. Chattanooga State runs the largest total section count at 4,698 sections across 563 unique courses.
+
+This three-anchor structure fits Tennessee's long, narrow geography — over 400 miles from the Appalachian highlands to the Mississippi River. No single dominant anchor holds an outsized share, unlike Georgia, where Central Georgia Technical College holds 41% of all point-source courses in a 20-college system. For students, the relevant campus depends on where you are. A student in the Tri-Cities needing one of Northeast State's 43 exclusive courses is at the right campus already.
+
+## Entirely scarce subject areas
+
+Five subject-area prefixes in TBR are 100% scarce — every course in the prefix available at fewer than 25% of the state's 12 colleges:
+
+- **ARTP (Art Practices):** 6 courses, all scarce. Studio art programs require equipment and facilities that not every campus maintains.
+- **DD:** 6 courses, all scarce. Concentrated at specific campuses.
+- **ANIM (Animation):** 8 courses, all scarce. Digital animation programs require software lab infrastructure and specialized faculty.
+- **SONO (Sonography):** 5 courses, all scarce. Diagnostic sonography is a clinical program requiring equipment and hospital partnership agreements.
+- **MD (Medical):** 7 courses, all scarce. Medical programs carry the same clinical concentration requirement as sonography.
+
+SONO and MD are the most consequential. If you're pursuing a sonography or medical program in Tennessee, your realistic campus options are determined first by which campuses have the clinical partnerships — not which are nearest to you. ANIM's 8-course scarcity reflects campuses that have invested in software labs and creative program faculty; verify your intended campus offers the full sequence before committing.
+
+## Coverage distribution
+
+TBR's full breakdown across 2,582 course IDs:
+
+| Tier | Courses | Share |
+|---|---|---|
+| Universal (≥80% of colleges) | 143 | 11.1% |
+| Common (50–79%) | 123 | 9.6% |
+| Selective (25–49%) | 249 | 19.3% |
+| Scarce (&lt;25%, ≥3 sections) | 521 | 40.5% |
+| Point-source (1 college, ≥5 sections) | 251 | 19.5% |
+
+The 34,599 total sections across 12 colleges reflect a high-volume system. Chattanooga State alone generates 4,698 sections; even the smallest TBR college — Cleveland State — runs 1,519 sections across 286 unique courses.
+
+The 60% scarcity ratio is the best in this five-state cluster. Tennessee's ratio is more favorable than [North Carolina's 78.9%](/blog/north-carolina-community-college-course-availability) across 55 colleges, Georgia's TCSG at 50.8% across 20 colleges, and comparable to [Kentucky's KCTCS at 44.4%](/blog/kentucky-community-college-course-availability) across 16 colleges. The point-source comparison is where Tennessee's profile stands out most: NC has 31 point-source courses across 55 colleges (0.9%), while Tennessee has 251 across 12 (19.5%). This reflects TBR's campus-identity culture — individual colleges build their own first-year and success programs under unique course codes rather than adopting a system-wide standard.
+
+## What to check before you register at a TBR college
+
+**For transfer and gen-ed courses:** The 143 universal courses will be available at your campus. The ENGL-1010 and ENGL-1020 sequence, MATH-1530, COMM-2025, PSYC-1030, and the full A&P sequence are at every TBR college with substantial section counts.
+
+**For nursing and allied health prerequisites:** BIOL-2010 and BIOL-2020 at all 12 campuses means the foundational sequence is accessible wherever you are. But check whether your campus has the clinical continuation — sonography, medical programs, nursing clinical sequences — or whether you'll need to transfer to a campus with those clinical partnerships.
+
+**For workforce and specialized programs:** SONO, MD, ANIM, and ARTP are scarce. Search the full TBR catalog to see which colleges actually offer the courses in your sequence before choosing a campus.
+
+**For First Year Experience courses:** These are campus-specific programs, not transferable credits. Don't treat their presence or absence as evidence of availability for other course types.
+
+**For students in East Tennessee:** Pellissippi State (49 exclusive courses, 4,163 sections, 427 unique courses) is the primary anchor. Northeast State in Blountville (43 exclusive courses, 3,209 sections, 412 unique courses) anchors the far northeast region.
+
+You can search the full TBR course catalog — all 34,599 sections across all 12 colleges — at [Community College Path's Tennessee page](/tn).
+
+<ProductCallout
+  text="Community College Path indexes Tennessee community college sections across all 12 TBR colleges. Search any course to see which campuses offer it and how many sections are open."
+  feature="courses"
+  label="Search TN Courses Across All 12 TBR Colleges"
+/>

--- a/content/blog/virginia-community-college-course-availability.mdx
+++ b/content/blog/virginia-community-college-course-availability.mdx
@@ -1,0 +1,116 @@
+# Virginia VCCS Course Availability: Which Courses Are at All 23 Colleges and Which Are at One
+
+Of Virginia's 2,147 unique community college course IDs, 710 — 33% of the catalog — are available at fewer than 25% of the state's 23 colleges. Another 21 are point-source courses: 5 or more sections concentrated at exactly one campus with no meaningful presence anywhere else in the system. The system's overall scarcity ratio is 68.6%.
+
+That number is notable because VCCS (the Virginia Community College System) uses common course numbering across all 23 colleges. Every VCCS college teaches ENG-111. Every one teaches BIO-101. The catalog looks unified from the top. Below the gen-ed tier, it isn't.
+
+For the framework behind how community college catalogs split into universal vs. concentrated tiers — and what to do when your course falls in the scarce half — see the [course availability hub article](/blog/which-community-college-courses-are-hard-to-find).
+
+## Why 68.6% is actually lower than you'd expect — and what that reveals
+
+VCCS's 68.6% scarcity ratio is meaningfully lower than [North Carolina's 78.9%](/blog/north-carolina-community-college-course-availability). NC runs a 55-college system with a Common Course Library enforced across all campuses. Virginia runs a 23-college system with common numbering and a unified catalog structure. You'd expect Virginia to have more concentrated availability — 23 colleges is less than half of NC's 55, so each college represents a larger share of the system, and courses that exist at 3 or 4 colleges in Virginia are already in the "selective" tier rather than scarce.
+
+The reason VA's scarcity ratio lands lower isn't that the catalog is more evenly distributed. It's that VCCS's course catalog is smaller and more standardized relative to NC's — the system has 2,147 unique course IDs across 26,236 total sections, a higher sections-per-course density than most comparable systems. More sections per course means more colleges teaching each course, which pulls the scarcity ratio down.
+
+The practical implication: when a VA course is scarce, it's genuinely scarce. A 68.6% scarcity ratio means roughly 2 in 3 courses in the VCCS catalog — outside the gen-ed core — are not broadly available.
+
+## The universal tier: 46 courses at all 23 colleges
+
+Of VCCS's 2,147 course IDs, 46 (4.3%) are universal — available at 80% or more of the system's 23 colleges. The top of the list:
+
+| Course | Colleges | Sections |
+|---|---|---|
+| ENG-111 College Composition I | 23 | 829 |
+| ENG-112 College Composition II | 23 | 823 |
+| BIO-101 General Biology I | 23 | 636 |
+| BIO-141 Human Anatomy and Physiology I | 23 | 477 |
+| MTH-154 Quantitative Reasoning | 23 | 413 |
+| ITE-152 Introduction to Digital and Information Literacy | 23 | 368 |
+| BIO-142 Human Anatomy and Physiology II | 23 | 365 |
+| BIO-102 General Biology II | 23 | 337 |
+| PSY-230 Developmental Psychology | 23 | 301 |
+| PSY-200 Principles of Psychology | 23 | 292 |
+
+Every course in this table appears at all 23 VCCS colleges. The guarantee is meaningful: 829 sections of ENG-111 across 23 campuses will not all fill simultaneously. If you're locked out of a section at NOVA or TCC, there are dozens of other options — online, at a nearby college, through a different session.
+
+412 courses in VCCS qualify as multi-choice: available at 5 or more colleges statewide. Students who can commute or take online sections from any VCCS college have real options for a substantial portion of the catalog.
+
+## The point-source tier: what's at one campus and nowhere else
+
+21 courses in VCCS's catalog have 5 or more sections at exactly one college and no meaningful presence elsewhere in the system:
+
+| Course | College | Sections |
+|---|---|---|
+| TRK-103 Tractor Trailer Driving | TCC (Tidewater) | 14 |
+| SDV-199 Supervised Study | WCC (Wytheville) | 11 |
+| SDV-108 College Survival Skills | TCC (Tidewater) | 10 |
+| MTS-130 Motorsports Structural Technology I | PHCC (Patrick Henry) | 8 |
+| ENG-125 Introduction to Literature | TCC (Tidewater) | 8 |
+| HLT-109 CPR Recertification | CAMP (Central Virginia) | 7 |
+| MAC-146 Metals/Heat Treatment | CVCC (Central Virginia) | 7 |
+| AUT-225 Automotive Emissions Inspection | NOVA (Northern Virginia) | 6 |
+| ESL-67 English Composition Readiness for ELL | NOVA (Northern Virginia) | 6 |
+| OPT-153 Optical Laboratory Clinical II | Reynolds (J. Sargeant Reynolds) | 6 |
+
+The logic behind each concentration is legible in the data. TRK-103 (Tractor Trailer Driving) at TCC requires commercial driving infrastructure — truck facilities, a training range, CDL-certified instruction — that most campuses don't have. MTS-130 (Motorsports Structural Technology I) at Patrick Henry Community College reflects PHCC's motorsports program, built around the racing industry presence in the Martinsville/Henry County area, home to Martinsville Speedway.
+
+OPT-153 (Optical Laboratory Clinical II) at J. Sargeant Reynolds is a clinical course requiring an optical laboratory and clinical site partnerships that Reynolds developed through its optician program. AUT-225 (Automotive Emissions Inspection) exists at NOVA because Virginia's emissions testing requirements are concentrated in Northern Virginia. ESL-67 concentrates at NOVA because Northern Virginia has the largest ESL-eligible population in the state. Neither is arbitrary concentration; both reflect NOVA's service area.
+
+## NOVA and TCC: two dominant colleges with 5 exclusive programs each
+
+VCCS has two colleges that stand apart from the rest of the system by every measure: NOVA (Northern Virginia Community College) and TCC (Tidewater Community College). Both hold 5 exclusive point-source courses.
+
+| College | Total Sections | Unique Courses | Exclusive Courses | Universal Courses |
+|---|---|---|---|---|
+| NOVA | 6,377 | 550 | 5 | 46 |
+| TCC | 3,585 | 597 | 5 | 46 |
+
+NOVA is by far the largest VCCS college by section count — 6,377 total sections, compared to TCC's 3,585. But TCC holds more unique course IDs (597 vs. 550), reflecting wider catalog breadth relative to its section count. Both hold all 46 universal courses and each holds 5 exclusive point-source programs.
+
+TCC's exclusives lean toward trades and specialized career programs: commercial truck driving, a college survival skills course with 10 sections, and ENG-125 as a standalone course. NOVA's exclusives lean toward its service area's specific demographics: automotive emissions inspection for Northern Virginia's regulatory context, and ESL coursework for the region's large immigrant and English-language-learner population.
+
+Two smaller colleges hold notable exclusives: VWCC (Virginia Western Community College) holds 2 exclusive courses across 1,140 total sections; Brightpoint Community College holds 1 exclusive course across 1,525 total sections.
+
+## Entirely scarce subject areas
+
+Several entire subject prefixes in VCCS are 100% scarce — every course in the prefix is available at fewer than 25% of the system's 23 colleges:
+
+- **ARC (Architecture):** 11 courses, all scarce. Architecture programs require studio space, specialized software, and faculty with professional licensure. The infrastructure investment prevents casual replication across campuses.
+- **VET (Veterinary Technology):** 12 courses, all scarce. Veterinary programs require animal facilities, clinical partnerships with veterinary practices, and AVMA accreditation. The accreditation process is campus-specific — not every campus can or wants to run one.
+- **PED (Physical Education):** 7 courses, all scarce. Activity-based courses require specific facilities — pools, courts, gymnasiums, outdoor spaces — that not all campuses maintain.
+- **PHT (Phlebotomy Technology):** 5 courses, all scarce. Phlebotomy programs require clinical placement agreements with blood draw sites — hospitals, outpatient labs, blood banks — that each campus must independently negotiate.
+- **MSC:** 6 courses, all scarce.
+
+Veterinary technology deserves specific attention. 12 VET courses represent a full program sequence, and every single one concentrates at campuses with accredited vet tech programs and animal facilities for clinical instruction. If you're pursuing veterinary technology in Virginia, your first step is identifying which VCCS colleges have accredited vet tech programs — not choosing a convenient campus. A campus without an active VET prefix doesn't have the program.
+
+Architecture follows the same structure. The 11 ARC courses represent a design program sequence that concentrates at campuses with dedicated studio space. VCCS's common numbering means the course codes are standardized statewide; the programs themselves are not.
+
+## The Eastern Shore gap: ESCC at the system's edge
+
+Eastern Shore Community College (ESCC) is the smallest VCCS campus by nearly every measure: 281 total sections, 107 unique course IDs. For context, NOVA runs 6,377 sections — more than 22 times ESCC's total.
+
+ESCC's position reflects its geography. The Eastern Shore of Virginia — Accomac and Northampton counties — is separated from the mainland by the Chesapeake Bay. It's the most isolated service area in the VCCS system, serving a population with no other realistic VCCS option within commuting distance.
+
+Any Eastern Shore student pursuing a specialized program should verify that ESCC offers the full sequence — or plan from the start which courses they'll take online through another VCCS college. VCCS's cross-enrollment policies allow students to take online sections from any in-system college, which is practically essential for ESCC students in programs their local campus doesn't run.
+
+## Coverage distribution
+
+VCCS's full catalog distribution across the 26,236 sections and 2,147 course IDs analyzed:
+
+| Tier | Courses | Share |
+|---|---|---|
+| Universal (≥80% of colleges) | 46 | 4.3% |
+| Common (50–79%) | 98 | 9.2% |
+| Selective (25–49%) | 190 | 17.8% |
+| Scarce (&lt;25% of colleges) | 710 | 66.7% |
+| Point-source (1 college, ≥5 sections) | 21 | 2% |
+
+The 412 multi-choice courses provide real flexibility for the transfer and gen-ed core. The 710 scarce courses require a different approach: identify where the course runs before you pick a campus. For 100%-scarce prefixes like ARC, VET, and PHT, confirm the target campus has the active program — not just the course code — before committing.
+
+[Browse all 23 VCCS colleges](/va/colleges) to compare section volume and course breadth before you commit to a campus.
+
+<ProductCallout
+  text="Community College Path indexes course sections across all 23 VCCS colleges. Search any course to see where it's offered, how many sections are open, and which campuses have availability."
+  feature="courses"
+  label="Search VA Courses Across All 23 Colleges"
+/>


### PR DESCRIPTION
## Strategic framing

**Trigger**: Trigger G (course-scarcity detector) — `detect-course-scarcity.ts` fired for VA (score 692), TN (score 510), SC (score 439)

**Cluster**: `course-availability-guide` — batch 2; NC, GA, KY were batch 1. This PR adds VA, TN, SC. FL and AL remain.

**Target readers**:
- VA: VCCS student deciding between campuses or courses not at their home college
- TN: TBR student building a specialized program (251 point-source courses = unusually high concentration)
- SC: SCTCS student in trades, nursing, or manufacturing (Tri-County holds 40% of all exclusive programs)

**Search intent**: State-specific queries like "Virginia community college courses", "Tennessee community college course availability", "South Carolina technical college programs"

**Strategic rationale**: All three articles source from precomputed `.blog-pipeline/slices/course-scarcity/` slice files (26k+ sections per state). Data-driven articles with concrete per-college comparisons, specific course-code examples, and cross-state scarcity ratios. Fills 3 of the 5 remaining gaps in the cluster (NC=78.9%, GA=50.8%, KY=44.4% are already published).

**Review cadence**: No — structural concentration patterns are stable across terms. Specific section counts will shift, but the tier structure and anchor campus identities rarely change.

**Also included**: `&lt;25%` MDX escaping fix for existing GA and KY articles (same parsing issue, no content change)

## What changed

| Article | Words | Scarcity | Universal tier | Key finding |
|---|---|---|---|---|
| Virginia VCCS | 1,688 | 68.6% | 46 courses (4.3%) | NOVA and TCC each hold 5 exclusive programs; VET/ARC 100% scarce |
| Tennessee TBR | 1,523 | 60% | 143 courses (11.1%) | 251 point-source courses (19.5%) — highest of any state indexed |
| South Carolina SCTCS | 1,716 | 70.4% | 21 courses (1.7%) | Tri-County holds 43 exclusive (40%); only 21 universal statewide |

## Reviewer checklist
- [ ] Read for fluff. Any "Top N tips" energy? Any generic education-blog filler?
- [ ] Verify factual claims against `.blog-pipeline/slices/course-scarcity/va.json`, `tn.json`, `sc.json`
- [ ] Click every internal link — do they resolve to existing posts/tools?
- [ ] State-specific posts: confirm StateToolsCTA renders top + bottom
- [ ] Cluster spokes: confirm the hub link is present and a sibling spoke is referenced
- [ ] If review-cadence flag is true, add a calendar reminder for annual review