### PR TITLE
feat(blog): 5 articles — transfer receivers (NJ/NC/MD) + course scarcity (FL/AL)

### DIFF
--- a/.blog-pipeline/cooldown.json
+++ b/.blog-pipeline/cooldown.json
@@ -329,6 +329,31 @@
       "slug": "kentucky-community-college-course-availability",
       "draftedAt": "2026-05-10T13:00:00Z",
       "trigger": "course-scarcity"
+    },
+    {
+      "slug": "new-jersey-transfer-receivers-compared",
+      "draftedAt": "2026-05-12T22:00:00Z",
+      "trigger": "transfer-receiver-patterns"
+    },
+    {
+      "slug": "north-carolina-transfer-receivers-compared",
+      "draftedAt": "2026-05-12T22:00:00Z",
+      "trigger": "transfer-receiver-patterns"
+    },
+    {
+      "slug": "maryland-transfer-receivers-compared",
+      "draftedAt": "2026-05-12T22:00:00Z",
+      "trigger": "transfer-receiver-patterns"
+    },
+    {
+      "slug": "florida-community-college-course-availability",
+      "draftedAt": "2026-05-12T22:00:00Z",
+      "trigger": "course-scarcity"
+    },
+    {
+      "slug": "alabama-community-college-course-availability",
+      "draftedAt": "2026-05-12T22:00:00Z",
+      "trigger": "course-scarcity"
     }
   ],
   "virginia-community-college-course-availability": "2026-05-11T03:29:31.895173Z",

--- a/content/blog/alabama-community-college-course-availability.mdx
+++ b/content/blog/alabama-community-college-course-availability.mdx
@@ -1,0 +1,59 @@
+Alabama's community college system is small — at least in our dataset. We currently index 6 colleges and 8,883 total sections across terms. That makes Alabama the smallest state system in this course-availability cluster by college count, well below [Georgia's 20-college TCSG](/blog/georgia-community-college-course-availability) or [Tennessee's 12-college TBR](/blog/tennessee-community-college-course-availability).
+
+But the fundamental pattern documented in the [course availability hub article](/blog/which-community-college-courses-are-hard-to-find) — where catalogs split into a universally available tier and a concentrated tier — holds in Alabama just as clearly as it does in systems five times the size. And in a smaller system, concentration has sharper consequences. When a course exists at only one of six campuses instead of one of twenty, there are fewer alternatives within driving distance.
+
+## Multi-choice courses: the accessible tier
+
+Alabama has 77 multi-choice courses — courses offered at 3 or more of the state's 6 colleges. That's the slice of the catalog where a student has genuine geographic flexibility. If the course you need falls in this tier, you can likely find it at your home campus or at least at a campus within reasonable travel distance.
+
+At 6 colleges, "3 or more" means at least half the system offers the course. That threshold is meaningful: it suggests these courses are part of the shared gen-ed and transfer-prep backbone that Alabama's community colleges coordinate around. The standard composition, algebra, psychology, and biology courses that anchor every community college system's universal tier live here.
+
+For students whose academic path runs entirely through gen-ed and transfer prerequisites, Alabama's 77 multi-choice courses represent the realistic catalog. These are the courses you can plan around without worrying about campus-specific availability.
+
+## George C. Wallace Community College (Dothan): the anchor campus
+
+Every state system in this cluster has at least one anchor campus — the college that holds a disproportionate share of exclusive courses. In Alabama, that campus is George C. Wallace Community College in Dothan, with 17 exclusive courses.
+
+Seventeen exclusive courses in a 6-college system is a significant concentration. For comparison, consider the proportional weight: Wallace-Dothan holds 17 courses that exist nowhere else in a system with only 5 other colleges. In Georgia's 20-college TCSG system, Central Georgia Technical College holds 43 exclusive courses — more in absolute terms, but spread across a system with 19 alternatives. In Alabama, if a course is exclusive to Wallace-Dothan, the next option isn't another campus across town — it may not exist in the state system at all.
+
+Wallace-Dothan sits in the Wiregrass region of southeast Alabama, serving Dothan and the surrounding area near the Florida and Georgia borders. The campus's exclusive courses likely reflect specialized program investments — workforce programs, technical certifications, and industry partnerships specific to the Dothan economy — that the other five campuses in the dataset don't replicate.
+
+For students in the Dothan area, this concentration is straightforward: Wallace-Dothan is where those programs are, and being local means access. For students elsewhere in Alabama, a course exclusive to Wallace-Dothan may require either a long commute, relocation, or reconsidering the program entirely.
+
+## Small system dynamics: why 6 colleges changes the math
+
+Most states in this cluster have enough colleges that scarcity distributes across multiple tiers with some nuance. North Carolina has 55 colleges. Georgia has 20. Tennessee has 12. Kentucky has 16. Alabama has 6.
+
+The practical difference is not just scale — it's the absence of a middle tier. In a 20-college system, a course offered at 4 campuses is "selective" — available at 20% of the system, but still giving a student in the right region a reasonable shot at finding it. In a 6-college system, a course at 2 campuses is already at 33% coverage, and a course at 1 campus is genuinely singular.
+
+This compression means that for Alabama students, the decision about which campus to attend carries more weight earlier in the process. In a large system, you can start at your local campus, take gen-ed courses, and transfer to a specialized campus later when your program demands it. In a 6-college system, the specialized campus may be the only one that has the program you need from day one. The cost of starting at the wrong campus — in terms of wasted semesters, courses that don't apply, and commute logistics — is higher when there are fewer places to go.
+
+## Comparing Alabama to larger southeastern systems
+
+Alabama's position in this cluster is distinctive precisely because of its size. The other systems provide useful reference points:
+
+**Georgia (TCSG):** 20 colleges, 54,262 sections, 2,327 unique course IDs. Central Georgia Tech holds 43 exclusive courses. Georgia's system is large enough that the selective and common tiers create a gradient between universal and scarce. Alabama's 6-college system doesn't have that gradient in the same way.
+
+**Tennessee (TBR):** 12 colleges, 34,599 sections, 2,582 unique course IDs. Three anchor campuses (Pellissippi, Northeast State, Chattanooga State) each hold 42–49 exclusive courses. Tennessee's multi-anchor structure distributes concentration across regions. Alabama concentrates at a single anchor — Wallace-Dothan.
+
+The scale difference matters for one reason: in larger systems, a student who discovers their campus doesn't offer a needed course can often find it at a nearby alternative within the same metro area or region. In Alabama's 6-college subset, the alternatives are fewer and likely farther apart.
+
+## What to check before choosing an Alabama community college
+
+**For gen-ed and transfer courses:** The 77 multi-choice courses are your safe zone. Composition, algebra, introductory sciences, and psychology will be available at most campuses. If your plan is to knock out transfer prerequisites and move to a four-year school, campus choice is flexible.
+
+**For specialized or workforce programs:** Check whether the specific program courses exist at your intended campus. If they don't, check Wallace-Dothan — it holds 17 exclusive courses, the most in the state. A program that doesn't appear at your local campus may exist only in Dothan.
+
+**For students in the Wiregrass region:** Wallace-Dothan's anchor status means you have access to the broadest course selection in the state. If your program aligns with Wallace-Dothan's exclusive offerings, proximity is an advantage.
+
+**For students far from Dothan:** If a course is exclusive to Wallace-Dothan and you're in north or central Alabama, consider whether online sections might be available, or whether a different program pathway at your local campus leads to the same credential. The 77 multi-choice courses define what's realistically accessible at every campus — everything outside that tier requires campus-specific verification.
+
+**Before registering for any term**, search the actual course catalog to confirm that the courses in your planned sequence are offered at your campus for the term you need them. A course that exists in the catalog but isn't scheduled for fall doesn't help a student who needs it in fall.
+
+You can search Alabama's community college sections — all 8,883 across 6 colleges — at [Community College Path's Alabama page](/al).
+
+<ProductCallout
+  text="Community College Path indexes sections across Alabama's community colleges. Search any course to see which campuses offer it this term."
+  feature="courses"
+  label="Search AL Community College Courses"
+/>

