### PR TITLE
SEO technical foundations: OG cards, CWV, freshness dates, anchor IDs

### DIFF
--- a/app/[state]/college/[id]/CollegeDetailClient.tsx
+++ b/app/[state]/college/[id]/CollegeDetailClient.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import dynamic from "next/dynamic";
 import CourseTable from "@/components/CourseTableDynamic";
-import AuditInstructions from "@/components/AuditInstructions";
 import PrintInstructions from "@/components/PrintInstructions";
 import ScheduleBuilder from "@/components/ScheduleBuilder";
+
+const AuditInstructions = dynamic(
+  () => import("@/components/AuditInstructions"),
+  { ssr: false }
+);
 import type { Institution, CourseSection } from "@/lib/types";
 
 type TransferLookup = Record<

--- a/app/[state]/college/[id]/courses/[prefix]/page.tsx
+++ b/app/[state]/college/[id]/courses/[prefix]/page.tsx
@@ -104,6 +104,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const title = `${subject} Courses at ${institution.name} — ${termLabel(resolvedTerm)} Schedule`;
   const description = `Browse ${filtered.length} ${subject} sections (${uniqueCourses} courses) at ${institution.name} for ${termLabel(resolvedTerm)}.${onlineCount > 0 ? ` ${onlineCount} available online.` : ""} View schedules, instructors, and prerequisites.`;
 
+  const canonical = `/${state}/college/${id}/courses/${rawPrefix}`;
   return {
     title,
     description,
@@ -114,8 +115,18 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
       `${subject.toLowerCase()} community college ${config.name}`,
       ...config.branding.metaKeywords,
     ],
-    alternates: {
-      canonical: `/${state}/college/${id}/courses/${rawPrefix}`,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      siteName: config.branding.siteName,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
   };
 }

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -23,6 +23,10 @@ import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
 import RelatedBlogPosts from "@/components/RelatedBlogPosts";
 import { getBlogRecommendations } from "@/lib/blog-recommendations";
+import {
+  getCollegeLastUpdated,
+  formatLastUpdated,
+} from "@/lib/data-freshness";
 
 // Revalidate every 24 hours — course data only changes when re-scraped
 export const revalidate = 86400;
@@ -167,6 +171,8 @@ export default async function CollegeDetailPage(props: PageProps) {
 
   const systemCollegeCoursesUrl = config.collegeCoursesUrl(collegeSlug);
 
+  const lastUpdated = getCollegeLastUpdated(state, institution.college_slug);
+
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
   const stateAbbr = state.toUpperCase();
   const jsonLd = {
@@ -195,6 +201,7 @@ export default async function CollegeDetailPage(props: PageProps) {
         longitude: institution.campuses[0].lng,
       },
     }),
