### PR TITLE
fix(seo): force HTTP 404 for invalid top-level state slugs (#337)

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -15,6 +15,12 @@ type Props = {
   params: Promise<{ state: string }>;
 };
 
+// Force HTTP 404 (not a cached HTTP 200 soft-404) for any state slug
+// that isn't in the registry. Vercel ISR otherwise caches the rendered
+// `notFound()` UI as a 200 response, causing soft-404 floods in Search
+// Console for every garbage URL bots probe. See issue #337.
+export const dynamicParams = false;
+
 export function generateStaticParams() {
   return getAllStates().map((s) => ({ state: s.slug }));
 }


### PR DESCRIPTION
## Summary
Adds `export const dynamicParams = false` to `app/[state]/page.tsx`. The page already enumerates every valid state via `generateStaticParams`, so this is a single-line change that causes Vercel to return a true HTTP 404 for unknown state slugs instead of caching the rendered `notFound()` UI as a 200 response.

## Empirical findings (production, before this PR)

| Route | HTTP status | Cause |
|---|---|---|
| `/this-route-does-not-exist` | **200** | `x-vercel-cache: HIT`, `x-matched-path: /[state]` — cached prerender of notFound() UI |
| `/zz` | 404 | Not cached — coincidentally correct |
| `/va/transfer/to/fake-uni` | 404 | Only ISR route using `dynamicParams = false` — the proven fix |

## Why draft
Local production build can't run due to network-dependent fetches during pre-render (transfer lookup hits external services). The fix is one line in a file that already correctly enumerates valid states, so the risk surface is minimal — but I want to verify on the Vercel preview before marking ready.

## Test plan
- [ ] Vercel preview builds successfully
- [ ] `curl -I <preview>/this-route-does-not-exist` returns **404** (was 200 on prod)
- [ ] `curl -I <preview>/garbage-slug` returns **404**
- [ ] `curl -I <preview>/va` returns **200** (no regression for valid states)
- [ ] `curl -I <preview>/nc` returns **200**
- [ ] `curl -I <preview>/va/colleges` returns **200** (nested routes for valid states still work)
- [ ] The 404 page renders the redesigned content (from PR #348)

## Scope / follow-ups
This PR handles **only** the top-level state route. The other soft-404 cases identified in the audit need separate evaluation:
- `/[state]/subject/[prefix]` (200 → should 404)
- `/[state]/program/[slug]` (200 → should 404)
- `/[state]/college/[id]` (200 → should 404)
- `/[state]/course/[code]` — deliberately renders fallback with `robots: noindex`, leave alone

Each needs an answer to "can we enumerate all valid params at build time without blowing up build duration?" Filed separately.

Closes part of #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)