### PR TITLE
fix(scorecard): show COA breakdown between sticker tuition and net price

### DIFF
--- a/app/[state]/college/[id]/CollegeScorecardSection.tsx
+++ b/app/[state]/college/[id]/CollegeScorecardSection.tsx
@@ -82,6 +82,120 @@ function IncomeRow({
 }
 
 /**
+ * Bridge between sticker tuition and average net price: itemize the
+ * federal cost-of-attendance components, then subtract average aid to
+ * show how the two cost numbers (often surprisingly far apart) actually
+ * reconcile. Renders nothing if there's not enough Scorecard data to
+ * tell a coherent story — at minimum we need the average net price plus
+ * at least one COA line item.
+ */
+function CostBreakdown({ record }: { record: ScorecardRecord }) {
+  const netPrice = record.cost.avgNetPricePublic;
+  const tuition = record.cost.tuitionInState;
+  const roomBoard = record.cost.roomBoardOffCampus;
+  const books = record.cost.bookSupply;
+  const totalCOA = record.cost.attendanceAcademicYear;
+
+  // Need enough to be useful — net price plus at least one line item.
+  if (netPrice == null) return null;
+  const lineItems: Array<{ label: string; amount: number | null; note?: string }> = [
+    { label: "Tuition & fees (in-state)", amount: tuition },
+    { label: "Room & board", amount: roomBoard, note: "off-campus, estimate" },
+    { label: "Books & supplies", amount: books },
+  ];
+  const hasAnyLine = lineItems.some((l) => l.amount != null);
+  if (!hasAnyLine && totalCOA == null) return null;
+
+  // "Other" = total COA - sum of broken-out lines (transportation + personal
+  // expenses + anything else IPEDS rolled into COA). Only shown if we have
+  // the total *and* at least one line item, so subtraction makes sense.
+  const knownSum = lineItems.reduce((s, l) => s + (l.amount ?? 0), 0);
+  const knownAnyNonNull = lineItems.some((l) => l.amount != null);
+  const other =
+    totalCOA != null && knownAnyNonNull && totalCOA > knownSum
+      ? totalCOA - knownSum
+      : null;
+
+  // Net aid is COA - net price. Only render if both knowns.
+  const avgAid = totalCOA != null && netPrice != null ? totalCOA - netPrice : null;
+
+  return (
+    <div className="mt-4 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-slate-100">
+        How cost adds up to net price
+      </h3>
+      <p className="mt-1 text-xs text-gray-500 dark:text-slate-400">
+        Sticker tuition only covers tuition and fees. Federal &ldquo;average
+        net price&rdquo; adds the full cost of attendance and subtracts
+        average aid — which is why it&rsquo;s usually larger.
+      </p>
+      <dl className="mt-3 divide-y divide-gray-100 dark:divide-slate-700 text-sm">
+        {lineItems.map(
+          (l) =>
+            l.amount != null && (
+              <div
+                key={l.label}
+                className="flex items-baseline justify-between py-2"
+              >
+                <dt className="text-gray-700 dark:text-slate-300">
+                  {l.label}
+                  {l.note && (
+                    <span className="ml-1 text-xs text-gray-400 dark:text-slate-500">
+                      ({l.note})
+                    </span>
+                  )}
+                </dt>
+                <dd className="font-medium text-gray-900 dark:text-slate-100 tabular-nums">
+                  {formatDollar(l.amount)}
+                </dd>
+              </div>
+            ),
+        )}
+        {other != null && (
+          <div className="flex items-baseline justify-between py-2">
+            <dt className="text-gray-700 dark:text-slate-300">
+              Other (transportation, personal)
+              <span className="ml-1 text-xs text-gray-400 dark:text-slate-500">
+                (estimate)
+              </span>
+            </dt>
+            <dd className="font-medium text-gray-900 dark:text-slate-100 tabular-nums">
+              {formatDollar(other)}
+            </dd>
+          </div>
+        )}
+        {totalCOA != null && (
+          <div className="flex items-baseline justify-between py-2 font-semibold">
+            <dt className="text-gray-900 dark:text-slate-100">
+              Total cost of attendance
+            </dt>
+            <dd className="text-gray-900 dark:text-slate-100 tabular-nums">
+              {formatDollar(totalCOA)}
+            </dd>
+          </div>
+        )}
+        {avgAid != null && avgAid > 0 && (
+          <div className="flex items-baseline justify-between py-2 text-teal-700 dark:text-teal-300">
+            <dt>Less: average grants &amp; scholarships</dt>
+            <dd className="font-medium tabular-nums">
+              &minus;{formatDollar(avgAid)}
+            </dd>
+          </div>
+        )}
+        <div className="flex items-baseline justify-between py-2 text-base font-bold">
+          <dt className="text-gray-900 dark:text-slate-100">
+            Average net price after aid
+          </dt>
+          <dd className="text-gray-900 dark:text-slate-100 tabular-nums">
+            {formatDollar(netPrice)}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}
+
+/**
  * Returns true if the record has enough non-null fields to be worth
  * rendering. A record with everything null (rare but possible) would render
  * a wall of "—" — we'd rather omit the whole section.
@@ -130,18 +244,12 @@ export default function CollegeScorecardSection({
         {collegeName}.
       </p>
 
-      <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3">
         <StatCard
           label="In-state tuition"
           value={formatDollar(record.cost.tuitionInState)}
           sub="per year (sticker)"
           tooltip="Published tuition and required fees for in-state students. Does not include books, transportation, or living expenses."
-        />
-        <StatCard
-          label="Avg net price"
-          value={formatDollar(record.cost.avgNetPricePublic)}
-          sub="after aid"
-          tooltip="Federal IPEDS definition: total cost of attendance (tuition, fees, books, room & board, transportation, personal expenses) minus the average grant and scholarship aid. Often higher than sticker tuition because it adds living expenses."
         />
         <StatCard
           label="Receive Pell"
@@ -154,6 +262,8 @@ export default function CollegeScorecardSection({
           sub="150% of normal time"
         />
       </div>
+
+      <CostBreakdown record={record} />
 
       {anyIncome && (
         <div className="mt-6 rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">


### PR DESCRIPTION
## Summary

Builds on the tooltip from [#400](https://github.com/rohan-c0de/cc-coursemap/pull/400). Restructures the Cost & outcomes section so the **sticker tuition** and **avg net price** numbers no longer sit next to each other looking contradictory.

**Before:** 4 stat tiles side-by-side. \$5,748 sticker next to \$17,345 net price ⇒ reads like a bug.

**After:**
- Top stat grid drops the "Avg net price" tile (now 3 tiles: in-state tuition / Pell / completion).
- New **"How cost adds up to net price"** panel below the grid itemizes the math:

  | | |
  |---|---:|
  | Tuition & fees (in-state) | $5,748 |
  | Room & board (off-campus, estimate) | $14,280 |
  | Books & supplies | $1,268 |
  | Other (transportation, personal) (estimate) | $2,351 |
  | **Total cost of attendance** | **$23,647** |
  | Less: average grants & scholarships | −$6,302 |
  | **Average net price after aid** | **$17,345** |

- Existing "Net price by family income" panel stays one row below.

## Why this is better than just the tooltip

The tooltip explained the discrepancy on hover. This shows the actual numbers — students can see where their $17k goes, not just be told "we promise it's not a bug." The story moves from *"why do the two numbers contradict"* to *"here's how the math works."*

## Graceful with sparse data

Real-world Scorecard records often have nulls. Defensive behavior:
- Each line item renders only when its value is non-null
- "Other (transportation, personal)" only shows when total COA is known *and* at least one line item exists (so subtraction is meaningful)
- "Less: average grants" only shows when total COA and net price are both known and aid is positive
- Whole panel renders nothing if avg net price is null

## Impact

Every college page on every state — `CollegeScorecardSection` is shared. Pages with thin Scorecard data degrade gracefully.

## Test plan

- [x] Verified locally on `/oh/college/terra-state-community-college`: full breakdown reconciles correctly ($5,748 + $14,280 + $1,268 + $2,351 = $23,647 COA, less $6,302 aid = $17,345 net)
- [x] `tsc --noEmit` clean
- [ ] After merge + Vercel deploy: load Terra State page and confirm new panel renders
- [ ] Spot-check a college with partial Scorecard data (e.g., one missing room & board) to confirm graceful degradation

## Order of merge

Should land after #400 (tooltip), but either order produces a sensible UI — #400's tooltip on the standalone net-price tile, or this PR's full breakdown panel. If both merge they compose cleanly (this PR removes the net-price tile, so the tooltip becomes inert for that tile but stays on in-state tuition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)