### PR TITLE
fix(seo): force HTTP 404 for invalid subject prefixes (#337)

### DIFF
--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -12,9 +12,13 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { loadCoursesBySubject, getDistinctSubjects } from "@/lib/courses";
+import {
+  loadCoursesBySubject,
+  getDistinctSubjects,
+  getSitemapCourseIndex,
+} from "@/lib/courses";
 import { getCurrentTerm, termLabel } from "@/lib/terms";
-import { isValidState } from "@/lib/states/registry";
+import { getAllStates, isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { subjectName } from "@/lib/subjects";
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
@@ -29,11 +33,34 @@ type PageProps = {
 };
 
 // ---------------------------------------------------------------------------
-// Static params — empty, all pages generated on-demand via ISR
+// Static params — enumerate every (state, prefix) pair with ≥5 sections in
+// the current term, matching the sitemap's threshold. `dynamicParams = false`
+// causes unlisted pairs to return HTTP 404 instead of a cached 200 soft-404.
+// See #337. Prefixes are lowercased to match the canonical URLs Google sees.
 // ---------------------------------------------------------------------------
 
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
-  return [];
+  const out: { state: string; prefix: string }[] = [];
+  for (const s of getAllStates()) {
+    try {
+      const term = await getCurrentTerm(s.slug);
+      const { subjectSectionCounts } = await getSitemapCourseIndex(
+        term,
+        s.slug
+      );
+      for (const [prefix, count] of subjectSectionCounts) {
+        if (count >= 5) {
+          out.push({ state: s.slug, prefix: prefix.toLowerCase() });
+        }
+      }
+    } catch {
+      // If the catalog can't be loaded for a state at build time, skip it
+      // rather than fail the whole build — the route is non-critical.
+    }
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Switches `/[state]/subject/[prefix]` from on-demand ISR to build-time enumeration; adds `dynamicParams = false`. Same fix pattern as #349, #351, #352 — closes the last soft-404 route family from the #337 audit (course pages excluded by design — see comment in `app/[state]/course/[code]/page.tsx`).

`generateStaticParams` enumerates every (state, prefix) pair with **≥5 sections** in the current term, matching the sitemap's existing threshold. Pairs outside that set return true HTTP 404.

## Why ≥5 sections (vs. ≥1)
- The sitemap already gates on `count >= 5`, so anything below isn't a URL Google has been pointed at.
- Pages with 1–4 sections are thin content and shouldn't be indexed anyway (aligns with the spirit of #337 deliverable 5: thin-content guards).
- Keeps the pre-render count bounded.

## Empirical motivation (production, before)
| Route | HTTP status |
|---|---|
| `/va/subject/zzz` | 200 (soft 404) |

## Local dev verification (after)
| Route | HTTP status |
|---|---|
| `/va/subject/eng` | 200 ✓ |
| `/va/subject/mth` | 200 ✓ |
| `/va/subject/bio` | 200 ✓ |
| `/nc/subject/eng` | 200 ✓ |
| `/va/subject/zzz` | 404 ✓ |
| `/va/subject/qqqq` | 404 ✓ |

## Build cost
- Per state: one paginated scan of `courses` filtered by term — same scan the sitemap runs, with the same `cached()` wrapper, so sequential build steps share the result.
- Pre-render count ≈ 22 states × 30–80 prefixes per state ≈ 700–1700 pages.
- This is the biggest pre-render expansion in the #337 series. If the Vercel build time jumps a lot, we can fall back to a smaller threshold or to the course-page strategy (render fallback with `robots: noindex`, status stays 200 but Google won't index).

## Test plan
- [ ] Vercel preview builds within a tolerable time
- [ ] `curl -I <preview>/va/subject/eng` returns **200**
- [ ] `curl -I <preview>/va/subject/mth` returns **200**
- [ ] `curl -I <preview>/nc/subject/eng` returns **200**
- [ ] `curl -I <preview>/va/subject/zzz` returns **404**
- [ ] `curl -I <preview>/ma/subject/qqqq` returns **404**

Closes the route-status portion of #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)