### PR TITLE
fix(oh): real Ohio metadata (dropdown + map fix)

### DIFF
--- a/data/state-metadata.json
+++ b/data/state-metadata.json
@@ -214,6 +214,23 @@
         "bannerDetail": "Most NY public community colleges, including all 7 CUNY CCs, allow residents 60+ to audit credit courses tuition-free on a space-available basis. Verify with each college."
       }
     },
+    "oh": {
+      "fullName": "Ohio",
+      "fipsCode": "39",
+      "systemName": "OACC",
+      "systemFullName": "Ohio Association of Community Colleges",
+      "systemUrl": "https://www.ohiocommunitycolleges.org/",
+      "defaultZip": "43215",
+      "defaultZipCity": "Columbus",
+      "seniorWaiver": {
+        "ageThreshold": 60,
+        "legalCitation": "Ohio Revised Code § 3345.27 (Program 60)",
+        "description": "Ohio residents 60+ may audit courses at state-supported colleges tuition-free on a space-available basis.",
+        "bannerTitle": "Ohio Program 60",
+        "bannerSummary": "Over 60 in Ohio? You can audit classes at state-supported colleges tuition-free.",
+        "bannerDetail": "Ohio Revised Code § 3345.27 (Program 60) lets Ohio residents 60+ audit courses at state-assisted institutions tuition-free on a space-available basis. Confirm with each college's registrar."
+      }
+    },
     "pa": {
       "fullName": "Pennsylvania",
       "fipsCode": "42",

--- a/lib/states/oh/config.ts
+++ b/lib/states/oh/config.ts
@@ -2,42 +2,53 @@ import type { StateConfig } from "../registry";
 
 const ohConfig: StateConfig = {
   slug: "oh",
-  name: "Oh",
-  systemName: "Public 2-year",
-  systemFullName: "Oh Public 2-year Colleges",
-  systemUrl: "",
+  name: "Ohio",
+  systemName: "OACC",
+  systemFullName: "Ohio Association of Community Colleges",
+  systemUrl: "https://www.ohiocommunitycolleges.org/",
   collegeCount: 22,
 
-  // TODO: research senior-waiver statute for Oh.
-  // Set to null if no waiver exists, or fill in per the SeniorWaiverConfig shape.
-  seniorWaiver: null,
+  seniorWaiver: {
+    ageThreshold: 60,
+    legalCitation: "Ohio Revised Code § 3345.27 (Program 60)",
+    description:
+      "Ohio residents 60 and older may audit courses at state-supported colleges tuition-free on a space-available basis. Regular fees may still apply and audited courses do not count for degree credit.",
+    bannerTitle: "Ohio Program 60",
+    bannerSummary:
+      "Over 60 in Ohio? You can audit classes at state-supported colleges tuition-free.",
+    bannerDetail:
+      "Ohio Revised Code § 3345.27 (Program 60) lets Ohio residents 60+ audit courses at state-assisted institutions tuition-free on a space-available basis. Confirm with each college's registrar.",
+  },
 
   transferSupported: false,
   popularCourses: [],
-  defaultZip: "",
-  defaultZipCity: "",
+  defaultZip: "43215",
+  defaultZipCity: "Columbus",
 
   courseDiscoveryUrl: (_collegeSlug: string, _prefix: string, _number: string) =>
-    "https://www.example.edu/",
+    "https://www.ohiocommunitycolleges.org/",
 
   collegeCoursesUrl: (_collegeSlug: string) =>
-    "https://www.example.edu/",
+    "https://www.ohiocommunitycolleges.org/",
 
   branding: {
-    siteName: "Community College Path Oh",
-    tagline: "Search Public 2-year courses across all 22 colleges.",
-    footerText: "Community College Path Oh — Find courses across all 22 Public 2-year colleges.",
-    disclaimer: "This is an independent project and is not affiliated with, endorsed by, or sponsored by Oh Public 2-year Colleges.",
+    siteName: "Community College Path Ohio",
+    tagline: "Search Ohio community college courses across all 22 colleges.",
+    footerText:
+      "Community College Path Ohio — Find courses across all 22 Ohio community colleges.",
+    disclaimer:
+      "This is an independent project and is not affiliated with, endorsed by, or sponsored by the Ohio Association of Community Colleges.",
     metaKeywords: [
-      "Oh community college courses",
-      "Public 2-year course search",
-      "Oh Public 2-year Colleges",
+      "Ohio community college courses",
+      "Ohio community college class search",
+      "Ohio Association of Community Colleges",
+      "Ohio Program 60",
     ],
   },
   scrapers: {
-    // manual-only: courses — Phase 2 (course scraper) not yet wired up.
-    // manual-only: transfers — Phase 3 (transfer-equiv) not yet wired up.
-    // manual-only: prereqs — Phase 4.
+    // manual-only: courses — mixed-platform state, 8 colleges scraped via banner-ssb-9 / colleague / banner-8 templates per-college; per-state cron not yet wired.
+    // manual-only: transfers — no articulation portal registered for OH yet.
+    // manual-only: prereqs — runs as part of course aggregation.
     // manual-only: programs — Phase 5+.
   },
 };


### PR DESCRIPTION
## Summary

Fixes two user-visible bugs from the [Ohio auto-add-state PR (#363)](https://github.com/rohan-c0de/cc-coursemap/pull/363):

1. **Home state dropdown showed "Oh"** instead of "Ohio"
2. **US map didn't fill Ohio green** despite the state having 22 colleges live

## Root cause

Both stem from the same thing: `data/state-metadata.json` had no curated entry for `oh`, so `lib/states/oh/config.ts` was generated with `name: capitalize(slug)` → `"Oh"`. `components/USMap.tsx` matches registry states to the us-atlas topojson by `name`, and `"Oh" !== "Ohio"`, so the SVG path stayed in the inactive group.

## Changes

- `data/state-metadata.json`: add curated entry for `oh` (OACC, Program 60 senior-waiver per Ohio Revised Code § 3345.27, Columbus default zip)
- `lib/states/oh/config.ts`: replace placeholder values (`name: "Oh"`, `systemName: "Public 2-year"`, empty zip, example.edu URLs) with real Ohio metadata

## Test plan

- [x] `/` home dropdown now lists "Ohio" (verified locally)
- [x] `/oh` landing page renders OACC branding + Program 60 senior banner
- [ ] After Vercel deploy: confirm Ohio is filled green on the homepage map

🤖 Generated with [Claude Code](https://claude.com/claude-code)