### PR TITLE
feat(scorecard): Cost & outcomes section on college pages (#392 PR 3/4)

### DIFF
--- a/app/[state]/college/[id]/CollegeScorecardSection.tsx
+++ b/app/[state]/college/[id]/CollegeScorecardSection.tsx
@@ -1,0 +1,198 @@
+/**
+ * Cost & outcomes section for /[state]/college/[id], driven by federal
+ * College Scorecard data. See issue #392.
+ *
+ * Server component — pure render, no client JS. The data is loaded
+ * synchronously from disk via `getScorecard()`; if it's missing (the two
+ * unmapped colleges, or any future case where ingest failed), the section
+ * renders nothing rather than blocking the page.
+ */
+
+import {
+  getScorecard,
+  formatDollar,
+  formatPercent,
+  type ScorecardRecord,
+} from "@/lib/scorecard";
+
+interface Props {
+  state: string;
+  collegeId: string;
+  collegeName: string;
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
+      <div className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-slate-400">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-bold text-gray-900 dark:text-slate-100">
+        {value}
+      </div>
+      {sub && (
+        <div className="mt-0.5 text-xs text-gray-500 dark:text-slate-400">
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IncomeRow({
+  band,
+  amount,
+}: {
+  band: string;
+  amount: number | null;
+}) {
+  return (
+    <div className="flex items-center justify-between border-b border-gray-100 dark:border-slate-700 py-2 last:border-0">
+      <span className="text-sm text-gray-700 dark:text-slate-300">{band}</span>
+      <span className="text-sm font-medium text-gray-900 dark:text-slate-100 tabular-nums">
+        {formatDollar(amount)}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Returns true if the record has enough non-null fields to be worth
+ * rendering. A record with everything null (rare but possible) would render
+ * a wall of "—" — we'd rather omit the whole section.
+ */
+function hasUsefulData(r: ScorecardRecord): boolean {
+  return (
+    r.cost.tuitionInState != null ||
+    r.cost.avgNetPricePublic != null ||
+    r.aid.pellGrantRate != null ||
+    r.completion.completionRate150nt != null
+  );
+}
+
+export default function CollegeScorecardSection({
+  state,
+  collegeId,
+  collegeName,
+}: Props) {
+  const record = getScorecard(state, collegeId);
+  if (!record || !hasUsefulData(record)) return null;
+
+  const incomes: Array<{ band: string; amount: number | null }> = [
+    { band: "$0 – $30,000", amount: record.cost.netPriceByIncome["0_30000"] },
+    { band: "$30,001 – $48,000", amount: record.cost.netPriceByIncome["30001_48000"] },
+    { band: "$48,001 – $75,000", amount: record.cost.netPriceByIncome["48001_75000"] },
+    { band: "$75,001 – $110,000", amount: record.cost.netPriceByIncome["75001_110000"] },
+    { band: "$110,001+", amount: record.cost.netPriceByIncome["110001_plus"] },
+  ];
+  const anyIncome = incomes.some((i) => i.amount != null);
+
+  // Format fetchedAt → "Fall 2025" or just the year, depending on month.
+  const fetched = new Date(record.fetchedAt);
+  const year = fetched.getUTCFullYear();
+  const reportedYear = fetched.getUTCMonth() >= 9 ? year : year - 1; // Scorecard refreshes in October
+
+  return (
+    <section className="mt-8" aria-labelledby="scorecard-heading">
+      <h2
+        id="scorecard-heading"
+        className="text-xl font-semibold text-gray-900 dark:text-slate-100"
+      >
+        Cost &amp; outcomes
+      </h2>
+      <p className="mt-1 text-sm text-gray-600 dark:text-slate-400">
+        Federal data on tuition, financial aid, and student outcomes at{" "}
+        {collegeName}.
+      </p>
+
+      <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard
+          label="In-state tuition"
+          value={formatDollar(record.cost.tuitionInState)}
+          sub="per year (sticker)"
+        />
+        <StatCard
+          label="Avg net price"
+          value={formatDollar(record.cost.avgNetPricePublic)}
+          sub="after aid"
+        />
+        <StatCard
+          label="Receive Pell"
+          value={formatPercent(record.aid.pellGrantRate)}
+          sub="federal grant"
+        />
+        <StatCard
+          label="Completion rate"
+          value={formatPercent(record.completion.completionRate150nt)}
+          sub="150% of normal time"
+        />
+      </div>
+
+      {anyIncome && (
+        <div className="mt-6 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+            Net price by family income
+          </h3>
+          <p className="mt-1 text-xs text-gray-500 dark:text-slate-400">
+            What students actually paid per year, after grants and scholarships,
+            grouped by household income.
+          </p>
+          <div className="mt-3">
+            {incomes.map((row) => (
+              <IncomeRow key={row.band} band={row.band} amount={row.amount} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(record.completion.transferRate != null ||
+        record.earnings.median10YrsAfterEntry != null ||
+        record.aid.medianDebtCompleters != null) && (
+        <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {record.completion.transferRate != null && (
+            <StatCard
+              label="Transfer rate"
+              value={formatPercent(record.completion.transferRate)}
+              sub="full-time students"
+            />
+          )}
+          {record.aid.medianDebtCompleters != null && (
+            <StatCard
+              label="Median debt at completion"
+              value={formatDollar(record.aid.medianDebtCompleters)}
+              sub="federal loans"
+            />
+          )}
+          {record.earnings.median10YrsAfterEntry != null && (
+            <StatCard
+              label="Median earnings"
+              value={formatDollar(record.earnings.median10YrsAfterEntry)}
+              sub="10 years after entry"
+            />
+          )}
+        </div>
+      )}
+
+      <p className="mt-4 text-xs text-gray-500 dark:text-slate-400">
+        Source:{" "}
+        <a
+          href={`https://collegescorecard.ed.gov/school/?${record.unitid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-gray-700 dark:hover:text-slate-300"
+        >
+          U.S. Department of Education College Scorecard
+        </a>
+        , reporting year ~{reportedYear}.
+      </p>
+    </section>
+  );
+}

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/courses";
 import { getCurrentTerm } from "@/lib/terms";
 import CollegeMap from "./CollegeMap";
+import CollegeScorecardSection from "./CollegeScorecardSection";
 import CollegeTermSection from "./CollegeTermSection";
 import { buildTransferLookupForCourses } from "@/lib/transfer-scoped";
 import { getAllStates } from "@/lib/states/registry";
@@ -274,6 +275,14 @@ export default async function CollegeDetailPage(props: PageProps) {
           <CollegeMap institution={institution} />
         </div>
       )}
+
+      {/* Cost & outcomes — federal Scorecard data. Renders nothing when
+          the institution lacks a Scorecard mapping (2 of 382 today). */}
+      <CollegeScorecardSection
+        state={state}
+        collegeId={id}
+        collegeName={institution.name}
+      />
 
       {/* Term-dependent content (staleness, term picker, course table, subject
           browser, instructor browser) — client-rendered so ?term= switches


### PR DESCRIPTION
Third slice of #392 — the user-facing payoff. Renders federal Scorecard data on every `/[state]/college/[id]` page.

## What's here
- **`CollegeScorecardSection.tsx`** — pure server component reading from `lib/scorecard.getScorecard()`. Four headline stat cards (in-state tuition, avg net price after aid, Pell rate, completion rate), a "net price by family income" table (the most useful number for cost-conscious students that nobody publishes prominently), and a secondary stat row for transfer rate, median debt at completion, and 10-year earnings. Deep-links to the federal Scorecard for transparency.
- **`page.tsx`** wires the section in right after the campus map and before the term/course section. Visible by default (not collapsed) so Googlebot indexes it.

## Graceful degradation
Returns `null` (renders nothing) in two cases:
- No Scorecard record on disk → the 2 unmapped colleges (`dc:udc-cc`, `oh:eastern-gateway-community-college`).
- Record exists but every useful field is null (paranoia — none today).

The rest of the page renders unchanged.

## Local verification — `/va/college/brightpoint`
```
In-state tuition $5,082          Avg net price $5,490
Receive Pell 23%                 Completion rate 38%

Net price by family income:
  $0 – $30,000      $4,150
  $30,001 – $48,000 $4,803
  $48,001 – $75,000 $6,376
  $75,001 – $110,000 $8,764
  $110,001+         $11,669

Transfer rate 18%  ·  Median debt $9,500  ·  Median earnings $41,223
```

`/oh/college/eastern-gateway-community-college` (unmapped) — section correctly omitted, rest of page unchanged. Verified via curl.

## Why this matters (SEO + monetization)
- Adds substantial **unique indexable content** per college page — financial-vertical numbers (cost banded by income, median debt, 10-year earnings) which are otherwise scattered across federal/state PDFs and hard to find.
- Cost-by-income-band is the highest-utility number we can publish for first-gen students, and it's data Google doesn't surface in featured snippets today.
- RPM on financial-vertical content is meaningfully higher than the rest of the site. Expect this PR to be the largest revenue lever in the #392 / #369 / #375 program once the editorial follow-ups land.

## Test plan
- [x] `tsc --noEmit` clean
- [x] No lint warnings on new files
- [x] `/va/college/brightpoint` renders all stat cards with real numbers
- [x] `/oh/college/eastern-gateway-community-college` (unmapped) renders rest of page without the section
- [ ] (reviewer) Spot-check a few colleges in different states on the Vercel preview — confirm visual layout and that no card is unexpectedly null

## What's next — PR 4/4
Auto-add-state skill hookup (so new states get Scorecard mapping + ingest automatically) and an annual freshness CI guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)