### PR TITLE
fix(scrape): leg-level + empty-result resilience for all-state scheduled scrapes

### DIFF
--- a/.github/workflows/scheduled-scrape.yml
+++ b/.github/workflows/scheduled-scrape.yml
@@ -151,18 +151,50 @@ jobs:
           # can write to prod from this workflow. See #59 design doc.
           SUPABASE_SERVICE_ROLE_KEY: ""
         run: |
-          set -e
+          # Per-script isolation: one bad script must not abort the rest of
+          # the leg. Without this, the first non-zero exit (one college's
+          # source 404'd, one Banner connect-timed-out) takes every later
+          # script in the same matrix entry offline — see issues #159, #160,
+          # #161 and the May 2026 scheduled-scrape failures where one bad
+          # PDF download killed seven NC college scrapes.
+          #
+          # We capture each script's exit code, log it, and continue. The
+          # step fails (exit 1) only if every script in the leg failed,
+          # preserving the red-x signal for genuine outages while letting
+          # partial successes ship their data through the rest of the
+          # workflow (upload, diff, commit).
           term_arg="${{ steps.terms.outputs.term_arg }}"
-          echo "${{ matrix.scripts }}" | while IFS= read -r script; do
+          succeeded=0
+          failed_scripts=()
+          while IFS= read -r script; do
             [ -z "$script" ] && continue
             echo "::group::$script"
+            rc=0
             if [ -n "$term_arg" ]; then
-              npx tsx "$script" --no-import --term "$term_arg"
+              npx tsx "$script" --no-import --term "$term_arg" || rc=$?
             else
-              npx tsx "$script" --no-import
+              npx tsx "$script" --no-import || rc=$?
             fi
             echo "::endgroup::"
-          done
+            if [ "$rc" -eq 0 ]; then
+              succeeded=$((succeeded + 1))
+            else
+              echo "::warning title=Scraper script failed::$script exited with code $rc"
+              failed_scripts+=("$script")
+            fi
+          done <<< "${{ matrix.scripts }}"
+
+          echo ""
+          echo "Leg summary: ${succeeded} script(s) succeeded, ${#failed_scripts[@]} failed"
+          if [ ${#failed_scripts[@]} -gt 0 ]; then
+            printf '  failed: %s\n' "${failed_scripts[@]}"
+          fi
+          # Red the step only when nothing worked. Partial success is
+          # still a success — the data that did get scraped should ship.
+          if [ "$succeeded" -eq 0 ]; then
+            echo "::error::All scripts in this leg failed"
+            exit 1
+          fi
 
       - name: Upload scraped data
         # Run even when the scrape step failed so any diagnostic dumps the

--- a/scripts/ct/scrape-banner.ts
+++ b/scripts/ct/scrape-banner.ts
@@ -8,6 +8,7 @@
 import fs from "fs";
 import path from "path";
 import { pickRecentSsbTerms } from "../lib/resolve-terms";
+import { safeWriteSections } from "../lib/safe-write-sections";
 
 const BASE_URL = "https://reg-prod.ec.ct.edu";
 const COLLEGE_SLUG = "ct-state";
@@ -353,10 +354,12 @@ async function main() {
     });
 
     const outFile = path.join(outDir, `${standardTerm}.json`);
-    fs.writeFileSync(outFile, JSON.stringify(converted, null, 2));
-    const withPrereqs = converted.filter((c) => c.prerequisite_text).length;
-    console.log(`  → ${converted.length} sections written to ${standardTerm}.json (${withPrereqs} with prereqs)`);
-    totalSections += converted.length;
+    const wrote = safeWriteSections(outFile, converted, standardTerm);
+    if (wrote) {
+      const withPrereqs = converted.filter((c) => c.prerequisite_text).length;
+      console.log(`  → ${converted.length} sections written to ${standardTerm}.json (${withPrereqs} with prereqs)`);
+      totalSections += converted.length;
+    }
   }
 
   // Auto-import into Supabase (skip with --no-import)