--- a/content/blog/florida-community-college-course-availability.mdx
+++ b/content/blog/florida-community-college-course-availability.mdx
@@ -1,0 +1,92 @@
+Florida's State College System uses the Statewide Course Numbering System (SCNS) — a unified catalog where course codes are identical across every public institution. ENC-1101 at Valencia College is ENC-1101 at Broward College is ENC-1101 at Tallahassee Community College. No translation tables, no equivalency lookups. Among state community college systems, SCNS is the cleanest transfer architecture in the country.
+
+But SCNS guarantees transfer. It does not guarantee availability. Across the 10 Florida colleges in our dataset, 3,280 unique course IDs produce 16,570 total sections — and 69.2% of those course IDs are scarce or point-source, meaning they appear at fewer than 25% of the system's colleges. That is one of the highest scarcity ratios we have measured in any state system.
+
+The paradox is specific to Florida: courses transfer perfectly, but you may not be able to find them at your campus. For the framework behind how community college catalogs split into universal vs. concentrated tiers — and what to do when your course falls in the scarce half — see the [course availability hub article](/blog/which-community-college-courses-are-hard-to-find).
+
+## The universal catalog: small but functional
+
+Of Florida's 3,280 unique course IDs, 29 (2.9%) are universal — offered at all or nearly all 10 colleges. The top universal courses:
+
+| Course | Sections |
+|---|---|
+| ENC-1101 English Composition I | 729 |
+| ENC-1102 English Composition II | 347 |
+| MAC-1105 College Algebra | 339 |
+| MGF-1130 Mathematical Thinking | 265 |
+| STA-2023 Intro to Probability &amp; Statistics I | 250 |
+| ECO-2013 Macroeconomics | 149 |
+| ECO-2023 Microeconomics | 104 |
+| MAC-2311 Calculus I | 64 |
+
+Every course on that list appears at all 10 colleges. ENC-1101 alone runs 729 sections across the system — the kind of density where getting locked out of every section is effectively impossible if you are willing to consider a different campus or session.
+
+The 29 universal courses cover what you would expect: composition, algebra, statistics, economics, and calculus. For a student whose entire path runs through gen-ed prerequisites and transfer to a State University System (SUS) institution, the universal catalog is sufficient. The SCNS guarantee means those 29 courses transfer identically regardless of which college delivers them.
+
+The problem starts one layer below.
+
+## The scarcity breakdown
+
+Florida's full coverage distribution across 3,280 course IDs:
+
+| Tier | Courses | Share |
+|---|---|---|
+| Universal (all/nearly all colleges) | 29 | 2.9% |
+| Common (majority of colleges) | 76 | 7.5% |
+| Selective (some colleges) | 207 | 20.5% |
+| Scarce (few colleges) | 538 | 53.2% |
+| Point-source (exactly 1 college) | 162 | 16.0% |
+
+The universal-plus-common tier covers 105 courses — 10.4% of the catalog. The selective tier adds another 207. Combined, roughly 31% of Florida's course catalog has meaningful geographic availability. The other 69.2% concentrates.
+
+For comparison, [Virginia's VCCS system](/blog/virginia-community-college-course-availability) has a 68.6% scarcity ratio across 23 colleges — nearly identical to Florida's 69.2% but across more than twice as many campuses. Georgia's TCSG system sits at 50.8% across 20 colleges. Florida's scarcity ratio is high for a 10-college system. In a larger system, you'd expect concentration — more colleges means more opportunity for niche programs to land at a single campus. Florida concentrates this aggressively with only 10 colleges, which means each campus has a meaningfully different catalog from its peers.
+
+## Valencia College: the dominant anchor campus
+
+162 courses in Florida's system are point-source — offered at exactly one college. Valencia College holds 69 of them. That is 42.6% of all point-source courses in the state, held by a single institution in a 10-college system.
+
+South Florida State College is the second-largest anchor campus with 44 exclusive courses. Together, Valencia and South Florida State account for 113 of 162 point-source courses — 69.7% of all single-campus courses held by two colleges.
+
+Valencia's concentration reflects its scale and program breadth. Serving the greater Orlando area, Valencia is one of the largest community colleges in the country by enrollment. Its 69 exclusive courses span specialized program areas — health sciences, technical programs, and upper-division coursework — that smaller colleges in the system cannot replicate without the same faculty depth, lab infrastructure, and industry partnerships.
+
+South Florida State College's 44 exclusive courses follow a different logic. SFSC serves Highlands, Hardee, and DeSoto counties — a rural service area in south-central Florida. Its exclusive courses likely reflect specialized agricultural, technical, and workforce programs tied to the specific economic base of that region, courses that metro-area colleges have no reason to offer and rural-area students cannot find elsewhere.
+
+The anchor-campus pattern matters for course planning. If your program path requires courses concentrated at Valencia, you need to be within reach of Valencia — physically or through online sections. SCNS ensures that any course you complete there transfers to any SUS institution. But SCNS cannot create sections at campuses that do not offer the course.
+
+## The SCNS paradox
+
+Florida's SCNS is genuinely exceptional as a transfer framework. In most states, a student who takes a course at one community college and wants to transfer credit to a university — or even to another community college — faces an equivalency lookup. Does MATH-151 at College A map to MTH-263 at College B? In Virginia, the answer requires checking VCCS transfer guides. In North Carolina, it means navigating the Common Course Library. In states without common numbering, it can mean filing a course-by-course petition.
+
+Florida skipped all of that. SCNS assigns one code per course, statewide. If ENC-1101 appears in the SUS catalog and you completed ENC-1101 at any Florida public institution, it transfers. Period.
+
+But SCNS creates a specific cognitive trap for students planning their schedules: because the course codes are identical everywhere, it is easy to assume the courses are available everywhere. They are not. 69.2% of Florida's catalog concentrates at a minority of campuses. A student browsing the SCNS database might see that a course exists in the Florida system and assume it will appear in the schedule at their local college. When it does not, the surprise is sharper because the system looked so unified.
+
+The practical lesson: check availability at your specific campus before building a plan around a course code you found in the SCNS database. The code is real. The section may not be.
+
+## 105 multi-choice courses: where flexibility exists
+
+105 courses in Florida's system are offered at 3 or more colleges. These are the courses where students have genuine geographic choice — where being locked out of a section at one campus does not mean being locked out of the course entirely.
+
+The multi-choice tier overlaps heavily with the universal and common tiers. Gen-ed courses, introductory sciences, survey-level humanities, and first-year math all appear across multiple campuses. For students building a transfer-oriented Associate of Arts (AA) degree, most of the required coursework falls within this tier. The AA pathway in Florida is explicitly designed to transfer to SUS institutions, and the gen-ed requirements align with courses that are broadly available.
+
+The gap emerges for students pursuing an Associate of Science (AS) degree or workforce-oriented programs. AS programs include specialized technical courses — healthcare sequences, IT certifications, trades coursework — that concentrate at campuses with the relevant program infrastructure. A student pursuing an AS in a health science field may find that 60% of their coursework is available everywhere, and the remaining 40% is only at a handful of campuses.
+
+## What to check before choosing a Florida college
+
+**For AA transfer students:** Your gen-ed requirements will be available at any of the 10 colleges. The 29 universal courses cover the core, and the 76 common courses extend the floor. Choose based on location, schedule convenience, and support services — the course availability constraint is not binding for most AA paths.
+
+**For AS and workforce students:** Identify which colleges offer the full program sequence for your target credential before committing. A campus may offer the gen-ed prerequisites but not the specialized courses that complete the degree. Check whether the upper-level courses in your program are universal, selective, or point-source — if they are point-source at Valencia or South Florida State, plan accordingly.
+
+**For students who need a specific course that is not at their campus:** Florida's cross-enrollment options and online course delivery can fill some gaps. SCNS means that any section you take at any Florida public institution transfers cleanly — there is no equivalency risk. The constraint is availability, not portability.
+
+**For students comparing Florida to other states:** Florida's 69.2% scarcity ratio is high, but its transfer infrastructure is the strongest of any system in this cluster. In [Georgia's TCSG system](/blog/georgia-community-college-course-availability), a similar scarcity ratio pairs with a common numbering system that applies within TCSG but not always across to the University System of Georgia. In Florida, SCNS covers the entire public higher education system. The tradeoff is real: fewer courses at your campus, but every course you do complete transfers without friction.
+
+[Search Florida college courses on Community College Path](/fl) to see which campuses offer the sections you need this term, before building your schedule around a course code.
+
+If your target course is full everywhere, the [guide to what to do when a community college class is full](/blog/what-to-do-when-community-college-class-is-full) covers waitlist strategies and cross-enrollment options that apply across Florida's system.
+
+<ProductCallout
+  text="Community College Path indexes sections across Florida's state colleges. Search any course to see which campuses offer it and how many sections are open."
+  feature="courses"
+  label="Search FL College Courses"
+/>

