### PR TITLE
feat(seo): 301 redirects for VCCS 2022 college renames (#337)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,8 +18,37 @@ const nextConfig: NextConfig = {
     "/api/[state]/prereqs/**": ["./data/*/prereqs.json"],
   },
   async redirects() {
-    // Backward-compatible redirects from old routes to /va/ prefixed routes
+    // VCCS 2022 renames — these colleges officially changed names in 2022
+    // and external links (press, Wikipedia, prior PDFs) may still point at
+    // the old slug. Map each old slug to the current one before the generic
+    // /college/:id → /va/college/:id rule below so the rename wins.
+    // See issue #337.
+    const vccsRenames: Array<{ old: string; current: string }> = [
+      { old: "john-tyler", current: "brightpoint" },
+      { old: "jtcc", current: "brightpoint" },
+      { old: "thomas-nelson", current: "vpcc" },
+      { old: "tncc", current: "vpcc" },
+      { old: "dabney-s-lancaster", current: "mgcc" },
+      { old: "dslcc", current: "mgcc" },
+      { old: "lord-fairfax", current: "laurelridge" },
+      { old: "lfcc", current: "laurelridge" },
+    ];
+    const renameRedirects = vccsRenames.flatMap((r) => [
+      {
+        source: `/va/college/${r.old}`,
+        destination: `/va/college/${r.current}`,
+        permanent: true,
+      },
+      {
+        source: `/college/${r.old}`,
+        destination: `/va/college/${r.current}`,
+        permanent: true,
+      },
+    ]);
+
+    // Backward-compatible redirects from old un-prefixed routes to /va/.
     return [
+      ...renameRedirects,
       // /colleges is now a real all-states directory page — no redirect
       { source: "/college/:id", destination: "/va/college/:id", permanent: true },
       { source: "/courses", destination: "/va/courses", permanent: true },
@@ -28,6 +57,7 @@ const nextConfig: NextConfig = {
       { source: "/transfer", destination: "/va/transfer", permanent: true },
       { source: "/results", destination: "/va/results", permanent: true },
       { source: "/about", destination: "/va/about", permanent: true },
+      { source: "/program/:slug", destination: "/va/program/:slug", permanent: true },
     ];
   },
 };


### PR DESCRIPTION
## Summary
Deliverable 4 of #337. Four VCCS colleges officially renamed in 2022 (John Tyler → Brightpoint, Thomas Nelson → Virginia Peninsula, Lord Fairfax → Laurel Ridge, Dabney S. Lancaster → Mountain Gateway). The repo itself never served the old slugs, but external links (press, Wikipedia, VCCS PDFs, blog backlinks) may still point at them — leaving those URLs as soft 404s instead of redirects costs us crawl budget *and* link equity.

This PR adds 301 (Next-emits-308-permanent, semantically equivalent) redirects for:

| Old slug | Current slug |
|---|---|
| john-tyler / jtcc | brightpoint |
| thomas-nelson / tncc | vpcc |
| lord-fairfax / lfcc | laurelridge |
| dabney-s-lancaster / dslcc | mgcc |

Each is added for both URL shapes: `/va/college/:old → /va/college/:current` **and** the legacy un-prefixed `/college/:old → /va/college/:current`. The rename rules are placed **before** the generic `/college/:id → /va/college/:id` rule so the rename wins.

Also adds `/program/:slug → /va/program/:slug` — the existing legacy redirects covered `/courses`, `/transfer`, `/schedule`, `/about`, `/results`, `/starting-soon`, and `/college/:id`, but missed `/program/:slug`. Any external link to a pre-state-prefix program URL would have 404'd.

## Audit method
Used a general-purpose agent to spelunk git history (`git log --all -p` on each state's `institutions.json`, `lib/programs/registry.ts`, and `git log --diff-filter=R`). Confirmed: zero in-repo slug renames have ever occurred. The redirects in this PR target externally-indexed URLs only.

Cases considered and ruled out:
- Patrick Henry CC — not renamed; still `phcc`
- Mountain Empire CC — never renamed
- Reynolds CC — dropped "J. Sargeant" branding but slug unchanged
- Program slugs — only added in history, never renamed
- Course codes — no normalization change that would invalidate URLs

## Local dev verification
```
/va/college/john-tyler          → 308 /va/college/brightpoint   ✓
/va/college/jtcc                → 308 /va/college/brightpoint   ✓
/va/college/thomas-nelson       → 308 /va/college/vpcc          ✓
/va/college/tncc                → 308 /va/college/vpcc          ✓
/va/college/lord-fairfax        → 308 /va/college/laurelridge   ✓
/va/college/lfcc                → 308 /va/college/laurelridge   ✓
/va/college/dabney-s-lancaster  → 308 /va/college/mgcc          ✓
/va/college/dslcc               → 308 /va/college/mgcc          ✓
/college/john-tyler             → 308 /va/college/brightpoint   ✓
/program/nursing                → 308 /va/program/nursing       ✓
/va/college/brightpoint         → 200                           ✓ (no regression)
/college/some-other-id          → 308 /va/college/some-other-id ✓ (existing rule preserved)
/va/college/totally-fake        → 404                           ✓ (404 path preserved)
```

## Test plan
- [ ] `curl -I <preview>/va/college/john-tyler` returns **308 → /va/college/brightpoint**
- [ ] `curl -I <preview>/college/john-tyler` returns **308 → /va/college/brightpoint**
- [ ] `curl -I <preview>/program/nursing` returns **308 → /va/program/nursing**
- [ ] `curl -I <preview>/va/college/brightpoint` returns **200** (no over-redirect)
- [ ] `curl -I <preview>/college/some-other-id` still returns **308 → /va/college/some-other-id**

## Why "feat" not "fix"
This adds new behavior (redirects for URLs that previously 404'd). Doesn't fix an existing bug per se — closes deliverable 4 of #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)