### PR TITLE
feat(seo): sitemap priority + changefreq tuning

### DIFF
--- a/app/sitemap/blog.xml/route.ts
+++ b/app/sitemap/blog.xml/route.ts
@@ -9,11 +9,11 @@ import {
 export function GET() {
   const url = siteOrigin();
   const entries: SitemapEntry[] = [
-    { url: `${url}/blog`, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${url}/blog`, changeFrequency: "weekly", priority: 0.9 },
     ...getAllArticles().map((article) => ({
       url: `${url}/blog/${article.slug}`,
       changeFrequency: "monthly" as const,
-      priority: 0.6,
+      priority: article.clusterRole === "hub" ? 0.7 : 0.6,
       lastModified: new Date(article.date),
     })),
   ];

--- a/app/sitemap/college-subjects.xml/route.ts
+++ b/app/sitemap/college-subjects.xml/route.ts
@@ -35,7 +35,7 @@ export async function GET() {
               entries.push({
                 url: `${url}/${state.slug}/college/${inst.id}/courses/${prefix.toLowerCase()}`,
                 changeFrequency: "weekly",
-                priority: 0.6,
+                priority: 0.5,
                 lastModified: new Date(),
               });
             }

--- a/app/sitemap/colleges.xml/route.ts
+++ b/app/sitemap/colleges.xml/route.ts
@@ -18,14 +18,14 @@ export function GET() {
       entries.push({
         url: `${url}/${state.slug}/college/${inst.id}`,
         changeFrequency: "weekly",
-        priority: 0.7,
+        priority: 0.8,
         lastModified,
       });
       if (hasPrograms) {
         entries.push({
           url: `${url}/${state.slug}/college/${inst.id}/programs`,
           changeFrequency: "monthly",
-          priority: 0.65,
+          priority: 0.6,
           lastModified,
         });
       }

--- a/app/sitemap/core.xml/route.ts
+++ b/app/sitemap/core.xml/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
   const url = siteOrigin();
   const now = new Date();
   const entries: SitemapEntry[] = [
-    { url, changeFrequency: "weekly", priority: 1, lastModified: now },
+    { url, changeFrequency: "daily", priority: 1, lastModified: now },
     { url: `${url}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
   ];
 
@@ -23,16 +23,16 @@ export async function GET() {
     const s = state.slug;
     entries.push(
       { url: `${url}/${s}`, changeFrequency: "weekly", priority: 1, lastModified: now },
-      { url: `${url}/${s}/courses`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
+      { url: `${url}/${s}/courses`, changeFrequency: "weekly", priority: 0.85, lastModified: now },
       { url: `${url}/${s}/colleges`, changeFrequency: "weekly", priority: 0.9, lastModified: now },
       // /starting-soon is noindex (client-rendered tool page) — omit from sitemap
-      { url: `${url}/${s}/about`, changeFrequency: "monthly", priority: 0.6, lastModified: now }
+      { url: `${url}/${s}/about`, changeFrequency: "yearly", priority: 0.5, lastModified: now }
     );
     if (state.transferSupported) {
       entries.push({
         url: `${url}/${s}/transfer`,
         changeFrequency: "weekly",
-        priority: 0.85,
+        priority: 0.9,
         lastModified: now,
       });
     }

--- a/app/sitemap/courses.xml/route.ts
+++ b/app/sitemap/courses.xml/route.ts
@@ -20,8 +20,8 @@ export async function GET() {
       const lastModified = new Date();
       return codes.map((c) => ({
         url: `${url}/${state.slug}/course/${`${c.prefix}-${c.number}`.toLowerCase()}`,
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
+        changeFrequency: "monthly" as const,
+        priority: 0.5,
         lastModified,
       }));
     })

--- a/app/sitemap/instructors.xml/route.ts
+++ b/app/sitemap/instructors.xml/route.ts
@@ -23,8 +23,8 @@ export async function GET() {
       const lastModified = new Date();
       return instructors.map((e) => ({
         url: `${url}/${state.slug}/college/${e.collegeId}/instructor/${e.slug}`,
-        changeFrequency: "weekly" as const,
-        priority: 0.6,
+        changeFrequency: "monthly" as const,
+        priority: 0.4,
         lastModified,
       }));
     })

--- a/app/sitemap/programs.xml/route.ts
+++ b/app/sitemap/programs.xml/route.ts
@@ -19,7 +19,7 @@ export async function GET() {
       return slugs.map((slug) => ({
         url: `${url}/${state.slug}/program/${slug}`,
         changeFrequency: "weekly" as const,
-        priority: 0.75,
+        priority: 0.6,
         lastModified,
       }));
     })

--- a/app/sitemap/state-subjects.xml/route.ts
+++ b/app/sitemap/state-subjects.xml/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
           entries.push({
             url: `${url}/${state.slug}/subject/${prefix.toLowerCase()}`,
             changeFrequency: "weekly",
-            priority: 0.65,
+            priority: 0.6,
             lastModified: new Date(),
           });
         }

--- a/app/sitemap/transfer.xml/route.ts
+++ b/app/sitemap/transfer.xml/route.ts
@@ -24,7 +24,7 @@ export async function GET() {
           .map((u) => ({
             url: `${url}/${state.slug}/transfer/to/${u.slug}`,
             changeFrequency: "weekly" as const,
-            priority: 0.8,
+            priority: 0.75,
             lastModified: new Date(),
           }));
       })


### PR DESCRIPTION
## Summary
- Tunes priority and changeFrequency values across all 9 sitemap files to better reflect content value tiers
- High-value navigation pages (homepage, state landing, transfer, blog index) get higher priority
- Long-tail pages (individual courses, instructors, college-subject breakdowns) get lower priority to concentrate crawl budget
- Blog hub articles get 0.7 vs spokes at 0.6
- Static pages (about) drop to yearly changefreq

Closes #341

## Test plan
- [x] Typecheck passes
- [x] All 9 sitemap files updated — no entry count changes, only value tuning
- [ ] After merge: resubmit sitemaps in Google Search Console
- [ ] Monitor crawl stats over 4-6 weeks for redistributed crawl frequency

🤖 Generated with [Claude Code](https://claude.com/claude-code)