--- a/scripts/dc/scrape-banner.ts
+++ b/scripts/dc/scrape-banner.ts
@@ -8,6 +8,7 @@
 import fs from "fs";
 import path from "path";
 import { pickRecentSsbTerms } from "../lib/resolve-terms";
+import { safeWriteSections } from "../lib/safe-write-sections";
 
 const BASE_URL = "https://reg-prod.ec.udc.edu";
 const COLLEGE_SLUG = "udc-cc";
@@ -360,10 +361,12 @@ async function main() {
     });
 
     const outFile = path.join(outDir, `${standardTerm}.json`);
-    fs.writeFileSync(outFile, JSON.stringify(converted, null, 2));
-    const withPrereqs = converted.filter((c) => c.prerequisite_text).length;
-    console.log(`  → ${converted.length} sections written to ${standardTerm}.json (${withPrereqs} with prereqs)`);
-    totalSections += converted.length;
+    const wrote = safeWriteSections(outFile, converted, standardTerm);
+    if (wrote) {
+      const withPrereqs = converted.filter((c) => c.prerequisite_text).length;
+      console.log(`  → ${converted.length} sections written to ${standardTerm}.json (${withPrereqs} with prereqs)`);
+      totalSections += converted.length;
+    }
   }
 
   // Auto-import into Supabase (skip with --no-import)

--- a/scripts/de/scrape-banner-ssb.ts
+++ b/scripts/de/scrape-banner-ssb.ts
@@ -16,6 +16,7 @@
 import fs from "fs";
 import path from "path";
 import { pickRecentSsbTerms } from "../lib/resolve-terms";
+import { safeWriteSections } from "../lib/safe-write-sections";
 
 const PAGE_SIZE = 500;
 const BASE_URL = "https://banner.dtcc.edu";
