### PR TITLE
feat(seo): anchor IDs on blog headings with hover link

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,3 +57,29 @@ body {
   --tw-prose-th-borders: #475569;
   --tw-prose-td-borders: #334155;
 }
+
+/* Anchor links on headings — hover-only, desktop-only */
+.heading-anchor {
+  position: relative;
+}
+
+.heading-anchor > a:first-child {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .heading-anchor > a:first-child {
+    display: block;
+    position: absolute;
+    left: -1.25em;
+    opacity: 0;
+    text-decoration: none;
+    color: #94a3b8;
+    font-weight: 400;
+    transition: opacity 0.15s;
+  }
+
+  .heading-anchor:hover > a:first-child {
+    opacity: 1;
+  }
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,6 +1,39 @@
 import type { MDXComponents } from "mdx/types";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import ProductCallout from "@/components/blog/ProductCallout";
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function childrenToText(children: ReactNode): string {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) return children.map(childrenToText).join("");
+  if (children && typeof children === "object" && "props" in children) {
+    return childrenToText((children as { props: { children?: ReactNode } }).props.children);
+  }
+  return "";
+}
+
+function AnchorHeading({
+  as: Tag,
+  children,
+  ...props
+}: { as: "h2" | "h3" | "h4"; children?: ReactNode } & Record<string, unknown>) {
+  const text = childrenToText(children);
+  const id = slugify(text);
+  return (
+    <Tag id={id} className="heading-anchor" {...props}>
+      <a href={`#${id}`} aria-hidden="true" tabIndex={-1}>#</a>
+      {children}
+    </Tag>
+  );
+}
 
 export function useMDXComponents(
   components: MDXComponents
@@ -21,6 +54,9 @@ export function useMDXComponents(
         </a>
       );
     },
+    h2: (props) => <AnchorHeading as="h2" {...props} />,
+    h3: (props) => <AnchorHeading as="h3" {...props} />,
+    h4: (props) => <AnchorHeading as="h4" {...props} />,
     // Custom blog components available in MDX files
     ProductCallout,
     ...components,


### PR DESCRIPTION
## Summary
- Custom MDX heading components auto-generate slug IDs from heading text and render a `#` anchor link
- Anchor visible on hover at desktop widths (768px+), hidden on mobile to avoid overflow
- Enables deep-linking to any blog post section (e.g. `/blog/how-to-find-late-start-community-college-classes#why-they-matter`)
- Improves document structure signal for Google

Partially addresses #344 — programmatic page IDs (college, course, program, subject pages) deferred to avoid conflict with in-progress soft-404 work on those route files.

## Test plan
- [x] Typecheck passes
- [x] All H2/H3/H4 headings get slug IDs and anchor links
- [x] Fragment navigation (`#section-id`) scrolls to correct heading
- [x] Anchor `#` hidden on mobile, visible on hover at desktop
- [x] No console errors
- [ ] After merge: verify on prod that heading anchors render and deep links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)