### PR TITLE
fix(seo): force HTTP 404 for invalid college IDs (#337)

### DIFF
--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -49,6 +49,11 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   };
 }
 
+// Force HTTP 404 (not a cached 200 soft-404) for any (state, college-id) pair
+// not in `loadInstitutions`. `generateStaticParams` already enumerates every
+// valid pair at build time, so this is zero extra build cost. See #337.
+export const dynamicParams = false;
+
 export function generateStaticParams() {
   return getAllStates().flatMap((config) =>
     loadInstitutions(config.slug).map((i) => ({ state: config.slug, id: i.id }))


### PR DESCRIPTION
## Summary
Adds `export const dynamicParams = false` to `app/[state]/college/[id]/page.tsx`. Same one-line pattern as #349.

`generateStaticParams` already enumerates every valid (state, college-id) pair at build time, so this is **zero extra build cost** — just a directive telling Vercel to return 404 (not a cached prerender) for unlisted IDs.

## Empirical motivation (production, before)

| Route | HTTP status |
|---|---|
| `/va/college/no-such-college` | 200 (soft 404) |
| `/nc/college/totally-fake` | 200 (soft 404) |

## Local dev verification (after)

| Route | HTTP status |
|---|---|
| `/va/college/nova` | 200 ✓ |
| `/va/college/brightpoint` | 200 ✓ |
| `/nc/college/wake-technical` | 200 ✓ |
| `/va/college/totally-fake-college-id-zzz` | 404 ✓ |

## Test plan
- [ ] Vercel preview builds successfully
- [ ] `curl -I <preview>/va/college/no-such-college` returns **404**
- [ ] `curl -I <preview>/va/college/nova` returns **200**
- [ ] `curl -I <preview>/nc/college/wake-technical` returns **200**

## Scope / follow-ups
Soft 404s on `/[state]/program/[slug]` and `/[state]/subject/[prefix]` are still open. Both currently use on-demand ISR (return `[]` from `generateStaticParams`); fixing them requires switching to build-time enumeration, which is a bigger decision (build cost vs. coverage). I'll open a discussion or separate PR with both options.

Part of #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)