### PR TITLE
feat(seo): add Guides dropdown in header + 3-column footer

### DIFF
--- a/app/[state]/layout.tsx
+++ b/app/[state]/layout.tsx
@@ -84,46 +84,136 @@ export default async function StateLayout({ children, params }: Props) {
       {/* Main content */}
       <main className="flex-1">{children}</main>
 
-      {/* Footer */}
+      {/* Footer — reorganized into 3-column layout (#374). Each topic-organized
+          column is a sitewide internal-link surface that funnels link equity
+          from every page on the site to the high-traffic guide clusters. */}
       <footer className="border-t border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
-            <p className="text-sm text-gray-500 dark:text-slate-400">{b.footerText}</p>
-            <div className="flex flex-wrap items-center gap-3 text-xs text-gray-400 dark:text-slate-500">
-              <Link
-                href="/privacy"
-                className="underline hover:text-gray-600 dark:hover:text-slate-300"
-              >
-                Privacy Policy
-              </Link>
-              <span>|</span>
-              <p>
-                Policy data is manually verified. Always confirm with the
-                college before enrolling.
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8 mb-8">
+            {/* Column 1: Tools (existing programmatic pages) */}
+            <div>
+              <p className="text-xs uppercase tracking-wide font-semibold text-gray-700 dark:text-slate-300 mb-3">
+                Tools
               </p>
-              <span>|</span>
-              <a
-                href="https://buymeacoffee.com/voidseer"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 rounded-md bg-amber-400 px-2.5 py-1 text-xs font-medium text-amber-900 hover:bg-amber-500 transition-colors"
-              >
-                <span>&#9749;</span> Support this project
-              </a>
+              <ul className="space-y-2 text-sm">
+                <li>
+                  <Link href={`/${state}/courses`} className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Find a Course
+                  </Link>
+                </li>
+                <li>
+                  <Link href={`/${state}/starting-soon`} className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Starting Soon
+                  </Link>
+                </li>
+                <li>
+                  <Link href={`/${state}/schedule`} className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Schedule Builder
+                  </Link>
+                </li>
+                {config.transferSupported && (
+                  <li>
+                    <Link href={`/${state}/transfer`} className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                      Transfer Lookup
+                    </Link>
+                  </li>
+                )}
+                <li>
+                  <Link href={`/${state}/colleges`} className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    All {config.systemName} Colleges
+                  </Link>
+                </li>
+              </ul>
+            </div>
+
+            {/* Column 2: Guides (high-traffic blog clusters) */}
+            <div>
+              <p className="text-xs uppercase tracking-wide font-semibold text-gray-700 dark:text-slate-300 mb-3">
+                Guides
+              </p>
+              <ul className="space-y-2 text-sm">
+                <li>
+                  <Link href="/blog/free-community-college-classes-for-seniors" className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Senior Waivers
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/blog/how-to-check-if-community-college-course-transfers" className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Transfer Guides
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/blog/what-does-audit-a-class-mean" className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Auditing a Class
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/blog/how-to-find-late-start-community-college-classes" className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Late-Start Classes
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/blog/hybrid-community-college-classes-explained" className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Hybrid Classes
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/blog" className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors font-medium">
+                    All articles →
+                  </Link>
+                </li>
+              </ul>
+            </div>
+
+            {/* Column 3: About */}
+            <div>
+              <p className="text-xs uppercase tracking-wide font-semibold text-gray-700 dark:text-slate-300 mb-3">
+                About
+              </p>
+              <ul className="space-y-2 text-sm">
+                <li>
+                  <Link href={`/${state}/about`} className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    About this site
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/privacy" className="text-gray-600 dark:text-slate-400 hover:text-teal-600 transition-colors">
+                    Privacy Policy
+                  </Link>
+                </li>
+                <li>
+                  <a
+                    href="https://buymeacoffee.com/voidseer"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 rounded-md bg-amber-400 px-2.5 py-1 text-xs font-medium text-amber-900 hover:bg-amber-500 transition-colors"
+                  >
+                    <span>&#9749;</span> Support this project
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
-          <p className="mt-4 text-center text-[11px] text-gray-400 dark:text-slate-500">
-            {b.disclaimer} For official information visit{" "}
-            <a
-              href={config.systemUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-gray-600 dark:hover:text-slate-300"
-            >
-              {config.systemUrl.replace("https://www.", "")}
-            </a>
-            .
-          </p>
+
+          {/* Disclaimer row — kept at the bottom, full width */}
+          <div className="pt-6 border-t border-gray-200 dark:border-slate-700">
+            <p className="text-xs text-gray-500 dark:text-slate-400 mb-2">
+              {b.footerText}
+            </p>
+            <p className="text-[11px] text-gray-400 dark:text-slate-500">
+              Policy data is manually verified — always confirm with the
+              college before enrolling. {b.disclaimer} For official information visit{" "}
+              <a
+                href={config.systemUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-gray-600 dark:hover:text-slate-300"
+              >
+                {config.systemUrl.replace("https://www.", "")}
+              </a>
+              .
+            </p>
+          </div>
         </div>
       </footer>
     </>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import ThemeToggle from "@/components/ThemeToggle";
 import UserMenu from "@/components/auth/UserMenu";
@@ -16,8 +16,64 @@ const NAV_ITEMS = [
   { path: "/about", label: "About" },
 ];
 
+// Guides dropdown — exposes high-traffic blog clusters from sitewide nav.
+// Issue #374: senior waivers cluster pulled 600+ monthly impressions across
+// 13 spokes; transfer-credit cluster pulled 930+ on 2 hubs alone. Both were
+// previously only discoverable via direct organic search, not header.
+const GUIDES_ITEMS = [
+  {
+    href: "/blog/free-community-college-classes-for-seniors",
+    label: "Senior Waivers",
+    description: "Free tuition for seniors by state",
+  },
+  {
+    href: "/blog/how-to-check-if-community-college-course-transfers",
+    label: "Transfer Guides",
+    description: "Direct match vs elective credit",
+  },
+  {
+    href: "/blog/what-does-audit-a-class-mean",
+    label: "Auditing a Class",
+    description: "Sit in without credit pressure",
+  },
+  {
+    href: "/blog/how-to-find-late-start-community-college-classes",
+    label: "Late-Start Classes",
+    description: "Enroll after the semester started",
+  },
+  {
+    href: "/blog",
+    label: "All Articles →",
+    description: "",
+  },
+];
+
 export default function Header({ state, stateName, transferSupported = true, prereqsAvailable = false }: { state: string; stateName?: string; transferSupported?: boolean; prereqsAvailable?: boolean }) {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [guidesOpen, setGuidesOpen] = useState(false);
+  const guidesRef = useRef<HTMLDivElement>(null);
+
+  // Close guides dropdown on outside click (matches UserMenu pattern)
+  useEffect(() => {
+    if (!guidesOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (guidesRef.current && !guidesRef.current.contains(e.target as Node)) {
+        setGuidesOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [guidesOpen]);
+
+  // Close guides dropdown on Escape
+  useEffect(() => {
+    if (!guidesOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setGuidesOpen(false);
+    };
+    document.addEventListener("keydown", handleEsc);
+    return () => document.removeEventListener("keydown", handleEsc);
+  }, [guidesOpen]);
 
   const links = NAV_ITEMS
     .filter((item) => item.path !== "/transfer" || transferSupported)
@@ -58,12 +114,49 @@ export default function Header({ state, stateName, transferSupported = true, pre
               {link.label}
             </Link>
           ))}
-          <Link
-            href="/blog"
-            className="hover:text-teal-600 transition-colors"
-          >
-            Blog
-          </Link>
+          {/* Guides dropdown — replaces the plain "Blog" link (#374) */}
+          <div className="relative" ref={guidesRef}>
+            <button
+              type="button"
+              onClick={() => setGuidesOpen(!guidesOpen)}
+              className="inline-flex items-center gap-1 hover:text-teal-600 transition-colors"
+              aria-expanded={guidesOpen}
+              aria-haspopup="true"
+            >
+              Guides
+              <svg
+                className={`w-3 h-3 transition-transform ${guidesOpen ? "rotate-180" : ""}`}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {guidesOpen && (
+              <div className="absolute right-0 mt-2 w-72 rounded-md shadow-lg bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 py-1 z-50">
+                {GUIDES_ITEMS.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setGuidesOpen(false)}
+                    className="block px-4 py-2.5 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+                  >
+                    <div className="text-sm font-medium text-gray-900 dark:text-slate-100">
+                      {item.label}
+                    </div>
+                    {item.description && (
+                      <div className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                        {item.description}
+                      </div>
+                    )}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
           <UserMenu />
           <ThemeToggle />
         </nav>
@@ -112,13 +205,22 @@ export default function Header({ state, stateName, transferSupported = true, pre
               {link.label}
             </Link>
           ))}
-          <Link
-            href="/blog"
-            onClick={() => setMobileOpen(false)}
-            className="block py-2.5 text-sm text-gray-700 dark:text-slate-300 hover:text-teal-600 transition-colors"
-          >
-            Blog
-          </Link>
+          {/* Guides section (#374) — same destinations as the desktop dropdown */}
+          <div className="mt-3 pt-3 border-t border-gray-100 dark:border-slate-700">
+            <p className="text-[11px] uppercase tracking-wide font-medium text-gray-400 dark:text-slate-500 mb-1">
+              Guides
+            </p>
+            {GUIDES_ITEMS.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setMobileOpen(false)}
+                className="block py-2 text-sm text-gray-700 dark:text-slate-300 hover:text-teal-600 transition-colors"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
         </nav>
       )}
     </header>


### PR DESCRIPTION
## Summary

Exposes high-traffic blog clusters from sitewide navigation so internal link equity from every page funnels to them.

GSC data shows the **senior-waivers cluster pulls ~600 monthly impressions** across 13 spokes and the **transfer-credit cluster pulls 930+ on 2 hubs alone** — but neither was discoverable from the header or footer before this PR. Users on `/va`, `/nc`, `/ga`, etc. had no way to find these clusters except by direct organic search.

Closes #374.

## Header changes (`components/Header.tsx`)

- Replace the single "Blog" link with a **"Guides" dropdown** button
- Dropdown contains 4 topic links + "All Articles →":
  - Senior Waivers → `/blog/free-community-college-classes-for-seniors`
  - Transfer Guides → `/blog/how-to-check-if-community-college-course-transfers`
  - Auditing a Class → `/blog/what-does-audit-a-class-mean`
  - Late-Start Classes → `/blog/how-to-find-late-start-community-college-classes`
  - All Articles → `/blog`
- Click-outside + Escape close handling matches the existing UserMenu pattern
- Mobile menu renders the same 5 links under a "Guides" section

## Footer changes (`app/[state]/layout.tsx`)

Reorganized from single flex row → **3-column grid**:

| Column | Links |
|---|---|
| **Tools** | Find a Course, Starting Soon, Schedule Builder, Transfer Lookup (if supported), All [System] Colleges |
| **Guides** | Senior Waivers, Transfer Guides, Auditing, Late-Start, Hybrid Classes, All articles → |
| **About** | About this site, Privacy Policy, Support this project button |

State-aware:
- VA footer shows "All VCCS Colleges"; GA shows "All TCSG Colleges"; etc. (uses `config.systemName`)
- Transfer Lookup hidden when `transferSupported === false`
- Disclaimer row preserved at the bottom, full width

## Verified

- [x] Typecheck passes
- [x] Header dropdown opens on click, closes on outside click, closes on Escape
- [x] `aria-expanded` and `aria-haspopup` toggle correctly
- [x] All 5 dropdown links resolve to existing blog hubs
- [x] Footer renders 3 columns with state-aware Tools column
- [x] Mobile hamburger menu shows the same Guides section
- [x] No console errors

## Why this matters

- **Internal link equity**: header + footer links from every page → thousands of additional internal links per cluster
- **Discovery**: homepage visitors who don't engage with the search tool now have a topical reason to click into the blog corpus
- **Compounding effect with #371**: programmatic-page sidebar links (just merged) get the blog clusters surfaced once; sitewide nav surfaces them again — bidirectional reinforcement strengthens topical-authority signal

## Out of scope

- Dedicated `/guides/senior-waivers` or `/guides/transfer` index pages (mentioned as optional in the issue) — links go to existing blog hubs which already function as topical entry points
- Adding "Guides" sub-pages with curated lists of all state spokes — can be a follow-up if useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)