### PR TITLE
fix(scorecard): clarify Avg net price vs In-state tuition with tooltips

### DIFF
--- a/app/[state]/college/[id]/CollegeScorecardSection.tsx
+++ b/app/[state]/college/[id]/CollegeScorecardSection.tsx
@@ -25,15 +25,32 @@ function StatCard({
   label,
   value,
   sub,
+  tooltip,
 }: {
   label: string;
   value: string;
   sub?: string;
+  /**
+   * Optional explanatory text. Rendered as a small "ⓘ" next to the label
+   * with a native `title` attribute — works without client JS (the section
+   * is a server component) and surfaces on hover on desktop. Mobile users
+   * who tap-and-hold also get the tooltip via the OS-level long-press menu.
+   */
+  tooltip?: string;
 }) {
   return (
     <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
-      <div className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-slate-400">
-        {label}
+      <div className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-slate-400">
+        <span>{label}</span>
+        {tooltip && (
+          <span
+            title={tooltip}
+            aria-label={tooltip}
+            className="cursor-help text-gray-400 dark:text-slate-500"
+          >
+            ⓘ
+          </span>
+        )}
       </div>
       <div className="mt-1 text-2xl font-bold text-gray-900 dark:text-slate-100">
         {value}
@@ -118,11 +135,13 @@ export default function CollegeScorecardSection({
           label="In-state tuition"
           value={formatDollar(record.cost.tuitionInState)}
           sub="per year (sticker)"
+          tooltip="Published tuition and required fees for in-state students. Does not include books, transportation, or living expenses."
         />
         <StatCard
           label="Avg net price"
           value={formatDollar(record.cost.avgNetPricePublic)}
           sub="after aid"
+          tooltip="Federal IPEDS definition: total cost of attendance (tuition, fees, books, room & board, transportation, personal expenses) minus the average grant and scholarship aid. Often higher than sticker tuition because it adds living expenses."
         />
         <StatCard
           label="Receive Pell"


### PR DESCRIPTION
## Summary

On every college page with scorecard data, the **In-state tuition** ($X,XXX sticker) tile and **Avg net price** ($XX,XXX after aid) tile sit side by side. Net price is frequently **higher than** sticker tuition — which looks contradictory at a glance, but it isn't a bug in the data. Federal IPEDS' "average net price" is the *total cost of attendance* (tuition + fees + books + room & board + transportation + personal expenses) minus average aid, while sticker tuition is just tuition + fees. The label "after aid" alone doesn't surface this.

This adds a small ⓘ next to each cost label with a native HTML tooltip explaining what each number includes.

## Impact

Every college page on every state, since `CollegeScorecardSection` is shared. Concrete example: [Terra State Community College](https://communitycollegepath.com/oh/college/terra-state-community-college) showed \$5,748 sticker tuition vs \$17,345 avg net price, with no contextual explanation.

## Implementation choices

- **Native `title` + `aria-label`** instead of a JS tooltip library. The scorecard section is a server component; adding client JS for this would be overkill.
- **Tooltips are opt-in** via a new optional `tooltip` prop on `StatCard`. Only the two cost tiles get them in this PR; Pell rate and completion rate can add their own later if useful.
- **Both `title` and `aria-label`** — `title` for sighted users hovering with a mouse, `aria-label` for screen-reader users.
- **Mobile**: `title` doesn't show on tap, but tap-and-hold surfaces it via the OS-level long-press menu. Not ideal, but better than nothing without adding client JS.

## Test plan

- [x] `/oh/college/terra-state-community-college` locally — tooltips present with correct copy
- [ ] After merge + Vercel deploy: hover over ⓘ on `/oh/college/terra-state-community-college` (or any college page) and confirm tooltip appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)