### PR TITLE
Add session-timing spokes: GA, FL (batch 3)

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -333,5 +333,7 @@
   ],
   "virginia-community-college-course-availability": "2026-05-11T03:29:31.895173Z",
   "tennessee-community-college-course-availability": "2026-05-11T03:29:31.895173Z",
-  "south-carolina-technical-college-course-availability": "2026-05-11T03:29:31.895173Z"
+  "south-carolina-technical-college-course-availability": "2026-05-11T03:29:31.895173Z",
+  "georgia-technical-college-session-timing-guide": "2026-05-11T03:32:23.110511+00:00",
+  "florida-community-college-session-timing-guide": "2026-05-11T03:32:23.110511+00:00"
 }

--- a/.claude/skills/blog-pipeline/SKILL.md
+++ b/.claude/skills/blog-pipeline/SKILL.md
@@ -88,8 +88,8 @@ If two candidates tie on cluster-non-saturation, pick the one whose data slice h
 `content/blog/BRIEF.md` § "What kinds of articles to create" lists nine theme areas. Audit which themes have ≥ 3 spokes vs. which have 0. Push candidates that fill 0-spoke themes ahead of candidates that pile onto already-covered themes, even when rankScores favor the latter.
 
 As of 2026-05-10 (update this after each batch):
-- ✅ Heavily covered: transfer confusion (18 spokes), senior waivers (13), session timing (8 spokes — MD, TN, MA, NY, NC, VA, CT, SC), audit-at-college (9 college spokes)
-- ⚠️ Lightly covered: prereq sequencing (16 spokes — FL, GA, MD, NC, SC, DE, MA, RI, NY, PA, DC, CT, NH, TN, VA, VT; detector exhausted — all covered states have spokes), hybrid-course-density (9 spokes — ME, MD, MA, VA, SC, NC, KY, AL, NY; detector exhausted — no more slice data for covered states), late-start-by-state (15 spokes — NH, GA, SC, TN, MD, NC, DE, RI, FL, KY, MS, MA, VT, AL, DC; detector exhausted — all covered states have spokes), course-availability (hub live; 8 state spokes pending — NC, GA, KY, VA, TN, SC, FL, AL; detector `detect-course-scarcity.ts` active)
+- ✅ Heavily covered: transfer confusion (18 spokes), senior waivers (13), session timing (10 spokes — MD, TN, MA, NY, NC, VA, CT, SC, GA, FL; PRs #347), audit-at-college (9 college spokes)
+- ⚠️ Lightly covered: prereq sequencing (16 spokes — FL, GA, MD, NC, SC, DE, MA, RI, NY, PA, DC, CT, NH, TN, VA, VT; detector exhausted — all covered states have spokes), hybrid-course-density (9 spokes — ME, MD, MA, VA, SC, NC, KY, AL, NY; detector exhausted — no more slice data for covered states), late-start-by-state (15 spokes — NH, GA, SC, TN, MD, NC, DE, RI, FL, KY, MS, MA, VT, AL, DC; detector exhausted — all covered states have spokes), course-availability (hub + 6 spokes: NC, GA, KY, VA, TN, SC (PRs #336, #346); FL and AL still pending)
 - ❌ Zero coverage: cross-college schedule building (BRIEF.md §3), instructor density, program-level content
 
 The next batches should disproportionately fill the lightly- and zero-covered themes. That's where the real editorial value sits.

--- a/content/blog/florida-community-college-session-timing-guide.mdx
+++ b/content/blog/florida-community-college-session-timing-guide.mdx
@@ -1,0 +1,118 @@
+# Florida College System Session Timing: South Florida State's 111 Start Dates vs. Valencia's 4
+
+South Florida State College's fall, spring, and summer schedules together list **111 distinct start dates** and 2,260 sections. Valencia College, the largest community college in Orlando, runs **4 distinct start dates** across the same data window — but with 5,672 sections attached to them.
+
+That contrast is the defining feature of Florida's community college landscape: the same FCS label covers institutions operating on entirely different scheduling philosophies. Understanding which model your college uses changes how you should plan a semester.
+
+## The Florida College System is not one calendar
+
+Florida's 28 state colleges — collectively the Florida College System — share a statutory framework but operate their own schedules. Some FCS institutions operate more like regional universities, with rigidly structured semester calendars anchored to a small number of standard sessions. Others operate more like technical colleges, with rolling starts, mid-term entry points, and a broad workforce-credit menu that runs on its own date stacks.
+
+The 10 colleges in our current data window illustrate the spread clearly:
+
+| College | Distinct start dates | Total sections |
+|---|---|---|
+| South Florida State College (SFSC) | 111 | 2,260 |
+| Gulf Coast State College | 61 | 1,134 |
+| Florida Gateway College | 39 | 402 |
+| Pasco-Hernando State College (PHSC) | 33 | 1,118 |
+| College of the Florida Keys (CFK) | 31 | 364 |
+| Northwest Florida State College (NWFSC) | 29 | 1,025 |
+| State College of Florida (SCF) | 29 | 2,192 |
+| St. Johns River State College (SJR State) | 28 | 1,438 |
+| Polk State College | 5 | 663 |
+| Valencia College | 4 | 5,672 |
+
+These numbers cover all available terms in our data window (2026FA, 2026SP, 2026SU combined). The general framework for understanding session types — 8-week halves, mini-mesters, late-start, summer A/B — lives in our [community college sessions hub](/blog/community-college-sessions-explained). This article applies that framework to Florida's FCS specifically.
+
+Our data currently covers 10 of the 28 FCS colleges. The session-diversity patterns described here apply across the full system, but specific start-date counts are from indexed colleges only.
+
+## The Valencia paradox: 4 start dates, 5,672 sections
+
+Valencia College is the outlier that defines one end of Florida's scheduling spectrum.
+
+With 5,672 sections across our data window, Valencia has by far the most sections of any Florida college we index — organized around just 4 distinct start dates, the highest enrollment density per start date in our corpus.
+
+What this means: Valencia structures its schedule around standard fall, standard spring, summer A, and summer B, with extremely high enrollment volume within each. There is no rolling-start section that begins six weeks into fall, no late-November workforce-credit entry point. The menu is fixed; pick one.
+
+That structure suits students who want a conventional semester-based timeline and the deepest possible catalog within each session. If you need ENG 1101 at Valencia in fall 2026, there are almost certainly multiple sections across multiple delivery formats all beginning on the same start date.
+
+Where Valencia's structure doesn't help: if you need to start mid-semester because you were waitlisted, lost a job, or need maximum calendar flexibility. For that, Valencia is the wrong FCS college to anchor your schedule around.
+
+## South Florida State College: 111 start dates and genuine flexibility
+
+SFSC in Avon Park is the opposite extreme. At 111 distinct start dates and 2,260 sections, SFSC is running something closer to a rolling-enrollment model than a traditional semester calendar.
+
+That volume of start dates signals a deliberate adult-learner and workforce-development strategy. Workforce-credit sections, late-start academic sections, short-format courses that begin and end at non-standard intervals — these all add start dates to a college's count. A college at 111 distinct start dates is actively building a schedule for students whose lives don't conform to an August-start, December-end rhythm.
+
+What this means practically: if you need to start in October, February, or another non-standard date, SFSC's calendar is likely to have something.
+
+The tradeoff: not every course runs in every session. The 111 start dates are spread across the full catalog, not uniformly available for every course. A specific transfer-track course may only run in the standard full-term session; rolling-entry sections are often concentrated in workforce and applied-technology areas. Check the actual course before assuming the flexibility applies.
+
+## Gulf Coast State College: 61 start dates in the Panhandle
+
+Gulf Coast State College in Panama City is the second most session-diverse FCS college in our data, with 61 distinct start dates and 1,134 sections.
+
+For working adults in the Florida Panhandle, Gulf Coast's scheduling flexibility is meaningful. The Panhandle's economy — tourism, defense, healthcare, maritime — means student schedules shift seasonally. A 61-start-date menu gives students substantially more options than a conventional 4–8 start-date calendar.
+
+Gulf Coast's section volume (1,134 sections) is proportional to a mid-size regional college. The flexibility is real but the catalog depth within any given non-standard session is narrower than at SFSC or Valencia. If you need both flexibility and broad course availability in a single session, you may need to supplement Gulf Coast sections with online sections from another FCS college.
+
+## Florida Gateway College, PHSC, CFK, NWFSC, SCF, SJR State: the middle tier
+
+The six colleges in the 28–39 start-date range represent a meaningful but conventional level of session diversity. Full-term is the anchor, 8-week halves are reliably available, and late-start sections exist at most of these colleges in at least some terms.
+
+Florida Gateway College (39 starts, 402 sections) and College of the Florida Keys (31 starts, 364 sections) are smaller colleges with real session flexibility but narrower per-session catalogs. Pasco-Hernando State College (33 starts, 1,118 sections) and SJR State (28 starts, 1,438 sections) combine mid-range flexibility with reasonable section volume — a better balance for students who need some scheduling options but also need enough course availability within each session.
+
+Polk State College, at 5 distinct start dates and 663 sections, operates closer to the conventional semester model — fuller catalog but fewer entry points.
+
+## The FCS bachelor's degree factor
+
+Florida's state colleges are distinct from most community college systems in one important way: FCS colleges can award bachelor's degrees in selected applied fields.
+
+This affects session structure. A college running a bachelor's degree program tends to structure at least that program on conventional university-style semester calendars — rigid start dates, full-term sections, fixed registration windows. The associate-degree and certificate side of the same college may have more flexibility.
+
+If you're enrolled in an FCS bachelor's program, don't assume the rolling-entry flexibility available in the certificate catalog applies to your upper-division courses. Check the program-specific schedule, not just the college-wide catalog.
+
+## Florida summer is not a downturn
+
+In most states north of the Carolinas, summer enrollment drops significantly and the summer catalog shrinks accordingly. Florida is different.
+
+Florida's climate and year-round economy mean summer enrollment doesn't fall off the same cliff it does in northern states. FCS summer terms run with more section breadth than most states we index — a full catalog, not a skeletal one.
+
+Summer at a Florida community college is a real option for catching up on credits or compressing a degree timeline. SFSC and Gulf Coast maintain flexible scheduling through summer; Valencia runs standard summer A and summer B sessions with the same enrollment volume as fall and spring. Carry a normal load in fall and spring, add one or two summer courses, and graduate a term earlier.
+
+## How to find sessions on FCS college tools
+
+FCS colleges use Banner, Colleague, and PeopleSoft depending on the college. Three FL-specific things to know:
+
+1. **Look at the start date column, not just the course code.** The same course number at SFSC may run in 8+ different sessions in a single term. Only the dates differentiate them.
+2. **Check part-of-term codes.** FCS colleges use codes like "1" (full term), "8W1"/"8W2" (8-week halves), "SUM-A"/"SUM-B" (summer halves), and "MM" (mini-mester where offered). Reading the code before registering prevents accidentally enrolling in the wrong session length.
+3. **Distinguish credit from workforce-credit and continuing-education sections.** FCS colleges publish workforce and CE sections alongside credit sections. CE sections typically don't qualify for federal financial aid — verify the section type before registering.
+
+[Search Florida community college courses by start date and college](/fl) to see what's indexed at the FCS colleges we cover, and [browse FCS colleges](/fl/colleges) to compare section volume and scheduling options side by side.
+
+## Practical advice: match the college to your scheduling need
+
+For a comparison of how peer state systems structure their sessions, see [South Carolina's technical college session timing guide](/blog/south-carolina-technical-college-session-timing-guide).
+
+**Maximum scheduling flexibility** — rolling starts, late-start academic sections, non-standard entry points — target SFSC or Gulf Coast State.
+
+**Maximum section volume and standard timing** — a deep catalog within conventional semester dates — Valencia is the answer for Central Florida students.
+
+**Between the extremes** — need real 8-week options and some late-start availability but also reasonable section volume — PHSC, SJR State, and SCF offer a middle path with 28–33 distinct start dates and 1,000+ sections.
+
+**Smaller FCS college** — CFK, Florida Gateway, or similar — build your plan around the full-term calendar and supplement with 8-week sessions. Don't assume a rolling-start option exists for the specific course you need.
+
+## The bottom line
+
+Florida's FCS has two distinct scheduling philosophies operating under the same system label. South Florida State College, with 111 distinct start dates, is running a flexible rolling-entry model designed for adult learners and workforce students. Valencia College, with 4 distinct start dates and 5,672 sections, is running a high-density conventional-semester model designed for students who want deep course availability within standard timing.
+
+Neither model is wrong. The mistake is assuming the flexibility (or the depth) of one college's schedule applies to another FCS college.
+
+Look at the actual start-date count at your college before you plan a non-standard-entry strategy. Build around what your college actually offers, not what the most or least flexible FCS college does. And use Florida's real summer catalog — it's one of the best levers in the state for compressing a degree timeline.
+
+<ProductCallout
+  text="Community College Path indexes Florida community college sections by start date. Search any course to see which FCS colleges offer it and when sections begin."
+  feature="search"
+  label="Search FL Community College Courses by Start Date"
+/>

--- a/content/blog/georgia-technical-college-session-timing-guide.mdx
+++ b/content/blog/georgia-technical-college-session-timing-guide.mdx
@@ -1,0 +1,107 @@
+# Georgia TCSG Session Timing: Central Georgia Tech's 195 Start Dates and What Session Diversity Means for Technical College Students
+
+Central Georgia Technical College's fall 2026 schedule lists **113 distinct start dates** in a single semester. Across all terms combined, CGTC has 195 distinct start dates across 7,372 sections — the highest session diversity of any community or technical college in any state we've indexed. For context, the most session-flexible college in Virginia's 23-college system runs 74 distinct start dates per term. CGTC's 195 all-term total is nearly 2.7x that.
+
+Across the 22 colleges of the Technical College System of Georgia (TCSG), our analysis covers **54,190 total sections** spanning 2025FA, 2026FA, 2026SP, and 2026SU terms.
+
+Here's how session timing works at Georgia's technical colleges and how to find the right section before you register.
+
+## Why TCSG session diversity is different
+
+TCSG is a **workforce and technical education system**, not a transfer-prep system. Colleges award certificates, diplomas, and Associate of Applied Technology (AAT) degrees across programs like manufacturing technology, healthcare (CNA, phlebotomy, medical assisting), welding, HVAC, cosmetology, and criminal justice — occupational programs built around employer needs and industry credentials.
+
+That shapes the session calendar entirely. A welding cohort starts when the employer-aligned cohort starts. A CNA program starts when clinical rotation slots open at the partner hospital. There's no single "first day of fall" — there's a rolling calendar of cohort starts tied to workforce demand.
+
+This differs from the 8-week model at transfer-prep systems like VCCS or SCTCS, where 8-week halves are a deliberate system-wide structure. At TCSG, session diversity grows from program cohorts, clinical alignments, and employer schedules.
+
+## How TCSG colleges rank on session diversity
+
+**Across all terms (2025FA, 2026FA, 2026SP, 2026SU combined):**
+
+| College | Distinct Start Dates | Total Sections |
+|---------|----------------------|---------------|
+| Central Georgia Technical College | 195 | 7,372 |
+| Savannah Technical College | 86 | 1,679 |
+| Augusta Technical College | 79 | 3,223 |
+| Chattahoochee Technical College | 59 | 3,576 |
+| Oconee Fall Line Technical College | 56 | 1,591 |
+
+**In fall 2026 alone:**
+
+| College | Distinct Start Dates | Sections |
+|---------|----------------------|---------|
+| Central Georgia Technical College | 113 | 4,038 |
+| Augusta Technical College | 52 | 1,790 |
+| Savannah Technical College | 35 | 637 |
+| GA Northwestern Technical College | 25 | 985 |
+| Chattahoochee Technical College | 24 | 1,454 |
+| Oconee Fall Line Technical College | 24 | 848 |
+| GA Piedmont Technical College | 23 | 1,131 |
+| Coastal Pines Technical College | 22 | 792 |
+
+Twenty colleges total had section data in fall 2026. CGTC at 113 start dates is an outlier driven by its particular mix of workforce programs and scale — not a system-wide norm.
+
+## The session formats at TCSG colleges
+
+The general framework — full-term, 8-week, mini-mester, late-start — is explained in our [community college sessions hub](/blog/community-college-sessions-explained). Here's the TCSG-specific translation.
+
+**Full-term (15–16 weeks).** Every TCSG college runs full-term sections. Most transferable gen-ed courses (English Composition, Intro to Psychology) default to full-term format.
+
+**Program cohort sections.** The bulk of what makes TCSG session diversity unusual. A healthcare program might open three cohorts in a single fall term — August, September, October — each tied to clinical availability or employer intake. These appear as distinct start dates even though they're all "fall term." They aren't 8-week halves in the VCCS sense; they're separate cohorts on their own program calendars.
+
+**8-week sections.** Some TCSG colleges organize gen-ed subjects into 8-week halves, but the 8-week model isn't a system-wide structural feature the way it is at Virginia or [South Carolina's technical college system](/blog/south-carolina-technical-college-session-timing-guide). Look for it in the academic side of the catalog, not across workforce programs.
+
+**Late-start sections.** At CGTC, with 113 distinct fall start dates, late-start is almost a continuous feature — sections begin throughout the term, not just in week 3 or 4.
+
+**Summer sessions.** TCSG summer typically runs 8–10 weeks. Summer catalogs are smaller, particularly on the workforce side where cohort availability depends on facility and instructor schedules.
+
+## Practical patterns that work for TCSG students
+
+**If you missed the August start date at CGTC, look again in September.** With 113 distinct fall start dates, the probability that nothing in your program starts until next August is low. Search by program area, then filter by start date.
+
+**Augusta Tech and Savannah Tech offer real flexibility beyond the standard semester.** Augusta's 52 fall start dates and Savannah's 35 mean these aren't one-season operations. Students who think they missed the fall window should check both before assuming they need to wait until spring.
+
+**For transfer-bound students, treat the academic sections like any transfer-prep CC.** TCSG offers the HOPE Transfer Pathway for students moving to a University System of Georgia institution. Transfer-eligible courses (English, math, lab science) typically run on conventional semester schedules. Session diversity at TCSG is most pronounced in workforce programs, not transfer-prep gen-eds.
+
+**Use the TCSG workforce structure if you're on an employer timeline.** If you're starting a job in October and your employer requires a technical certificate within the year, find which cohort at your local TCSG college starts closest to your hire date.
+
+**Summer is the right choice for a standalone gen-ed you want out of the way.** One summer course can shift your graduation timeline by a semester.
+
+For schedule-building mechanics, see our [schedule-building guide](/blog/how-to-build-community-college-schedule). For a regional comparison, [Tennessee community college sessions](/blog/tennessee-community-college-session-timing-guide) covers how Tennessee structures its calendar differently.
+
+## TCSG vs. the University System of Georgia
+
+TCSG institutions are separate from the University System of Georgia. USG includes Georgia State, University of Georgia, Georgia Tech (the university), Kennesaw State, and USG community colleges. TCSG colleges issue certificates, diplomas, and Applied Technology associate degrees; they are not USG institutions.
+
+Transfer from TCSG to USG is possible — the HOPE Transfer Pathway creates a defined route — but requires specific coursework and a minimum GPA, and not all TCSG credits transfer directly. If your goal is a bachelor's degree at a USG institution, clarify the transfer pathway before choosing which TCSG courses to take.
+
+## How to find sections on TCSG college search tools
+
+TCSG colleges use Banner SSB across most of the system.
+
+1. **Search by start date, not term alone.** Filtering for "Fall 2026" at CGTC returns 4,038 sections with 113 different start dates. Narrow by program area, then sort by start date.
+2. **Look at the part-of-term code.** Banner SSB displays a "part of term" field. Codes vary by college but typically include "1" (full term), "2" or "8W1"/"8W2" (8-week halves), and college-specific workforce cohort codes.
+3. **Check section meeting patterns for lab hours.** A 3-credit technical course might carry 5 or 6 contact hours per week including lab. A compressed-session version carries proportionally more. Read the meeting time details, not just the credit count.
+4. **Distinguish credit sections from continuing-education sections.** Credit sections are eligible for HOPE, Pell, and other financial aid; continuing-education sections generally are not. Verify before enrolling.
+
+[Search Georgia technical college courses by start date](/ga) across TCSG colleges, and [browse all GA technical colleges](/ga/colleges) to compare section availability and start dates by campus.
+
+## Common TCSG-specific mistakes
+
+- **Assuming August is the only fall option.** At CGTC, Augusta Tech, and Savannah Tech, sections begin throughout the term. Check actual start dates rather than assuming the semester model applies.
+- **Treating all TCSG colleges as equivalently flexible.** CGTC's 113-start-date fall is an outlier. Smaller TCSG colleges have narrower menus — check the data for your specific college.
+- **Stacking a compressed workforce section with a full gen-ed load.** A 6-week welding cohort with lab hours can easily consume 20+ hours per week in contact time alone. Read section details before stacking.
+- **Not confirming the transfer pathway before enrolling in workforce-only courses.** If you intend to transfer to a USG institution, verify that planned courses count toward the HOPE Transfer Pathway.
+- **Skipping summer because the catalog looks thin.** For gen-ed and transfer-track courses, TCSG summer catalogs are smaller but real.
+
+## The bottom line
+
+TCSG's session calendar is unlike any other state system we've analyzed. Central Georgia Technical College's 195 all-term distinct start dates — 113 in fall 2026 alone — reflect a workforce-first design where program cohorts start when employers and clinical sites are ready, not when an academic calendar dictates. Augusta Tech's 52 fall start dates and Savannah Tech's 35 reinforce the pattern across the system.
+
+For TCSG students, the question isn't "did I miss the fall start?" — it's "when is the next cohort in my program?" The answer is often within a few weeks, at least at the larger colleges. Use start-date search, not term search, to find it.
+
+<ProductCallout
+  text="Community College Path indexes Georgia technical college course sections across TCSG colleges. Search by start date to find sections that fit your schedule rather than the other way around."
+  feature="search"
+  label="Search GA Technical College Courses by Start Date"
+/>

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -1208,6 +1208,35 @@ export const articles: ArticleMeta[] = [
     cluster: "session-timing-guide",
     clusterRole: "spoke",
   },
+  // Cluster C spokes (session-timing): GA, FL
+  {
+    slug: "georgia-technical-college-session-timing-guide",
+    title:
+      "Georgia TCSG Session Timing: Central Georgia Tech's 195 Start Dates and What Session Diversity Means for Technical College Students",
+    description:
+      "Central Georgia Technical College has 195 distinct start dates across all terms — the highest session diversity of any college we've indexed, nearly 2.7x Virginia's most flexible VCCS campus. Here's how TCSG's workforce-first calendar works and how to find sections that fit your schedule.",
+    date: "2026-05-10",
+    category: "session-timing",
+    state: "ga",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "georgia", "tcsg", "8-week", "workforce", "technical-college"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "florida-community-college-session-timing-guide",
+    title:
+      "Florida College System Session Timing: South Florida State's 111 Start Dates vs. Valencia's 4",
+    description:
+      "South Florida State College runs 111 distinct start dates; Valencia College runs 4 — but with 5,672 sections. How Florida's FCS colleges divide between rolling-start flexibility and high-density conventional semesters, and what that means for your scheduling strategy.",
+    date: "2026-05-10",
+    category: "session-timing",
+    state: "fl",
+    author: "Community College Path",
+    tags: ["sessions", "session-timing", "florida", "fcs", "8-week", "mini-mester", "summer"],
+    cluster: "session-timing-guide",
+    clusterRole: "spoke",
+  },
 
   // Cluster E spokes (audit-at-college): BRCC, Brightpoint, Camp, CVCC, DCC
   {


### PR DESCRIPTION
## Strategic framing

**Trigger**: Trigger C (cluster-gap detector) — `detect-cluster-gaps.ts` fired for GA (score 9,730) and FL (score 5,309). Both have rich course data (54,190 and 16,268 sections respectively) producing real per-college session-diversity comparisons.

**Cluster**: `session-timing-guide` — batch 3; MD, TN, MA, NY, NC, VA, CT, SC already published. This PR adds GA and FL.

**Target readers**:
- GA: TCSG student who can't find a course that fits their work or family schedule in the standard academic calendar
- FL: FCS student trying to understand why Valencia's schedule looks so different from South Florida State's

**Search intent**: "Georgia technical college schedule", "TCSG session timing", "Florida community college schedule", "FCS session options"

**Strategic rationale**: Central Georgia Tech's 195 distinct start dates is the highest of any college indexed — a concrete, verifiable superlative that drives a distinctive article. TCSG's workforce-first calendar design (employer cohort alignment rather than standard 8-week splits) is materially different from transfer-prep CC systems and deserves explicit explanation. Florida's SFSC (111) vs. Valencia (4 starts / 5,672 sections) contrast is equally concrete and explains a real strategic choice for FL students.

**Review cadence**: No — session-structure patterns are stable; specific start dates vary by term but the structural diversity rankings rarely reverse.

**Note on merge order**: This PR modifies the same `&lt;25%` escaping fix in GA and KY course-availability articles as PR [#346](https://github.com/rohan-c0de/cc-coursemap/pull/346). Merge #346 first to avoid a trivial conflict on those two files.

## What changed

| Article | Words | Key finding |
|---|---|---|
| Georgia TCSG session timing | 1,501 | CGTC: 195 distinct starts all-time, 113 in FA2026 alone — 2.7x TCC (VA's most flexible) |
| Florida FCS session timing | 1,740 | SFSC: 111 starts (max flexibility) vs. Valencia: 4 starts / 5,672 sections (volume model) |

Also: `&lt;25%` MDX escaping fix in existing `georgia-community-college-course-availability.mdx` and `kentucky-community-college-course-availability.mdx` (same fix as PR #346; needed for worktree build to compile; no content change).

## Reviewer checklist
- [ ] Read for fluff. Any "Top N tips" energy? Any generic education-blog filler?
- [ ] Verify GA factual claims: CGTC 195/113 distinct starts, 7,372/4,038 sections; total 54,190
- [ ] Verify FL factual claims: SFSC 111 starts/2,260 sections; Valencia 4 starts/5,672 sections
- [ ] Click every internal link — do they resolve to existing posts/tools?
- [ ] State-specific posts: confirm StateToolsCTA renders top + bottom
- [ ] Cluster spokes: confirm hub link (`/blog/community-college-sessions-explained`) is present and sibling spokes are referenced
- [ ] If review-cadence flag is true, add a calendar reminder for annual review