### PR TITLE
chore(devx): enable autoPort for the dev preview server

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "cc-coursemap-dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }


### PR DESCRIPTION
Tiny QoL: adds `"autoPort": true` to `.claude/launch.json`.

When multiple worktrees are active, the first one to claim port 3000 holds it, and other worktrees' preview-server starts return an error. With autoPort, the Claude Code preview tool falls back to a random port instead.

No effect on the primary worktree — it still gets 3000 when free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)