### PR TITLE
fix(build): exclude bulky data dirs from serverless function tracing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,42 @@ const nextConfig: NextConfig = {
   // /api/[state]/prereqs/* handlers actually read the files.
   outputFileTracingIncludes: {
     "/api/[state]/prereqs/**": ["./data/*/prereqs.json"],
+    // Routes that read transfer-equiv.json at runtime via lib/transfer.ts
+    // (or its sitemap helper). Re-included after the blanket exclusion
+    // below so the data ships only to functions that need it.
+    "/api/[state]/transfer/**": ["./data/*/transfer-equiv.json"],
+    "/sitemap/transfer.xml/**": ["./data/*/transfer-equiv.json"],
+    "/[state]/transfer/**": ["./data/*/transfer-equiv.json"],
+    "/[state]/course/[code]/**": ["./data/*/transfer-equiv.json"],
+    "/[state]/schedule/**": ["./data/*/transfer-equiv.json"],
+  },
+  // `lib/data-freshness.ts` (#401) calls `fs.readdirSync(path.join(
+  // "data", state, "courses", collegeSlug))` with dynamic state+slug
+  // parameters to look up the latest mtime per course-data directory.
+  // Next.js' tracer can't narrow the dynamic pattern, so it
+  // conservatively bundles ALL matching files into every function that
+  // imports the module — ~180 MB of course JSON across 25+ states.
+  // That blew past Vercel's 250 MB serverless function cap on the
+  // post-#402 main deploy.
+  //
+  // Course JSON is in Supabase at runtime; the on-disk files exist
+  // only for build-time generation and the freshness mtime lookup.
+  // Excluding the dirs from function tracing means freshness lookups
+  // return null in production (no files to stat) and callers degrade
+  // to hiding the "Last updated" line — better than failing the deploy.
+  // Same exclusion for transfer-equiv.json (heavy per-state mappings,
+  // also read by data-freshness via `getTransferLastUpdated` and at
+  // runtime in `lib/transfer.ts`; the transfer routes that genuinely
+  // need it are re-included below).
+  //
+  // The follow-up to drop the null-degradation is to pre-build a
+  // small `data/{state}/.last-updated.json` manifest at scrape time
+  // and read that instead. Out of scope for this hotfix.
+  outputFileTracingExcludes: {
+    "**/*": [
+      "./data/*/courses/**",
+      "./data/*/transfer-equiv.json",
+    ],
   },
   async redirects() {
     // VCCS 2022 renames — these colleges officially changed names in 2022


### PR DESCRIPTION
## Summary

**Unblocks Vercel deploys.** Main has been failing with the 250 MB serverless function size cap after #399 + #401 landed. This narrows Next.js' file tracing so the bulky per-state course and transfer JSON doesn't get auto-bundled into every state route.

## Root cause

`lib/data-freshness.ts` (added in #401) calls:

```ts
fs.readdirSync(path.join("data", state, "courses", collegeSlug))
```

with dynamic `state` and `collegeSlug` parameters. Next.js' static-output tracer can't narrow the pattern, so it conservatively bundles **every file matching `data/*/courses/**`** — about **180 MB** of course JSON across 25+ states — into every serverless function that imports the freshness module.

After #399 added Phase 5 scorecard routes and #401 wired freshness into every state-scoped page (college, course, subject, program), the total bundled per function crossed Vercel's 250 MB cap. The failed-deploy screenshot:

> A Serverless Function has exceeded the unzipped maximum size of 250 MB.

## Fix

`next.config.ts` gets two narrowing rules:

1. **`outputFileTracingExcludes` for `**/*`** — drop `data/*/courses/**` and `data/*/transfer-equiv.json` (MD alone is 49 MB, the top 5 states together are 135 MB) from every function bundle. Course JSON is in Supabase at runtime; on-disk files exist only for build-time generation and the freshness mtime lookup.

2. **`outputFileTracingIncludes`** re-adds `transfer-equiv.json` to the handful of routes that genuinely read it at runtime via `lib/transfer.ts`:
   - `/api/[state]/transfer/**`
   - `/sitemap/transfer.xml/**`
   - `/[state]/transfer/**`
   - `/[state]/course/[code]/**`
   - `/[state]/schedule/**`

Without the re-include, those routes would 500 on prod.

## Graceful degradation

When the freshness module's `fs.statSync` doesn't find a file (because it's not in the deployed function bundle), it returns `null`. Every caller already guards with `?? undefined`:

- `app/[state]/college/[id]/page.tsx`, `course/[code]/page.tsx`, `subject/[prefix]/page.tsx`, `program/[slug]/page.tsx`: render without the "Last updated" line
- `app/sitemap/colleges.xml/route.ts`, `courses.xml`, `state-subjects.xml`, `programs.xml`: omit `lastModified`, Vercel/search engines fall back to crawl-time defaults

The "Last updated" date temporarily disappears from college / course / subject / program pages on prod. Cosmetic only — no broken functionality.

## Follow-up (separate PR)

Pre-build a small `data/{state}/.last-updated.json` manifest at scrape time, and have `data-freshness.ts` read that single small file instead of `fs.readdirSync`. That restores the dates without re-introducing the tracing bloat. Out of scope for this hotfix.

## Test plan

- [x] Pushed branch with empty commit first: Vercel deploy **failed** at 250 MB cap (reproduces the bug)
- [x] Pushed fix: Vercel deploy **succeeds** on https://vercel.com/rohan-c0des-projects/cc-coursemap/94Dqo836LWiZuTC2FNZQjSsmbbLo
- [ ] After merge: main's Vercel deploy completes and prod shows #402's "How cost adds up to net price" panel on Terra State page
- [ ] Manual: check `/[state]/transfer/to/[universitySlug]` still works (the route still has transfer-equiv via the re-include)

🤖 Generated with [Claude Code](https://claude.com/claude-code)