### PR TITLE
fix(seo): force HTTP 404 for non-qualifying program slugs (#337)

### DIFF
--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -12,13 +12,14 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { isValidState } from "@/lib/states/registry";
+import { getAllStates, isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
 import {
   loadProgramData,
   qualifies,
   getProgramBySlug,
+  getQualifyingProgramSlugs,
   PROGRAMS,
 } from "@/lib/programs";
 import { loadProgramAcrossColleges, checkCourseAvailability } from "@/lib/programs/requirements";
@@ -32,9 +33,23 @@ type PageProps = {
   params: Promise<{ state: string; slug: string }>;
 };
 
+// Force HTTP 404 (not a cached 200 soft-404) for any (state, slug) pair
+// that's not in the qualifying-program set. See #337. Build cost: one
+// loadProgramData call per (state, PROGRAMS[i]) pair (~22 × ~10 = ~220).
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
-  // On-demand ISR: sitemap drives discovery, no upfront generation
-  return [];
+  // Serialize across states — each call iterates every program and runs
+  // multiple subject queries, so a parallel fan-out across 22 states would
+  // saturate Supabase connections at build time.
+  const out: { state: string; slug: string }[] = [];
+  for (const s of getAllStates()) {
+    const slugs = await getQualifyingProgramSlugs(s.slug).catch(
+      () => [] as string[]
+    );
+    for (const slug of slugs) out.push({ state: s.slug, slug });
+  }
+  return out;
 }
 
 function siteUrl() {


### PR DESCRIPTION
## Summary
Switches `/[state]/program/[slug]` from on-demand ISR to build-time enumeration, then adds `dynamicParams = false`. Same fix pattern as #349 and #351.

`generateStaticParams` now enumerates every (state, slug) pair where the program clears the existing `qualifies()` gate (≥3 colleges, each with ≥5 sections). Unlisted slugs return true HTTP 404 instead of a cached 200.

## Empirical motivation (production, before)
| Route | HTTP status |
|---|---|
| `/va/program/totally-fake-slug` | 200 (soft 404 — `x-vercel-cache: HIT`) |

## Local dev verification (after)
| Route | HTTP status |
|---|---|
| `/va/program/nursing` | 200 ✓ |
| `/va/program/totally-fake-slug` | 404 ✓ |

## Build cost
- ~22 states × ~10 programs ≈ 220 pre-renders.
- `generateStaticParams` runs serially across states. Parallel fan-out timed out in dev mode by hammering Supabase — sequential adds a small wall-clock cost but keeps connection load bounded.

## Test plan
- [ ] Vercel preview builds successfully (no Supabase timeouts in build log)
- [ ] `curl -I <preview>/va/program/nursing` returns **200**
- [ ] `curl -I <preview>/va/program/totally-fake-slug` returns **404**
- [ ] Spot-check a couple of qualifying programs in non-VA states (e.g. `/nc/program/nursing`, `/ma/program/business`) return **200**

## Scope / follow-up
The last remaining soft-404 route is `/[state]/subject/[prefix]`. That's a larger build-cost question (~1000–2000 pages) and will land separately.

Part of #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)