--- a/content/blog/index.ts
+++ b/content/blog/index.ts
@@ -189,6 +189,48 @@ export const articles: ArticleMeta[] = [
     cluster: "course-availability-guide",
     clusterRole: "spoke",
   },
+  {
+    slug: "florida-community-college-course-availability",
+    title:
+      "Florida Community College Course Availability: 69.2% Scarcity Despite the Best Transfer System in the Country",
+    description:
+      "Florida's Statewide Course Numbering System guarantees transfer — but 69.2% of course IDs are scarce or point-source across 10 colleges. Valencia College alone holds 69 exclusive courses. Here's what actually transfers vs. what you can actually find.",
+    date: "2026-05-12",
+    category: "registration-timing",
+    state: "fl",
+    author: "Community College Path",
+    tags: [
+      "course-availability",
+      "registration",
+      "florida",
+      "fcs",
+      "anchor-campus",
+      "transfer",
+      "schedule-planning",
+    ],
+    cluster: "course-availability-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "alabama-community-college-course-availability",
+    title:
+      "Alabama Community College Course Availability: 6 Colleges, 8,883 Sections, and Why Wallace-Dothan Is the Campus That Matters Most",
+    description:
+      "Alabama's community college system has only 6 colleges in our dataset, but the universal-vs-concentrated pattern still holds. George C. Wallace Community College (Dothan) holds 17 exclusive courses — the most in the state.",
+    date: "2026-05-12",
+    category: "registration-timing",
+    state: "al",
+    author: "Community College Path",
+    tags: [
+      "course-availability",
+      "registration",
+      "alabama",
+      "anchor-campus",
+      "schedule-planning",
+    ],
+    cluster: "course-availability-guide",
+    clusterRole: "spoke",
+  },
 
   // --- Cluster J: Transfer-receiver patterns (hub + data-driven spokes per issue #367) ---
   {
@@ -231,6 +273,75 @@ export const articles: ArticleMeta[] = [
       "gsu",
       "kennesaw-state",
       "uwg",
+      "receiver-patterns",
+    ],
+    cluster: "transfer-receiver-patterns-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "new-jersey-transfer-receivers-compared",
+    title:
+      "New Jersey Transfer Receivers Compared: Why Rutgers Engineering Accepts 13% While Rowan Accepts 96%",
+    description:
+      "NJ has 40 transfer receivers with direct-match rates from 13% to 96% — and the widest variance is within Rutgers itself. Here's how all 40 receivers compare across 68,357 mappings.",
+    date: "2026-05-12",
+    category: "transfer-confusion",
+    state: "nj",
+    author: "Community College Path",
+    tags: [
+      "transfer",
+      "new-jersey",
+      "rutgers",
+      "njit",
+      "rowan",
+      "nj-transfer",
+      "receiver-patterns",
+    ],
+    cluster: "transfer-receiver-patterns-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "north-carolina-transfer-receivers-compared",
+    title:
+      "North Carolina Transfer Receivers Compared: No Rejections Anywhere, but an 80-Point Spread in Direct-Match Rates",
+    description:
+      "Every NC university accepts every NCCCS course for at least elective credit — no student loses hours entirely. But direct-match rates range from 20% at ECU to 100% at Winston-Salem State and NC A&T across 25,622 mappings.",
+    date: "2026-05-12",
+    category: "transfer-confusion",
+    state: "nc",
+    author: "Community College Path",
+    tags: [
+      "transfer",
+      "north-carolina",
+      "ncccs",
+      "unc",
+      "nc-state",
+      "ecu",
+      "receiver-patterns",
+      "caa",
+    ],
+    cluster: "transfer-receiver-patterns-guide",
+    clusterRole: "spoke",
+  },
+  {
+    slug: "maryland-transfer-receivers-compared",
+    title:
+      "Maryland Transfer Receivers Compared: UMGC Grants 30% Direct Match While Bowie State Hits 99% — Across 123,477 Mappings",
+    description:
+      "Maryland's 8 public university receivers all grant at least elective credit — no outright rejections. But the direct-match spread ranges from 30% (UMGC) to 98.9% (Bowie State) across the largest single-state dataset we track.",
+    date: "2026-05-12",
+    category: "transfer-confusion",
+    state: "md",
+    author: "Community College Path",
+    tags: [
+      "transfer",
+      "maryland",
+      "artsys",
+      "umgc",
+      "umd",
+      "towson",
+      "bowie-state",
+      "umbc",
       "receiver-patterns",
     ],
     cluster: "transfer-receiver-patterns-guide",

--- a/content/blog/maryland-transfer-receivers-compared.mdx
+++ b/content/blog/maryland-transfer-receivers-compared.mdx
@@ -1,0 +1,131 @@
+You're transferring from a Maryland community college to a public university. Someone tells you "Maryland has ARTSYS — all the credits transfer." And technically, they're right: across every receiver in our dataset, **zero percent of community college credits are rejected outright**. Maryland is a pure elective-credit state — nothing gets thrown away.
+
+But "transfers" and "counts toward your degree the way you planned" are not the same thing. The **direct-match rate across Maryland's 8 qualifying receivers ranges from 30.0% to 98.9%** — a 69-point spread that determines whether your community college coursework satisfies specific degree requirements or just piles up as undifferentiated elective hours.
+
+Here's how each receiver actually treats community college credit, based on 123,477 individual course-transfer mappings — the largest single-state dataset we track.
+
+## Quick answer
+
+| University | Total mappings | Direct match | Elective credit | No credit |
+|---|---|---|---|---|
+| Bowie State University | 1,387 | **98.9%** | 1.1% | 0% |
+| Towson University | 7,093 | **73.6%** | 26.4% | 0% |
+| Salisbury University | 9,173 | **68.3%** | 31.7% | 0% |
+| University of Maryland, College Park | 12,352 | **65.8%** | 34.2% | 0% |
+| University of Maryland, Baltimore County | 17,410 | **53.7%** | 46.3% | 0% |
+| Morgan State University | 14,230 | **48.7%** | 51.3% | 0% |
+| Frostburg State University | 22,682 | **47.4%** | 52.6% | 0% |
+| University of Maryland Global Campus | 39,150 | **30.0%** | 70.0% | 0% |
+
+Notice the rightmost column: every row is 0%. Maryland does not reject community college credit. That's different from [Georgia, where UGA and GSU reject 78–81% of TCSG credits](/blog/georgia-transfer-receivers-compared). In Maryland, the question is never "will my credits count?" — it's "will they count toward the right thing?"
+
+If you're unfamiliar with the distinction between direct match and elective credit, our [explainer on what direct match vs elective credit means](/blog/what-direct-match-vs-elective-credit-means) covers the practical difference.
+
+## UMGC: the default destination with the toughest match rate
+
+University of Maryland Global Campus is Maryland's largest online-focused public institution and a common first choice for community college transfers — especially working adults and military-connected students. It also has the single largest mapping count of any receiver in any state we track: 39,150 course pairings.
+
+The numbers:
+
+- 39,150 course mappings tracked
+- **30.0% direct match**
+- **70.0% elective credit**
+- 0% no credit
+
+A student transferring 60 community college credits to UMGC can expect roughly:
+- 18 credits as direct match (satisfies specific UMGC requirements)
+- 42 credits as elective (counts toward graduation hours, but doesn't replace specific courses)
+
+None of those 60 credits get thrown away — but 42 of them land as generic elective filler. That student likely still needs to retake versions of courses they already passed at the community college, because UMGC doesn't recognize them as equivalent to specific degree requirements.
+
+This is the pattern that catches students off guard. UMGC accepts everything, which sounds generous. But "accepted as elective" and "accepted as the course you need" are very different outcomes. A student who chose UMGC expecting a clean 2+2 path may need closer to 2.5–3 years at UMGC to finish, because the elective hours don't reduce the list of required courses.
+
+The dataset is large enough (39k mappings) to treat this as a confident signal, not sampling noise. This is how UMGC evaluates community college coursework at scale.
+
+## Bowie State: the cleanest transfer path in Maryland
+
+At the opposite end of the table:
+
+- 1,387 course mappings tracked
+- **98.9% direct match** (1,372 of 1,387 courses)
+- 1.1% elective credit
+- 0% no credit
+
+Bowie State accepts virtually everything as a direct match. Out of 1,387 tracked course pairings, only 15 land as elective credit. A student transferring 60 community college credits to Bowie State keeps **all 60 credits** — and 59 of them satisfy specific degree requirements.
+
+The dataset is smaller than UMGC's (1,387 vs. 39,150), which reflects Bowie State's enrollment size relative to UMGC. But the pattern is unambiguous: Bowie State has built articulation agreements that recognize community college coursework at nearly 100%.
+
+If your major is available at Bowie State and you want the cleanest credit transfer in Maryland, the data supports it.
+
+## UMD College Park: the flagship tax
+
+UMD is Maryland's flagship — the most selective, the highest-ranked, the one with the biggest brand. Its transfer numbers:
+
+- 12,352 course mappings tracked
+- **65.8% direct match**
+- **34.2% elective credit**
+- 0% no credit
+
+A student transferring 60 community college credits to UMD can expect roughly:
+- 39 credits as direct match
+- 21 credits as elective
+
+That's better than UMGC by a wide margin, and better than Morgan State or Frostburg. But a third of the credits still land as elective — meaning the student keeps the hours but may need to retake equivalent courses in major-specific sequences.
+
+For UMD specifically, this matters most in competitive programs (engineering, computer science, business) where course-by-course alignment drives progression. A student who took the community college version of a calculus sequence might find UMD accepts it as elective math credit rather than as the specific prerequisite equivalent, which means they're repeating calculus.
+
+Practical advice if UMD is your target: check each course against ARTSYS before you register. ARTSYS is Maryland's statewide articulation database — it publishes exactly how each community college course maps to each university. You can verify specific equivalencies through [our Maryland transfer tool](/md/transfer) or directly through ARTSYS.
+
+## The mid-tier: Towson, Salisbury, UMBC
+
+Three receivers cluster between 53% and 74% direct match:
+
+**Towson University** — 7,093 mappings, 73.6% direct match, 26.4% elective. Towson is Maryland's second-largest public university and a major transfer destination for Baltimore-area community college students. Three-quarters of credits transfer as direct match — strong but not Bowie State levels.
+
+**Salisbury University** — 9,173 mappings, 68.3% direct match, 31.7% elective. Salisbury's direct-match rate is close to UMD's (68% vs. 66%), but its profile as a smaller regional institution means students sometimes overlook it as a transfer destination. The data says it deserves consideration.
+
+**UMBC** — 17,410 mappings, 53.7% direct match, 46.3% elective. UMBC is selective (especially in STEM), and the 54% direct-match rate reflects tighter course-by-course evaluation — particularly in sciences and engineering, where lab sequences and specific content requirements drive evaluation decisions.
+
+## The lower tier: Morgan State and Frostburg
+
+**Morgan State University** — 14,230 mappings, 48.7% direct match, 51.3% elective. Morgan State is Maryland's public HBCU and a significant transfer destination. Just under half of community college credits land as direct match; the rest become elective hours.
+
+**Frostburg State University** — 22,682 mappings, 47.4% direct match, 52.6% elective. Frostburg has the second-largest mapping count (22k+), which means this is a high-confidence signal. Slightly more than half of all credits land as elective rather than direct match.
+
+Both Morgan State and Frostburg accept everything — no rejections. But the roughly 50/50 split between direct and elective means a transfer student should plan for some retaking, especially in major-specific sequences.
+
+## How to choose your Maryland transfer destination
+
+Maryland's zero-rejection pattern means the decision is less dramatic than in states like Georgia, where the wrong choice means losing 80% of your credits entirely. Here, every receiver keeps your hours. The question is what those hours do.
+
+If you have flexibility:
+
+1. **Bowie State if your major is available.** 98.9% direct match is the cleanest transfer path in our 16-state dataset — not just in Maryland, across all states.
+2. **Towson or Salisbury second.** Both sit in the upper 60s-to-70s range for direct match, and both serve a wide range of majors.
+3. **UMD with eyes open.** The flagship is at 66% direct match — good but not great. Budget for some retaking in your major sequence. Verify each course against ARTSYS before enrolling.
+4. **UMGC only if you understand the elective pattern.** UMGC is convenient (fully online, rolling enrollment), but 70% of your credits land as elective. If you're optimizing for time-to-degree, check whether a different receiver matches more of your coursework directly.
+
+If you're already committed to a specific receiver:
+
+1. **Look up each course on ARTSYS before you take it.** Maryland's statewide articulation system publishes exactly how each community college course maps to each receiver. Use [our Maryland transfer tool](/md/transfer) to search course-by-course.
+2. **Prioritize courses with published direct-match equivalencies.** Take the version of the course that your target receiver has explicitly approved as equivalent to their own, not a different section title that might land as elective.
+3. **Talk to your target university's transfer office early.** Maryland law requires public universities to accept community college credits per ARTSYS, but individual program requirements can still create gaps between "credit accepted" and "credit applied to your major."
+
+## Maryland in the national picture
+
+Maryland's 0% no-credit rate puts it in the same category as North Carolina — states where the policy infrastructure prevents outright rejection. ARTSYS and Maryland's transfer legislation ensure every community college course gets at least elective credit at every public university.
+
+That's a meaningful floor. In Georgia, the absence of statewide course numbering means 78–81% of credits get rejected at UGA and GSU. Maryland students never face that.
+
+But a floor isn't a ceiling. The 69-point spread between UMGC (30% direct) and Bowie State (99% direct) shows that even in a strong-policy state, which receiver you pick shapes whether your community college work satisfies requirements or just pads credit totals. For a broader look at how this pattern plays out across 16 states, our [hub article on transfer-receiver patterns](/blog/which-universities-are-toughest-transfer-receivers) covers the full comparison.
+
+## The bottom line
+
+Maryland's 123,477 course-transfer mappings — the largest dataset of any single state we track — tell a consistent story: your credits will not be rejected, but where they land on the direct-vs-elective spectrum depends entirely on which receiver you choose.
+
+- **Bowie State**: 99% direct match — essentially a 1:1 credit transfer
+- **Towson**: 74% direct match — strong, some elective overflow
+- **UMD College Park**: 66% direct match — the flagship takes a third as elective
+- **UMGC**: 30% direct match — most credits become generic elective hours
+
+Every receiver keeps your hours. The difference is whether those hours check boxes on your degree audit or just add to the total. Use [ARTSYS and our Maryland transfer tool](/md/transfer) to verify course-by-course before you register — the lookup takes five minutes and can save you a semester.

--- a/content/blog/new-jersey-transfer-receivers-compared.mdx
+++ b/content/blog/new-jersey-transfer-receivers-compared.mdx
@@ -1,0 +1,128 @@
+You're at a New Jersey community college, weighing where to transfer. You've heard Rutgers is the obvious choice — it's the state university, it has campuses everywhere, and NJ Transfer is supposed to make the whole thing seamless. So you apply to Rutgers, get in, and send your transcript.
+
+Then the evaluation comes back: of your 60 credits, 8 transferred as direct matches. The other 52 were rejected entirely. No elective credit. No partial credit. Just gone.
+
+This isn't a hypothetical. It's the actual pattern at Rutgers School of Engineering, where **only 13.1% of community college course mappings transfer as direct matches** — and the remaining 86.9% receive no credit at all. Meanwhile, at Rowan University, the same community college transcript would land a **95.6% direct-match rate**.
+
+Same state. Same community college system. Same student. Completely different outcomes.
+
+## The NJ binary: direct match or nothing
+
+Before getting into the receiver data, one structural fact about New Jersey's transfer system needs to be on the table: **NJ has no elective-credit middle ground.** Across all 40 receivers in our dataset, the elective-credit rate is 0%. Every community college course either transfers as a direct match — satisfying a specific requirement at the receiving institution — or receives no credit at all.
+
+This is unusual. In [Georgia](/blog/georgia-transfer-receivers-compared), universities like UWG give 57% of courses elective credit, meaning the hours count toward graduation even if they don't replace a specific course. In Virginia and Tennessee, the elective bucket is substantial. New Jersey's system is binary: you either get full credit or you get nothing.
+
+If you're unfamiliar with these distinctions, our [direct match vs. elective credit explainer](/blog/what-direct-match-vs-elective-credit-means) covers what each classification means for your degree timeline and tuition bill.
+
+The binary structure makes NJ receiver selection higher-stakes than in most states. There's no soft landing.
+
+## Quick answer: the full NJ receiver spectrum
+
+NJ has 40 qualifying receivers across 68,357 total course-transfer mappings. Here's where they fall.
+
+**Most generous (direct-match rate above 90%):**
+
+| Receiver | Mappings | Direct match | No credit |
+|---|---|---|---|
+| Rowan University | 1,530 | **95.6%** | 4.4% |
+| William Paterson University | 1,492 | **95.1%** | 4.9% |
+| Rutgers — Mgmt & Labor Relations | 1,957 | **94.4%** | 5.6% |
+| Caldwell University | 1,863 | **93.9%** | 6.1% |
+| Thomas Edison State University | 1,678 | **93.4%** | 6.6% |
+
+**Toughest (direct-match rate below 35%):**
+
+| Receiver | Mappings | Direct match | No credit |
+|---|---|---|---|
+| Rutgers — Engineering | 1,527 | **13.1%** | 86.9% |
+| Rutgers — Pharmacy | 1,846 | **17.7%** | 82.3% |
+| New Jersey Institute of Technology | 1,575 | **20.6%** | 79.4% |
+| Berkeley College | 1,875 | **29.4%** | 70.6% |
+| DeVry University | 1,767 | **33.3%** | 66.7% |
+
+**Middle tier (50%–85%):**
+
+| Receiver | Mappings | Direct match | No credit |
+|---|---|---|---|
+| Rutgers — Camden Business | 1,901 | 68.5% | 31.5% |
+| Rutgers — NB Arts & Sciences | 1,891 | 71.7% | 28.3% |
+| Rutgers — Newark Business | 1,893 | 71.7% | 28.3% |
+| Montclair State University | 2,423 | 72.6% | 27.4% |
+| Kean University | 1,585 | 79.7% | 20.3% |
+| Stockton University | 1,625 | 82.2% | 17.8% |
+
+The statewide average across all 40 receivers is 64.3% direct match — above the median among the 16 states we track. But that average conceals an 82-point spread between best and worst, telling you almost nothing about any individual receiver.
+
+## The Rutgers story: one university, seven different answers
+
+This is the headline finding for New Jersey, and it's unlike anything in the other states we've measured. Rutgers is one institution — one admissions office, one brand, one set of campuses. But it operates multiple schools and colleges, each with its own transfer-equivalency tables. The results vary enormously:
+
+| Rutgers school/college | Direct match | No credit |
+|---|---|---|
+| School of Mgmt & Labor Relations | **94.4%** | 5.6% |
+| NB Arts & Sciences | 71.7% | 28.3% |
+| Newark Business School | 71.7% | 28.3% |
+| Camden School of Business | 68.5% | 31.5% |
+| Ernest Mario School of Pharmacy | 17.7% | 82.3% |
+| School of Engineering | **13.1%** | 86.9% |
+
+The spread within Rutgers alone — from 94.4% at Management & Labor Relations to 13.1% at Engineering — is **81 percentage points**. That's wider than the entire gap between the most and least generous receivers in most states.
+
+A student who says "I'm transferring to Rutgers" hasn't actually made a meaningful decision about credit transfer yet. Which Rutgers school they're admitted to determines whether they keep 94% of their credits or lose 87% of them. Same transcript, same Rutgers admissions letter, radically different outcomes.
+
+Why the gap? Engineering and Pharmacy have highly specific prerequisite sequences with lab and accreditation requirements; they reject most community college equivalents rather than risk a student arriving underprepared. Management & Labor Relations has broader course-acceptance criteria and maps most community college courses to direct equivalents.
+
+This isn't unique to Rutgers — our [hub article on transfer-receiver patterns](/blog/which-universities-are-toughest-transfer-receivers) shows that professional schools and engineering programs are consistently tougher receivers across states. But the magnitude of the within-institution variance at Rutgers is the largest we've recorded.
+
+## NJIT: the engineering alternative
+
+New Jersey Institute of Technology shows a 20.6% direct-match rate — tough, but meaningfully better than Rutgers Engineering's 13.1%. For community college students aiming at an engineering bachelor's, the difference is real: at NJIT, roughly 1 in 5 courses transfer directly. At Rutgers Engineering, it's 1 in 8.
+
+Neither is generous. An engineering-bound community college student should expect to retake a significant portion of their coursework at either institution. But the 7.5-point gap translates to 4–5 additional courses that transfer at NJIT versus Rutgers Engineering — a semester's worth of tuition and time.
+
+## The generous tier: where 90%+ transfers
+
+Five NJ receivers accept more than 90% of community college credits as direct matches. Rowan, William Paterson, Caldwell, Thomas Edison State, and the Rutgers Management & Labor Relations school all sit above 93%.
+
+Thomas Edison State University deserves specific mention. Founded in 1972 as a degree-completion institution for adult learners and transfer students, its 93.4% direct-match rate reflects a curriculum designed around credit acceptance rather than gatekeeping. For students who prioritize finishing the bachelor's efficiently over institutional brand, TESU is the best-aligned receiver in NJ.
+
+Rowan University's 95.6% rate is the highest among traditional four-year institutions in NJ. A student transferring 60 community college credits to Rowan can expect roughly 57 to transfer directly. That's close to the clean 2+2 transfer path — two years at community college, two at Rowan, done.
+
+## NJ Transfer: what it does and doesn't guarantee
+
+New Jersey has a statewide transfer agreement — NJ Transfer — that publishes course-by-course equivalency tables between all 18 NJ community colleges and four-year institutions. This is the infrastructure our data is drawn from.
+
+NJ Transfer does two useful things: it makes equivalency data publicly available before you enroll, and it guarantees that approved equivalencies will be honored. What it does not do is guarantee that most of your courses will transfer. The equivalency tables themselves show the acceptance rates above — and at Rutgers Engineering, the table says "no credit" for 87% of the courses listed.
+
+The existence of a statewide agreement is better than states with no published tables. But "we publish the rejection" is not the same as "we don't reject." Students sometimes hear "NJ Transfer" and assume it means their credits will transfer. It means the transfer evaluation is predictable — not that it's favorable.
+
+## How to use this data
+
+If you're at a New Jersey community college choosing a transfer destination:
+
+**1. Look up your specific courses, not just the receiver average.** The percentages above are aggregate rates across all course mappings. Your specific courses might transfer at a higher or lower rate than the average. Use the [NJ transfer tool on Community College Path](/nj/transfer) to check individual course equivalencies before you commit.
+
+**2. If you're aiming at Rutgers, know which school.** "I want to go to Rutgers" is not specific enough. Rutgers Arts & Sciences (71.7%) and Rutgers Engineering (13.1%) are functionally different transfer destinations. Find out which Rutgers school your program falls under before assuming your credits will carry over.
+
+**3. For engineering, compare NJIT and Rutgers Engineering directly.** Neither is generous, but NJIT's 20.6% rate means fewer courses to retake. Run both equivalency tables against your actual transcript and compare the credit totals.
+
+**4. Consider the generous receivers seriously.** Rowan (95.6%) and William Paterson (95.1%) are accredited public universities with strong programs. If your major is available at one of these schools and you're not locked into a specific institution for location or program reasons, the credit savings are substantial — potentially a full year of tuition and time.
+
+**5. Budget for the gap.** At any receiver below 80% direct match, plan for extra time beyond the idealized 2+2 path. At receivers below 50%, plan for three years post-transfer, not two. At Rutgers Engineering or Pharmacy, plan for essentially starting over in your major courses.
+
+## How NJ compares to other states
+
+At 64.3% statewide direct match, NJ sits in the upper half of the 16 states we track — above Maryland (48.4%), Virginia (26.5%), and Georgia (12.3%), but below South Carolina (83.6%) and well below Florida (100%). The [full state comparison](/blog/which-universities-are-toughest-transfer-receivers) shows where each system falls.
+
+The critical difference between NJ and lower-ranked states isn't just the average — it's that NJ has multiple high-acceptance receivers readily available. A Georgia community college student has one strong option (Kennesaw State at 90%). A New Jersey community college student has five receivers above 93%. The problem isn't a lack of transfer-friendly destinations; it's that the toughest receivers (Rutgers professional schools, NJIT) are often the ones students default to without checking the data first.
+
+## The bottom line
+
+New Jersey's transfer system is binary — direct match or nothing — and the receiver you pick determines which side of that binary most of your credits land on.
+
+- **Rowan, William Paterson, Caldwell, Thomas Edison State**: 93–96% direct match. Clean transfer. The 2+2 path works.
+- **Montclair, Stockton, Kean**: 73–82% direct match. Solid, with some courses to retake.
+- **Rutgers Arts & Sciences, Camden/Newark Business**: 68–72%. Workable but expect a semester of retaking.
+- **Rutgers Engineering, Pharmacy; NJIT**: 13–21%. Plan to retake most of your major coursework.
+
+The 82-point spread between best and worst is almost entirely a function of which door you walk through — and in Rutgers's case, which door within the same institution. [Check your specific courses](/blog/how-to-check-if-community-college-course-transfers) before you pick.

--- a/content/blog/north-carolina-transfer-receivers-compared.mdx
+++ b/content/blog/north-carolina-transfer-receivers-compared.mdx
@@ -1,0 +1,124 @@
+You're finishing your associate degree at one of North Carolina's 58 community colleges. You've heard that NC has a statewide transfer agreement — the Comprehensive Articulation Agreement — so your credits should transfer cleanly, right?
+
+They do transfer. Every single one. But "transfers" and "counts toward your major" are two very different things. Across 20 NC universities and **25,622 individual course-transfer mappings**, the direct-match rate ranges from **20.4% to 100%** — an 80-point spread that determines whether your community college transcript satisfies degree requirements or just pads your graduation hours.
+
+The good news first: **North Carolina has 0% no-credit across every receiver in our dataset.** No NC university outright rejects a community college course. That's a fundamentally better floor than [Georgia, where UGA and GSU reject 78–81% of TCSG credits entirely](/blog/georgia-transfer-receivers-compared), or New Jersey, where Rutgers Engineering rejects 87%. In NC, you always keep your credit hours.
+
+The catch: keeping hours as **elective credit** and having them **satisfy specific requirements** are very different student outcomes. Our [direct match vs elective credit explainer](/blog/what-direct-match-vs-elective-credit-means) covers the distinction in detail. This article is about which NC receivers fall where on that spectrum — and what it means for your transfer plan.
+
+## The full picture: 20 receivers ranked
+
+| University | Total mappings | Direct match | Elective credit | No credit |
+|---|---|---|---|---|
+| Winston-Salem State University | 1,033 | **100.0%** | 0% | 0% |
+| NC A&amp;T State University | 1,240 | **100.0%** | 0% | 0% |
+| UNC Asheville | 804 | 94.2% | 5.8% | 0% |
+| UNC Wilmington | 4,685 | 81.3% | 18.7% | 0% |
+| High Point University | 219 | 76.7% | 23.3% | 0% |
+| UNC Greensboro | 1,034 | 60.3% | 39.7% | 0% |
+| Appalachian State University | 1,095 | 50.0% | 50.0% | 0% |
+| NC State University | 1,040 | 43.2% | 56.8% | 0% |
+| UNC Chapel Hill | 595 | 39.3% | 60.7% | 0% |
+| Fayetteville State University | 2,015 | 31.8% | 68.2% | 0% |
+| UNC Charlotte | 1,723 | 31.5% | 68.5% | 0% |
+| Wingate University | 817 | 32.1% | 67.9% | 0% |
+| Western Carolina University | 2,742 | 25.7% | 74.3% | 0% |
+| East Carolina University | 1,943 | **20.4%** | 79.6% | 0% |
+
+That rightmost column — 0% across the board — is the NC story. Every row. Every university. No rejections.
+
+But look at the leftmost percentages. A student transferring 60 community college credits to Winston-Salem State keeps all 60 as direct requirement-satisfying matches. The same student transferring 60 credits to East Carolina keeps all 60 hours — but only about 12 of them satisfy specific ECU degree requirements. The other 48 land as elective credit: hours toward the 120-credit graduation total, but not replacements for ECU courses the student still needs to take.
+
+## The toughest NC receivers
+
+### East Carolina University: 20.4% direct match
+
+ECU has the lowest direct-match rate in NC — and it's one of the lowest elective-pattern receivers we track nationally, alongside Austin Peay State in Tennessee (also 20.4%) and Old Dominion in Virginia (22%).
+
+With 1,943 mappings in our dataset:
+- About 12 of every 60 transfer credits satisfy a specific ECU requirement
+- The remaining 48 count as elective hours
+- Zero credits are rejected
+
+The practical impact: an NCCCS student transferring to ECU will need to retake most of the major-specific coursework at ECU. The elective hours help reach the 120-credit graduation requirement, but they don't shorten the major sequence. Budget for closer to 3 years at ECU after the associate, not 2.
+
+### Western Carolina University: 25.7% direct match
+
+WCU tracks the second-largest number of mappings among the toughest receivers (2,742) and converts only about a quarter as direct matches. Similar practical outcome to ECU — you keep everything, but most of it doesn't replace WCU courses.
+
+### UNC Charlotte: 31.5% direct match
+
+UNCC sits at the boundary between the toughest and mid-tier NC receivers. With 1,723 mappings, roughly 19 of every 60 credits transfer as direct matches. Better than ECU and WCU, but still means the majority of a student's community college coursework won't satisfy UNCC-specific requirements.
+
+## The mid-tier: UNC Chapel Hill and NC State
+
+The two flagships land in the middle of the pack — which is itself an important finding.
+
+**UNC Chapel Hill**: 595 mappings, 39.3% direct match, 60.7% elective. The state's most selective university is not its toughest transfer receiver. Chapel Hill's direct-match rate is nearly double ECU's. The smaller mapping count (595 vs. ECU's 1,943) likely reflects the more selective set of courses that Chapel Hill has formally articulated with the community college system.
+
+**NC State**: 1,040 mappings, 43.2% direct match, 56.8% elective. Slightly more generous than Chapel Hill, and with a broader set of articulated courses. An NCCCS student transferring to NC State can expect roughly 26 of 60 credits to satisfy specific degree requirements — not great, but substantially better than ECU's 12.
+
+The takeaway for students targeting either flagship: you won't lose hours, but you'll retake more than half your major coursework. The CAA covers your general education transfer, but [major-specific articulation](/blog/how-to-check-if-community-college-course-transfers) is where the credit conversion actually happens. Look up each course individually before you register for it.
+
+## The most generous NC receivers
+
+### Winston-Salem State and NC A&amp;T: 100% direct match
+
+Two HBCUs at the top of the list with perfect direct-match rates across every mapping in our dataset. Winston-Salem State (1,033 mappings) and NC A&amp;T (1,240 mappings) both classify every NCCCS course as a direct requirement-satisfying match.
+
+This is the cleanest transfer outcome in NC. A student transferring 60 community college credits to either school keeps all 60 as credits that count toward specific degree requirements. The 2+2 model works exactly as advertised.
+
+### UNC Asheville: 94.2% direct match
+
+With 804 mappings, UNC Asheville converts the vast majority of NCCCS coursework into direct matches. Only 5.8% lands as elective. This is a near-complete transfer for any NCCCS student.
+
+### UNC Wilmington: 81.3% direct match
+
+UNCW has the largest mapping count of any NC receiver in our dataset (4,685) and converts over four-fifths of those as direct matches. For the volume of courses articulated, this is a strong transfer outcome — roughly 49 of every 60 credits satisfy specific UNCW requirements.
+
+## The CAA promise vs. the data
+
+North Carolina's Comprehensive Articulation Agreement is one of the stronger statewide transfer frameworks in the country. It guarantees that students completing an Associate in Arts or Associate in Science will enter a UNC-system school with junior standing and have their general-education requirements satisfied.
+
+The data confirms that the CAA achieves its floor: no NCCCS course is rejected outright at any NC university. That's a real structural advantage. In the [16-state comparison](/blog/which-universities-are-toughest-transfer-receivers), only Florida (100% direct match via SCNS) provides a strictly better transfer experience.
+
+But the CAA primarily covers **general education**. It does not force universities to accept major-specific community college courses as direct equivalents. That's where the 80-point spread comes from: at ECU, most major-specific courses land as elective; at Winston-Salem State and NC A&amp;T, those same courses count as direct requirement matches.
+
+NC's overall direct-match rate across all 20 receivers is **55.7%** — solidly above the national average in our dataset, and substantially better than Virginia (26.5%) or Georgia (12.3%). But the within-state variance is what matters for an individual student choosing where to apply.
+
+## How to choose your NC transfer destination
+
+If you have flexibility on where to apply:
+
+1. **Winston-Salem State and NC A&amp;T offer the cleanest transfer paths.** 100% direct match means the 2+2 plan works without asterisks. If your major is available at either school, the credit math is unbeatable in NC.
+
+2. **UNC Asheville and UNC Wilmington are strong second-tier options.** At 94% and 81% direct match respectively, most of your coursework satisfies degree requirements directly.
+
+3. **NC State and UNC Chapel Hill are mid-tier on credit conversion despite being top-tier on selectivity.** If you're targeting either flagship, plan for roughly half your major courses to land as elective rather than direct match. The CAA protects your gen-ed transfer, but your major sequence will likely need partial retaking.
+
+4. **ECU and WCU require the most course retaking.** Not because they reject anything — they don't — but because 75–80% of the credits that transfer do so as elective hours rather than requirement replacements.
+
+If you're already committed to a specific NC university:
+
+1. **Look up each course individually.** Use our [NC transfer tool](/nc/transfer) to check how a specific NCCCS course maps to your target university before you register for it at the community college.
+
+2. **Prioritize courses with published direct-match equivalencies.** The CAA handles gen-ed, but within your major, the specific courses you choose at the community college determine whether they arrive as direct matches or electives at the receiving end.
+
+3. **Get an unofficial transfer evaluation before you apply.** Most UNC-system schools will evaluate your transcript informally before admission. Use it.
+
+## The bottom line
+
+North Carolina gives NCCCS students something that students in many other states don't get: a guaranteed floor. No credits are rejected. Every hour you earn at a community college counts for something at every NC public university. That's the CAA doing its job.
+
+But "counts for something" and "counts toward your degree requirements" are different. The spread across NC receivers:
+
+- **Winston-Salem State / NC A&amp;T**: 100% direct match — every credit replaces a requirement
+- **UNC Asheville**: 94% direct match — nearly complete transfer
+- **UNC Wilmington**: 81% direct match — strong outcome across the largest mapping set in NC
+- **NC State**: 43% direct match — majority lands as elective
+- **UNC Chapel Hill**: 39% direct match — similar to NC State
+- **East Carolina**: 20% direct match — four out of five credits are elective-only
+
+For the full cross-state comparison and the conceptual framework behind these numbers, see our [hub article on transfer-receiver patterns](/blog/which-universities-are-toughest-transfer-receivers). For how NC compares to [Georgia's much harsher rejection pattern](/blog/georgia-transfer-receivers-compared), the contrast is stark — NC's worst receiver (ECU at 20% direct, 80% elective) is structurally kinder than Georgia's best non-KSU receiver (UWG at 7% direct, 36% no-credit).
+
+The receiver you pick within NC won't cost you credit hours. But it can cost you semesters. Check the mappings for your specific courses at your specific target before you commit — the [NC transfer lookup](/nc/transfer) shows them course by course.


### PR DESCRIPTION
## Summary

Five new blog articles from the pipeline's transfer-receiver and course-scarcity detectors:

### Transfer receiver spokes (cluster: `transfer-receiver-patterns-guide`)
- **NJ** — 40 receivers, 82-point direct-match spread. Lead story: Rutgers has 81-point *within-institution* variance (Engineering 13% → Management 94%). NJ is binary: direct match or nothing, 0% elective credit anywhere.
- **NC** — 20 receivers, 0% no-credit across the board (pure elective pattern). Lead story: even without rejections, the 80-point spread (ECU 20% → WSSU 100%) creates very different outcomes.
- **MD** — 8 receivers, 123,477 mappings (largest single-state dataset). Lead story: UMGC is the default transfer destination but the toughest at 30%; Bowie State is 99%.

### Course scarcity spokes (cluster: `course-availability-guide`)
- **FL** — SCNS paradox: perfect transfer system but 69.2% scarcity ratio. Valencia holds 69 exclusive courses.
- **AL** — Small-system dynamics: 6 colleges magnify concentration effects. Wallace-Dothan is the single anchor with 17 exclusives.

## Quality gates
- ✅ G1 (word count): all within 1000–1800 for state-spoke
- ✅ G2 (internal links): hub + sibling spoke + tool page links present
- ✅ G3 (banned phrases): clean
- ⏭️ G4 (embedding similarity): skipped (no API key in worktree)
- ⏭️ G5 (build): pre-existing env var issue in worktree; index.ts parses cleanly
- ⏭️ G6 (output block): N/A for manual pipeline run

## Reviewer checklist
- [ ] Read for fluff. Any "Top N tips" energy? Any generic education-blog filler?
- [ ] Verify factual claims against data slices (`.blog-pipeline/slices/transfer-receivers/{nj,nc,md}.json` and `.blog-pipeline/slices/course-scarcity/{fl,al}.json`)
- [ ] Click every internal link — do they resolve to existing posts/tools?
- [ ] State-specific posts: confirm StateToolsCTA renders top + bottom
- [ ] Cluster spokes: confirm the hub link is present and a sibling spoke is referenced
- [ ] If review-cadence flag is true, add a calendar reminder for annual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)