### PR TITLE
feat(scorecard): add-state Phase 5 + freshness CI guard (#392 PR 4/4)

### DIFF
--- a/.claude/skills/auto-add-state/SKILL.md
+++ b/.claude/skills/auto-add-state/SKILL.md
@@ -17,6 +17,10 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
   (`scripts/lib/scrape-{banner-ssb,colleague,banner-8}.ts`)
 - Phase 3 — articulation lookup (`data/articulation-portals.json`)
 - Phase 4 — prereq aggregation (`scripts/lib/aggregate-prereqs.ts`)
+- Phase 5 — Scorecard ingest (`scripts/scorecard-map.ts` + `scripts/ingest-scorecard.ts`).
+  Maps each new college to its IPEDS unitid then fetches federal cost / aid /
+  completion data into `data/{slug}/scorecard/`. Auto-skips if
+  `COLLEGE_SCORECARD_API_KEY` is unset.
 
 ## Workflow
 
@@ -50,6 +54,7 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
      `courses.banner8.grandTotal`
    - `transfers.portal` (or null + `fallbackSuggestion`)
    - `prereqs.aggregated`
+   - `scorecard.mapped` / `scorecard.ingested` / `scorecard.ran`
    - `manualTodos[]`
 
 6. **Sanity-check the result.** If `bootstrap.collegesDiscovered === 0`,
@@ -87,6 +92,10 @@ The full pipeline (orchestrated by `scripts/lib/add-state.ts`):
    # Phase 3 + 4 (if any transfer / prereq data)
    git add data/{slug}/prereqs.json
    git commit -m "feat: aggregate {state} prereqs — {N} courses"
+
+   # Phase 5 (if any scorecard data — only when COLLEGE_SCORECARD_API_KEY is set)
+   git add data/{slug}/scorecard/ data/{slug}/institutions.json data/scorecard-mapping.json
+   git commit -m "feat: ingest {state} College Scorecard data — {ingested} colleges"
    ```
 
    Skip a chunk if its files don't exist (e.g. if every college had a

--- a/.github/workflows/scorecard-freshness.yml
+++ b/.github/workflows/scorecard-freshness.yml
@@ -1,0 +1,26 @@
+name: Scorecard freshness
+
+on:
+  pull_request:
+    paths:
+      - "data/*/scorecard/**"
+      - "scripts/check-scorecard-freshness.ts"
+      - ".github/workflows/scorecard-freshness.yml"
+  push:
+    branches: [main]
+  # Monthly sanity check so the freshness window doesn't expire silently
+  # between PRs touching scorecard data.
+  schedule:
+    - cron: "0 9 1 * *" # 09:00 UTC on the 1st of every month
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run check:scorecard

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check:scraper-terms": "tsx scripts/check-scraper-term-hardcoding.ts",
     "check:data": "tsx scripts/check-data-integrity.ts",
     "check:blog-mdx": "tsx scripts/check-blog-mdx.ts",
+    "check:scorecard": "tsx scripts/check-scorecard-freshness.ts",
     "eval:search": "tsx scripts/eval-search-intent.ts",
     "scrape": "tsx scripts/scrape-vccs.ts",
     "scrape:college": "tsx scripts/scrape-vccs.ts --college",

--- a/scripts/check-scorecard-freshness.ts
+++ b/scripts/check-scorecard-freshness.ts
@@ -1,0 +1,141 @@
+/**
+ * CI guard: flag any Scorecard record older than 18 months.
+ *
+ * Scorecard publishes refreshed data each October. An 18-month window means
+ * one annual refresh can be missed without firing, but two cannot — so this
+ * gives us a year of slack to catch up after a missed October refresh
+ * without the check screaming on every PR.
+ *
+ * Exit codes:
+ *   0 — every record is fresh (or there are no records to check)
+ *   1 — one or more records are stale; details are printed
+ *
+ * Usage:
+ *   npm run check:scorecard
+ *   tsx scripts/check-scorecard-freshness.ts            # all states
+ *   tsx scripts/check-scorecard-freshness.ts va nc      # specific states
+ *
+ * To refresh after the check fires, run:
+ *   tsx scripts/ingest-scorecard.ts                     # all states
+ *   tsx scripts/ingest-scorecard.ts <stale-state-slug>  # one state
+ */
+
+import fs from "fs";
+import path from "path";
+
+const MAX_AGE_MS = 18 * 30 * 24 * 60 * 60 * 1000; // ~18 months
+
+interface StaleEntry {
+  state: string;
+  collegeId: string;
+  fetchedAt: string;
+  ageDays: number;
+}
+
+function listStates(filter: string[]): string[] {
+  const all = fs
+    .readdirSync("data", { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .filter((s) => fs.existsSync(`data/${s}/scorecard`));
+  if (filter.length === 0) return all;
+  return all.filter((s) => filter.includes(s));
+}
+
+function checkFile(
+  state: string,
+  collegeId: string,
+  file: string
+): StaleEntry | null {
+  let parsed: { fetchedAt?: string };
+  try {
+    parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+  } catch {
+    // Invalid JSON is a different kind of problem; let it be caught
+    // elsewhere (the ingest script regenerates these, so they should never
+    // be malformed).
+    return null;
+  }
+  const fetchedAt = parsed.fetchedAt;
+  if (!fetchedAt) {
+    return {
+      state,
+      collegeId,
+      fetchedAt: "missing",
+      ageDays: Number.POSITIVE_INFINITY,
+    };
+  }
+  const fetched = Date.parse(fetchedAt);
+  if (Number.isNaN(fetched)) {
+    return {
+      state,
+      collegeId,
+      fetchedAt,
+      ageDays: Number.POSITIVE_INFINITY,
+    };
+  }
+  const ageMs = Date.now() - fetched;
+  if (ageMs > MAX_AGE_MS) {
+    return {
+      state,
+      collegeId,
+      fetchedAt,
+      ageDays: Math.round(ageMs / (24 * 60 * 60 * 1000)),
+    };
+  }
+  return null;
+}
+
+function main(): void {
+  const states = listStates(process.argv.slice(2));
+  if (states.length === 0) {
+    console.log("No Scorecard data found. (Run `tsx scripts/ingest-scorecard.ts` to populate.)");
+    process.exit(0);
+  }
+
+  const stale: StaleEntry[] = [];
+  let checked = 0;
+  for (const state of states) {
+    const dir = `data/${state}/scorecard`;
+    for (const file of fs.readdirSync(dir)) {
+      if (!file.endsWith(".json")) continue;
+      const collegeId = file.slice(0, -".json".length);
+      checked++;
+      const result = checkFile(state, collegeId, path.join(dir, file));
+      if (result) stale.push(result);
+    }
+  }
+
+  console.log(
+    `Checked ${checked} Scorecard records across ${states.length} state${states.length === 1 ? "" : "s"}.`
+  );
+
+  if (stale.length === 0) {
+    console.log("All records are fresh (≤ 18 months old).");
+    process.exit(0);
+  }
+
+  // Group stale by state for readability.
+  const byState = new Map<string, StaleEntry[]>();
+  for (const e of stale) {
+    if (!byState.has(e.state)) byState.set(e.state, []);
+    byState.get(e.state)!.push(e);
+  }
+
+  console.error(`\n${stale.length} stale Scorecard record${stale.length === 1 ? "" : "s"} (> 18 months old):\n`);
+  for (const [state, entries] of byState) {
+    console.error(`  ${state}: ${entries.length} stale`);
+    // Show the worst offenders in each state.
+    const worst = [...entries].sort((a, b) => b.ageDays - a.ageDays).slice(0, 3);
+    for (const e of worst) {
+      console.error(`    - ${e.collegeId}  (${e.ageDays} days old, fetchedAt=${e.fetchedAt})`);
+    }
+    if (entries.length > 3) console.error(`    ...and ${entries.length - 3} more`);
+  }
+  console.error(
+    `\nTo refresh, run:\n  tsx scripts/ingest-scorecard.ts            # all states\n  tsx scripts/ingest-scorecard.ts ${[...byState.keys()].join(" ")}   # only stale states\n`
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/lib/add-state.ts
+++ b/scripts/lib/add-state.ts
@@ -2,7 +2,7 @@
  * add-state.ts (orchestrator)
  *
  * Top-level orchestrator for the auto-add-state skill. Given a state slug,
- * runs the entire 5-phase workflow end-to-end:
+ * runs the entire 6-phase workflow end-to-end:
  *
  *   Phase 1  Bootstrap (PR 6)        — institutions.json, zipcodes.json,
  *                                       config.ts skeleton, registry edits
@@ -18,8 +18,11 @@
  *   Phase 4  Prereqs aggregation      — call existing aggregate-prereqs.ts
  *                                       to roll inline prereq data into
  *                                       data/{state}/prereqs.json
+ *   Phase 5  Scorecard ingest (#392)  — map each college to its IPEDS unitid,
+ *                                       fetch federal cost/aid/completion
+ *                                       data into data/{state}/scorecard/.
  *
- * Phase 5 (programs) is left as a manual TODO — IPEDS-driven program
+ * Programs discovery is left as a manual TODO — IPEDS-driven program
  * discovery isn't templated yet, and the existing program-scraper
  * templates (Acalog/Coursedog/etc.) require per-college catalog URLs that
  * the orchestrator can't reliably auto-derive.
@@ -47,7 +50,9 @@
  */
 
 import { spawn } from "child_process";
+import fs from "fs";
 import path from "path";
+import { loadEnv } from "./load-env";
 import {
   bootstrapState,
   type BootstrapStateResult,
@@ -105,6 +110,8 @@ export interface AddStateOptions {
   skipTransfers?: boolean;
   /** Skip Phase 4 (prereqs). */
   skipPrereqs?: boolean;
+  /** Skip Phase 5 (scorecard ingest). Useful when the API key isn't set. */
+  skipScorecard?: boolean;
   /** Filter to a single college slug (debug aid). */
   collegeFilter?: string;
   /** Override IPEDS year. Default = latest known. */
@@ -144,6 +151,15 @@ export interface AddStateResult {
   };
   prereqs: {
     aggregated: boolean;
+    error?: string;
+  };
+  scorecard: {
+    /** Number of (state, college) pairs with a unitid after mapping. */
+    mapped: number;
+    /** Number of scorecard JSON files written under data/{state}/scorecard/. */
+    ingested: number;
+    /** True if the phase ran and produced data; false if skipped/failed. */
+    ran: boolean;
     error?: string;
   };
   manualTodos: string[];
@@ -662,6 +678,93 @@ async function phasePrereqs(
 }
 
 // ---------------------------------------------------------------------------
+// Phase 5: Scorecard — map IPEDS unitids + ingest per-college Scorecard data
+// ---------------------------------------------------------------------------
+
+async function phaseScorecard(
+  state: string,
+  opts: AddStateOptions,
+  todos: string[]
+): Promise<AddStateResult["scorecard"]> {
+  if (opts.skipScorecard || opts.dryRun) {
+    if (opts.skipScorecard)
+      console.log("\nPhase 5 (scorecard): skipped (--skip-scorecard).");
+    else console.log("\nPhase 5 (scorecard): skipped (--dry-run).");
+    return { mapped: 0, ingested: 0, ran: false };
+  }
+  // Load .env.local so the API-key check below sees the key the same way
+  // the subprocesses will. (Subprocesses load it on their own via the
+  // college-scorecard module; this parent check would otherwise miss a
+  // key that's only set via .env.local.)
+  loadEnv();
+  if (!process.env.COLLEGE_SCORECARD_API_KEY) {
+    const msg =
+      "COLLEGE_SCORECARD_API_KEY is not set; skipping scorecard ingest. Get a free key at https://api.data.gov/signup and add it to .env.local.";
+    console.warn(`\nPhase 5 (scorecard): ${msg}`);
+    todos.push(`[scorecard] ${msg}`);
+    return { mapped: 0, ingested: 0, ran: false, error: "no API key" };
+  }
+  console.log("\n=== Phase 5: Scorecard ingest ===");
+
+  // 5a — map every college in this state to its IPEDS unitid.
+  const mapResult = await runSubprocess(
+    "npx",
+    ["tsx", "scripts/scorecard-map.ts", "--apply", "--state", state],
+    true
+  );
+  if (!mapResult.ok) {
+    const msg = `scorecard-map failed: ${mapResult.stderr || "(no stderr)"}`;
+    console.error(`  ${msg}`);
+    todos.push(`[scorecard] ${msg}`);
+    return { mapped: 0, ingested: 0, ran: false, error: msg };
+  }
+  process.stdout.write(mapResult.stdout);
+
+  // Count how many colleges in this state now have a unitid.
+  const instsFile = `data/${state}/institutions.json`;
+  let mapped = 0;
+  try {
+    const insts = JSON.parse(fs.readFileSync(instsFile, "utf-8")) as Array<{
+      unitid?: number;
+    }>;
+    mapped = insts.filter((i) => typeof i.unitid === "number").length;
+    const unmapped = insts.length - mapped;
+    if (unmapped > 0) {
+      todos.push(
+        `[scorecard] ${unmapped} college(s) in ${state} have no Scorecard unitid — see data/scorecard-mapping-review.json for candidates and edit the file then re-run \`tsx scripts/scorecard-map.ts --apply --state ${state}\`.`
+      );
+    }
+  } catch (e) {
+    todos.push(`[scorecard] failed to count mapped colleges: ${e}`);
+  }
+
+  // 5b — fetch the Scorecard record for each mapped college.
+  const ingestResult = await runSubprocess(
+    "npx",
+    ["tsx", "scripts/ingest-scorecard.ts", state],
+    true
+  );
+  if (!ingestResult.ok) {
+    const msg = `ingest-scorecard failed: ${ingestResult.stderr || "(no stderr)"}`;
+    console.error(`  ${msg}`);
+    todos.push(`[scorecard] ${msg}`);
+    return { mapped, ingested: 0, ran: false, error: msg };
+  }
+  process.stdout.write(ingestResult.stdout);
+
+  // Count ingested files on disk.
+  let ingested = 0;
+  const scoredir = `data/${state}/scorecard`;
+  if (fs.existsSync(scoredir)) {
+    ingested = fs
+      .readdirSync(scoredir)
+      .filter((f) => f.endsWith(".json")).length;
+  }
+
+  return { mapped, ingested, ran: true };
+}
+
+// ---------------------------------------------------------------------------
 // Reporter — pretty-prints the result for end-of-run consumption
 // ---------------------------------------------------------------------------
 
@@ -729,6 +832,17 @@ export function formatReport(r: AddStateResult): string {
     `Phase 4 — Prereqs:          ${r.prereqs.aggregated ? "aggregated from inline data" : `not aggregated${r.prereqs.error ? ` (${r.prereqs.error})` : ""}`}`
   );
 
+  // Phase 5
+  if (r.scorecard.ran) {
+    lines.push(
+      `Phase 5 — Scorecard:        ${r.scorecard.mapped} unitid(s) mapped, ${r.scorecard.ingested} record(s) ingested`
+    );
+  } else {
+    lines.push(
+      `Phase 5 — Scorecard:        not run${r.scorecard.error ? ` (${r.scorecard.error})` : ""}`
+    );
+  }
+
   // Manual TODOs
   if (r.manualTodos.length > 0) {
     lines.push("");
@@ -770,6 +884,7 @@ export async function addState(
     catalog: {},
     transfers: { portal: null, scriptsRun: [], fallbackSuggestion: null },
     prereqs: { aggregated: false },
+    scorecard: { mapped: 0, ingested: 0, ran: false },
     manualTodos: [],
     durations: {},
   };
@@ -848,6 +963,15 @@ export async function addState(
   }
   result.durations["4-prereqs"] = Date.now() - t4;
 
+  // Phase 5 (scorecard ingest — federal cost/aid/completion data)
+  const t5 = Date.now();
+  try {
+    result.scorecard = await phaseScorecard(state, opts, result.manualTodos);
+  } catch (e) {
+    result.manualTodos.push(`[scorecard] failed: ${e}`);
+  }
+  result.durations["5-scorecard"] = Date.now() - t5;
+
   result.finishedAt = new Date().toISOString();
   return result;
 }
@@ -873,6 +997,7 @@ function parseArgs(argv: string[]): CliArgs {
     else if (a === "--skip-courses") out.skipCourses = true;
     else if (a === "--skip-transfers") out.skipTransfers = true;
     else if (a === "--skip-prereqs") out.skipPrereqs = true;
+    else if (a === "--skip-scorecard") out.skipScorecard = true;
     else if (a === "--college-filter") out.collegeFilter = argv[++i];
     else if (a === "--ipeds-year") out.ipedsYear = parseInt(argv[++i], 10);
     else if (a === "--json") out.json = true;
@@ -886,8 +1011,8 @@ function printHelp() {
   console.log(`Usage:
   npx tsx scripts/lib/add-state.ts --state <slug> [options]
 
-Top-level orchestrator for the auto-add-state skill. Runs all 5 phases:
-bootstrap → fingerprint → course scraping → articulation → prereqs.
+Top-level orchestrator for the auto-add-state skill. Runs all 6 phases:
+bootstrap → fingerprint → course scraping → articulation → prereqs → scorecard.
 
 Options:
   --state <slug>          Required. Lowercase 2-letter state slug.
@@ -897,6 +1022,7 @@ Options:
   --skip-courses          Skip Phase 2b.
   --skip-transfers        Skip Phase 3.
   --skip-prereqs          Skip Phase 4.
+  --skip-scorecard        Skip Phase 5 (auto-skipped if COLLEGE_SCORECARD_API_KEY unset).
   --college-filter <slug> Only fingerprint+scrape this one college.
   --ipeds-year <YYYY>     Override IPEDS data year (default: latest).
   --json                  Print structured JSON result instead of report.

--- a/scripts/scorecard-map.ts
+++ b/scripts/scorecard-map.ts
@@ -186,17 +186,30 @@ async function mapOne(
   };
 }
 
-async function runMapping(): Promise<MappingRow[]> {
+async function runMapping(stateFilter: string[] = []): Promise<MappingRow[]> {
+  // Load existing mapping. When running with a state filter, rows for
+  // other states must be preserved on disk; this map carries them forward.
+  const existingRows = loadMapping();
   const existing = new Map<string, MappingRow>(
-    loadMapping().map((r) => [`${r.state}:${r.id}`, r])
+    existingRows.map((r) => [`${r.state}:${r.id}`, r])
   );
-  const rows: MappingRow[] = [];
 
-  const stateDirs = fs
+  const allStateDirs = fs
     .readdirSync("data", { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name)
     .filter((s) => fs.existsSync(`data/${s}/institutions.json`));
+  const stateDirs =
+    stateFilter.length > 0
+      ? allStateDirs.filter((s) => stateFilter.includes(s))
+      : allStateDirs;
+
+  // Track which (state, id) we touch this run and the fresh row for each.
+  // We preserve original row order — when we re-run for a subset of states,
+  // rows for that subset are updated in place, others stay untouched.
+  // Brand-new rows (a college not present in the existing mapping yet)
+  // get appended at the end.
+  const freshByKey = new Map<string, MappingRow>();
 
   for (const state of stateDirs) {
     const insts = JSON.parse(
@@ -204,17 +217,41 @@ async function runMapping(): Promise<MappingRow[]> {
     ) as Institution[];
     process.stdout.write(`${state} (${insts.length}): `);
     for (const inst of insts) {
+      const key = `${state}:${inst.id}`;
       const row = await mapOne(state, inst, existing);
-      rows.push(row);
+      freshByKey.set(key, row);
       process.stdout.write(
         row.unitid != null ? "·" : row.tier === "review" ? "?" : "x"
       );
-      // Save after each row so a crash mid-run preserves progress.
-      saveMapping(rows);
+      // Save after each step so a crash mid-run preserves progress.
+      saveMapping(mergeOrdered(existingRows, freshByKey));
     }
     process.stdout.write("\n");
   }
-  return rows;
+
+  return mergeOrdered(existingRows, freshByKey);
+}
+
+/**
+ * Preserve original-file row order. Any (state, id) present in existingRows
+ * is updated in place if it appears in freshByKey; rows not in
+ * existingRows yet (brand-new colleges) are appended at the end.
+ */
+function mergeOrdered(
+  existingRows: MappingRow[],
+  freshByKey: Map<string, MappingRow>
+): MappingRow[] {
+  const seen = new Set<string>();
+  const out: MappingRow[] = [];
+  for (const r of existingRows) {
+    const key = `${r.state}:${r.id}`;
+    seen.add(key);
+    out.push(freshByKey.get(key) ?? r);
+  }
+  for (const [key, r] of freshByKey) {
+    if (!seen.has(key)) out.push(r);
+  }
+  return out;
 }
 
 function summarize(rows: MappingRow[]): void {
@@ -279,20 +316,38 @@ function applyMappings(rows: MappingRow[]): void {
   console.log(`\nApplied ${totalWritten} unitids across ${byState.size} states.`);
 }
 
+function parseStateFilter(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--state") {
+      const v = argv[i + 1];
+      if (v && !v.startsWith("--")) out.push(v.toLowerCase());
+    } else if (argv[i].startsWith("--state=")) {
+      out.push(argv[i].slice("--state=".length).toLowerCase());
+    }
+  }
+  return out;
+}
+
 async function main(): Promise<void> {
   const apply = process.argv.includes("--apply");
+  const stateFilter = parseStateFilter(process.argv.slice(2));
 
+  const scopeLabel =
+    stateFilter.length > 0 ? ` (state${stateFilter.length > 1 ? "s" : ""}: ${stateFilter.join(", ")})` : "";
   console.log(
     apply
-      ? "Running scorecard-map with --apply (will write unitid to institutions.json)\n"
-      : "Running scorecard-map dry-run (mapping JSON only)\n"
+      ? `Running scorecard-map with --apply${scopeLabel} (will write unitid to institutions.json)\n`
+      : `Running scorecard-map dry-run${scopeLabel} (mapping JSON only)\n`
   );
 
   // Skip the API run if a fresh mapping already exists AND we're in apply
-  // mode. This makes --apply act on whatever's in the mapping file (so the
-  // human can edit it and re-apply without re-hitting the API).
+  // mode AND no state filter was passed. This makes a bare `--apply` act on
+  // whatever's in the mapping file (so a human can edit it and re-apply
+  // without re-hitting the API). When a --state filter is passed, we DO
+  // re-run the API for that state so new colleges get fresh candidates.
   let rows: MappingRow[];
-  if (apply && fs.existsSync(MAPPING_FILE)) {
+  if (apply && stateFilter.length === 0 && fs.existsSync(MAPPING_FILE)) {
     const existing = loadMapping();
     if (existing.length > 0) {
       console.log(`Loading existing mapping (${existing.length} rows) from ${MAPPING_FILE}.\n`);
@@ -301,7 +356,7 @@ async function main(): Promise<void> {
       rows = await runMapping();
     }
   } else {
-    rows = await runMapping();
+    rows = await runMapping(stateFilter);
   }
 
   summarize(rows);
@@ -309,7 +364,7 @@ async function main(): Promise<void> {
 
   if (apply) {
     console.log("");
-    applyMappings(rows);
+    applyMappings(rows.filter((r) => stateFilter.length === 0 || stateFilter.includes(r.state)));
   } else {
     console.log(
       `\nDry run complete. Inspect ${MAPPING_FILE}, edit ${REVIEW_FILE} for any 'review' rows, then re-run with --apply.`


### PR DESCRIPTION
Closes the workflow loop on #392. Two changes — both pure infrastructure / no user-facing rendering.

## 1. Phase 5 in the auto-add-state pipeline
When `scripts/lib/add-state.ts` runs for a new state, after prereqs aggregation it now:
1. Calls `scorecard-map --apply --state {slug}` to populate IPEDS unitids for the new state's institutions
2. Calls `ingest-scorecard {slug}` to fetch and write per-college Scorecard JSON

Auto-skips with a clear manual TODO if `COLLEGE_SCORECARD_API_KEY` isn't set. New flag `--skip-scorecard` available for manual control.

## 2. CI freshness guard
- `scripts/check-scorecard-freshness.ts` flags any record older than **18 months** (one missed annual refresh of slack — Scorecard publishes new data each October).
- Wired into a new workflow `.github/workflows/scorecard-freshness.yml`:
  - PRs touching `data/*/scorecard/**`
  - Push to main
  - Monthly cron (1st of month, 09:00 UTC) so the window doesn't expire silently between PRs
- Available as `npm run check:scorecard`.

## Companion change in `scorecard-map.ts`
- **New `--state <slug>` CLI filter** so Phase 5 can map a single state's colleges without re-fetching the rest.
- **Order-preserving merge** in `data/scorecard-mapping.json`: when a subset run completes, rows for unaffected states stay in their original positions, keeping PR diffs clean.

## Skill doc updated
`.claude/skills/auto-add-state/SKILL.md` documents the new phase and the additional commit step for scorecard data.

## Local verification
```
$ tsx scripts/lib/add-state.ts --state va \
    --skip-bootstrap --skip-fingerprint --skip-courses --skip-transfers --skip-prereqs
... Phase 5 ran in 14s: 23 unitids mapped, 23 records ingested.

$ mv .env.local .env.local.bak && (run same command)
... Phase 5 — Scorecard: not run (no API key)
    Manual TODOs (1):
      - [scorecard] COLLEGE_SCORECARD_API_KEY is not set; ...

$ (with --skip-scorecard flag added)
... Phase 5 — Scorecard: not run    (silent skip, no TODO)

$ npm run check:scorecard
Checked 380 Scorecard records across 24 states.
All records are fresh (≤ 18 months old).
```

## What this completes for #392
All four PRs of the issue are now in flight / merged:
- ✅ PR 1 (#394): API client + smoke-test CLI — **merged**
- ✅ PR 2 (#396): IPEDS unitid mapping + ingest + library helpers — **merged**
- 🟡 PR 3 (#397): Cost & outcomes UI on `/[state]/college/[id]` — open
- 🟢 PR 4 (this one): auto-add-state hook + freshness CI guard

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run check:scorecard` returns clean against current data
- [x] Phase 5 happy path: ran end-to-end against VA in 14s
- [x] Phase 5 no-key path: produces manual TODO instead of failing
- [x] Phase 5 explicit skip: `--skip-scorecard` works
- [x] `--state` filter on scorecard-map: VA-only run produces zero diff against main
- [ ] (reviewer) On Vercel preview / merge: the monthly cron will fire and verify freshness in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)