### PR TITLE
feat(seo): transform /[state] into topical pillar pages (#373)

### DIFF
--- a/app/[state]/page.tsx
+++ b/app/[state]/page.tsx
@@ -7,7 +7,7 @@ import NotifyBanner from "@/components/NotifyBanner";
 import { getNextTerm } from "@/lib/terms";
 import { getAllStates, isValidState } from "@/lib/states/registry";
 import { requireStateConfig } from "@/lib/states/route-helpers";
-import { getArticlesByState, categoryLabel } from "@/lib/blog";
+import { getArticlesByState, getStateTopicLinks, categoryLabel } from "@/lib/blog";
 import { getQualifyingProgramSlugs, getProgramBySlug } from "@/lib/programs";
 import { loadOnlineData, onlineQualifies } from "@/lib/online";
 
@@ -32,7 +32,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const b = config.branding;
   return {
     title: `${config.name} Community College Course Finder`,
-    description: b.tagline,
+    description: `Search courses, check transfer equivalencies, find late-start sections, and compare ${config.collegeCount} ${config.systemName} colleges. ${b.tagline}`,
     keywords: b.metaKeywords,
     alternates: { canonical: `/${state}` },
   };
@@ -43,7 +43,8 @@ export default async function HomePage({ params }: Props) {
   if (!isValidState(state)) notFound();
   const config = requireStateConfig(state);
   const nextTerm = await getNextTerm(state);
-  const stateArticles = getArticlesByState(state).slice(0, 4);
+  const stateArticles = getArticlesByState(state);
+  const topicLinks = getStateTopicLinks(state);
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
 
@@ -312,7 +313,40 @@ export default async function HomePage({ params }: Props) {
         </section>
       )}
 
-      {/* Related guides — blog posts tagged for this state */}
+      {/* Topics hub — one card per state-level cluster spoke */}
+      {topicLinks.length > 0 && (
+        <section className="py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-slate-800">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-slate-100 mb-2 text-center">
+              What We Cover for {config.name}
+            </h2>
+            <p className="text-center text-sm text-gray-600 dark:text-slate-400 mb-8">
+              Data-driven guides built from {config.systemName} course records.
+            </p>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {topicLinks.map(({ cluster, title, blurb, article }) => (
+                <Link
+                  key={cluster}
+                  href={`/blog/${article.slug}`}
+                  className="group rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-5 transition hover:border-teal-300 dark:hover:border-teal-700 hover:shadow-sm"
+                >
+                  <h3 className="font-semibold text-gray-900 dark:text-slate-100 group-hover:text-teal-600 transition-colors">
+                    {title}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-slate-400">
+                    {blurb}
+                  </p>
+                  <span className="mt-3 inline-block text-xs font-medium text-teal-600 dark:text-teal-400 group-hover:text-teal-700 dark:group-hover:text-teal-300 transition-colors">
+                    Read the guide &rarr;
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Related guides — all blog posts tagged for this state */}
       {stateArticles.length > 0 && (
         <section className="py-12 px-4 sm:px-6 lg:px-8">
           <div className="max-w-4xl mx-auto">

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -31,6 +31,73 @@ export function getClusterArticles(clusterId: string): ArticleMeta[] {
   return getAllArticles().filter((a) => a.cluster === clusterId);
 }
 
+export type TopicLink = {
+  cluster: string;
+  title: string;
+  blurb: string;
+  article: ArticleMeta;
+};
+
+const CLUSTER_DISPLAY: Record<string, { title: string; blurb: string }> = {
+  "course-availability-guide": {
+    title: "Course Availability",
+    blurb: "Which courses run at every campus vs. just one or two",
+  },
+  "transfer-credit-guide": {
+    title: "Transfer Credits",
+    blurb: "How courses map to 4-year university requirements",
+  },
+  "senior-waivers-guide": {
+    title: "Senior Waivers",
+    blurb: "Free or reduced tuition for qualifying older adults",
+  },
+  "late-start-by-state-guide": {
+    title: "Late-Start Classes",
+    blurb: "Sections that begin weeks after the standard start date",
+  },
+  "prereq-chains-guide": {
+    title: "Prerequisite Chains",
+    blurb: "Courses that gate transfer-ready sequences",
+  },
+  "hybrid-course-density-guide": {
+    title: "Hybrid & Online",
+    blurb: "How courses split between in-person, hybrid, and online",
+  },
+  "session-timing-guide": {
+    title: "Session Timing",
+    blurb: "Multiple start dates, mini-terms, and accelerated sessions",
+  },
+};
+
+/**
+ * State-level topic links for the pillar page.
+ * Returns one entry per cluster where a state-level spoke exists (college
+ * spokes are excluded — they link to a specific institution, not the state).
+ */
+export function getStateTopicLinks(state: string): TopicLink[] {
+  const seen = new Set<string>();
+  const results: TopicLink[] = [];
+  for (const article of getAllArticles()) {
+    if (
+      article.state === state &&
+      article.cluster &&
+      article.clusterRole === "spoke" &&
+      !article.college &&
+      CLUSTER_DISPLAY[article.cluster] &&
+      !seen.has(article.cluster)
+    ) {
+      seen.add(article.cluster);
+      results.push({
+        cluster: article.cluster,
+        title: CLUSTER_DISPLAY[article.cluster].title,
+        blurb: CLUSTER_DISPLAY[article.cluster].blurb,
+        article,
+      });
+    }
+  }
+  return results;
+}
+
 /** Human-readable category label. */
 export function categoryLabel(category: string): string {
   return CATEGORIES[category] ?? category;


### PR DESCRIPTION
Closes #373.

## Summary
- Adds a **"What We Cover for [State]"** section to every `/[state]` landing page — one topic card per cluster spoke that exists for that state (course availability, transfer credits, prereq chains, session timing, hybrid/online, late-start, senior waivers)
- Cards render **conditionally** — only clusters with an actual state-level spoke appear. States with no spokes skip the section entirely
- Shows **all** state blog articles in the guides section (was capped at 4)
- Improves metadata `description` to enumerate the specific tools and college count

## How it works
New `getStateTopicLinks(state)` helper in `lib/blog.ts`:
- Walks all articles, filters to `state === X`, `clusterRole === 'spoke'`, no `college` field (excludes per-college audit spokes)
- Deduplicates by cluster (one card per topic)
- Maps cluster ID → display title + blurb via `CLUSTER_DISPLAY` manifest

VA renders 5 topic cards (course availability, hybrid & online, prereq chains, session timing, transfer credits). DE renders 3. States with no spokes skip the section.

## Test plan
- [x] TypeScript clean
- [x] `/va` — 5 topic cards render, all link to correct blog posts
- [x] `/de` — 3 topic cards render correctly
- [x] No console errors
- [x] States with no spokes: section omitted (no empty sections)
- [x] "Virginia Guides" section now shows all articles, not just 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)