### PR TITLE
feat(scorecard): API client + smoke-test CLI (#392 PR 1/4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
 # Google AdSense — set to your publisher ID to enable ads (e.g. ca-pub-xxxxxxxxxxxxxxxx).
 # Leave unset to disable ads entirely (AdSenseScript returns null when missing).
 NEXT_PUBLIC_ADSENSE_ID=ca-pub-xxxxxxxxxxxxxxxx
+
+# College Scorecard (federal cost/aid/completion/earnings data per institution).
+# Free key from https://api.data.gov/signup — instant, email-based.
+# Used by scripts/lib/college-scorecard.ts to fetch per-college metrics.
+# See issue #392.
+COLLEGE_SCORECARD_API_KEY=

--- a/scripts/lib/college-scorecard.ts
+++ b/scripts/lib/college-scorecard.ts
@@ -1,0 +1,259 @@
+/**
+ * College Scorecard API client.
+ *
+ * Federal data source for per-institution cost, aid, completion, and earnings
+ * metrics. Free, public, requires an `api.data.gov` key (sign up at
+ * https://api.data.gov/signup — instant). Documented at
+ * https://collegescorecard.ed.gov/data/api-documentation/.
+ *
+ * This file (PR 1 of issue #392) only provides the API client and the
+ * persisted-record schema. The per-college ingest, IPEDS unitid mapping,
+ * and library helpers land in follow-up PRs.
+ *
+ * Field selection rationale:
+ *   The issue (#392) originally listed `completion.completion_rate_4yr_150nt`
+ *   as the canonical completion metric. Empirically that field is null for
+ *   community colleges (it's a 4-year-institution metric). The correct CC
+ *   equivalent is `completion.completion_rate_less_than_4yr_150nt`. This
+ *   client picks the less-than-4-year variants where they exist.
+ */
+
+import { fetchJsonWithRetry } from "@/scripts/lib/http-retry";
+import { loadEnv } from "@/scripts/lib/load-env";
+
+const API_BASE = "https://api.data.gov/ed/collegescorecard/v1/schools";
+
+// Fields to request from the API. Comma-joined into the `fields` query param.
+// Keeping this narrow keeps response payloads small (~2 KB per school vs.
+// ~500 KB for the full record).
+const FIELDS = [
+  "id",
+  "school.name",
+  "school.state",
+  "school.city",
+  "school.school_url",
+  "latest.student.size",
+  "latest.student.share_firstgeneration",
+  "latest.cost.tuition.in_state",
+  "latest.cost.tuition.out_of_state",
+  "latest.cost.attendance.academic_year",
+  "latest.cost.avg_net_price.public",
+  "latest.cost.booksupply",
+  "latest.cost.roomboard.offcampus",
+  "latest.cost.net_price.public.by_income_level.0-30000",
+  "latest.cost.net_price.public.by_income_level.30001-48000",
+  "latest.cost.net_price.public.by_income_level.48001-75000",
+  "latest.cost.net_price.public.by_income_level.75001-110000",
+  "latest.cost.net_price.public.by_income_level.110001-plus",
+  "latest.aid.pell_grant_rate",
+  "latest.aid.federal_loan_rate",
+  "latest.aid.median_debt.completers.overall",
+  "latest.completion.completion_rate_less_than_4yr_150nt",
+  "latest.completion.completion_rate_less_than_4yr_200nt",
+  "latest.completion.transfer_rate.less_than_4yr.full_time",
+  "latest.earnings.10_yrs_after_entry.median",
+];
+
+const FIELDS_PARAM = FIELDS.join(",");
+
+/**
+ * Canonical persisted shape. This is what gets written to
+ * `data/{state}/scorecard/{college}.json` once per ingest cycle.
+ *
+ * Every number-valued field is nullable because Scorecard suppresses values
+ * with small cohorts and not every metric applies to every institution.
+ * Consumers must handle null gracefully (don't show "$null tuition").
+ */
+export interface ScorecardRecord {
+  /** IPEDS unitid — the federal institution ID. */
+  unitid: number;
+  schoolName: string;
+  state: string;
+  city: string;
+  schoolUrl: string | null;
+  /** When this record was fetched, ISO 8601. Used for freshness checks. */
+  fetchedAt: string;
+
+  /** Enrollment headcount. */
+  size: number | null;
+  /** Share of first-generation students (0–1). */
+  shareFirstGeneration: number | null;
+
+  cost: {
+    tuitionInState: number | null;
+    tuitionOutOfState: number | null;
+    attendanceAcademicYear: number | null;
+    avgNetPricePublic: number | null;
+    bookSupply: number | null;
+    roomBoardOffCampus: number | null;
+    /**
+     * Net price after aid, banded by family income. The dollar value is
+     * what a student in that band would actually pay per year.
+     */
+    netPriceByIncome: {
+      "0_30000": number | null;
+      "30001_48000": number | null;
+      "48001_75000": number | null;
+      "75001_110000": number | null;
+      "110001_plus": number | null;
+    };
+  };
+
+  aid: {
+    /** Share of students receiving Pell grants (0–1). */
+    pellGrantRate: number | null;
+    /** Share receiving federal loans (0–1). */
+    federalLoanRate: number | null;
+    /** Median cumulative debt for completers, $. */
+    medianDebtCompleters: number | null;
+  };
+
+  completion: {
+    /** 150%-of-normal-time completion rate for <4yr institutions (0–1). */
+    completionRate150nt: number | null;
+    /** 200%-of-normal-time completion rate for <4yr institutions (0–1). */
+    completionRate200nt: number | null;
+    /** Transfer-out rate for full-time <4yr students (0–1). */
+    transferRate: number | null;
+  };
+
+  earnings: {
+    /** Median earnings 10 years after enrollment entry, $. */
+    median10YrsAfterEntry: number | null;
+  };
+}
+
+/** Raw Scorecard API response row. We map this into ScorecardRecord. */
+interface ScorecardApiRow {
+  id?: number;
+  "school.name"?: string | null;
+  "school.state"?: string | null;
+  "school.city"?: string | null;
+  "school.school_url"?: string | null;
+  "latest.student.size"?: number | null;
+  "latest.student.share_firstgeneration"?: number | null;
+  "latest.cost.tuition.in_state"?: number | null;
+  "latest.cost.tuition.out_of_state"?: number | null;
+  "latest.cost.attendance.academic_year"?: number | null;
+  "latest.cost.avg_net_price.public"?: number | null;
+  "latest.cost.booksupply"?: number | null;
+  "latest.cost.roomboard.offcampus"?: number | null;
+  "latest.cost.net_price.public.by_income_level.0-30000"?: number | null;
+  "latest.cost.net_price.public.by_income_level.30001-48000"?: number | null;
+  "latest.cost.net_price.public.by_income_level.48001-75000"?: number | null;
+  "latest.cost.net_price.public.by_income_level.75001-110000"?: number | null;
+  "latest.cost.net_price.public.by_income_level.110001-plus"?: number | null;
+  "latest.aid.pell_grant_rate"?: number | null;
+  "latest.aid.federal_loan_rate"?: number | null;
+  "latest.aid.median_debt.completers.overall"?: number | null;
+  "latest.completion.completion_rate_less_than_4yr_150nt"?: number | null;
+  "latest.completion.completion_rate_less_than_4yr_200nt"?: number | null;
+  "latest.completion.transfer_rate.less_than_4yr.full_time"?: number | null;
+  "latest.earnings.10_yrs_after_entry.median"?: number | null;
+}
+
+interface ScorecardApiResponse {
+  metadata: { page: number; total: number; per_page: number };
+  results: ScorecardApiRow[];
+}
+
+function requireApiKey(): string {
+  loadEnv();
+  const key = process.env.COLLEGE_SCORECARD_API_KEY;
+  if (!key) {
+    throw new Error(
+      "COLLEGE_SCORECARD_API_KEY is not set. Sign up free at https://api.data.gov/signup and add the key to .env.local."
+    );
+  }
+  return key;
+}
+
+function rowToRecord(row: ScorecardApiRow): ScorecardRecord {
+  if (typeof row.id !== "number") {
+    throw new Error("Scorecard row is missing `id` — likely a bad API response.");
+  }
+  return {
+    unitid: row.id,
+    schoolName: row["school.name"] ?? "",
+    state: row["school.state"] ?? "",
+    city: row["school.city"] ?? "",
+    schoolUrl: row["school.school_url"] ?? null,
+    fetchedAt: new Date().toISOString(),
+    size: row["latest.student.size"] ?? null,
+    shareFirstGeneration: row["latest.student.share_firstgeneration"] ?? null,
+    cost: {
+      tuitionInState: row["latest.cost.tuition.in_state"] ?? null,
+      tuitionOutOfState: row["latest.cost.tuition.out_of_state"] ?? null,
+      attendanceAcademicYear: row["latest.cost.attendance.academic_year"] ?? null,
+      avgNetPricePublic: row["latest.cost.avg_net_price.public"] ?? null,
+      bookSupply: row["latest.cost.booksupply"] ?? null,
+      roomBoardOffCampus: row["latest.cost.roomboard.offcampus"] ?? null,
+      netPriceByIncome: {
+        "0_30000": row["latest.cost.net_price.public.by_income_level.0-30000"] ?? null,
+        "30001_48000": row["latest.cost.net_price.public.by_income_level.30001-48000"] ?? null,
+        "48001_75000": row["latest.cost.net_price.public.by_income_level.48001-75000"] ?? null,
+        "75001_110000": row["latest.cost.net_price.public.by_income_level.75001-110000"] ?? null,
+        "110001_plus": row["latest.cost.net_price.public.by_income_level.110001-plus"] ?? null,
+      },
+    },
+    aid: {
+      pellGrantRate: row["latest.aid.pell_grant_rate"] ?? null,
+      federalLoanRate: row["latest.aid.federal_loan_rate"] ?? null,
+      medianDebtCompleters: row["latest.aid.median_debt.completers.overall"] ?? null,
+    },
+    completion: {
+      completionRate150nt:
+        row["latest.completion.completion_rate_less_than_4yr_150nt"] ?? null,
+      completionRate200nt:
+        row["latest.completion.completion_rate_less_than_4yr_200nt"] ?? null,
+      transferRate:
+        row["latest.completion.transfer_rate.less_than_4yr.full_time"] ?? null,
+    },
+    earnings: {
+      median10YrsAfterEntry:
+        row["latest.earnings.10_yrs_after_entry.median"] ?? null,
+    },
+  };
+}
+
+/**
+ * Fetch a single institution by IPEDS unitid. Returns null if not found.
+ * Throws on transport errors or auth failures.
+ */
+export async function fetchScorecardByUnitid(
+  unitid: number
+): Promise<ScorecardRecord | null> {
+  const key = requireApiKey();
+  const url = `${API_BASE}?id=${unitid}&fields=${encodeURIComponent(FIELDS_PARAM)}&api_key=${key}`;
+  const data = await fetchJsonWithRetry<ScorecardApiResponse>(url, undefined, {
+    label: `scorecard:${unitid}`,
+  });
+  if (!data.results || data.results.length === 0) return null;
+  return rowToRecord(data.results[0]);
+}
+
+/**
+ * Search Scorecard for institutions matching a name and state. Useful for
+ * the unitid-mapping work (PR 2) — given a college name from
+ * institutions.json, find candidate IPEDS matches. Returns up to 20 results.
+ *
+ * Caller is responsible for disambiguating: a query like "Northern Virginia"
+ * matches both NVCC and a massage school. Real CC ingest should filter to
+ * results with non-null `latest.cost.tuition.in_state` and large
+ * enrollment.
+ */
+export async function searchScorecardByName(
+  name: string,
+  state: string
+): Promise<ScorecardRecord[]> {
+  const key = requireApiKey();
+  const url =
+    `${API_BASE}?school.name=${encodeURIComponent(name)}` +
+    `&school.state=${encodeURIComponent(state.toUpperCase())}` +
+    `&fields=${encodeURIComponent(FIELDS_PARAM)}` +
+    `&api_key=${key}`;
+  const data = await fetchJsonWithRetry<ScorecardApiResponse>(url, undefined, {
+    label: `scorecard-search:${name}/${state}`,
+  });
+  return (data.results ?? []).map(rowToRecord);
+}

--- a/scripts/test-scorecard.ts
+++ b/scripts/test-scorecard.ts
@@ -1,0 +1,95 @@
+/**
+ * Smoke test for the College Scorecard API client.
+ *
+ * Usage:
+ *   tsx scripts/test-scorecard.ts <unitid>
+ *   tsx scripts/test-scorecard.ts search "<name>" <state>
+ *
+ * Examples:
+ *   tsx scripts/test-scorecard.ts 232450
+ *   tsx scripts/test-scorecard.ts search "Wake Technical" NC
+ *   tsx scripts/test-scorecard.ts search "Northern Virginia" VA
+ *
+ * Useful for verifying COLLEGE_SCORECARD_API_KEY works end-to-end and for
+ * eyeballing what fields are actually populated on a given college before
+ * the full ingest (PR 2) runs against ~600 institutions.
+ */
+
+import {
+  fetchScorecardByUnitid,
+  searchScorecardByName,
+  type ScorecardRecord,
+} from "@/scripts/lib/college-scorecard";
+
+function formatPct(v: number | null): string {
+  if (v == null) return "—";
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function formatDollar(v: number | null): string {
+  if (v == null) return "—";
+  return `$${v.toLocaleString("en-US")}`;
+}
+
+function printRecord(r: ScorecardRecord): void {
+  console.log(`\n${r.schoolName} — ${r.city}, ${r.state} (unitid ${r.unitid})`);
+  console.log(`  Enrollment: ${r.size ?? "—"}`);
+  console.log(`  Share first-gen: ${formatPct(r.shareFirstGeneration)}`);
+  console.log(`  Tuition (in-state / out-of-state): ${formatDollar(r.cost.tuitionInState)} / ${formatDollar(r.cost.tuitionOutOfState)}`);
+  console.log(`  Avg net price (after aid): ${formatDollar(r.cost.avgNetPricePublic)}`);
+  console.log(`  Net price by income:`);
+  console.log(`    $0–30k:        ${formatDollar(r.cost.netPriceByIncome["0_30000"])}`);
+  console.log(`    $30–48k:       ${formatDollar(r.cost.netPriceByIncome["30001_48000"])}`);
+  console.log(`    $48–75k:       ${formatDollar(r.cost.netPriceByIncome["48001_75000"])}`);
+  console.log(`    $75–110k:      ${formatDollar(r.cost.netPriceByIncome["75001_110000"])}`);
+  console.log(`    $110k+:        ${formatDollar(r.cost.netPriceByIncome["110001_plus"])}`);
+  console.log(`  Pell rate / fed loan rate: ${formatPct(r.aid.pellGrantRate)} / ${formatPct(r.aid.federalLoanRate)}`);
+  console.log(`  Median debt at completion: ${formatDollar(r.aid.medianDebtCompleters)}`);
+  console.log(`  Completion (150% / 200% time): ${formatPct(r.completion.completionRate150nt)} / ${formatPct(r.completion.completionRate200nt)}`);
+  console.log(`  Transfer rate (FT): ${formatPct(r.completion.transferRate)}`);
+  console.log(`  Median earnings 10y after entry: ${formatDollar(r.earnings.median10YrsAfterEntry)}`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.error("Usage:");
+    console.error("  tsx scripts/test-scorecard.ts <unitid>");
+    console.error('  tsx scripts/test-scorecard.ts search "<name>" <state>');
+    process.exit(1);
+  }
+
+  if (args[0] === "search") {
+    const name = args[1];
+    const state = args[2];
+    if (!name || !state) {
+      console.error('Usage: tsx scripts/test-scorecard.ts search "<name>" <state>');
+      process.exit(1);
+    }
+    const results = await searchScorecardByName(name, state);
+    if (results.length === 0) {
+      console.log(`No matches for "${name}" in ${state}.`);
+      return;
+    }
+    console.log(`Found ${results.length} match${results.length === 1 ? "" : "es"}:`);
+    for (const r of results) printRecord(r);
+    return;
+  }
+
+  const unitid = Number(args[0]);
+  if (!Number.isInteger(unitid) || unitid <= 0) {
+    console.error(`Invalid unitid: ${args[0]}`);
+    process.exit(1);
+  }
+  const record = await fetchScorecardByUnitid(unitid);
+  if (!record) {
+    console.log(`No record found for unitid ${unitid}.`);
+    return;
+  }
+  printRecord(record);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
First slice of #392 — ingest College Scorecard data per institution. This PR adds only the API client and a smoke-test CLI. The per-college ingest, IPEDS unitid mapping, library helpers, and UI surface land in follow-ups.

## What's here
- **`scripts/lib/college-scorecard.ts`** — typed API client with two entry points: `fetchScorecardByUnitid` (direct fetch) and `searchScorecardByName` (for the upcoming unitid-mapping work). Selects ~25 cost / aid / completion / earnings / demographic fields relevant to community colleges. Uses the existing `fetchJsonWithRetry` for transient-failure resilience and `loadEnv` for key loading.
- **`scripts/test-scorecard.ts`** — CLI for verifying end-to-end:
  ```
  tsx scripts/test-scorecard.ts 232450
  tsx scripts/test-scorecard.ts search "Wake Technical" NC
  ```
- **`.env.example`** — documented `COLLEGE_SCORECARD_API_KEY` (free, instant via api.data.gov/signup).

## Two empirical findings that shaped this PR
- **The issue's recommended completion field is wrong for community colleges.** `completion.completion_rate_4yr_150nt` is null for every 2-year institution — it's a 4-year-institution metric. The right CC equivalent is `completion.completion_rate_less_than_4yr_150nt`, which this client uses. (Brightpoint shows 38.3% completion-at-150%-time on this field; the original would have shown null.)
- **The API now requires an auth key.** The issue said "no auth required" — that's stale. Free signup is instant. Code throws a clear message pointing at the signup URL if `COLLEGE_SCORECARD_API_KEY` is unset.

## Verification — both queries returned complete, real records

```
Brightpoint Community College — Chester, VA (unitid 232450)
  Enrollment: 5792
  Tuition (in / out): $5,082 / $11,520
  Avg net price: $5,490
  Net price by income (0–30k → 110k+): $4,150 / $4,803 / $6,376 / $8,764 / $11,669
  Pell rate: 22.5%
  Median debt at completion: $9,500
  Completion (150% / 200% time): 38.3% / 42.0%
  Transfer rate (FT): 17.7%
  Median earnings 10y after entry: $41,223

Wake Technical Community College — Raleigh, NC (unitid 199856)
  Enrollment: 19675
  Tuition (in / out): $2,254 / $6,862
  Avg net price: $8,759
  Pell rate: 28.3%
  Completion: 33.0% / 39.1%
  Median earnings 10y after entry: $41,769
```

## What's next
- **PR 2 (data layer):** IPEDS unitid mapping for the ~600 colleges currently in `data/*/institutions.json`, ingest script, library helpers in `lib/scorecard.ts`. Most of the work — needs disambiguation logic for the name-search false positives (e.g. "Northern Virginia" → NVCC vs. a massage school).
- **PR 3 (UI):** "Cost & outcomes" section on `/[state]/college/[id]`. Proves end-to-end.
- **PR 4 (workflow):** auto-add-state hook + freshness CI guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)