### PR TITLE
feat(seo): redesigned 404 page with helpful navigation (#337)

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,30 +1,139 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+import { getAllStates } from "@/lib/states/registry";
+
+export const metadata: Metadata = {
+  title: "Page not found — Community College Path",
+  description:
+    "We couldn't find that page. Browse community colleges, courses, and transfer guides across the states we cover.",
+  robots: { index: false, follow: true },
+};
 
 export default function NotFound() {
+  const states = getAllStates()
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+
   return (
-    <div className="flex flex-1 flex-col items-center justify-center px-4 py-24 bg-white dark:bg-slate-900 min-h-screen">
-      <h1 className="text-6xl font-bold text-gray-200 dark:text-slate-700">404</h1>
-      <h2 className="mt-4 text-xl font-semibold text-gray-900 dark:text-slate-100">
-        Page not found
-      </h2>
-      <p className="mt-2 text-gray-600 dark:text-slate-400 text-center max-w-md">
-        The page you&apos;re looking for doesn&apos;t exist or may have been
-        moved.
-      </p>
-      <div className="mt-6 flex gap-3">
-        <Link
-          href="/"
-          className="rounded-lg bg-teal-600 px-4 py-2 text-sm font-medium text-white hover:bg-teal-700 transition"
-        >
-          Go Home
-        </Link>
-        <Link
-          href="/colleges"
-          className="rounded-lg border border-gray-300 dark:border-slate-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-800 transition"
-        >
-          Browse Colleges
-        </Link>
-      </div>
+    <div className="min-h-screen bg-white dark:bg-slate-900">
+      <header className="border-b border-gray-200 dark:border-slate-800">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4">
+          <Link
+            href="/"
+            className="text-lg font-semibold text-teal-700 dark:text-teal-400 hover:text-teal-800"
+          >
+            Community College Path
+          </Link>
+          <nav className="flex gap-4 text-sm">
+            <Link
+              href="/colleges"
+              className="text-gray-600 dark:text-slate-400 hover:text-gray-900"
+            >
+              Colleges
+            </Link>
+            <Link
+              href="/blog"
+              className="text-gray-600 dark:text-slate-400 hover:text-gray-900"
+            >
+              Blog
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-16">
+        <p className="text-sm font-semibold uppercase tracking-wide text-teal-700 dark:text-teal-400">
+          404 — Page not found
+        </p>
+        <h1 className="mt-2 text-3xl font-bold text-gray-900 dark:text-slate-100 sm:text-4xl">
+          We couldn&apos;t find that page.
+        </h1>
+        <p className="mt-3 max-w-xl text-base text-gray-600 dark:text-slate-400">
+          The page may have moved or never existed. Here are a few ways to find
+          what you&apos;re looking for.
+        </p>
+
+        <section className="mt-10">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">
+            Popular destinations
+          </h2>
+          <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+            <li>
+              <Link
+                href="/colleges"
+                className="block rounded-lg border border-gray-200 dark:border-slate-700 px-4 py-3 hover:border-teal-400 hover:bg-teal-50/40 dark:hover:bg-slate-800"
+              >
+                <span className="font-medium text-gray-900 dark:text-slate-100">
+                  Browse all colleges
+                </span>
+                <span className="block text-sm text-gray-500 dark:text-slate-400">
+                  Every community college we cover, by state.
+                </span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/blog"
+                className="block rounded-lg border border-gray-200 dark:border-slate-700 px-4 py-3 hover:border-teal-400 hover:bg-teal-50/40 dark:hover:bg-slate-800"
+              >
+                <span className="font-medium text-gray-900 dark:text-slate-100">
+                  Guides & articles
+                </span>
+                <span className="block text-sm text-gray-500 dark:text-slate-400">
+                  How to find courses, transfer credit, and pay less.
+                </span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/va"
+                className="block rounded-lg border border-gray-200 dark:border-slate-700 px-4 py-3 hover:border-teal-400 hover:bg-teal-50/40 dark:hover:bg-slate-800"
+              >
+                <span className="font-medium text-gray-900 dark:text-slate-100">
+                  Search courses
+                </span>
+                <span className="block text-sm text-gray-500 dark:text-slate-400">
+                  Find a specific course offered this term.
+                </span>
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/"
+                className="block rounded-lg border border-gray-200 dark:border-slate-700 px-4 py-3 hover:border-teal-400 hover:bg-teal-50/40 dark:hover:bg-slate-800"
+              >
+                <span className="font-medium text-gray-900 dark:text-slate-100">
+                  Start from the home page
+                </span>
+                <span className="block text-sm text-gray-500 dark:text-slate-400">
+                  Pick your state and search from there.
+                </span>
+              </Link>
+            </li>
+          </ul>
+        </section>
+
+        <section className="mt-10">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100">
+            Pick a state
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-slate-400">
+            We cover {states.length} states. Jump straight to one.
+          </p>
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {states.map((s) => (
+              <li key={s.slug}>
+                <Link
+                  href={`/${s.slug}`}
+                  className="inline-block rounded-full border border-gray-200 dark:border-slate-700 px-3 py-1 text-sm text-gray-700 dark:text-slate-300 hover:border-teal-400 hover:bg-teal-50 dark:hover:bg-slate-800"
+                >
+                  {s.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the bare-bones 404 page (big number + two links) with a branded page that gives users real ways to recover: popular destinations, full state picker, contextual copy.
- Adds `robots: { index: false, follow: true }` so the 404 page itself doesn't waste crawl budget.

Part of #337 (SEO soft 404 audit). HTTP-status verification on Vercel preview and thin-content guards land in follow-up PRs.

## Screenshot
Dark mode rendering verified locally — branded header, 4 popular-destination cards, 22 state chips.

## Test plan
- [ ] Visit any unknown route on the Vercel preview (e.g. `/this-route-does-not-exist`) and confirm the new design renders
- [ ] Confirm `curl -I` returns HTTP 404 (not 200) on the preview — if not, this becomes input for the follow-up PR1
- [ ] Click each "popular destination" card and each state chip; verify all links land on valid pages
- [ ] Toggle dark mode; confirm legibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)