### PR TITLE
feat(seo): add contextual blog recommendations to programmatic pages

### DIFF
--- a/app/[state]/college/[id]/instructor/[slug]/page.tsx
+++ b/app/[state]/college/[id]/instructor/[slug]/page.tsx
@@ -21,6 +21,8 @@ import { subjectName } from "@/lib/subjects";
 import type { CourseSection } from "@/lib/types";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
+import RelatedBlogPosts from "@/components/RelatedBlogPosts";
+import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
 export const revalidate = 604800; // 7 days — pSEO content rarely changes
 
@@ -477,6 +479,16 @@ export default async function InstructorPage(props: PageProps) {
         <div className="mb-8">
           <AdUnit slot="7261548390" format="auto" className="min-h-[100px]" />
         </div>
+
+        {/* Related blog posts — programmatic → editorial cross-pollination (#371) */}
+        <RelatedBlogPosts
+          articles={getBlogRecommendations({
+            state,
+            pageType: "instructor",
+            college: institution.college_slug,
+          })}
+          heading={`Related ${config.name} guides`}
+        />
 
         {/* Rate My Professors link */}
         <div className="mb-8 rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 px-4 py-3">

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -20,6 +20,8 @@ import { subjectName } from "@/lib/subjects";
 import type { CourseSection } from "@/lib/types";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
+import RelatedBlogPosts from "@/components/RelatedBlogPosts";
+import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
 // Revalidate every 24 hours — course data only changes when re-scraped
 export const revalidate = 86400;
@@ -535,6 +537,16 @@ export default async function CollegeDetailPage(props: PageProps) {
       <div className="mt-8">
         <AdUnit slot="3816492750" format="auto" className="min-h-[100px]" />
       </div>
+
+      {/* Related blog posts — programmatic → editorial cross-pollination (#371) */}
+      <RelatedBlogPosts
+        articles={getBlogRecommendations({
+          state,
+          pageType: "college",
+          college: institution.college_slug,
+        })}
+        heading={`Related ${config.name} guides`}
+      />
 
       {/* Other colleges in this state — internal linking for SEO */}
       {(() => {

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -12,6 +12,8 @@ import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import type { CourseSection } from "@/lib/types";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
+import RelatedBlogPosts from "@/components/RelatedBlogPosts";
+import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
 export const revalidate = 604800; // 7 days — pSEO content rarely changes
 
@@ -731,6 +733,15 @@ export default async function CoursePage(props: PageProps) {
         <div className="mb-8">
           <AdUnit slot="7261548390" format="auto" className="min-h-[100px]" />
         </div>
+
+        {/* Related blog posts — programmatic → editorial cross-pollination (#371) */}
+        <RelatedBlogPosts
+          articles={getBlogRecommendations({
+            state,
+            pageType: "course",
+          })}
+          heading={`Related ${config.name} guides`}
+        />
 
         {/* Related courses */}
         {related.length > 0 && (

--- a/app/[state]/online/page.tsx
+++ b/app/[state]/online/page.tsx
@@ -16,6 +16,8 @@ import { termLabel } from "@/lib/terms";
 import { subjectName } from "@/lib/subjects";
 import { loadOnlineData, onlineQualifies } from "@/lib/online";
 import Breadcrumbs from "@/components/Breadcrumbs";
+import RelatedBlogPosts from "@/components/RelatedBlogPosts";
+import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
 export const revalidate = 604800; // 7 days
 
@@ -204,6 +206,15 @@ export default async function OnlinePage(props: PageProps) {
             </ul>
           </section>
         )}
+
+        {/* Related blog posts — programmatic → editorial cross-pollination (#371) */}
+        <RelatedBlogPosts
+          articles={getBlogRecommendations({
+            state,
+            pageType: "online",
+          })}
+          heading={`Related ${config.name} guides`}
+        />
       </div>
     </>
   );

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -24,6 +24,8 @@ import { subjectName } from "@/lib/subjects";
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
+import RelatedBlogPosts from "@/components/RelatedBlogPosts";
+import { getBlogRecommendations } from "@/lib/blog-recommendations";
 import type { CourseSection } from "@/lib/types";
 
 export const revalidate = 604800; // 7 days — pSEO content rarely changes
@@ -523,6 +525,15 @@ export default async function StateSubjectPage(props: PageProps) {
         <div className="mb-10">
           <AdUnit slot="2854671930" format="auto" className="min-h-[100px]" />
         </div>
+
+        {/* Related blog posts — programmatic → editorial cross-pollination (#371) */}
+        <RelatedBlogPosts
+          articles={getBlogRecommendations({
+            state,
+            pageType: "subject",
+          })}
+          heading={`Related ${config.name} guides`}
+        />
 
         {/* Browse other subjects */}
         {allSubjects.length > 0 && (

--- a/app/[state]/transfer/to/[universitySlug]/page.tsx
+++ b/app/[state]/transfer/to/[universitySlug]/page.tsx
@@ -16,6 +16,8 @@ import type { TransferMapping } from "@/lib/types";
 import TransferHubClient from "./TransferHubClient";
 import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
+import RelatedBlogPosts from "@/components/RelatedBlogPosts";
+import { getBlogRecommendations } from "@/lib/blog-recommendations";
 
 export const revalidate = 86400;
 
@@ -351,6 +353,15 @@ export default async function TransferHubPage(props: PageProps) {
       <div className="mb-8">
         <AdUnit slot="9402617538" format="auto" className="min-h-[100px]" />
       </div>
+
+      {/* Related blog posts — programmatic → editorial cross-pollination (#371) */}
+      <RelatedBlogPosts
+        articles={getBlogRecommendations({
+          state,
+          pageType: "transfer",
+        })}
+        heading={`Related ${config.name} guides`}
+      />
 
       {/* Other universities in this state */}
       {universities.length > 1 && (

--- a/components/RelatedBlogPosts.tsx
+++ b/components/RelatedBlogPosts.tsx
@@ -1,0 +1,57 @@
+/**
+ * Sidebar component for programmatic pages (college, course, transfer,
+ * instructor, online, subject) that surfaces 2-3 contextually relevant
+ * blog posts. Visual mirror of components/blog/BlogProgrammaticLinks
+ * but in the reverse direction (tools → blog).
+ *
+ * Renders nothing if `articles` is empty — callers fetch
+ * recommendations via getBlogRecommendations() and pass the result.
+ */
+import Link from "next/link";
+import type { ArticleMeta } from "@/lib/blog";
+import { categoryLabel } from "@/lib/blog";
+
+interface RelatedBlogPostsProps {
+  articles: ArticleMeta[];
+  /**
+   * Heading shown above the link list. Defaults to "Related guides".
+   * Pages may override for context, e.g. "Related Virginia guides".
+   */
+  heading?: string;
+}
+
+export default function RelatedBlogPosts({
+  articles,
+  heading = "Related guides",
+}: RelatedBlogPostsProps) {
+  if (articles.length === 0) return null;
+
+  return (
+    <aside className="mt-10 rounded-xl border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 px-5 py-4">
+      <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+        {heading}
+      </p>
+      <p className="mt-1 text-sm text-gray-600 dark:text-slate-400">
+        Background reading from the Community College Path blog.
+      </p>
+      <ul className="mt-3 space-y-3">
+        {articles.map((article) => (
+          <li key={article.slug}>
+            <Link
+              href={`/blog/${article.slug}`}
+              className="group block rounded-md transition hover:bg-white dark:hover:bg-slate-700 -mx-2 px-2 py-1.5"
+            >
+              <span className="inline-block rounded-full bg-gray-200 dark:bg-slate-700 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-600 dark:text-slate-400">
+                {categoryLabel(article.category)}
+              </span>
+              <div className="mt-1 text-sm font-medium text-teal-700 dark:text-teal-300 group-hover:text-teal-900 dark:group-hover:text-teal-200">
+                {article.title}
+                <span aria-hidden="true" className="ml-1">→</span>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/lib/blog-recommendations.ts
+++ b/lib/blog-recommendations.ts
@@ -1,0 +1,150 @@
+/**
+ * Pick 2-3 contextually relevant blog posts to surface on a programmatic
+ * page. Each programmatic page type has a curated list of preferred
+ * clusters; within each cluster we prefer the state-specific spoke, then
+ * fall back to the cluster hub.
+ *
+ * Why this exists: programmatic pages (college, course, transfer, etc.)
+ * historically had zero blog backlinks. Adding contextual blog
+ * recommendations strengthens topical-depth signal to Google and gives
+ * users a discovery path from data pages to explainer content. See
+ * GitHub issue #371.
+ */
+import type { ArticleMeta } from "@/lib/blog";
+import { getAllArticles, getClusterArticles } from "@/lib/blog";
+
+export type ProgrammaticPageType =
+  | "college"
+  | "course"
+  | "transfer"
+  | "instructor"
+  | "online"
+  | "subject";
+
+/**
+ * Ordered preference of blog clusters per page type. The first cluster
+ * in the list is the most topically aligned; later clusters are
+ * fallbacks. Clusters listed here that don't yet exist are skipped
+ * gracefully.
+ */
+const CLUSTERS_BY_PAGE_TYPE: Record<ProgrammaticPageType, string[]> = {
+  college: [
+    "senior-waivers-guide",
+    "audit-at-college-guide",
+    "transfer-credit-guide",
+  ],
+  course: [
+    "late-start-by-state-guide",
+    "prereq-chains-guide",
+    "transfer-credit-guide",
+    "course-availability-guide",
+  ],
+  transfer: [
+    "transfer-credit-guide",
+    "transfer-receiver-patterns-guide", // proposed, see issue #367
+  ],
+  instructor: [
+    // No instructor-specific cluster exists yet (proposed in #371). Fall
+    // back to general "how to navigate community college" content.
+    "audit-at-college-guide",
+  ],
+  online: [
+    "hybrid-course-density-guide",
+    "session-timing-guide",
+  ],
+  subject: [
+    "course-availability-guide",
+    "prereq-chains-guide",
+  ],
+};
+
+export interface BlogRecommendationOptions {
+  state: string;
+  pageType: ProgrammaticPageType;
+  /** Optional: scope recommendations to a specific institution. */
+  college?: string;
+  /** Default 3. */
+  limit?: number;
+}
+
+/**
+ * Returns 0-N blog posts most relevant to the given programmatic page.
+ *
+ * Selection priority within each preferred cluster:
+ *   1. State-specific spoke that matches `opts.state`
+ *   2. College-specific spoke that matches `opts.college` (if provided)
+ *   3. Cluster hub
+ *   4. Most-recent spoke (last resort)
+ *
+ * The function returns an empty array if no clusters yield matches —
+ * callers should handle the empty case (typically by not rendering
+ * the recommendation block).
+ */
+export function getBlogRecommendations(
+  opts: BlogRecommendationOptions
+): ArticleMeta[] {
+  const limit = opts.limit ?? 3;
+  const preferredClusters = CLUSTERS_BY_PAGE_TYPE[opts.pageType] ?? [];
+  const picked: ArticleMeta[] = [];
+  const pickedSlugs = new Set<string>();
+
+  function tryAdd(article: ArticleMeta | undefined) {
+    if (!article) return;
+    if (pickedSlugs.has(article.slug)) return;
+    picked.push(article);
+    pickedSlugs.add(article.slug);
+  }
+
+  for (const clusterId of preferredClusters) {
+    if (picked.length >= limit) break;
+
+    const articles = getClusterArticles(clusterId);
+    if (articles.length === 0) continue;
+
+    // College-specific spoke takes top priority if we have a college
+    // and a matching post exists.
+    if (opts.college) {
+      const collegeMatch = articles.find(
+        (a) => a.college === opts.college && a.state === opts.state
+      );
+      if (collegeMatch) {
+        tryAdd(collegeMatch);
+        continue; // one pick per cluster
+      }
+    }
+
+    // Otherwise: state-specific spoke
+    const stateMatch = articles.find(
+      (a) => a.state === opts.state && a.clusterRole === "spoke"
+    );
+    if (stateMatch) {
+      tryAdd(stateMatch);
+      continue;
+    }
+
+    // Fall back to the cluster hub (national, no state)
+    const hub = articles.find((a) => a.clusterRole === "hub");
+    if (hub) {
+      tryAdd(hub);
+      continue;
+    }
+
+    // Last resort: any spoke
+    tryAdd(articles[0]);
+  }
+
+  // If we still have fewer than `limit` recommendations, top up with
+  // any remaining state-tagged blog posts (any cluster) so the
+  // sidebar isn't half-empty.
+  if (picked.length < limit) {
+    const stateExtras = getAllArticles().filter(
+      (a) => a.state === opts.state && !pickedSlugs.has(a.slug)
+    );
+    for (const a of stateExtras) {
+      if (picked.length >= limit) break;
+      tryAdd(a);
+    }
+  }
+
+  return picked.slice(0, limit);
+}


### PR DESCRIPTION
## Summary

Programmatic pages (college, course, transfer, instructor, online, subject) previously had **zero blog backlinks**. This PR adds a "Related [State] guides" sidebar with 2-3 topically relevant blog posts on each page template — strengthening topical-depth signal to Google and giving users a discovery path from data pages to explainer content.

Closes #371.

## What's new

- **`lib/blog-recommendations.ts`** — `getBlogRecommendations({ state, pageType, college? })` returns 0-3 best-matching `ArticleMeta` entries
- **`components/RelatedBlogPosts.tsx`** — sidebar renderer (visual mirror of the existing `BlogProgrammaticLinks` component, reverse direction)
- Wired into 6 page templates: college, course, transfer-to-university, instructor, online, subject

## Per-page-type cluster preferences

| Page type | Preferred clusters (in order) |
|---|---|
| `college` | senior-waivers, audit-at-college, transfer-credit |
| `course` | late-start, prereq-chains, transfer-credit, course-availability |
| `transfer` | transfer-credit (+ transfer-receiver-patterns when it ships per #367) |
| `instructor` | audit-at-college (no instructor-specific cluster yet) |
| `online` | hybrid-density, session-timing |
| `subject` | course-availability, prereq-chains |

## Selection priority within each cluster

1. College-specific spoke (if `college` slug provided) — e.g. "How to Audit a Class at Germanna"
2. State-specific spoke — e.g. "Virginia Community College Transfer: Guaranteed Admission"
3. Cluster hub — e.g. "Free Community College for Seniors: Which 17 States Offer It"
4. Any remaining cluster spoke
5. Top-up with state-tagged posts from any cluster if fewer than 3 recs

## Verified end-to-end

| Page | Recommendations rendered |
|---|---|
| VA Germanna college | VA senior-waiver spoke + Germanna audit-at-college spoke + VA GAA transfer (all 3 perfect) |
| NC PHY 251 course | NC late-start + NC prereqs + NC→UNC transfer (all 3 NC-specific spokes) |
| NC Wake Tech instructor | NC course-availability + NC prereqs + "What does audit mean" hub |
| NC BIO subject | NC course-availability + NC hybrid-density + NC prereqs |
| OH Belmont college (no OH blog posts yet) | 3 national hubs as graceful fallback |

## Test plan

- [x] Typecheck passes
- [x] All 6 page templates render the "Related guides" sidebar
- [x] State-specific spokes are preferred when they exist
- [x] College-specific spokes win over state-specific spokes on college/instructor pages
- [x] Graceful fallback to hubs for states with no spoke content
- [x] No console errors
- [ ] After merge: verify the sidebar appears on prod and links resolve

## Out of scope (per issue #371)

- Behavioral / ML-driven recommendations (this is config + lookup)
- Cross-state recommendations (per the in-state-only memory rule)
- Backlinks on courses-by-subject (`/[state]/college/[id]/courses/[prefix]`) — can be added in a follow-up if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)