+    ...(lastUpdated && { dateModified: lastUpdated.toISOString() }),
   };
   const breadcrumbLd = {
     "@context": "https://schema.org",
@@ -236,6 +243,11 @@ export default async function CollegeDetailPage(props: PageProps) {
         <p className="text-gray-600 dark:text-slate-400 mt-1">
           {institution.campuses.map((c) => c.name).join(" · ")}
         </p>
+        {lastUpdated && (
+          <p className="text-xs text-gray-400 dark:text-slate-500 mt-1">
+            {formatLastUpdated(lastUpdated)}
+          </p>
+        )}
 
         {/* Status badge */}
         <div className="mt-3">

--- a/app/[state]/college/[id]/page.tsx
+++ b/app/[state]/college/[id]/page.tsx
@@ -316,7 +316,7 @@ export default async function CollegeDetailPage(props: PageProps) {
       />
 
       {/* Audit Policy — collapsed by default, below courses */}
-      <section className="mt-8">
+      <section id="audit-policy" className="mt-8">
         <details className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg">
           <summary className="px-6 py-4 cursor-pointer select-none flex items-center justify-between text-lg font-semibold text-gray-900 dark:text-slate-100 hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors rounded-lg">
             <span>Audit Policy</span>
@@ -458,7 +458,7 @@ export default async function CollegeDetailPage(props: PageProps) {
           require running the client-side course catalog component. */}
       {offeringProfile && offeringProfile.total > 0 && (
         <section className="mt-8 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+          <h2 id="offering-profile" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
             Course Offering Profile
           </h2>
           <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
@@ -588,7 +588,7 @@ export default async function CollegeDetailPage(props: PageProps) {
         if (others.length === 0) return null;
         return (
           <section className="mt-8">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            <h2 id="other-colleges" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
               Other {config.systemName} Colleges
             </h2>
             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/app/[state]/college/[id]/programs/page.tsx
+++ b/app/[state]/college/[id]/programs/page.tsx
@@ -35,10 +35,23 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const title = `Degree Programs at ${institution.name} | Community College Path`;
   const description = `Browse degree and certificate programs at ${institution.name}. See requirements, courses, and credits needed for graduation.`;
 
+  const canonical = `/${state}/college/${id}/programs`;
   return {
     title,
     description,
-    alternates: { canonical: `/${state}/college/${id}/programs` },
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      type: "website",
+      siteName: config.branding.siteName,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
   };
 }
 

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -14,6 +14,10 @@ import AdUnit from "@/components/AdUnit";
 import TrackView from "@/components/TrackView";
 import RelatedBlogPosts from "@/components/RelatedBlogPosts";
 import { getBlogRecommendations } from "@/lib/blog-recommendations";
+import {
+  getCourseLastUpdated,
+  formatLastUpdated,
+} from "@/lib/data-freshness";
 
 export const revalidate = 604800; // 7 days — pSEO content rarely changes
 
@@ -335,6 +339,8 @@ export default async function CoursePage(props: PageProps) {
   const totalSeats = sections.reduce((sum, s) => sum + (s.seats_open ?? 0), 0);
   const sectionsWithSeats = sections.filter((s) => s.seats_open !== null && s.seats_open > 0).length;
 
+  const lastUpdated = getCourseLastUpdated(state);
+
   // JSON-LD
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
   const jsonLd = {
@@ -354,6 +360,7 @@ export default async function CoursePage(props: PageProps) {
     educationalLevel: "Community College",
     isAccessibleForFree: false,
     inLanguage: "en",
+    ...(lastUpdated && { dateModified: lastUpdated.toISOString() }),
     hasCourseInstance: colleges.slice(0, 10).map((c) => ({
       "@type": "CourseInstance",
       name: `${prefix} ${number} at ${c.name}`,
@@ -456,6 +463,11 @@ export default async function CoursePage(props: PageProps) {
             {sectionsWithSeats > 0 && (
               <span className="text-emerald-600 dark:text-emerald-400">
                 {totalSeats} {totalSeats === 1 ? "seat" : "seats"} open
+              </span>
+            )}
+            {lastUpdated && (
+              <span className="text-gray-400 dark:text-slate-500">
+                {formatLastUpdated(lastUpdated)}
               </span>
             )}
           </div>

--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -522,7 +522,7 @@ export default async function CoursePage(props: PageProps) {
         {/* Transfer equivalencies */}
         {transferInfo.length > 0 && (
           <section className="mb-8">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            <h2 id="transfer" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
               Transfer Equivalencies
             </h2>
             <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden">
@@ -591,7 +591,7 @@ export default async function CoursePage(props: PageProps) {
             offered without having to scroll through every section. */}
         {availabilityProfile && availabilityProfile.totalSections > 0 && (
           <section className="mb-8 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+            <h2 id="availability" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
               Availability Profile
             </h2>
             <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
@@ -731,7 +731,7 @@ export default async function CoursePage(props: PageProps) {
 
         {/* Availability by college */}
         <section className="mb-8">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+          <h2 id="colleges" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
             Available at {colleges.length} {colleges.length === 1 ? "college" : "colleges"}
           </h2>
           <div className="space-y-3">

--- a/app/[state]/courses/CourseSearchClient.tsx
+++ b/app/[state]/courses/CourseSearchClient.tsx
@@ -7,9 +7,14 @@ import type { CourseMode } from "@/lib/types";
 import type { Answer } from "@/lib/search-intent/answer";
 import { expandDays } from "@/lib/time-utils";
 import { termCodeFromLabel } from "@/lib/term-label";
+import dynamic from "next/dynamic";
 import DayToggle from "@/components/DayToggle";
 import PrereqChain from "@/components/PrereqChain";
-import AnswerCard, { type ClassificationSummary } from "@/components/AnswerCard";
+import type { ClassificationSummary } from "@/components/AnswerCard";
+
+const AnswerCard = dynamic(() => import("@/components/AnswerCard"), {
+  ssr: false,
+});
 import { useAuth } from "@/lib/hooks/useAuth";
 import { createClient } from "@/lib/supabase/client";
 import { track } from "@/lib/analytics";

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -210,7 +210,7 @@ export default async function ProgramPage(props: PageProps) {
         </header>
 
         <section className="mb-10">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+          <h2 id="colleges" className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
             Colleges offering {program.name}
           </h2>
           <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-900">
@@ -261,7 +261,7 @@ export default async function ProgramPage(props: PageProps) {
             Computed inline from data.flatSections — no extra I/O. */}
         {programProfile && programProfile.totalSections > 0 && (
           <section className="mb-10 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+            <h2 id="availability" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
               {program.name} Availability Snapshot
             </h2>
             <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
@@ -405,7 +405,7 @@ export default async function ProgramPage(props: PageProps) {
 
         {data.sampleCourses.length > 0 && (
           <section className="mb-10">
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+            <h2 id="common-courses" className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
               Common {program.name} courses
             </h2>
             <ul className="grid sm:grid-cols-2 gap-2">
@@ -433,7 +433,7 @@ export default async function ProgramPage(props: PageProps) {
         )}
 
         <section className="mb-10">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
+          <h2 id="other-programs" className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-4">
             Other programs in {config.name}
           </h2>
           <div className="flex flex-wrap gap-2">

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -26,6 +26,10 @@ import { loadProgramAcrossColleges, checkCourseAvailability } from "@/lib/progra
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import ProgramRequirements from "@/components/ProgramRequirements";
+import {
+  getProgramLastUpdated,
+  formatLastUpdated,
+} from "@/lib/data-freshness";
 
 export const revalidate = 604800; // 7 days
 
@@ -128,6 +132,7 @@ export default async function ProgramPage(props: PageProps) {
   }
 
   const url = siteUrl();
+  const lastUpdated = getProgramLastUpdated(state);
 
   const itemListLd = {
     "@context": "https://schema.org",
@@ -140,6 +145,7 @@ export default async function ProgramPage(props: PageProps) {
     // Connect to the site-wide WebSite/Organization graph from the root
     // layout so Google sees this program list as part of the site.
     isPartOf: { "@id": `${url}/#website` },
+    ...(lastUpdated && { dateModified: lastUpdated.toISOString() }),
     itemListElement: data.colleges.slice(0, 25).map((c, i) => ({
       "@type": "ListItem",
       position: i + 1,
@@ -197,6 +203,9 @@ export default async function ProgramPage(props: PageProps) {
             {data.totalColleges === 1 ? "college" : "colleges"} &middot;{" "}
             {data.totalSections} sections &middot; {data.totalUniqueCourses}{" "}
             unique courses &middot; {termLabel(term)}
+            {lastUpdated && (
+              <> &middot; {formatLastUpdated(lastUpdated)}</>
+            )}
           </p>
         </header>
 

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -27,6 +27,10 @@ import TrackView from "@/components/TrackView";
 import RelatedBlogPosts from "@/components/RelatedBlogPosts";
 import { getBlogRecommendations } from "@/lib/blog-recommendations";
 import type { CourseSection } from "@/lib/types";
+import {
+  getSubjectLastUpdated,
+  formatLastUpdated,
+} from "@/lib/data-freshness";
 
 export const revalidate = 604800; // 7 days — pSEO content rarely changes
 
@@ -202,6 +206,8 @@ export default async function StateSubjectPage(props: PageProps) {
     (s) => s !== prefix
   );
 
+  const lastUpdated = getSubjectLastUpdated(state);
+
   // Structured data — ItemList of courses
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
@@ -216,6 +222,7 @@ export default async function StateSubjectPage(props: PageProps) {
     // Connect to the site-wide WebSite/Organization graph from the root
     // layout so Google sees this subject list as part of the site.
     isPartOf: { "@id": `${siteUrl}/#website` },
+    ...(lastUpdated && { dateModified: lastUpdated.toISOString() }),
     itemListElement: courses.slice(0, 25).map((c, i) => ({
       "@type": "ListItem",
       position: i + 1,
@@ -321,6 +328,9 @@ export default async function StateSubjectPage(props: PageProps) {
             {sections.length} sections &middot; {courses.length} courses
             &middot; {collegeCount} {collegeCount === 1 ? "college" : "colleges"}{" "}
             &middot; {term}
+            {lastUpdated && (
+              <> &middot; {formatLastUpdated(lastUpdated)}</>
+            )}
           </p>
         </div>
 

--- a/app/[state]/subject/[prefix]/page.tsx
+++ b/app/[state]/subject/[prefix]/page.tsx
@@ -362,7 +362,7 @@ export default async function StateSubjectPage(props: PageProps) {
             Computed inline from sections — no extra I/O. */}
         {subjectProfile && subjectProfile.totalSections > 0 && (
           <section className="mb-8 rounded-xl border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-6">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
+            <h2 id="availability" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">
               {subject} Availability Snapshot
             </h2>
             <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
@@ -462,7 +462,7 @@ export default async function StateSubjectPage(props: PageProps) {
 
         {/* Course table */}
         <section className="mb-8">
-          <h2 className="sr-only">All {subject} courses</h2>
+          <h2 id="courses" className="sr-only">All {subject} courses</h2>
           <div className="rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden bg-white dark:bg-slate-900">
             <table className="w-full text-left text-sm">
               <thead className="bg-gray-50 dark:bg-slate-800 text-xs uppercase tracking-wider text-gray-500 dark:text-slate-400">
@@ -548,7 +548,7 @@ export default async function StateSubjectPage(props: PageProps) {
         {/* Browse other subjects */}
         {allSubjects.length > 0 && (
           <section className="mt-10">
-            <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+            <h2 id="other-subjects" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
               Browse Other Subjects
             </h2>
             <div className="flex flex-wrap gap-2">

--- a/app/[state]/transfer/to/[universitySlug]/page.tsx
+++ b/app/[state]/transfer/to/[universitySlug]/page.tsx
@@ -315,7 +315,7 @@ export default async function TransferHubPage(props: PageProps) {
       {/* Browse by subject */}
       {subjects.length > 0 && (
         <section className="mb-8">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+          <h2 id="subjects" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
             Browse by Subject
           </h2>
           <div className="flex flex-wrap gap-2">
@@ -337,7 +337,7 @@ export default async function TransferHubPage(props: PageProps) {
 
       {/* Filterable course table (client) */}
       <section className="mb-8">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+        <h2 id="courses" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
           All Transferable Courses
         </h2>
         <TransferHubClient
@@ -366,7 +366,7 @@ export default async function TransferHubPage(props: PageProps) {
       {/* Other universities in this state */}
       {universities.length > 1 && (
         <section className="mt-10">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+          <h2 id="other-universities" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
             Transfer to Other Universities from {config.name} CCs
           </h2>
           <div className="flex flex-wrap gap-2">
@@ -394,7 +394,7 @@ export default async function TransferHubPage(props: PageProps) {
       {/* Browse all community colleges in the state */}
       {institutions.length > 0 && (
         <section className="mt-10">
-          <h2 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
+          <h2 id="colleges" className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-3">
             Community Colleges in {config.name}
           </h2>
           <div className="flex flex-wrap gap-2">

--- a/app/colleges/page.tsx
+++ b/app/colleges/page.tsx
@@ -22,6 +22,22 @@ export const metadata: Metadata = {
   alternates: {
     canonical: "/colleges",
   },
+  openGraph: {
+    title:
+      "All Community Colleges — Browse Every College Across All States | Community College Path",
+    description:
+      "Browse every community college on Community College Path. Find courses, check transfer equivalencies, and compare colleges across states — all in one place.",
+    url: "/colleges",
+    type: "website",
+    siteName: "Community College Path",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title:
+      "All Community Colleges — Browse Every College Across All States | Community College Path",
+    description:
+      "Browse every community college on Community College Path. Find courses, check transfer equivalencies, and compare colleges across states — all in one place.",
+  },
 };
 
 export default async function AllCollegesPage() {

--- a/app/sitemap/colleges.xml/route.ts
+++ b/app/sitemap/colleges.xml/route.ts
@@ -6,11 +6,14 @@ import {
   xmlResponse,
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
+import {
+  getCollegeLastUpdated,
+  getProgramLastUpdated,
+} from "@/lib/data-freshness";
 
 export function GET() {
   const url = siteOrigin();
   const entries: SitemapEntry[] = [];
-  const lastModified = new Date();
 
   for (const state of getAllStates()) {
     const hasPrograms = hasProgramsCoverage(state.slug);
@@ -19,14 +22,16 @@ export function GET() {
         url: `${url}/${state.slug}/college/${inst.id}`,
         changeFrequency: "weekly",
         priority: 0.8,
-        lastModified,
+        lastModified:
+          getCollegeLastUpdated(state.slug, inst.college_slug) ?? undefined,
       });
       if (hasPrograms) {
         entries.push({
           url: `${url}/${state.slug}/college/${inst.id}/programs`,
           changeFrequency: "monthly",
           priority: 0.6,
-          lastModified,
+          lastModified:
+            getProgramLastUpdated(state.slug, inst.college_slug) ?? undefined,
         });
       }
     }

--- a/app/sitemap/courses.xml/route.ts
+++ b/app/sitemap/courses.xml/route.ts
@@ -7,6 +7,7 @@ import {
   xmlResponse,
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
+import { getCourseLastUpdated } from "@/lib/data-freshness";
 
 export const revalidate = 86400;
 
@@ -17,7 +18,7 @@ export async function GET() {
     getAllStates().map(async (state) => {
       const currentTerm = await getCurrentTerm(state.slug);
       const { codes } = await getSitemapCourseIndex(currentTerm, state.slug);
-      const lastModified = new Date();
+      const lastModified = getCourseLastUpdated(state.slug) ?? undefined;
       return codes.map((c) => ({
         url: `${url}/${state.slug}/course/${`${c.prefix}-${c.number}`.toLowerCase()}`,
         changeFrequency: "monthly" as const,

--- a/app/sitemap/programs.xml/route.ts
+++ b/app/sitemap/programs.xml/route.ts
@@ -6,6 +6,7 @@ import {
   xmlResponse,
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
+import { getProgramLastUpdated } from "@/lib/data-freshness";
 
 export const revalidate = 86400;
 
@@ -15,7 +16,7 @@ export async function GET() {
   const results = await Promise.allSettled(
     getAllStates().map(async (state) => {
       const slugs = await getQualifyingProgramSlugs(state.slug);
-      const lastModified = new Date();
+      const lastModified = getProgramLastUpdated(state.slug) ?? undefined;
       return slugs.map((slug) => ({
         url: `${url}/${state.slug}/program/${slug}`,
         changeFrequency: "weekly" as const,

--- a/app/sitemap/state-subjects.xml/route.ts
+++ b/app/sitemap/state-subjects.xml/route.ts
@@ -7,6 +7,7 @@ import {
   xmlResponse,
   type SitemapEntry,
 } from "@/lib/sitemap-xml";
+import { getSubjectLastUpdated } from "@/lib/data-freshness";
 
 export const revalidate = 86400;
 
@@ -20,6 +21,7 @@ export async function GET() {
         currentTerm,
         state.slug
       );
+      const lastModified = getSubjectLastUpdated(state.slug) ?? undefined;
       const entries: SitemapEntry[] = [];
       for (const [prefix, count] of subjectSectionCounts) {
         if (count >= 5) {
@@ -27,7 +29,7 @@ export async function GET() {
             url: `${url}/${state.slug}/subject/${prefix.toLowerCase()}`,
             changeFrequency: "weekly",
             priority: 0.6,
-            lastModified: new Date(),
+            lastModified,
           });
         }
       }

--- a/lib/data-freshness.ts
+++ b/lib/data-freshness.ts
@@ -1,0 +1,146 @@
+/**
+ * Resolve the most-recent modification date for data files backing a page.
+ *
+ * Used by programmatic pages to:
+ *  1. Show a visible "Last updated" line (user trust / freshness signal)
+ *  2. Populate `dateModified` in JSON-LD
+ *  3. Supply accurate `lastModified` to sitemap partitions
+ *
+ * All functions return `Date | null`; callers should gracefully degrade
+ * when null (data files missing or unreadable).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const DATA_ROOT = path.join(process.cwd(), "data");
+
+// -------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------
+
+/** Return the mtime of a single file, or null if it doesn't exist. */
+function fileMtime(filePath: string): Date | null {
+  try {
+    return fs.statSync(filePath).mtime;
+  } catch {
+    return null;
+  }
+}
+
+/** Return the most recent mtime across an array of files. */
+function latestMtime(filePaths: string[]): Date | null {
+  let latest: Date | null = null;
+  for (const fp of filePaths) {
+    const mt = fileMtime(fp);
+    if (mt && (!latest || mt > latest)) latest = mt;
+  }
+  return latest;
+}
+
+// -------------------------------------------------------------------------
+// Per-page helpers
+// -------------------------------------------------------------------------
+
+/**
+ * Per-college page: latest mtime across all term JSON files for this college.
+ */
+export function getCollegeLastUpdated(
+  state: string,
+  collegeSlug: string
+): Date | null {
+  const dir = path.join(DATA_ROOT, state, "courses", collegeSlug);
+  try {
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+    return latestMtime(files.map((f) => path.join(dir, f)));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-course page: latest mtime across all term files that could contain this
+ * course for any college in the state.
+ *
+ * Scanning every college directory would be expensive, so we use the state-
+ * level courses directory mtime as a proxy — still accurate because the
+ * scraper rewrites term files atomically.
+ */
+export function getCourseLastUpdated(state: string): Date | null {
+  const dir = path.join(DATA_ROOT, state, "courses");
+  try {
+    // Walk one level (college dirs) and take the latest mtime of any term file
+    const collegeDirs = fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((d) => d.isDirectory());
+    const allTermFiles: string[] = [];
+    for (const cd of collegeDirs) {
+      const collegePath = path.join(dir, cd.name);
+      const files = fs
+        .readdirSync(collegePath)
+        .filter((f) => f.endsWith(".json"));
+      allTermFiles.push(...files.map((f) => path.join(collegePath, f)));
+    }
+    return latestMtime(allTermFiles);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-program page: mtime of the programs directory for this state.
+ */
+export function getProgramLastUpdated(
+  state: string,
+  collegeSlug?: string
+): Date | null {
+  const dir = path.join(DATA_ROOT, state, "programs");
+  try {
+    if (collegeSlug) {
+      const file = path.join(dir, `${collegeSlug}.json`);
+      return fileMtime(file);
+    }
+    // All programs across state — latest file
+    const files = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+    return latestMtime(files.map((f) => path.join(dir, f)));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-subject page: same as course data (subjects are derived from courses).
+ */
+export const getSubjectLastUpdated = getCourseLastUpdated;
+
+/**
+ * Transfer data: mtime of the transfer-equiv.json for this state.
+ */
+export function getTransferLastUpdated(state: string): Date | null {
+  return fileMtime(path.join(DATA_ROOT, state, "transfer-equiv.json"));
+}
+
+// -------------------------------------------------------------------------
+// Formatting
+// -------------------------------------------------------------------------
+
+/**
+ * Format a Date for user-visible display.
+ * - Within 7 days: "Updated 2 days ago"
+ * - Older: "Last updated: May 10, 2026"
+ */
+export function formatLastUpdated(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Updated today";
+  if (diffDays === 1) return "Updated yesterday";
+  if (diffDays < 7) return `Updated ${diffDays} days ago`;
+
+  return `Last updated: ${date.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+}


### PR DESCRIPTION
## Summary

Batch of SEO technical improvements covering issues #319, #339, #340, #344 — the "foundation" tier from the SEO prioritization audit.

- **#319 — OG/Twitter cards**: Added `openGraph` + `twitter` metadata to `/colleges`, `/[state]/college/[id]/programs`, and `/[state]/college/[id]/courses/[prefix]` — the only 3 routes missing them. All other routes already had full coverage.
- **#339 — Core Web Vitals**: Dynamically import `AnswerCard` (900 lines) and `AuditInstructions` (277 lines) since both render conditionally. Saves ~1,200 lines of JS from initial bundles on course-search and college-detail pages. (Code audit confirmed Leaflet, CourseTable, fonts, and third-party scripts were already well-optimized.)
- **#340 — Last-updated dates**: New `lib/data-freshness.ts` resolves data-file mtimes per page type. Three uses: visible "Updated X days ago" text on college/course/program/subject pages, `dateModified` in JSON-LD, and real `lastModified` in sitemap partitions (replacing `new Date()`).
- **#344 — Anchor IDs**: Added `id` attributes to every H2 on 5 programmatic page types (college, course, program, subject, transfer hub) for deep linking and Google sitelink generation. Blog MDX headings already had this via `mdx-components.tsx`.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Spot-check OG tags: view source on `/colleges`, confirm `og:title` and `twitter:card` present
- [ ] Spot-check freshness: load `/va/college/gcc`, confirm "Updated X days ago" appears below college name
- [ ] Spot-check anchors: load `/va/course/eng-111#transfer`, confirm page scrolls to Transfer Equivalencies section
- [ ] Verify sitemap `<lastmod>` entries are actual dates (not always today's date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)