@@ -478,7 +479,8 @@ async function scrapeTerm(term: BannerTerm): Promise<number> {
     fs.mkdirSync(outDir, { recursive: true });
 
     const outFile = path.join(outDir, `${standardTerm}.json`);
-    fs.writeFileSync(outFile, JSON.stringify(converted, null, 2));
+    const wrote = safeWriteSections(outFile, converted, standardTerm);
+    if (!wrote) return 0;
     const withPrereqs = converted.filter((c) => c.prerequisite_text).length;
     console.log(
       `  → ${converted.length} sections written to ${standardTerm}.json (${withPrereqs} with prereqs)`

--- a/scripts/lib/safe-write-sections.ts
+++ b/scripts/lib/safe-write-sections.ts
@@ -1,0 +1,36 @@
+import fs from "fs";
+
+/**
+ * Write a term's scraped sections to disk, refusing to overwrite a
+ * non-empty existing file with an empty result.
+ *
+ * Per CLAUDE.md invariant #4: "If a scraper fails, leave the existing
+ * data untouched rather than substitute placeholder courses." A scraper
+ * that crashed mid-pagination, or hit a transient 0-result response,
+ * or had its session cookie expire, must not silently erase the prior
+ * good data on disk.
+ *
+ * Returns true if the file was written, false if the guard kicked in.
+ */
+export function safeWriteSections<T>(
+  outFile: string,
+  sections: T[],
+  label?: string
+): boolean {
+  if (sections.length === 0 && fs.existsSync(outFile)) {
+    try {
+      const prev = JSON.parse(fs.readFileSync(outFile, "utf-8"));
+      if (Array.isArray(prev) && prev.length > 0) {
+        const tag = label ? `${label}: ` : "";
+        console.warn(
+          `  ⚠ ${tag}scraper returned 0 sections but existing file has ${prev.length}; keeping previous data`
+        );
+        return false;
+      }
+    } catch {
+      // Existing file unreadable — fall through and write the empty result
+    }
+  }
+  fs.writeFileSync(outFile, JSON.stringify(sections, null, 2));
+  return true;
+}


### PR DESCRIPTION
Closes #159 (DC scraper), #160 (CT scraper). Companion to #391 (MD-specific within-script hardening).

## Problem

Two distinct vulnerabilities are knocking out scheduled scrapes for multiple states:

### A. Workflow loop \`set -e\` (cross-script blast radius)

The scheduled-scrape "Run scraper scripts" step ran with \`set -e\` in a \`while read\` loop. **One bad script aborted every later script in the same matrix entry.** May 2026 cron runs:

| State leg | Cause | Scripts killed |
|---|---|---|
| \`nc-courses-0\` | scrape-cape-fear.ts hit HTTP 404 on a PDF source | 7 later NC college scripts never executed |
| \`md-courses-0\` | scrape-banner-ssb.ts timed out on Harford | scrape-banner8.ts + scrape-custom.ts never executed |

### B. Empty-result overwrite (CLAUDE.md invariant #4 violation)

CT, DC, and DE banner scrapers wrote whatever \`converted\` array they produced — including \`[]\` — without checking against existing data. A scraper that crashed mid-pagination, hit a transient 0-result response, or had its session cookie expire silently overwrote real on-disk data with \`[]\`. Hit Montgomery College during PR #391's manual testing.

## Fix

### 1. Workflow loop captures exit codes, isolates failures

\`.github/workflows/scheduled-scrape.yml\` "Run scraper scripts" step:
- Each script's exit code captured via \`|| rc=\$?\` instead of relying on \`set -e\`
- Failures logged as \`::warning\` annotations on the workflow run
- Step exits 0 if **any** script succeeded; exits 1 only if all failed
- Preserves the red-x signal for genuine outages while letting partial successes ship their data through the rest of the workflow (upload → diff → per-state PR)

This is **leg-level** isolation. Complements #391's **within-script** per-college isolation in MD's banner-ssb / banner8.

### 2. \`safeWriteSections\` helper (new \`scripts/lib/safe-write-sections.ts\`)

Small, single-purpose helper: refuses to overwrite a non-empty existing JSON file with an empty result. Returns \`true\` if it wrote, \`false\` if the guard kicked in.

Wired into:
- \`scripts/ct/scrape-banner.ts\`
- \`scripts/dc/scrape-banner.ts\`
- \`scripts/de/scrape-banner-ssb.ts\`

MD's \`scrape-banner-ssb.ts\` already inlines this logic from #391 (a follow-up could collapse it onto the helper). MD's \`scrape-banner8.ts\` already had \`if (allSections.length > 0)\` and \`scrape-custom.ts\` already has per-college try/catch — neither needs the helper.

## Coverage impact

| State / leg | Before | After |
|---|---|---|
| NC courses (8-script leg) | one 404 = whole leg dies | one 404 = one college skipped, other 7 still run |
| MD courses (3-script leg) | already fixed by #391 within-script | also isolated leg-level now |
| CT / DC / DE banner | 0-section response wipes good data | guard preserves existing file |
| Future states | same vulnerability if they have multi-script legs | leg loop isolation applies automatically |

## Verification

- \`npx tsc --noEmit\` passes
- Workflow YAML structurally valid: loop terminates on \`done\`, here-string \`<<<\` and bash arrays both work in GitHub-hosted ubuntu-24.04 (bash 5.x)
- The exit-0-on-partial-success behavior matches the pattern shipped in #391's MD scraper \`main()\` loops; downstream workflow steps already use \`if: always()\` for artifact upload

## Test plan

- [ ] Trigger workflow_dispatch \`scheduled-scrape\` with datatype=courses
- [ ] Confirm \`md-courses-0\` and \`nc-courses-0\` both exit 0 if at least one script in the leg succeeds (check \`::warning\` annotations for the failures that no longer red the step)
- [ ] Check \`data/{ct,dc,de}/courses/.../<term>.json\` after a run — if the source returns 0 sections, the file should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)