### PR TITLE
feat(scorecard): Tier 1 outcomes — retention, 1yr earnings, distribution, '% above HS'

### DIFF
--- a/app/[state]/college/[id]/CollegeScorecardSection.tsx
+++ b/app/[state]/college/[id]/CollegeScorecardSection.tsx
@@ -196,6 +196,149 @@ function CostBreakdown({ record }: { record: ScorecardRecord }) {
 }
 
 /**
+ * Outcomes block: retention + completion + transfer. Surfaces retention
+ * specifically because it's the single strongest leading indicator of
+ * completion (Pell-eligible students who return for year two are 3-4x
+ * more likely to graduate than those who don't), and the federal
+ * Scorecard site doesn't prominently feature it.
+ */
+function OutcomesSection({ record }: { record: ScorecardRecord }) {
+  const retentionFt = record.completion.retentionRateFullTime;
+  const retentionPt = record.completion.retentionRatePartTime;
+  const transfer = record.completion.transferRate;
+  const completion200 = record.completion.completionRate200nt;
+  if (retentionFt == null && transfer == null && completion200 == null)
+    return null;
+  const retentionTooltip =
+    retentionPt != null
+      ? `Share of full-time first-year students who returned the next year. Part-time retention is ${formatPercent(retentionPt)}. Returning for year two is the single best predictor of finishing.`
+      : "Share of full-time first-year students who returned the next year. Returning for year two is the single best predictor of finishing.";
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700 dark:text-slate-300">
+        After enrollment
+      </h3>
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {retentionFt != null && (
+          <StatCard
+            label="1st-year retention"
+            value={formatPercent(retentionFt)}
+            sub="full-time students"
+            tooltip={retentionTooltip}
+          />
+        )}
+        {transfer != null && (
+          <StatCard
+            label="Transfer rate"
+            value={formatPercent(transfer)}
+            sub="to a 4-year school"
+            tooltip="Share of full-time students who transferred out to a 4-year institution. Important for community colleges where transferring is a common goal."
+          />
+        )}
+        {completion200 != null && (
+          <StatCard
+            label="Completion rate"
+            value={formatPercent(completion200)}
+            sub="200% of normal time"
+            tooltip="Share of students who completed within 200% of the normal program length — i.e., 4 years for a 2-year associate's. Broader, more realistic figure for working students."
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Earnings block: 1yr-after-completion, 10yr-after-entry median with a
+ * P25/P75 range, the federal "% earning above HS-grad median" flagship
+ * stat, plus loan rate and median debt. Together these answer "did the
+ * money pay off."
+ */
+function EarningsSection({ record }: { record: ScorecardRecord }) {
+  const earn1Yr = record.earnings.median1YrAfterCompletion;
+  const earn10Yr = record.earnings.median10YrsAfterEntry;
+  const p25 = record.earnings.percentile25_10YrsAfterEntry;
+  const p75 = record.earnings.percentile75_10YrsAfterEntry;
+  const aboveHs = record.earnings.shareEarningAboveHsGrad;
+  const debt = record.aid.medianDebtCompleters;
+  const loanRate = record.aid.federalLoanRate;
+
+  if (
+    earn1Yr == null &&
+    earn10Yr == null &&
+    aboveHs == null &&
+    debt == null &&
+    (loanRate == null || loanRate === 0)
+  ) {
+    return null;
+  }
+
+  const earn10YrSub =
+    p25 != null && p75 != null
+      ? `10 yrs after entry · ${formatDollar(p25)}–${formatDollar(p75)}`
+      : "10 years after entry";
+
+  return (
+    <div className="mt-6">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700 dark:text-slate-300">
+        Earnings &amp; debt
+      </h3>
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {earn1Yr != null && (
+          <StatCard
+            label="Earnings 1 yr after"
+            value={formatDollar(earn1Yr)}
+            sub="median, completers"
+            tooltip="Median annual earnings one year after completion, completers only. Faster post-graduation signal than the 10-year figure (which mixes completers and non-completers)."
+          />
+        )}
+        {earn10Yr != null && (
+          <StatCard
+            label="Median earnings"
+            value={formatDollar(earn10Yr)}
+            sub={earn10YrSub}
+            tooltip={
+              p25 != null && p75 != null
+                ? `Median annual earnings 10 years after first entering college. The range shown is the 25th–75th percentile (middle half of working former students), so half earn within this band and half are outside it.`
+                : "Median annual earnings 10 years after first entering college, working former students."
+            }
+          />
+        )}
+        {aboveHs != null && (
+          <StatCard
+            label="Earn above $28k"
+            value={formatPercent(aboveHs)}
+            sub="10 yrs after entry"
+            tooltip="Share of former students earning more than $28,000 — roughly the median annual wage for someone with only a high school diploma. The federal Scorecard's headline 'did college pay off' metric."
+          />
+        )}
+      </div>
+      {(debt != null || (loanRate != null && loanRate > 0)) && (
+        <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {debt != null && (
+            <StatCard
+              label="Median debt at completion"
+              value={formatDollar(debt)}
+              sub="federal loans, completers"
+              tooltip="Median federal student loan debt for students who completed their program. Excludes private loans."
+            />
+          )}
+          {loanRate != null && loanRate > 0 && (
+            <StatCard
+              label="Take federal loans"
+              value={formatPercent(loanRate)}
+              sub="of all students"
+              tooltip="Share of students taking out federal student loans. A 0% or very low rate (common at low-tuition community colleges) means loan debt isn't a typical part of the cost story here."
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
  * Returns true if the record has enough non-null fields to be worth
  * rendering. A record with everything null (rare but possible) would render
  * a wall of "—" — we'd rather omit the whole section.
@@ -282,33 +425,9 @@ export default function CollegeScorecardSection({
         </div>
       )}
 
-      {(record.completion.transferRate != null ||
-        record.earnings.median10YrsAfterEntry != null ||
-        record.aid.medianDebtCompleters != null) && (
-        <div className="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-3">
-          {record.completion.transferRate != null && (
-            <StatCard
-              label="Transfer rate"
-              value={formatPercent(record.completion.transferRate)}
-              sub="full-time students"
-            />
-          )}
-          {record.aid.medianDebtCompleters != null && (
-            <StatCard
-              label="Median debt at completion"
-              value={formatDollar(record.aid.medianDebtCompleters)}
-              sub="federal loans"
-            />
-          )}
-          {record.earnings.median10YrsAfterEntry != null && (
-            <StatCard
-              label="Median earnings"
-              value={formatDollar(record.earnings.median10YrsAfterEntry)}
-              sub="10 years after entry"
-            />
-          )}
-        </div>
-      )}
+      <OutcomesSection record={record} />
+
+      <EarningsSection record={record} />
 
       <p className="mt-4 text-xs text-gray-500 dark:text-slate-400">
         Source:{" "}

--- a/data/al/scorecard/bevill-state-community-college.json
+++ b/data/al/scorecard/bevill-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bscc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:05.037Z",
+  "fetchedAt": "2026-05-13T02:12:24.233Z",
   "size": 2177,
   "shareFirstGeneration": 0.5308083663,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.38,
     "completionRate200nt": 0.4752,
-    "transferRate": 0.1889
+    "transferRate": 0.1889,
+    "retentionRateFullTime": 0.6639,
+    "retentionRatePartTime": 0.5723
   },
   "earnings": {
-    "median10YrsAfterEntry": 34107
+    "median10YrsAfterEntry": 34107,
+    "median1YrAfterCompletion": 44447,
+    "percentile25_10YrsAfterEntry": 17891,
+    "percentile75_10YrsAfterEntry": 51517,
+    "shareEarningAboveHsGrad": 0.503
   }
 }

--- a/data/al/scorecard/bishop-state-community-college.json
+++ b/data/al/scorecard/bishop-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bishop.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:02.872Z",
+  "fetchedAt": "2026-05-13T02:12:22.303Z",
   "size": 2437,
   "shareFirstGeneration": 0.4853977845,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3596,
     "completionRate200nt": 0.2634,
-    "transferRate": 0.3012
+    "transferRate": 0.3012,
+    "retentionRateFullTime": 0.5504,
+    "retentionRatePartTime": 0.3116
   },
   "earnings": {
-    "median10YrsAfterEntry": 29916
+    "median10YrsAfterEntry": 29916,
+    "median1YrAfterCompletion": 35298,
+    "percentile25_10YrsAfterEntry": 15254,
+    "percentile75_10YrsAfterEntry": 47250,
+    "shareEarningAboveHsGrad": 0.394
   }
 }

--- a/data/al/scorecard/central-alabama-community-college.json
+++ b/data/al/scorecard/central-alabama-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cacc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:53.199Z",
+  "fetchedAt": "2026-05-13T02:12:13.573Z",
   "size": 1203,
   "shareFirstGeneration": 0.5496760259,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3288,
     "completionRate200nt": 0.3156,
-    "transferRate": 0.3653
+    "transferRate": 0.3653,
+    "retentionRateFullTime": 0.5985,
+    "retentionRatePartTime": 0.3084
   },
   "earnings": {
-    "median10YrsAfterEntry": 33506
+    "median10YrsAfterEntry": 33506,
+    "median1YrAfterCompletion": 46467,
+    "percentile25_10YrsAfterEntry": 18635,
+    "percentile75_10YrsAfterEntry": 50656,
+    "shareEarningAboveHsGrad": 0.494
   }
 }

--- a/data/al/scorecard/chattahoochee-valley-community-college.json
+++ b/data/al/scorecard/chattahoochee-valley-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.cv.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:53.881Z",
+  "fetchedAt": "2026-05-13T02:12:14.041Z",
   "size": 1110,
   "shareFirstGeneration": 0.4302670623,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3605,
     "completionRate200nt": 0.3874,
-    "transferRate": 0.25
+    "transferRate": 0.25,
+    "retentionRateFullTime": 0.5215,
+    "retentionRatePartTime": 0.2742
   },
   "earnings": {
-    "median10YrsAfterEntry": 36438
+    "median10YrsAfterEntry": 36438,
+    "median1YrAfterCompletion": 38963,
+    "percentile25_10YrsAfterEntry": 20404,
+    "percentile75_10YrsAfterEntry": 52873,
+    "shareEarningAboveHsGrad": 0.519
   }
 }

--- a/data/al/scorecard/coastal-alabama-community-college.json
+++ b/data/al/scorecard/coastal-alabama-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.coastalalabama.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:12:54.814Z",
+  "fetchedAt": "2026-05-13T02:12:15.253Z",
   "size": 4798,
   "shareFirstGeneration": 0.4351196495,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3133,
     "completionRate200nt": 0.3006,
-    "transferRate": 0.2521
+    "transferRate": 0.2521,
+    "retentionRateFullTime": 0.6207,
+    "retentionRatePartTime": 0.4441
   },
   "earnings": {
-    "median10YrsAfterEntry": 34894
+    "median10YrsAfterEntry": 34894,
+    "median1YrAfterCompletion": 47740,
+    "percentile25_10YrsAfterEntry": 18526,
+    "percentile75_10YrsAfterEntry": 54820,
+    "shareEarningAboveHsGrad": 0.524
   }
 }

--- a/data/al/scorecard/enterprise-state-community-college.json
+++ b/data/al/scorecard/enterprise-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.escc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:54.356Z",
+  "fetchedAt": "2026-05-13T02:12:14.613Z",
   "size": 1585,
   "shareFirstGeneration": 0.4218916047,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4176,
     "completionRate200nt": 0.3259,
-    "transferRate": 0.1853
+    "transferRate": 0.1853,
+    "retentionRateFullTime": 0.6347,
+    "retentionRatePartTime": 0.3966
   },
   "earnings": {
-    "median10YrsAfterEntry": 42572
+    "median10YrsAfterEntry": 42572,
+    "median1YrAfterCompletion": 26648,
+    "percentile25_10YrsAfterEntry": 21710,
+    "percentile75_10YrsAfterEntry": 71583,
+    "shareEarningAboveHsGrad": 0.553
   }
 }

--- a/data/al/scorecard/gadsden-state-community-college.json
+++ b/data/al/scorecard/gadsden-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.gadsdenstate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:55.491Z",
+  "fetchedAt": "2026-05-13T02:12:15.677Z",
   "size": 3548,
   "shareFirstGeneration": 0.5149544863,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3824,
     "completionRate200nt": 0.3862,
-    "transferRate": 0.1024
+    "transferRate": 0.1024,
+    "retentionRateFullTime": 0.6245,
+    "retentionRatePartTime": 0.3681
   },
   "earnings": {
-    "median10YrsAfterEntry": 32937
+    "median10YrsAfterEntry": 32937,
+    "median1YrAfterCompletion": 37458,
+    "percentile25_10YrsAfterEntry": 17231,
+    "percentile75_10YrsAfterEntry": 51839,
+    "shareEarningAboveHsGrad": 0.473
   }
 }

--- a/data/al/scorecard/george-c-wallace-community-college-dothan.json
+++ b/data/al/scorecard/george-c-wallace-community-college-dothan.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wallace.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:55.936Z",
+  "fetchedAt": "2026-05-13T02:12:16.141Z",
   "size": 3017,
   "shareFirstGeneration": 0.4851537646,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3502,
     "completionRate200nt": 0.3333,
-    "transferRate": 0.1576
+    "transferRate": 0.1576,
+    "retentionRateFullTime": 0.6247,
+    "retentionRatePartTime": 0.4286
   },
   "earnings": {
-    "median10YrsAfterEntry": 31399
+    "median10YrsAfterEntry": 31399,
+    "median1YrAfterCompletion": 40372,
+    "percentile25_10YrsAfterEntry": 16986,
+    "percentile75_10YrsAfterEntry": 49632,
+    "shareEarningAboveHsGrad": 0.44
   }
 }

--- a/data/al/scorecard/george-c-wallace-state-community-college-hanceville.json
+++ b/data/al/scorecard/george-c-wallace-state-community-college-hanceville.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.wallacestate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:56.594Z",
+  "fetchedAt": "2026-05-13T02:12:16.746Z",
   "size": 4423,
   "shareFirstGeneration": 0.498813157,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.512,
     "completionRate200nt": 0.5114,
-    "transferRate": 0.1238
+    "transferRate": 0.1238,
+    "retentionRateFullTime": 0.6553,
+    "retentionRatePartTime": 0.4713
   },
   "earnings": {
-    "median10YrsAfterEntry": 39842
+    "median10YrsAfterEntry": 39842,
+    "median1YrAfterCompletion": 44726,
+    "percentile25_10YrsAfterEntry": 22380,
+    "percentile75_10YrsAfterEntry": 58549,
+    "shareEarningAboveHsGrad": 0.569
   }
 }

--- a/data/al/scorecard/george-c-wallace-state-community-college-selma.json
+++ b/data/al/scorecard/george-c-wallace-state-community-college-selma.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.wccs.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:12:57.033Z",
+  "fetchedAt": "2026-05-13T02:12:17.183Z",
   "size": 855,
   "shareFirstGeneration": 0.5125881168,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4064,
     "completionRate200nt": 0.4302,
-    "transferRate": 0.137
+    "transferRate": 0.137,
+    "retentionRateFullTime": 0.6261,
+    "retentionRatePartTime": 0.3636
   },
   "earnings": {
-    "median10YrsAfterEntry": 31598
+    "median10YrsAfterEntry": 31598,
+    "median1YrAfterCompletion": 35882,
+    "percentile25_10YrsAfterEntry": 15581,
+    "percentile75_10YrsAfterEntry": 49326,
+    "shareEarningAboveHsGrad": 0.393
   }
 }

--- a/data/al/scorecard/h-councill-trenholm-state-community-college.json
+++ b/data/al/scorecard/h-councill-trenholm-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.trenholmstate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:04.415Z",
+  "fetchedAt": "2026-05-13T02:12:23.771Z",
   "size": 1674,
   "shareFirstGeneration": 0.4304399524,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1614,
     "completionRate200nt": 0.2781,
-    "transferRate": 0.1772
+    "transferRate": 0.1772,
+    "retentionRateFullTime": 0.5084,
+    "retentionRatePartTime": 0.3333
   },
   "earnings": {
-    "median10YrsAfterEntry": 32183
+    "median10YrsAfterEntry": 32183,
+    "median1YrAfterCompletion": 39198,
+    "percentile25_10YrsAfterEntry": 16879,
+    "percentile75_10YrsAfterEntry": 48592,
+    "shareEarningAboveHsGrad": 0.398
   }
 }

--- a/data/al/scorecard/j-f-drake-state-community-and-technical-college.json
+++ b/data/al/scorecard/j-f-drake-state-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://drakestate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:57.531Z",
+  "fetchedAt": "2026-05-13T02:12:17.844Z",
   "size": 755,
   "shareFirstGeneration": 0.5899653979,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1404,
     "completionRate200nt": 0.127,
-    "transferRate": 0.1579
+    "transferRate": 0.1579,
+    "retentionRateFullTime": 0.5052,
+    "retentionRatePartTime": 0.4
   },
   "earnings": {
-    "median10YrsAfterEntry": 28281
+    "median10YrsAfterEntry": 28281,
+    "median1YrAfterCompletion": 34491,
+    "percentile25_10YrsAfterEntry": 13620,
+    "percentile75_10YrsAfterEntry": 45400,
+    "shareEarningAboveHsGrad": 0.42
   }
 }

--- a/data/al/scorecard/jefferson-state-community-college.json
+++ b/data/al/scorecard/jefferson-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.jeffersonstate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:12:57.979Z",
+  "fetchedAt": "2026-05-13T02:12:18.279Z",
   "size": 5470,
   "shareFirstGeneration": 0.4502907782,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2564,
     "completionRate200nt": 0.2866,
-    "transferRate": 0.3718
+    "transferRate": 0.3718,
+    "retentionRateFullTime": 0.5919,
+    "retentionRatePartTime": 0.4365
   },
   "earnings": {
-    "median10YrsAfterEntry": 40719
+    "median10YrsAfterEntry": 40719,
+    "median1YrAfterCompletion": 51892,
+    "percentile25_10YrsAfterEntry": 24505,
+    "percentile75_10YrsAfterEntry": 62034,
+    "shareEarningAboveHsGrad": 0.546
   }
 }

--- a/data/al/scorecard/john-c-calhoun-state-community-college.json
+++ b/data/al/scorecard/john-c-calhoun-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://calhoun.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:58.679Z",
+  "fetchedAt": "2026-05-13T02:12:18.914Z",
   "size": 7070,
   "shareFirstGeneration": 0.455343703,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4147,
     "completionRate200nt": 0.4626,
-    "transferRate": 0.1695
+    "transferRate": 0.1695,
+    "retentionRateFullTime": 0.6516,
+    "retentionRatePartTime": 0.4783
   },
   "earnings": {
-    "median10YrsAfterEntry": 38192
+    "median10YrsAfterEntry": 38192,
+    "median1YrAfterCompletion": 43676,
+    "percentile25_10YrsAfterEntry": 21172,
+    "percentile75_10YrsAfterEntry": 57398,
+    "shareEarningAboveHsGrad": 0.498
   }
 }

--- a/data/al/scorecard/lawson-state-community-college.json
+++ b/data/al/scorecard/lawson-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.lawsonstate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:12:59.167Z",
+  "fetchedAt": "2026-05-13T02:12:19.457Z",
   "size": 2900,
   "shareFirstGeneration": 0.4747231584,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.266,
     "completionRate200nt": 0.2727,
-    "transferRate": 0.0689
+    "transferRate": 0.0689,
+    "retentionRateFullTime": 0.5947,
+    "retentionRatePartTime": 0.3437
   },
   "earnings": {
-    "median10YrsAfterEntry": 31701
+    "median10YrsAfterEntry": 31701,
+    "median1YrAfterCompletion": 33056,
+    "percentile25_10YrsAfterEntry": 15415,
+    "percentile75_10YrsAfterEntry": 47563,
+    "shareEarningAboveHsGrad": 0.413
   }
 }

--- a/data/al/scorecard/lurleen-b-wallace-community-college.json
+++ b/data/al/scorecard/lurleen-b-wallace-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.lbwcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:12:59.782Z",
+  "fetchedAt": "2026-05-13T02:12:19.884Z",
   "size": 1097,
   "shareFirstGeneration": 0.5203426124,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4099,
     "completionRate200nt": 0.4712,
-    "transferRate": 0.1854
+    "transferRate": 0.1854,
+    "retentionRateFullTime": 0.6352,
+    "retentionRatePartTime": 0.3906
   },
   "earnings": {
-    "median10YrsAfterEntry": 32307
+    "median10YrsAfterEntry": 32307,
+    "median1YrAfterCompletion": 31975,
+    "percentile25_10YrsAfterEntry": 17935,
+    "percentile75_10YrsAfterEntry": 49606,
+    "shareEarningAboveHsGrad": 0.466
   }
 }

--- a/data/al/scorecard/marion-military-institute.json
+++ b/data/al/scorecard/marion-military-institute.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.marionmilitary.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:00.501Z",
+  "fetchedAt": "2026-05-13T02:12:20.312Z",
   "size": 329,
   "shareFirstGeneration": 0.2338028169,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3596,
     "completionRate200nt": 0.3189,
-    "transferRate": 0.5337
+    "transferRate": 0.5337,
+    "retentionRateFullTime": 0.4624,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 59644
+    "median10YrsAfterEntry": 59644,
+    "median1YrAfterCompletion": 27114,
+    "percentile25_10YrsAfterEntry": 34500,
+    "percentile75_10YrsAfterEntry": 83934,
+    "shareEarningAboveHsGrad": 0.798
   }
 }

--- a/data/al/scorecard/northeast-alabama-community-college.json
+++ b/data/al/scorecard/northeast-alabama-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nacc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:01.534Z",
+  "fetchedAt": "2026-05-13T02:12:21.350Z",
   "size": 1629,
   "shareFirstGeneration": 0.5827759197,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5597,
     "completionRate200nt": 0.5719,
-    "transferRate": 0.0483
+    "transferRate": 0.0483,
+    "retentionRateFullTime": 0.695,
+    "retentionRatePartTime": 0.6228
   },
   "earnings": {
-    "median10YrsAfterEntry": 34913
+    "median10YrsAfterEntry": 34913,
+    "median1YrAfterCompletion": 36190,
+    "percentile25_10YrsAfterEntry": 19863,
+    "percentile75_10YrsAfterEntry": 53108,
+    "shareEarningAboveHsGrad": 0.499
   }
 }

--- a/data/al/scorecard/northwest-shoals-community-college.json
+++ b/data/al/scorecard/northwest-shoals-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nwscc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:01.072Z",
+  "fetchedAt": "2026-05-13T02:12:20.895Z",
   "size": 1969,
   "shareFirstGeneration": 0.5141117875,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3873,
     "completionRate200nt": 0.3897,
-    "transferRate": 0.1275
+    "transferRate": 0.1275,
+    "retentionRateFullTime": 0.6886,
+    "retentionRatePartTime": 0.3624
   },
   "earnings": {
-    "median10YrsAfterEntry": 33828
+    "median10YrsAfterEntry": 33828,
+    "median1YrAfterCompletion": 35767,
+    "percentile25_10YrsAfterEntry": 17252,
+    "percentile75_10YrsAfterEntry": 51875,
+    "shareEarningAboveHsGrad": 0.471
   }
 }

--- a/data/al/scorecard/reid-state-technical-college.json
+++ b/data/al/scorecard/reid-state-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.rstc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:02.210Z",
+  "fetchedAt": "2026-05-13T02:12:21.835Z",
   "size": 416,
   "shareFirstGeneration": 0.5903225806,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.589,
     "completionRate200nt": 0.5946,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.6329,
+    "retentionRatePartTime": 0.4286
   },
   "earnings": {
-    "median10YrsAfterEntry": 28982
+    "median10YrsAfterEntry": 28982,
+    "median1YrAfterCompletion": 35385,
+    "percentile25_10YrsAfterEntry": 15362,
+    "percentile75_10YrsAfterEntry": 48258,
+    "shareEarningAboveHsGrad": 0.361
   }
 }

--- a/data/al/scorecard/shelton-state-community-college.json
+++ b/data/al/scorecard/shelton-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sheltonstate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:03.535Z",
+  "fetchedAt": "2026-05-13T02:12:22.739Z",
   "size": 3148,
   "shareFirstGeneration": 0.4763044519,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2956,
     "completionRate200nt": 0.2163,
-    "transferRate": 0.1946
+    "transferRate": 0.1946,
+    "retentionRateFullTime": 0.5809,
+    "retentionRatePartTime": 0.3991
   },
   "earnings": {
-    "median10YrsAfterEntry": 35014
+    "median10YrsAfterEntry": 35014,
+    "median1YrAfterCompletion": 40647,
+    "percentile25_10YrsAfterEntry": 19005,
+    "percentile75_10YrsAfterEntry": 52090,
+    "shareEarningAboveHsGrad": 0.48
   }
 }

--- a/data/al/scorecard/snead-state-community-college.json
+++ b/data/al/scorecard/snead-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.snead.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:03.980Z",
+  "fetchedAt": "2026-05-13T02:12:23.176Z",
   "size": 1427,
   "shareFirstGeneration": 0.5326251897,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4898,
     "completionRate200nt": 0.4854,
-    "transferRate": 0.1434
+    "transferRate": 0.1434,
+    "retentionRateFullTime": 0.6803,
+    "retentionRatePartTime": 0.3521
   },
   "earnings": {
-    "median10YrsAfterEntry": 35735
+    "median10YrsAfterEntry": 35735,
+    "median1YrAfterCompletion": 33687,
+    "percentile25_10YrsAfterEntry": 17797,
+    "percentile75_10YrsAfterEntry": 54322,
+    "shareEarningAboveHsGrad": 0.499
   }
 }

--- a/data/al/scorecard/southern-union-state-community-college.json
+++ b/data/al/scorecard/southern-union-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.suscc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:05.599Z",
+  "fetchedAt": "2026-05-13T02:12:24.704Z",
   "size": 4173,
   "shareFirstGeneration": 0.4423157018,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3578,
     "completionRate200nt": 0.3388,
-    "transferRate": 0.2959
+    "transferRate": 0.2959,
+    "retentionRateFullTime": 0.6716,
+    "retentionRatePartTime": 0.377
   },
   "earnings": {
-    "median10YrsAfterEntry": 36597
+    "median10YrsAfterEntry": 36597,
+    "median1YrAfterCompletion": 37708,
+    "percentile25_10YrsAfterEntry": 20430,
+    "percentile75_10YrsAfterEntry": 56788,
+    "shareEarningAboveHsGrad": 0.544
   }
 }

--- a/data/ct/scorecard/ct-state.json
+++ b/data/ct/scorecard/ct-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://ctstate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:06.192Z",
+  "fetchedAt": "2026-05-13T02:12:25.157Z",
   "size": 33645,
   "shareFirstGeneration": 0.576844956,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2414,
     "completionRate200nt": 0.2424,
-    "transferRate": 0.131
+    "transferRate": 0.131,
+    "retentionRateFullTime": 0.685,
+    "retentionRatePartTime": 0.5072
   },
   "earnings": {
-    "median10YrsAfterEntry": 41344
+    "median10YrsAfterEntry": 41344,
+    "median1YrAfterCompletion": 39303,
+    "percentile25_10YrsAfterEntry": 22093,
+    "percentile75_10YrsAfterEntry": 63375,
+    "shareEarningAboveHsGrad": 0.583
   }
 }

--- a/data/de/scorecard/dtcc.json
+++ b/data/de/scorecard/dtcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.dtcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:06.864Z",
+  "fetchedAt": "2026-05-13T02:12:25.825Z",
   "size": 10867,
   "shareFirstGeneration": 0.4992614476,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41448
+    "median10YrsAfterEntry": 41448,
+    "median1YrAfterCompletion": 41830,
+    "percentile25_10YrsAfterEntry": 23434,
+    "percentile75_10YrsAfterEntry": 61211,
+    "shareEarningAboveHsGrad": 0.567
   }
 }

--- a/data/fl/scorecard/broward.json
+++ b/data/fl/scorecard/broward.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.broward.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:07.315Z",
+  "fetchedAt": "2026-05-13T02:12:26.273Z",
   "size": 24922,
   "shareFirstGeneration": 0.4873697419,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41939
+    "median10YrsAfterEntry": 41939,
+    "median1YrAfterCompletion": 38818,
+    "percentile25_10YrsAfterEntry": 21991,
+    "percentile75_10YrsAfterEntry": 63877,
+    "shareEarningAboveHsGrad": 0.625
   }
 }

--- a/data/fl/scorecard/cf.json
+++ b/data/fl/scorecard/cf.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cf.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:08.423Z",
+  "fetchedAt": "2026-05-13T02:12:27.374Z",
   "size": 5033,
   "shareFirstGeneration": 0.4876564085,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 38203
+    "median10YrsAfterEntry": 38203,
+    "median1YrAfterCompletion": 37892,
+    "percentile25_10YrsAfterEntry": 21603,
+    "percentile75_10YrsAfterEntry": 56432,
+    "shareEarningAboveHsGrad": 0.569
   }
 }

--- a/data/fl/scorecard/cfk.json
+++ b/data/fl/scorecard/cfk.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.cfk.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:10.556Z",
+  "fetchedAt": "2026-05-13T02:12:29.355Z",
   "size": 1012,
   "shareFirstGeneration": 0.4184782609,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 42508
+    "median10YrsAfterEntry": 42508,
+    "median1YrAfterCompletion": 42669,
+    "percentile25_10YrsAfterEntry": 22938,
+    "percentile75_10YrsAfterEntry": 66494,
+    "shareEarningAboveHsGrad": 0.535
   }
 }

--- a/data/fl/scorecard/chipola.json
+++ b/data/fl/scorecard/chipola.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.chipola.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:07.773Z",
+  "fetchedAt": "2026-05-13T02:12:26.918Z",
   "size": 1312,
   "shareFirstGeneration": 0.5083969466,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 37378
+    "median10YrsAfterEntry": 37378,
+    "median1YrAfterCompletion": 38779,
+    "percentile25_10YrsAfterEntry": 21069,
+    "percentile75_10YrsAfterEntry": 54848,
+    "shareEarningAboveHsGrad": 0.543
   }
 }

--- a/data/fl/scorecard/daytonastate.json
+++ b/data/fl/scorecard/daytonastate.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.daytonastate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:08.924Z",
+  "fetchedAt": "2026-05-13T02:12:27.868Z",
   "size": 10176,
   "shareFirstGeneration": 0.41995441,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 37096
+    "median10YrsAfterEntry": 37096,
+    "median1YrAfterCompletion": 39145,
+    "percentile25_10YrsAfterEntry": 19272,
+    "percentile75_10YrsAfterEntry": 56849,
+    "shareEarningAboveHsGrad": 0.514
   }
 }

--- a/data/fl/scorecard/easternflorida.json
+++ b/data/fl/scorecard/easternflorida.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.easternflorida.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:09.499Z",
+  "fetchedAt": "2026-05-13T02:12:28.456Z",
   "size": 10490,
   "shareFirstGeneration": 0.4004611837,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 37195
+    "median10YrsAfterEntry": 37195,
+    "median1YrAfterCompletion": 37099,
+    "percentile25_10YrsAfterEntry": 20193,
+    "percentile75_10YrsAfterEntry": 56671,
+    "shareEarningAboveHsGrad": 0.522
   }
 }

--- a/data/fl/scorecard/fgc.json
+++ b/data/fl/scorecard/fgc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.fgc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:09.968Z",
+  "fetchedAt": "2026-05-13T02:12:28.912Z",
   "size": 2301,
   "shareFirstGeneration": 0.5539906103,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 37894
+    "median10YrsAfterEntry": 37894,
+    "median1YrAfterCompletion": 42263,
+    "percentile25_10YrsAfterEntry": 21851,
+    "percentile75_10YrsAfterEntry": 55093,
+    "shareEarningAboveHsGrad": 0.528
   }
 }

--- a/data/fl/scorecard/fscj.json
+++ b/data/fl/scorecard/fscj.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.fscj.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:11.451Z",
+  "fetchedAt": "2026-05-13T02:12:30.255Z",
   "size": 19648,
   "shareFirstGeneration": 0.4410528917,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 42244
+    "median10YrsAfterEntry": 42244,
+    "median1YrAfterCompletion": 44004,
+    "percentile25_10YrsAfterEntry": 23927,
+    "percentile75_10YrsAfterEntry": 62565,
+    "shareEarningAboveHsGrad": 0.576
   }
 }

--- a/data/fl/scorecard/fsw.json
+++ b/data/fl/scorecard/fsw.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.fsw.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:11.000Z",
+  "fetchedAt": "2026-05-13T02:12:29.789Z",
   "size": 11052,
   "shareFirstGeneration": 0.504302926,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 43421
+    "median10YrsAfterEntry": 43421,
+    "median1YrAfterCompletion": 39162,
+    "percentile25_10YrsAfterEntry": 26268,
+    "percentile75_10YrsAfterEntry": 63096,
+    "shareEarningAboveHsGrad": 0.621
   }
 }

--- a/data/fl/scorecard/gulfcoast.json
+++ b/data/fl/scorecard/gulfcoast.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://gulfcoast.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:11.967Z",
+  "fetchedAt": "2026-05-13T02:12:30.710Z",
   "size": 3934,
   "shareFirstGeneration": 0.4887218045,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 38359
+    "median10YrsAfterEntry": 38359,
+    "median1YrAfterCompletion": 44034,
+    "percentile25_10YrsAfterEntry": 20608,
+    "percentile75_10YrsAfterEntry": 56280,
+    "shareEarningAboveHsGrad": 0.523
   }
 }

--- a/data/fl/scorecard/hccfl.json
+++ b/data/fl/scorecard/hccfl.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.hccfl.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:12.483Z",
+  "fetchedAt": "2026-05-13T02:12:31.139Z",
   "size": 21472,
   "shareFirstGeneration": 0.4631021524,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 40782
+    "median10YrsAfterEntry": 40782,
+    "median1YrAfterCompletion": 39071,
+    "percentile25_10YrsAfterEntry": 22231,
+    "percentile75_10YrsAfterEntry": 60796,
+    "shareEarningAboveHsGrad": 0.603
   }
 }

--- a/data/fl/scorecard/irsc.json
+++ b/data/fl/scorecard/irsc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.irsc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:13.095Z",
+  "fetchedAt": "2026-05-13T02:12:31.607Z",
   "size": 11822,
   "shareFirstGeneration": 0.4801352494,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 38315
+    "median10YrsAfterEntry": 38315,
+    "median1YrAfterCompletion": 36684,
+    "percentile25_10YrsAfterEntry": 21540,
+    "percentile75_10YrsAfterEntry": 56244,
+    "shareEarningAboveHsGrad": 0.535
   }
 }

--- a/data/fl/scorecard/lssc.json
+++ b/data/fl/scorecard/lssc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.lssc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:13.549Z",
+  "fetchedAt": "2026-05-13T02:12:32.070Z",
   "size": 4177,
   "shareFirstGeneration": 0.4565217391,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39876
+    "median10YrsAfterEntry": 39876,
+    "median1YrAfterCompletion": 34175,
+    "percentile25_10YrsAfterEntry": 23045,
+    "percentile75_10YrsAfterEntry": 57179,
+    "shareEarningAboveHsGrad": 0.565
   }
 }

--- a/data/fl/scorecard/mdc.json
+++ b/data/fl/scorecard/mdc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mdc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:14.025Z",
+  "fetchedAt": "2026-05-13T02:12:32.555Z",
   "size": 46182,
   "shareFirstGeneration": 0.4858954041,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 40654
+    "median10YrsAfterEntry": 40654,
+    "median1YrAfterCompletion": 36815,
+    "percentile25_10YrsAfterEntry": 20876,
+    "percentile75_10YrsAfterEntry": 62653,
+    "shareEarningAboveHsGrad": 0.556
   }
 }

--- a/data/fl/scorecard/nfc.json
+++ b/data/fl/scorecard/nfc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nfc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:14.619Z",
+  "fetchedAt": "2026-05-13T02:12:33.138Z",
   "size": 793,
   "shareFirstGeneration": 0.5452586207,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 33929
+    "median10YrsAfterEntry": 33929,
+    "median1YrAfterCompletion": 38687,
+    "percentile25_10YrsAfterEntry": 18775,
+    "percentile75_10YrsAfterEntry": 52202,
+    "shareEarningAboveHsGrad": 0.529
   }
 }

--- a/data/fl/scorecard/nwfsc.json
+++ b/data/fl/scorecard/nwfsc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nwfsc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:15.059Z",
+  "fetchedAt": "2026-05-13T02:12:33.611Z",
   "size": 3010,
   "shareFirstGeneration": 0.4357734807,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39664
+    "median10YrsAfterEntry": 39664,
+    "median1YrAfterCompletion": 38825,
+    "percentile25_10YrsAfterEntry": 21051,
+    "percentile75_10YrsAfterEntry": 57646,
+    "shareEarningAboveHsGrad": 0.498
   }
 }

--- a/data/fl/scorecard/palmbeachstate.json
+++ b/data/fl/scorecard/palmbeachstate.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.palmbeachstate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:15.552Z",
+  "fetchedAt": "2026-05-13T02:12:34.237Z",
   "size": 21956,
   "shareFirstGeneration": 0.4944391484,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41923
+    "median10YrsAfterEntry": 41923,
+    "median1YrAfterCompletion": 37708,
+    "percentile25_10YrsAfterEntry": 23109,
+    "percentile75_10YrsAfterEntry": 62462,
+    "shareEarningAboveHsGrad": 0.601
   }
 }

--- a/data/fl/scorecard/pensacolastate.json
+++ b/data/fl/scorecard/pensacolastate.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.pensacolastate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:16.823Z",
+  "fetchedAt": "2026-05-13T02:12:35.141Z",
   "size": 7538,
   "shareFirstGeneration": 0.4935842601,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 36739
+    "median10YrsAfterEntry": 36739,
+    "median1YrAfterCompletion": 37504,
+    "percentile25_10YrsAfterEntry": 19318,
+    "percentile75_10YrsAfterEntry": 56096,
+    "shareEarningAboveHsGrad": 0.503
   }
 }

--- a/data/fl/scorecard/phsc.json
+++ b/data/fl/scorecard/phsc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.phsc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:16.371Z",
+  "fetchedAt": "2026-05-13T02:12:34.683Z",
   "size": 6900,
   "shareFirstGeneration": 0.431160221,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39903
+    "median10YrsAfterEntry": 39903,
+    "median1YrAfterCompletion": 45099,
+    "percentile25_10YrsAfterEntry": 21632,
+    "percentile75_10YrsAfterEntry": 59483,
+    "shareEarningAboveHsGrad": 0.529
   }
 }

--- a/data/fl/scorecard/polk.json
+++ b/data/fl/scorecard/polk.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.polk.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:17.289Z",
+  "fetchedAt": "2026-05-13T02:12:35.597Z",
   "size": 7180,
   "shareFirstGeneration": 0.5143329658,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 40624
+    "median10YrsAfterEntry": 40624,
+    "median1YrAfterCompletion": 45888,
+    "percentile25_10YrsAfterEntry": 23502,
+    "percentile75_10YrsAfterEntry": 60243,
+    "shareEarningAboveHsGrad": 0.58
   }
 }

--- a/data/fl/scorecard/scf.json
+++ b/data/fl/scorecard/scf.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.scf.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:20.338Z",
+  "fetchedAt": "2026-05-13T02:12:38.412Z",
   "size": 7379,
   "shareFirstGeneration": 0.4584276018,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 40318
+    "median10YrsAfterEntry": 40318,
+    "median1YrAfterCompletion": 44016,
+    "percentile25_10YrsAfterEntry": 22359,
+    "percentile75_10YrsAfterEntry": 58900,
+    "shareEarningAboveHsGrad": 0.563
   }
 }

--- a/data/fl/scorecard/seminolestate.json
+++ b/data/fl/scorecard/seminolestate.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.seminolestate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:18.316Z",
+  "fetchedAt": "2026-05-13T02:12:36.642Z",
   "size": 12864,
   "shareFirstGeneration": 0.4066587396,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41733
+    "median10YrsAfterEntry": 41733,
+    "median1YrAfterCompletion": 41399,
+    "percentile25_10YrsAfterEntry": 23051,
+    "percentile75_10YrsAfterEntry": 62446,
+    "shareEarningAboveHsGrad": 0.568
   }
 }

--- a/data/fl/scorecard/sfcollege.json
+++ b/data/fl/scorecard/sfcollege.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sfcollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:17.806Z",
+  "fetchedAt": "2026-05-13T02:12:36.206Z",
   "size": 11122,
   "shareFirstGeneration": 0.4184346586,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41631
+    "median10YrsAfterEntry": 41631,
+    "median1YrAfterCompletion": 42955,
+    "percentile25_10YrsAfterEntry": 23742,
+    "percentile75_10YrsAfterEntry": 62377,
+    "shareEarningAboveHsGrad": 0.622
   }
 }

--- a/data/fl/scorecard/sjrstate.json
+++ b/data/fl/scorecard/sjrstate.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sjrstate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:19.254Z",
+  "fetchedAt": "2026-05-13T02:12:37.475Z",
   "size": 4403,
   "shareFirstGeneration": 0.4292929293,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41728
+    "median10YrsAfterEntry": 41728,
+    "median1YrAfterCompletion": 41450,
+    "percentile25_10YrsAfterEntry": 23951,
+    "percentile75_10YrsAfterEntry": 60854,
+    "shareEarningAboveHsGrad": 0.553
   }
 }

--- a/data/fl/scorecard/southflorida.json
+++ b/data/fl/scorecard/southflorida.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.southflorida.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:18.758Z",
+  "fetchedAt": "2026-05-13T02:12:37.108Z",
   "size": 2045,
   "shareFirstGeneration": 0.5544354839,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39990
+    "median10YrsAfterEntry": 39990,
+    "median1YrAfterCompletion": 37102,
+    "percentile25_10YrsAfterEntry": 24070,
+    "percentile75_10YrsAfterEntry": 57852,
+    "shareEarningAboveHsGrad": 0.483
   }
 }

--- a/data/fl/scorecard/spcollege.json
+++ b/data/fl/scorecard/spcollege.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.spcollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:19.858Z",
+  "fetchedAt": "2026-05-13T02:12:37.947Z",
   "size": 18950,
   "shareFirstGeneration": 0.4442639594,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 42557
+    "median10YrsAfterEntry": 42557,
+    "median1YrAfterCompletion": 45775,
+    "percentile25_10YrsAfterEntry": 23808,
+    "percentile75_10YrsAfterEntry": 63709,
+    "shareEarningAboveHsGrad": 0.582
   }
 }

--- a/data/fl/scorecard/tcc-fl.json
+++ b/data/fl/scorecard/tcc-fl.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.tsc.fl.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:20.876Z",
+  "fetchedAt": "2026-05-13T02:12:38.933Z",
   "size": 11053,
   "shareFirstGeneration": 0.4186651794,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 37561
+    "median10YrsAfterEntry": 37561,
+    "median1YrAfterCompletion": 41966,
+    "percentile25_10YrsAfterEntry": 20148,
+    "percentile75_10YrsAfterEntry": 56002,
+    "shareEarningAboveHsGrad": 0.556
   }
 }

--- a/data/fl/scorecard/valencia.json
+++ b/data/fl/scorecard/valencia.json
@@ -6,7 +6,7 @@
   "schoolUrl": "valenciacollege.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:21.538Z",
+  "fetchedAt": "2026-05-13T02:12:39.493Z",
   "size": 39486,
   "shareFirstGeneration": 0.4214585852,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 40594
+    "median10YrsAfterEntry": 40594,
+    "median1YrAfterCompletion": 30627,
+    "percentile25_10YrsAfterEntry": 22495,
+    "percentile75_10YrsAfterEntry": 60732,
+    "shareEarningAboveHsGrad": 0.596
   }
 }

--- a/data/ga/scorecard/albany-tech.json
+++ b/data/ga/scorecard/albany-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.albanytech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:22.018Z",
+  "fetchedAt": "2026-05-13T02:12:40.071Z",
   "size": 2029,
   "shareFirstGeneration": 0.4639423077,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4225,
     "completionRate200nt": 0.4087,
-    "transferRate": 0.0588
+    "transferRate": 0.0588,
+    "retentionRateFullTime": 0.507,
+    "retentionRatePartTime": 0.2941
   },
   "earnings": {
-    "median10YrsAfterEntry": 30541
+    "median10YrsAfterEntry": 30541,
+    "median1YrAfterCompletion": 32970,
+    "percentile25_10YrsAfterEntry": 16430,
+    "percentile75_10YrsAfterEntry": 47525,
+    "shareEarningAboveHsGrad": 0.361
   }
 }

--- a/data/ga/scorecard/athens-tech.json
+++ b/data/ga/scorecard/athens-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.athenstech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:22.516Z",
+  "fetchedAt": "2026-05-13T02:12:40.575Z",
   "size": 3318,
   "shareFirstGeneration": 0.4912758997,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5056,
     "completionRate200nt": 0.4793,
-    "transferRate": 0.0722
+    "transferRate": 0.0722,
+    "retentionRateFullTime": 0.73,
+    "retentionRatePartTime": 0.5513
   },
   "earnings": {
-    "median10YrsAfterEntry": 35951
+    "median10YrsAfterEntry": 35951,
+    "median1YrAfterCompletion": 39217,
+    "percentile25_10YrsAfterEntry": 19921,
+    "percentile75_10YrsAfterEntry": 54454,
+    "shareEarningAboveHsGrad": 0.495
   }
 }

--- a/data/ga/scorecard/atlanta-tech.json
+++ b/data/ga/scorecard/atlanta-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://atlantatech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:22.992Z",
+  "fetchedAt": "2026-05-13T02:12:41.010Z",
   "size": 3875,
   "shareFirstGeneration": 0.484984985,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4874,
     "completionRate200nt": 0.48,
-    "transferRate": 0.084
+    "transferRate": 0.084,
+    "retentionRateFullTime": 0.6488,
+    "retentionRatePartTime": 0.4289
   },
   "earnings": {
-    "median10YrsAfterEntry": 30350
+    "median10YrsAfterEntry": 30350,
+    "median1YrAfterCompletion": 31118,
+    "percentile25_10YrsAfterEntry": 14500,
+    "percentile75_10YrsAfterEntry": 48443,
+    "shareEarningAboveHsGrad": 0.371
   }
 }

--- a/data/ga/scorecard/augusta-tech.json
+++ b/data/ga/scorecard/augusta-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.augustatech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:23.464Z",
+  "fetchedAt": "2026-05-13T02:12:41.478Z",
   "size": 3923,
   "shareFirstGeneration": 0.4495338468,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3107,
     "completionRate200nt": 0.3817,
-    "transferRate": 0.0914
+    "transferRate": 0.0914,
+    "retentionRateFullTime": 0.5667,
+    "retentionRatePartTime": 0.3764
   },
   "earnings": {
-    "median10YrsAfterEntry": 33523
+    "median10YrsAfterEntry": 33523,
+    "median1YrAfterCompletion": 36224,
+    "percentile25_10YrsAfterEntry": 18463,
+    "percentile75_10YrsAfterEntry": 51114,
+    "shareEarningAboveHsGrad": 0.426
   }
 }

--- a/data/ga/scorecard/central-ga-tech.json
+++ b/data/ga/scorecard/central-ga-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.centralgatech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:24.112Z",
+  "fetchedAt": "2026-05-13T02:12:42.023Z",
   "size": 6174,
   "shareFirstGeneration": 0.4825493171,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4697,
     "completionRate200nt": 0.5,
-    "transferRate": 0.0859
+    "transferRate": 0.0859,
+    "retentionRateFullTime": 0.5608,
+    "retentionRatePartTime": 0.4809
   },
   "earnings": {
-    "median10YrsAfterEntry": 30848
+    "median10YrsAfterEntry": 30848,
+    "median1YrAfterCompletion": 36207,
+    "percentile25_10YrsAfterEntry": 15625,
+    "percentile75_10YrsAfterEntry": 48547,
+    "shareEarningAboveHsGrad": 0.368
   }
 }

--- a/data/ga/scorecard/chattahoochee-tech.json
+++ b/data/ga/scorecard/chattahoochee-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.chattahoocheetech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:24.671Z",
+  "fetchedAt": "2026-05-13T02:12:42.517Z",
   "size": 8727,
   "shareFirstGeneration": 0.4184714961,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3827,
     "completionRate200nt": 0.4652,
-    "transferRate": 0.128
+    "transferRate": 0.128,
+    "retentionRateFullTime": 0.6751,
+    "retentionRatePartTime": 0.5386
   },
   "earnings": {
-    "median10YrsAfterEntry": 37138
+    "median10YrsAfterEntry": 37138,
+    "median1YrAfterCompletion": 37470,
+    "percentile25_10YrsAfterEntry": 18614,
+    "percentile75_10YrsAfterEntry": 56819,
+    "shareEarningAboveHsGrad": 0.507
   }
 }

--- a/data/ga/scorecard/coastal-pines-tech.json
+++ b/data/ga/scorecard/coastal-pines-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.coastalpines.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:25.113Z",
+  "fetchedAt": "2026-05-13T02:12:42.974Z",
   "size": 1648,
   "shareFirstGeneration": 0.5185185185,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4828,
     "completionRate200nt": 0.5761,
-    "transferRate": 0.0517
+    "transferRate": 0.0517,
+    "retentionRateFullTime": 0.663,
+    "retentionRatePartTime": 0.3614
   },
   "earnings": {
-    "median10YrsAfterEntry": 30214
+    "median10YrsAfterEntry": 30214,
+    "median1YrAfterCompletion": 33158,
+    "percentile25_10YrsAfterEntry": 15311,
+    "percentile75_10YrsAfterEntry": 47201,
+    "shareEarningAboveHsGrad": 0.409
   }
 }

--- a/data/ga/scorecard/columbus-tech.json
+++ b/data/ga/scorecard/columbus-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.columbustech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:25.564Z",
+  "fetchedAt": "2026-05-13T02:12:43.564Z",
   "size": 2719,
   "shareFirstGeneration": 0.4165232358,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2674,
     "completionRate200nt": 0.3005,
-    "transferRate": 0.0909
+    "transferRate": 0.0909,
+    "retentionRateFullTime": 0.5217,
+    "retentionRatePartTime": 0.3911
   },
   "earnings": {
-    "median10YrsAfterEntry": 34238
+    "median10YrsAfterEntry": 34238,
+    "median1YrAfterCompletion": 26913,
+    "percentile25_10YrsAfterEntry": 18245,
+    "percentile75_10YrsAfterEntry": 49911,
+    "shareEarningAboveHsGrad": 0.446
   }
 }

--- a/data/ga/scorecard/ga-northwestern-tech.json
+++ b/data/ga/scorecard/ga-northwestern-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.gntc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:26.139Z",
+  "fetchedAt": "2026-05-13T02:12:44.034Z",
   "size": 4244,
   "shareFirstGeneration": 0.547123623,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4344,
     "completionRate200nt": 0.4699,
-    "transferRate": 0.0375
+    "transferRate": 0.0375,
+    "retentionRateFullTime": 0.6232,
+    "retentionRatePartTime": 0.4574
   },
   "earnings": {
-    "median10YrsAfterEntry": 35759
+    "median10YrsAfterEntry": 35759,
+    "median1YrAfterCompletion": 36365,
+    "percentile25_10YrsAfterEntry": 19147,
+    "percentile75_10YrsAfterEntry": 52724,
+    "shareEarningAboveHsGrad": 0.447
   }
 }

--- a/data/ga/scorecard/ga-piedmont-tech.json
+++ b/data/ga/scorecard/ga-piedmont-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.gptc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:26.589Z",
+  "fetchedAt": "2026-05-13T02:12:44.649Z",
   "size": 2198,
   "shareFirstGeneration": 0.463255814,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4409,
     "completionRate200nt": 0.3721,
-    "transferRate": 0.0945
+    "transferRate": 0.0945,
+    "retentionRateFullTime": 0.5822,
+    "retentionRatePartTime": 0.4301
   },
   "earnings": {
-    "median10YrsAfterEntry": 34619
+    "median10YrsAfterEntry": 34619,
+    "median1YrAfterCompletion": 34461,
+    "percentile25_10YrsAfterEntry": 17125,
+    "percentile75_10YrsAfterEntry": 53298,
+    "shareEarningAboveHsGrad": 0.457
   }
 }

--- a/data/ga/scorecard/gwinnett-tech.json
+++ b/data/ga/scorecard/gwinnett-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.gwinnetttech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:27.125Z",
+  "fetchedAt": "2026-05-13T02:12:45.231Z",
   "size": 8728,
   "shareFirstGeneration": 0.4030079021,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3166,
     "completionRate200nt": 0.4013,
-    "transferRate": 0.1473
+    "transferRate": 0.1473,
+    "retentionRateFullTime": 0.5835,
+    "retentionRatePartTime": 0.489
   },
   "earnings": {
-    "median10YrsAfterEntry": 45025
+    "median10YrsAfterEntry": 45025,
+    "median1YrAfterCompletion": 40663,
+    "percentile25_10YrsAfterEntry": 24949,
+    "percentile75_10YrsAfterEntry": 66239,
+    "shareEarningAboveHsGrad": 0.609
   }
 }

--- a/data/ga/scorecard/lanier-tech.json
+++ b/data/ga/scorecard/lanier-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.laniertech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:27.571Z",
+  "fetchedAt": "2026-05-13T02:12:45.678Z",
   "size": 4613,
   "shareFirstGeneration": 0.5151515152,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3397,
     "completionRate200nt": 0.4985,
-    "transferRate": 0.1168
+    "transferRate": 0.1168,
+    "retentionRateFullTime": 0.5787,
+    "retentionRatePartTime": 0.5641
   },
   "earnings": {
-    "median10YrsAfterEntry": 37623
+    "median10YrsAfterEntry": 37623,
+    "median1YrAfterCompletion": 36481,
+    "percentile25_10YrsAfterEntry": 20654,
+    "percentile75_10YrsAfterEntry": 56857,
+    "shareEarningAboveHsGrad": 0.468
   }
 }

--- a/data/ga/scorecard/north-ga-tech.json
+++ b/data/ga/scorecard/north-ga-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://northgatech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:28.013Z",
+  "fetchedAt": "2026-05-13T02:12:46.607Z",
   "size": 1910,
   "shareFirstGeneration": 0.4933949802,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3925,
     "completionRate200nt": 0.5121,
-    "transferRate": 0.0966
+    "transferRate": 0.0966,
+    "retentionRateFullTime": 0.5824,
+    "retentionRatePartTime": 0.5962
   },
   "earnings": {
-    "median10YrsAfterEntry": 32932
+    "median10YrsAfterEntry": 32932,
+    "median1YrAfterCompletion": 32985,
+    "percentile25_10YrsAfterEntry": 16709,
+    "percentile75_10YrsAfterEntry": 49841,
+    "shareEarningAboveHsGrad": 0.432
   }
 }

--- a/data/ga/scorecard/oconee-fall-line-tech.json
+++ b/data/ga/scorecard/oconee-fall-line-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.oftc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:28.457Z",
+  "fetchedAt": "2026-05-13T02:12:47.074Z",
   "size": 1708,
   "shareFirstGeneration": 0.5374841169,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.6515,
     "completionRate200nt": 0.4833,
-    "transferRate": 0.0152
+    "transferRate": 0.0152,
+    "retentionRateFullTime": 0.6615,
+    "retentionRatePartTime": 0.476
   },
   "earnings": {
-    "median10YrsAfterEntry": 30899
+    "median10YrsAfterEntry": 30899,
+    "median1YrAfterCompletion": 38357,
+    "percentile25_10YrsAfterEntry": 16069,
+    "percentile75_10YrsAfterEntry": 46474,
+    "shareEarningAboveHsGrad": 0.352
   }
 }

--- a/data/ga/scorecard/ogeechee-tech.json
+++ b/data/ga/scorecard/ogeechee-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ogeecheetech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:28.966Z",
+  "fetchedAt": "2026-05-13T02:12:47.507Z",
   "size": 1820,
   "shareFirstGeneration": 0.459937565,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4294,
     "completionRate200nt": 0.4386,
-    "transferRate": 0.0734
+    "transferRate": 0.0734,
+    "retentionRateFullTime": 0.5851,
+    "retentionRatePartTime": 0.5056
   },
   "earnings": {
-    "median10YrsAfterEntry": 31248
+    "median10YrsAfterEntry": 31248,
+    "median1YrAfterCompletion": 33804,
+    "percentile25_10YrsAfterEntry": 16362,
+    "percentile75_10YrsAfterEntry": 48302,
+    "shareEarningAboveHsGrad": 0.439
   }
 }

--- a/data/ga/scorecard/savannah-tech.json
+++ b/data/ga/scorecard/savannah-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.savannahtech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:29.445Z",
+  "fetchedAt": "2026-05-13T02:12:47.936Z",
   "size": 3366,
   "shareFirstGeneration": 0.4419836302,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4249,
     "completionRate200nt": 0.4,
-    "transferRate": 0.0806
+    "transferRate": 0.0806,
+    "retentionRateFullTime": 0.558,
+    "retentionRatePartTime": 0.4856
   },
   "earnings": {
-    "median10YrsAfterEntry": 33018
+    "median10YrsAfterEntry": 33018,
+    "median1YrAfterCompletion": 35235,
+    "percentile25_10YrsAfterEntry": 17510,
+    "percentile75_10YrsAfterEntry": 49609,
+    "shareEarningAboveHsGrad": 0.445
   }
 }

--- a/data/ga/scorecard/south-ga-tech.json
+++ b/data/ga/scorecard/south-ga-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.southgatech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:29.899Z",
+  "fetchedAt": "2026-05-13T02:12:48.406Z",
   "size": 1407,
   "shareFirstGeneration": 0.4782608696,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.6117,
     "completionRate200nt": 0.6364,
-    "transferRate": 0.0485
+    "transferRate": 0.0485,
+    "retentionRateFullTime": 0.7706,
+    "retentionRatePartTime": 0.5033
   },
   "earnings": {
-    "median10YrsAfterEntry": 30364
+    "median10YrsAfterEntry": 30364,
+    "median1YrAfterCompletion": 35410,
+    "percentile25_10YrsAfterEntry": 15356,
+    "percentile75_10YrsAfterEntry": 46878,
+    "shareEarningAboveHsGrad": 0.399
   }
 }

--- a/data/ga/scorecard/southeastern-tech.json
+++ b/data/ga/scorecard/southeastern-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.southeasterntech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:30.379Z",
+  "fetchedAt": "2026-05-13T02:12:48.863Z",
   "size": 1008,
   "shareFirstGeneration": 0.4972737186,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.375,
     "completionRate200nt": 0.4091,
-    "transferRate": 0.1607
+    "transferRate": 0.1607,
+    "retentionRateFullTime": 0.6863,
+    "retentionRatePartTime": 0.5333
   },
   "earnings": {
-    "median10YrsAfterEntry": 30329
+    "median10YrsAfterEntry": 30329,
+    "median1YrAfterCompletion": 37367,
+    "percentile25_10YrsAfterEntry": 16321,
+    "percentile75_10YrsAfterEntry": 45499,
+    "shareEarningAboveHsGrad": 0.346
   }
 }

--- a/data/ga/scorecard/southern-crescent-tech.json
+++ b/data/ga/scorecard/southern-crescent-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sctech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:30.975Z",
+  "fetchedAt": "2026-05-13T02:12:49.330Z",
   "size": 4098,
   "shareFirstGeneration": 0.492650147,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5828,
     "completionRate200nt": 0.5934,
-    "transferRate": 0.0724
+    "transferRate": 0.0724,
+    "retentionRateFullTime": 0.628,
+    "retentionRatePartTime": 0.4839
   },
   "earnings": {
-    "median10YrsAfterEntry": 36104
+    "median10YrsAfterEntry": 36104,
+    "median1YrAfterCompletion": 36503,
+    "percentile25_10YrsAfterEntry": 18492,
+    "percentile75_10YrsAfterEntry": 52236,
+    "shareEarningAboveHsGrad": 0.481
   }
 }

--- a/data/ga/scorecard/southern-regional-tech.json
+++ b/data/ga/scorecard/southern-regional-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "southernregional.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:31.430Z",
+  "fetchedAt": "2026-05-13T02:12:49.805Z",
   "size": 3098,
   "shareFirstGeneration": 0.4892086331,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3063,
     "completionRate200nt": 0.5238,
-    "transferRate": 0.0811
+    "transferRate": 0.0811,
+    "retentionRateFullTime": 0.5623,
+    "retentionRatePartTime": 0.5429
   },
   "earnings": {
-    "median10YrsAfterEntry": 31293
+    "median10YrsAfterEntry": 31293,
+    "median1YrAfterCompletion": 41050,
+    "percentile25_10YrsAfterEntry": 17357,
+    "percentile75_10YrsAfterEntry": 46945,
+    "shareEarningAboveHsGrad": 0.425
   }
 }

--- a/data/ga/scorecard/west-ga-tech.json
+++ b/data/ga/scorecard/west-ga-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.westgatech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:31.890Z",
+  "fetchedAt": "2026-05-13T02:12:50.257Z",
   "size": 5163,
   "shareFirstGeneration": 0.4755351682,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3539,
     "completionRate200nt": 0.3615,
-    "transferRate": 0.098
+    "transferRate": 0.098,
+    "retentionRateFullTime": 0.5783,
+    "retentionRatePartTime": 0.485
   },
   "earnings": {
-    "median10YrsAfterEntry": 35479
+    "median10YrsAfterEntry": 35479,
+    "median1YrAfterCompletion": 38146,
+    "percentile25_10YrsAfterEntry": 18056,
+    "percentile75_10YrsAfterEntry": 53505,
+    "shareEarningAboveHsGrad": 0.51
   }
 }

--- a/data/ga/scorecard/wiregrass-tech.json
+++ b/data/ga/scorecard/wiregrass-tech.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.wiregrass.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:32.364Z",
+  "fetchedAt": "2026-05-13T02:12:50.712Z",
   "size": 2887,
   "shareFirstGeneration": 0.4798798799,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5032,
     "completionRate200nt": 0.5156,
-    "transferRate": 0.0382
+    "transferRate": 0.0382,
+    "retentionRateFullTime": 0.6316,
+    "retentionRatePartTime": 0.4903
   },
   "earnings": {
-    "median10YrsAfterEntry": 30864
+    "median10YrsAfterEntry": 30864,
+    "median1YrAfterCompletion": 37483,
+    "percentile25_10YrsAfterEntry": 16411,
+    "percentile75_10YrsAfterEntry": 46280,
+    "shareEarningAboveHsGrad": 0.374
   }
 }

--- a/data/ia/scorecard/des-moines-area-community-college.json
+++ b/data/ia/scorecard/des-moines-area-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.dmacc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:32.829Z",
+  "fetchedAt": "2026-05-13T02:12:51.156Z",
   "size": 10446,
   "shareFirstGeneration": 0.368889583,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3917,
     "completionRate200nt": 0.4028,
-    "transferRate": 0.1658
+    "transferRate": 0.1658,
+    "retentionRateFullTime": 0.634,
+    "retentionRatePartTime": 0.4691
   },
   "earnings": {
-    "median10YrsAfterEntry": 41018
+    "median10YrsAfterEntry": 41018,
+    "median1YrAfterCompletion": 42189,
+    "percentile25_10YrsAfterEntry": 21828,
+    "percentile75_10YrsAfterEntry": 60028,
+    "shareEarningAboveHsGrad": 0.624
   }
 }

--- a/data/ia/scorecard/eastern-iowa-community-college-district.json
+++ b/data/ia/scorecard/eastern-iowa-community-college-district.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.eicc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:33.876Z",
+  "fetchedAt": "2026-05-13T02:12:52.191Z",
   "size": 3520,
   "shareFirstGeneration": 0.4479010495,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4541,
     "completionRate200nt": 0.3911,
-    "transferRate": 0.1524
+    "transferRate": 0.1524,
+    "retentionRateFullTime": 0.5903,
+    "retentionRatePartTime": 0.4873
   },
   "earnings": {
-    "median10YrsAfterEntry": 39060
+    "median10YrsAfterEntry": 39060,
+    "median1YrAfterCompletion": 40901,
+    "percentile25_10YrsAfterEntry": 20277,
+    "percentile75_10YrsAfterEntry": 58998,
+    "shareEarningAboveHsGrad": 0.528
   }
 }

--- a/data/ia/scorecard/ellsworth-community-college.json
+++ b/data/ia/scorecard/ellsworth-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://ecc.iavalley.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:33.369Z",
+  "fetchedAt": "2026-05-13T02:12:51.593Z",
   "size": 499,
   "shareFirstGeneration": 0.3151408451,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.375,
     "completionRate200nt": 0.4385,
-    "transferRate": 0.2917
+    "transferRate": 0.2917,
+    "retentionRateFullTime": 0.6385,
+    "retentionRatePartTime": 0
   },
   "earnings": {
-    "median10YrsAfterEntry": 40562
+    "median10YrsAfterEntry": 40562,
+    "median1YrAfterCompletion": 35719,
+    "percentile25_10YrsAfterEntry": 23291,
+    "percentile75_10YrsAfterEntry": 58572,
+    "shareEarningAboveHsGrad": 0.605
   }
 }

--- a/data/ia/scorecard/hawkeye-community-college.json
+++ b/data/ia/scorecard/hawkeye-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.hawkeyecollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:34.352Z",
+  "fetchedAt": "2026-05-13T02:12:52.660Z",
   "size": 2626,
   "shareFirstGeneration": 0.3601875533,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4329,
     "completionRate200nt": 0.3276,
-    "transferRate": 0.1342
+    "transferRate": 0.1342,
+    "retentionRateFullTime": 0.6316,
+    "retentionRatePartTime": 0.3702
   },
   "earnings": {
-    "median10YrsAfterEntry": 42849
+    "median10YrsAfterEntry": 42849,
+    "median1YrAfterCompletion": 39111,
+    "percentile25_10YrsAfterEntry": 26051,
+    "percentile75_10YrsAfterEntry": 61050,
+    "shareEarningAboveHsGrad": 0.646
   }
 }

--- a/data/ia/scorecard/indian-hills-community-college.json
+++ b/data/ia/scorecard/indian-hills-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.indianhills.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:34.804Z",
+  "fetchedAt": "2026-05-13T02:12:53.241Z",
   "size": 1495,
   "shareFirstGeneration": 0.4116702355,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4012,
     "completionRate200nt": 0.4329,
-    "transferRate": 0.1109
+    "transferRate": 0.1109,
+    "retentionRateFullTime": 0.5892,
+    "retentionRatePartTime": 0.4516
   },
   "earnings": {
-    "median10YrsAfterEntry": 40507
+    "median10YrsAfterEntry": 40507,
+    "median1YrAfterCompletion": 39862,
+    "percentile25_10YrsAfterEntry": 22194,
+    "percentile75_10YrsAfterEntry": 58915,
+    "shareEarningAboveHsGrad": 0.575
   }
 }

--- a/data/ia/scorecard/iowa-central-community-college.json
+++ b/data/ia/scorecard/iowa-central-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.iowacentral.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:35.251Z",
+  "fetchedAt": "2026-05-13T02:12:53.864Z",
   "size": 3103,
   "shareFirstGeneration": 0.4016949153,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4158,
     "completionRate200nt": 0.4571,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.5171,
+    "retentionRatePartTime": 0.3947
   },
   "earnings": {
-    "median10YrsAfterEntry": 42046
+    "median10YrsAfterEntry": 42046,
+    "median1YrAfterCompletion": 36243,
+    "percentile25_10YrsAfterEntry": 24936,
+    "percentile75_10YrsAfterEntry": 59799,
+    "shareEarningAboveHsGrad": 0.659
   }
 }

--- a/data/ia/scorecard/iowa-lakes-community-college.json
+++ b/data/ia/scorecard/iowa-lakes-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.iowalakes.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:35.870Z",
+  "fetchedAt": "2026-05-13T02:12:54.731Z",
   "size": 941,
   "shareFirstGeneration": 0.366745283,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5,
     "completionRate200nt": 0.3111,
-    "transferRate": 0.1412
+    "transferRate": 0.1412,
+    "retentionRateFullTime": 0.6086,
+    "retentionRatePartTime": 0.375
   },
   "earnings": {
-    "median10YrsAfterEntry": 43108
+    "median10YrsAfterEntry": 43108,
+    "median1YrAfterCompletion": 39212,
+    "percentile25_10YrsAfterEntry": 26631,
+    "percentile75_10YrsAfterEntry": 61799,
+    "shareEarningAboveHsGrad": 0.646
   }
 }

--- a/data/ia/scorecard/iowa-western-community-college.json
+++ b/data/ia/scorecard/iowa-western-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.iwcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:36.340Z",
+  "fetchedAt": "2026-05-13T02:12:55.194Z",
   "size": 2916,
   "shareFirstGeneration": 0.4247491639,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3998,
     "completionRate200nt": 0.4162,
-    "transferRate": 0.2164
+    "transferRate": 0.2164,
+    "retentionRateFullTime": 0.5702,
+    "retentionRatePartTime": 0.4167
   },
   "earnings": {
-    "median10YrsAfterEntry": 42793
+    "median10YrsAfterEntry": 42793,
+    "median1YrAfterCompletion": 39698,
+    "percentile25_10YrsAfterEntry": 25532,
+    "percentile75_10YrsAfterEntry": 61019,
+    "shareEarningAboveHsGrad": 0.603
   }
 }

--- a/data/ia/scorecard/kirkwood-community-college.json
+++ b/data/ia/scorecard/kirkwood-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.kirkwood.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:36.797Z",
+  "fetchedAt": "2026-05-13T02:12:55.639Z",
   "size": 7591,
   "shareFirstGeneration": 0.386761488,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4295,
     "completionRate200nt": 0.4391,
-    "transferRate": 0.0838
+    "transferRate": 0.0838,
+    "retentionRateFullTime": 0.7114,
+    "retentionRatePartTime": 0.4534
   },
   "earnings": {
-    "median10YrsAfterEntry": 41016
+    "median10YrsAfterEntry": 41016,
+    "median1YrAfterCompletion": 39018,
+    "percentile25_10YrsAfterEntry": 22310,
+    "percentile75_10YrsAfterEntry": 59805,
+    "shareEarningAboveHsGrad": 0.645
   }
 }

--- a/data/ia/scorecard/marshalltown-community-college.json
+++ b/data/ia/scorecard/marshalltown-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://mcc.iavalley.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:37.260Z",
+  "fetchedAt": "2026-05-13T02:12:56.064Z",
   "size": 788,
   "shareFirstGeneration": 0.4500792393,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4234,
     "completionRate200nt": 0.4009,
-    "transferRate": 0.1261
+    "transferRate": 0.1261,
+    "retentionRateFullTime": 0.6871,
+    "retentionRatePartTime": 0.2647
   },
   "earnings": {
-    "median10YrsAfterEntry": 41010
+    "median10YrsAfterEntry": 41010,
+    "median1YrAfterCompletion": 38401,
+    "percentile25_10YrsAfterEntry": 23459,
+    "percentile75_10YrsAfterEntry": 57594,
+    "shareEarningAboveHsGrad": 0.561
   }
 }

--- a/data/ia/scorecard/north-iowa-area-community-college.json
+++ b/data/ia/scorecard/north-iowa-area-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.niacc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:37.747Z",
+  "fetchedAt": "2026-05-13T02:12:56.497Z",
   "size": 1320,
   "shareFirstGeneration": 0.311790393,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.6054,
     "completionRate200nt": 0.5598,
-    "transferRate": 0.1273
+    "transferRate": 0.1273,
+    "retentionRateFullTime": 0.6674,
+    "retentionRatePartTime": 0.4167
   },
   "earnings": {
-    "median10YrsAfterEntry": 43462
+    "median10YrsAfterEntry": 43462,
+    "median1YrAfterCompletion": 40016,
+    "percentile25_10YrsAfterEntry": 26244,
+    "percentile75_10YrsAfterEntry": 59290,
+    "shareEarningAboveHsGrad": 0.623
   }
 }

--- a/data/ia/scorecard/northeast-iowa-community-college.json
+++ b/data/ia/scorecard/northeast-iowa-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nicc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:38.420Z",
+  "fetchedAt": "2026-05-13T02:12:56.954Z",
   "size": 1697,
   "shareFirstGeneration": 0.3688362919,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5144,
     "completionRate200nt": 0.5249,
-    "transferRate": 0.0731
+    "transferRate": 0.0731,
+    "retentionRateFullTime": 0.6182,
+    "retentionRatePartTime": 0.5088
   },
   "earnings": {
-    "median10YrsAfterEntry": 41306
+    "median10YrsAfterEntry": 41306,
+    "median1YrAfterCompletion": 41897,
+    "percentile25_10YrsAfterEntry": 24896,
+    "percentile75_10YrsAfterEntry": 58281,
+    "shareEarningAboveHsGrad": 0.615
   }
 }

--- a/data/ia/scorecard/northwest-iowa-community-college.json
+++ b/data/ia/scorecard/northwest-iowa-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.nwicc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:38.895Z",
+  "fetchedAt": "2026-05-13T02:12:57.540Z",
   "size": 864,
   "shareFirstGeneration": 0.3539967374,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5789,
     "completionRate200nt": 0.5721,
-    "transferRate": 0.0769
+    "transferRate": 0.0769,
+    "retentionRateFullTime": 0.727,
+    "retentionRatePartTime": 0.5135
   },
   "earnings": {
-    "median10YrsAfterEntry": 50776
+    "median10YrsAfterEntry": 50776,
+    "median1YrAfterCompletion": 55270,
+    "percentile25_10YrsAfterEntry": 32871,
+    "percentile75_10YrsAfterEntry": 74189,
+    "shareEarningAboveHsGrad": 0.761
   }
 }

--- a/data/ia/scorecard/southeastern-community-college.json
+++ b/data/ia/scorecard/southeastern-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.scciowa.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:39.592Z",
+  "fetchedAt": "2026-05-13T02:12:58.171Z",
   "size": 1699,
   "shareFirstGeneration": 0.4366972477,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4349,
     "completionRate200nt": 0.5098,
-    "transferRate": 0.0744
+    "transferRate": 0.0744,
+    "retentionRateFullTime": 0.7009,
+    "retentionRatePartTime": 0.5182
   },
   "earnings": {
-    "median10YrsAfterEntry": 36882
+    "median10YrsAfterEntry": 36882,
+    "median1YrAfterCompletion": 41282,
+    "percentile25_10YrsAfterEntry": 19031,
+    "percentile75_10YrsAfterEntry": 55291,
+    "shareEarningAboveHsGrad": 0.511
   }
 }

--- a/data/ia/scorecard/southwestern-community-college.json
+++ b/data/ia/scorecard/southwestern-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.swcciowa.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:40.040Z",
+  "fetchedAt": "2026-05-13T02:12:58.626Z",
   "size": 729,
   "shareFirstGeneration": 0.3856942496,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.593,
     "completionRate200nt": 0.5392,
-    "transferRate": 0.1589
+    "transferRate": 0.1589,
+    "retentionRateFullTime": 0.6831,
+    "retentionRatePartTime": 0.3415
   },
   "earnings": {
-    "median10YrsAfterEntry": 40129
+    "median10YrsAfterEntry": 40129,
+    "median1YrAfterCompletion": 39446,
+    "percentile25_10YrsAfterEntry": 24224,
+    "percentile75_10YrsAfterEntry": 56339,
+    "shareEarningAboveHsGrad": 0.584
   }
 }

--- a/data/ia/scorecard/western-iowa-tech-community-college.json
+++ b/data/ia/scorecard/western-iowa-tech-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.witcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:40.520Z",
+  "fetchedAt": "2026-05-13T02:12:59.065Z",
   "size": 2647,
   "shareFirstGeneration": 0.4493506494,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4955,
     "completionRate200nt": 0.5015,
-    "transferRate": 0.0664
+    "transferRate": 0.0664,
+    "retentionRateFullTime": 0.6384,
+    "retentionRatePartTime": 0.5238
   },
   "earnings": {
-    "median10YrsAfterEntry": 40473
+    "median10YrsAfterEntry": 40473,
+    "median1YrAfterCompletion": 36272,
+    "percentile25_10YrsAfterEntry": 25850,
+    "percentile75_10YrsAfterEntry": 58572,
+    "shareEarningAboveHsGrad": 0.575
   }
 }

--- a/data/ky/scorecard/ashland-community-and-technical-college.json
+++ b/data/ky/scorecard/ashland-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://ashland.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:40.992Z",
+  "fetchedAt": "2026-05-13T02:12:59.500Z",
   "size": 1631,
   "shareFirstGeneration": 0.5445094217,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5091,
     "completionRate200nt": 0.613,
-    "transferRate": 0.0732
+    "transferRate": 0.0732,
+    "retentionRateFullTime": 0.6498,
+    "retentionRatePartTime": 0.5638
   },
   "earnings": {
-    "median10YrsAfterEntry": 34504
+    "median10YrsAfterEntry": 34504,
+    "median1YrAfterCompletion": 34392,
+    "percentile25_10YrsAfterEntry": 16193,
+    "percentile75_10YrsAfterEntry": 55750,
+    "shareEarningAboveHsGrad": 0.453
   }
 }

--- a/data/ky/scorecard/big-sandy-community-and-technical-college.json
+++ b/data/ky/scorecard/big-sandy-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://bigsandy.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:47.092Z",
+  "fetchedAt": "2026-05-13T02:13:04.888Z",
   "size": 1604,
   "shareFirstGeneration": 0.6030736619,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3774,
     "completionRate200nt": 0.4181,
-    "transferRate": 0.157
+    "transferRate": 0.157,
+    "retentionRateFullTime": 0.6129,
+    "retentionRatePartTime": 0.407
   },
   "earnings": {
-    "median10YrsAfterEntry": 32954
+    "median10YrsAfterEntry": 32954,
+    "median1YrAfterCompletion": 28677,
+    "percentile25_10YrsAfterEntry": 16634,
+    "percentile75_10YrsAfterEntry": 52074,
+    "shareEarningAboveHsGrad": 0.402
   }
 }

--- a/data/ky/scorecard/bluegrass-community-and-technical-college.json
+++ b/data/ky/scorecard/bluegrass-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://bluegrass.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:41.917Z",
+  "fetchedAt": "2026-05-13T02:13:00.396Z",
   "size": 8244,
   "shareFirstGeneration": 0.445931362,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4311,
     "completionRate200nt": 0.435,
-    "transferRate": 0.1274
+    "transferRate": 0.1274,
+    "retentionRateFullTime": 0.6691,
+    "retentionRatePartTime": 0.4813
   },
   "earnings": {
-    "median10YrsAfterEntry": 36343
+    "median10YrsAfterEntry": 36343,
+    "median1YrAfterCompletion": 42755,
+    "percentile25_10YrsAfterEntry": 18236,
+    "percentile75_10YrsAfterEntry": 55372,
+    "shareEarningAboveHsGrad": 0.501
   }
 }

--- a/data/ky/scorecard/elizabethtown-community-and-technical-college.json
+++ b/data/ky/scorecard/elizabethtown-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://elizabethtown.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:42.483Z",
+  "fetchedAt": "2026-05-13T02:13:00.849Z",
   "size": 4088,
   "shareFirstGeneration": 0.4796453043,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5946,
     "completionRate200nt": 0.5274,
-    "transferRate": 0.0888
+    "transferRate": 0.0888,
+    "retentionRateFullTime": 0.7634,
+    "retentionRatePartTime": 0.4594
   },
   "earnings": {
-    "median10YrsAfterEntry": 36143
+    "median10YrsAfterEntry": 36143,
+    "median1YrAfterCompletion": 38824,
+    "percentile25_10YrsAfterEntry": 18734,
+    "percentile75_10YrsAfterEntry": 54609,
+    "shareEarningAboveHsGrad": 0.523
   }
 }

--- a/data/ky/scorecard/gateway-community-and-technical-college.json
+++ b/data/ky/scorecard/gateway-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://gateway.kctcs.edu/index.aspx",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:45.975Z",
+  "fetchedAt": "2026-05-13T02:13:03.981Z",
   "size": 3167,
   "shareFirstGeneration": 0.521817095,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5905,
     "completionRate200nt": 0.5105,
-    "transferRate": 0.1164
+    "transferRate": 0.1164,
+    "retentionRateFullTime": 0.7017,
+    "retentionRatePartTime": 0.6545
   },
   "earnings": {
-    "median10YrsAfterEntry": 36147
+    "median10YrsAfterEntry": 36147,
+    "median1YrAfterCompletion": 44644,
+    "percentile25_10YrsAfterEntry": 16749,
+    "percentile75_10YrsAfterEntry": 55386,
+    "shareEarningAboveHsGrad": 0.511
   }
 }

--- a/data/ky/scorecard/hazard-community-and-technical-college.json
+++ b/data/ky/scorecard/hazard-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://hazard.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:42.998Z",
+  "fetchedAt": "2026-05-13T02:13:01.310Z",
   "size": 1506,
   "shareFirstGeneration": 0.607879925,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4757,
     "completionRate200nt": 0.4884,
-    "transferRate": 0.1049
+    "transferRate": 0.1049,
+    "retentionRateFullTime": 0.6693,
+    "retentionRatePartTime": 0.5714
   },
   "earnings": {
-    "median10YrsAfterEntry": 29868
+    "median10YrsAfterEntry": 29868,
+    "median1YrAfterCompletion": 31384,
+    "percentile25_10YrsAfterEntry": 14924,
+    "percentile75_10YrsAfterEntry": 49067,
+    "shareEarningAboveHsGrad": 0.431
   }
 }

--- a/data/ky/scorecard/henderson-community-college.json
+++ b/data/ky/scorecard/henderson-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://henderson.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:43.507Z",
+  "fetchedAt": "2026-05-13T02:13:01.738Z",
   "size": 880,
   "shareFirstGeneration": 0.4844720497,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3491,
     "completionRate200nt": 0.4967,
-    "transferRate": 0.1792
+    "transferRate": 0.1792,
+    "retentionRateFullTime": 0.6829,
+    "retentionRatePartTime": 0.5676
   },
   "earnings": {
-    "median10YrsAfterEntry": 35714
+    "median10YrsAfterEntry": 35714,
+    "median1YrAfterCompletion": 36607,
+    "percentile25_10YrsAfterEntry": 20328,
+    "percentile75_10YrsAfterEntry": 51119,
+    "shareEarningAboveHsGrad": 0.489
   }
 }

--- a/data/ky/scorecard/hopkinsville-community-college.json
+++ b/data/ky/scorecard/hopkinsville-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://hopkinsville.kctcs.edu/index.aspx",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:44.023Z",
+  "fetchedAt": "2026-05-13T02:13:02.171Z",
   "size": 1630,
   "shareFirstGeneration": 0.4824561404,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4513,
     "completionRate200nt": 0.3989,
-    "transferRate": 0.1026
+    "transferRate": 0.1026,
+    "retentionRateFullTime": 0.6575,
+    "retentionRatePartTime": 0.5238
   },
   "earnings": {
-    "median10YrsAfterEntry": 36323
+    "median10YrsAfterEntry": 36323,
+    "median1YrAfterCompletion": 37391,
+    "percentile25_10YrsAfterEntry": 19756,
+    "percentile75_10YrsAfterEntry": 54276,
+    "shareEarningAboveHsGrad": 0.488
   }
 }

--- a/data/ky/scorecard/jefferson-community-and-technical-college.json
+++ b/data/ky/scorecard/jefferson-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://jefferson.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:44.495Z",
+  "fetchedAt": "2026-05-13T02:13:02.656Z",
   "size": 7744,
   "shareFirstGeneration": 0.4840193148,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3547,
     "completionRate200nt": 0.3596,
-    "transferRate": 0.1459
+    "transferRate": 0.1459,
+    "retentionRateFullTime": 0.5952,
+    "retentionRatePartTime": 0.5292
   },
   "earnings": {
-    "median10YrsAfterEntry": 38171
+    "median10YrsAfterEntry": 38171,
+    "median1YrAfterCompletion": 42070,
+    "percentile25_10YrsAfterEntry": 19055,
+    "percentile75_10YrsAfterEntry": 56456,
+    "shareEarningAboveHsGrad": 0.517
   }
 }

--- a/data/ky/scorecard/madisonville-community-college.json
+++ b/data/ky/scorecard/madisonville-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://madisonville.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:45.043Z",
+  "fetchedAt": "2026-05-13T02:13:03.103Z",
   "size": 1841,
   "shareFirstGeneration": 0.5324324324,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4865,
     "completionRate200nt": 0.572,
-    "transferRate": 0.1081
+    "transferRate": 0.1081,
+    "retentionRateFullTime": 0.6596,
+    "retentionRatePartTime": 0.5897
   },
   "earnings": {
-    "median10YrsAfterEntry": 35733
+    "median10YrsAfterEntry": 35733,
+    "median1YrAfterCompletion": 44154,
+    "percentile25_10YrsAfterEntry": 18925,
+    "percentile75_10YrsAfterEntry": 56327,
+    "shareEarningAboveHsGrad": 0.503
   }
 }

--- a/data/ky/scorecard/maysville-community-and-technical-college.json
+++ b/data/ky/scorecard/maysville-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://maysville.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:45.504Z",
+  "fetchedAt": "2026-05-13T02:13:03.524Z",
   "size": 2284,
   "shareFirstGeneration": 0.5823019802,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5646,
     "completionRate200nt": 0.5292,
-    "transferRate": 0.0544
+    "transferRate": 0.0544,
+    "retentionRateFullTime": 0.7008,
+    "retentionRatePartTime": 0.5113
   },
   "earnings": {
-    "median10YrsAfterEntry": 32194
+    "median10YrsAfterEntry": 32194,
+    "median1YrAfterCompletion": 34730,
+    "percentile25_10YrsAfterEntry": 15627,
+    "percentile75_10YrsAfterEntry": 50246,
+    "shareEarningAboveHsGrad": 0.451
   }
 }

--- a/data/ky/scorecard/owensboro-community-and-technical-college.json
+++ b/data/ky/scorecard/owensboro-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://owensboro.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:48.729Z",
+  "fetchedAt": "2026-05-13T02:13:06.205Z",
   "size": 2648,
   "shareFirstGeneration": 0.4952316076,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5374,
     "completionRate200nt": 0.5365,
-    "transferRate": 0.0607
+    "transferRate": 0.0607,
+    "retentionRateFullTime": 0.6902,
+    "retentionRatePartTime": 0.5591
   },
   "earnings": {
-    "median10YrsAfterEntry": 35798
+    "median10YrsAfterEntry": 35798,
+    "median1YrAfterCompletion": 34579,
+    "percentile25_10YrsAfterEntry": 18751,
+    "percentile75_10YrsAfterEntry": 55436,
+    "shareEarningAboveHsGrad": 0.482
   }
 }

--- a/data/ky/scorecard/somerset-community-college.json
+++ b/data/ky/scorecard/somerset-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://somerset.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:47.557Z",
+  "fetchedAt": "2026-05-13T02:13:05.309Z",
   "size": 4166,
   "shareFirstGeneration": 0.5561151079,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4308,
     "completionRate200nt": 0.4316,
-    "transferRate": 0.0998
+    "transferRate": 0.0998,
+    "retentionRateFullTime": 0.665,
+    "retentionRatePartTime": 0.5266
   },
   "earnings": {
-    "median10YrsAfterEntry": 30787
+    "median10YrsAfterEntry": 30787,
+    "median1YrAfterCompletion": 33829,
+    "percentile25_10YrsAfterEntry": 15419,
+    "percentile75_10YrsAfterEntry": 46950,
+    "shareEarningAboveHsGrad": 0.424
   }
 }

--- a/data/ky/scorecard/southcentral-kentucky-community-and-technical-college.json
+++ b/data/ky/scorecard/southcentral-kentucky-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://southcentral.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:41.445Z",
+  "fetchedAt": "2026-05-13T02:12:59.955Z",
   "size": 3308,
   "shareFirstGeneration": 0.5151691949,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5769,
     "completionRate200nt": 0.5561,
-    "transferRate": 0.0687
+    "transferRate": 0.0687,
+    "retentionRateFullTime": 0.7288,
+    "retentionRatePartTime": 0.5336
   },
   "earnings": {
-    "median10YrsAfterEntry": 34242
+    "median10YrsAfterEntry": 34242,
+    "median1YrAfterCompletion": 37468,
+    "percentile25_10YrsAfterEntry": 16113,
+    "percentile75_10YrsAfterEntry": 53331,
+    "shareEarningAboveHsGrad": 0.547
   }
 }

--- a/data/ky/scorecard/southeast-kentucky-community-and-technical-college.json
+++ b/data/ky/scorecard/southeast-kentucky-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://southeast.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:48.226Z",
+  "fetchedAt": "2026-05-13T02:13:05.781Z",
   "size": 1721,
   "shareFirstGeneration": 0.5599647266,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4732,
     "completionRate200nt": 0.4958,
-    "transferRate": 0.0759
+    "transferRate": 0.0759,
+    "retentionRateFullTime": 0.6753,
+    "retentionRatePartTime": 0.3684
   },
   "earnings": {
-    "median10YrsAfterEntry": 29482
+    "median10YrsAfterEntry": 29482,
+    "median1YrAfterCompletion": 34743,
+    "percentile25_10YrsAfterEntry": 13774,
+    "percentile75_10YrsAfterEntry": 46993,
+    "shareEarningAboveHsGrad": 0.408
   }
 }

--- a/data/ky/scorecard/west-kentucky-community-and-technical-college.json
+++ b/data/ky/scorecard/west-kentucky-community-and-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://westkentucky.kctcs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:13:46.428Z",
+  "fetchedAt": "2026-05-13T02:13:04.433Z",
   "size": 2851,
   "shareFirstGeneration": 0.477191184,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4983,
     "completionRate200nt": 0.5194,
-    "transferRate": 0.0943
+    "transferRate": 0.0943,
+    "retentionRateFullTime": 0.7057,
+    "retentionRatePartTime": 0.5329
   },
   "earnings": {
-    "median10YrsAfterEntry": 34891
+    "median10YrsAfterEntry": 34891,
+    "median1YrAfterCompletion": 32770,
+    "percentile25_10YrsAfterEntry": 18094,
+    "percentile75_10YrsAfterEntry": 52276,
+    "shareEarningAboveHsGrad": 0.482
   }
 }

--- a/data/ma/scorecard/berkshire.json
+++ b/data/ma/scorecard/berkshire.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.berkshirecc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:49.245Z",
+  "fetchedAt": "2026-05-13T02:13:06.662Z",
   "size": 1358,
   "shareFirstGeneration": 0.4486842105,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2,
     "completionRate200nt": 0.2868,
-    "transferRate": 0.1857
+    "transferRate": 0.1857,
+    "retentionRateFullTime": 0.569,
+    "retentionRatePartTime": 0.4038
   },
   "earnings": {
-    "median10YrsAfterEntry": 38832
+    "median10YrsAfterEntry": 38832,
+    "median1YrAfterCompletion": 40052,
+    "percentile25_10YrsAfterEntry": 13684,
+    "percentile75_10YrsAfterEntry": 62484,
+    "shareEarningAboveHsGrad": 0.553
   }
 }

--- a/data/ma/scorecard/bhcc.json
+++ b/data/ma/scorecard/bhcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bhcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:50.202Z",
+  "fetchedAt": "2026-05-13T02:13:07.603Z",
   "size": 8612,
   "shareFirstGeneration": 0.5489702517,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1323,
     "completionRate200nt": 0.2437,
-    "transferRate": 0.0683
+    "transferRate": 0.0683,
+    "retentionRateFullTime": 0.6651,
+    "retentionRatePartTime": 0.4597
   },
   "earnings": {
-    "median10YrsAfterEntry": 47618
+    "median10YrsAfterEntry": 47618,
+    "median1YrAfterCompletion": 43564,
+    "percentile25_10YrsAfterEntry": 23320,
+    "percentile75_10YrsAfterEntry": 74837,
+    "shareEarningAboveHsGrad": 0.614
   }
 }

--- a/data/ma/scorecard/bristol.json
+++ b/data/ma/scorecard/bristol.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bristolcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:49.716Z",
+  "fetchedAt": "2026-05-13T02:13:07.126Z",
   "size": 6083,
   "shareFirstGeneration": 0.5073836723,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2246,
     "completionRate200nt": 0.26,
-    "transferRate": 0.0687
+    "transferRate": 0.0687,
+    "retentionRateFullTime": 0.5438,
+    "retentionRatePartTime": 0.4369
   },
   "earnings": {
-    "median10YrsAfterEntry": 38663
+    "median10YrsAfterEntry": 38663,
+    "median1YrAfterCompletion": 36168,
+    "percentile25_10YrsAfterEntry": 21287,
+    "percentile75_10YrsAfterEntry": 59563,
+    "shareEarningAboveHsGrad": 0.573
   }
 }

--- a/data/ma/scorecard/capecod.json
+++ b/data/ma/scorecard/capecod.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.capecod.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:50.654Z",
+  "fetchedAt": "2026-05-13T02:13:08.061Z",
   "size": 2911,
   "shareFirstGeneration": 0.4132302405,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.223,
     "completionRate200nt": 0.2765,
-    "transferRate": 0.1463
+    "transferRate": 0.1463,
+    "retentionRateFullTime": 0.6875,
+    "retentionRatePartTime": 0.5372
   },
   "earnings": {
-    "median10YrsAfterEntry": 43670
+    "median10YrsAfterEntry": 43670,
+    "median1YrAfterCompletion": 42250,
+    "percentile25_10YrsAfterEntry": 23811,
+    "percentile75_10YrsAfterEntry": 63744,
+    "shareEarningAboveHsGrad": 0.573
   }
 }

--- a/data/ma/scorecard/gcc.json
+++ b/data/ma/scorecard/gcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.gcc.mass.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:51.395Z",
+  "fetchedAt": "2026-05-13T02:13:08.670Z",
   "size": 1395,
   "shareFirstGeneration": 0.3669724771,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3077,
     "completionRate200nt": 0.2925,
-    "transferRate": 0.2088
+    "transferRate": 0.2088,
+    "retentionRateFullTime": 0.63,
+    "retentionRatePartTime": 0.5694
   },
   "earnings": {
-    "median10YrsAfterEntry": 37132
+    "median10YrsAfterEntry": 37132,
+    "median1YrAfterCompletion": 40039,
+    "percentile25_10YrsAfterEntry": 18690,
+    "percentile75_10YrsAfterEntry": 55452,
+    "shareEarningAboveHsGrad": 0.573
   }
 }

--- a/data/ma/scorecard/hcc.json
+++ b/data/ma/scorecard/hcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.hcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:51.912Z",
+  "fetchedAt": "2026-05-13T02:13:09.140Z",
   "size": 3591,
   "shareFirstGeneration": 0.4725609756,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2938,
     "completionRate200nt": 0.3636,
-    "transferRate": 0.1801
+    "transferRate": 0.1801,
+    "retentionRateFullTime": 0.6224,
+    "retentionRatePartTime": 0.4923
   },
   "earnings": {
-    "median10YrsAfterEntry": 37277
+    "median10YrsAfterEntry": 37277,
+    "median1YrAfterCompletion": 34858,
+    "percentile25_10YrsAfterEntry": 20595,
+    "percentile75_10YrsAfterEntry": 55479,
+    "shareEarningAboveHsGrad": 0.563
   }
 }

--- a/data/ma/scorecard/massasoit.json
+++ b/data/ma/scorecard/massasoit.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.massasoit.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:52.825Z",
+  "fetchedAt": "2026-05-13T02:13:10.038Z",
   "size": 4235,
   "shareFirstGeneration": 0.4609403924,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1938,
     "completionRate200nt": 0.2826,
-    "transferRate": 0.2504
+    "transferRate": 0.2504,
+    "retentionRateFullTime": 0.6263,
+    "retentionRatePartTime": 0.4722
   },
   "earnings": {
-    "median10YrsAfterEntry": 46111
+    "median10YrsAfterEntry": 46111,
+    "median1YrAfterCompletion": 39651,
+    "percentile25_10YrsAfterEntry": 29090,
+    "percentile75_10YrsAfterEntry": 70341,
+    "shareEarningAboveHsGrad": 0.627
   }
 }

--- a/data/ma/scorecard/massbay.json
+++ b/data/ma/scorecard/massbay.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.massbay.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:52.377Z",
+  "fetchedAt": "2026-05-13T02:13:09.576Z",
   "size": 3837,
   "shareFirstGeneration": 0.4324534161,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.172,
     "completionRate200nt": 0.2127,
-    "transferRate": 0.258
+    "transferRate": 0.258,
+    "retentionRateFullTime": 0.5589,
+    "retentionRatePartTime": 0.4977
   },
   "earnings": {
-    "median10YrsAfterEntry": 52654
+    "median10YrsAfterEntry": 52654,
+    "median1YrAfterCompletion": 42083,
+    "percentile25_10YrsAfterEntry": 28486,
+    "percentile75_10YrsAfterEntry": 83507,
+    "shareEarningAboveHsGrad": 0.681
   }
 }

--- a/data/ma/scorecard/middlesex.json
+++ b/data/ma/scorecard/middlesex.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.middlesex.mass.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:53.302Z",
+  "fetchedAt": "2026-05-13T02:13:10.472Z",
   "size": 5412,
   "shareFirstGeneration": 0.4976355038,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2343,
     "completionRate200nt": 0.2882,
-    "transferRate": 0.2115
+    "transferRate": 0.2115,
+    "retentionRateFullTime": 0.6364,
+    "retentionRatePartTime": 0.4064
   },
   "earnings": {
-    "median10YrsAfterEntry": 50651
+    "median10YrsAfterEntry": 50651,
+    "median1YrAfterCompletion": 40236,
+    "percentile25_10YrsAfterEntry": 29121,
+    "percentile75_10YrsAfterEntry": 73366,
+    "shareEarningAboveHsGrad": 0.628
   }
 }

--- a/data/ma/scorecard/mwcc.json
+++ b/data/ma/scorecard/mwcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "mwcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:53.851Z",
+  "fetchedAt": "2026-05-13T02:13:10.926Z",
   "size": 3059,
   "shareFirstGeneration": 0.4831288344,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2381,
     "completionRate200nt": 0.3439,
-    "transferRate": 0.1502
+    "transferRate": 0.1502,
+    "retentionRateFullTime": 0.6337,
+    "retentionRatePartTime": 0.4401
   },
   "earnings": {
-    "median10YrsAfterEntry": 41118
+    "median10YrsAfterEntry": 41118,
+    "median1YrAfterCompletion": 44743,
+    "percentile25_10YrsAfterEntry": 22360,
+    "percentile75_10YrsAfterEntry": 60797,
+    "shareEarningAboveHsGrad": 0.586
   }
 }

--- a/data/ma/scorecard/necc.json
+++ b/data/ma/scorecard/necc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.necc.mass.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:54.908Z",
+  "fetchedAt": "2026-05-13T02:13:11.849Z",
   "size": 3685,
   "shareFirstGeneration": 0.5093194625,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2087,
     "completionRate200nt": 0.2238,
-    "transferRate": 0.1673
+    "transferRate": 0.1673,
+    "retentionRateFullTime": 0.6106,
+    "retentionRatePartTime": 0.5015
   },
   "earnings": {
-    "median10YrsAfterEntry": 42862
+    "median10YrsAfterEntry": 42862,
+    "median1YrAfterCompletion": 40197,
+    "percentile25_10YrsAfterEntry": 22038,
+    "percentile75_10YrsAfterEntry": 61430,
+    "shareEarningAboveHsGrad": 0.59
   }
 }

--- a/data/ma/scorecard/northshore.json
+++ b/data/ma/scorecard/northshore.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.northshore.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:54.464Z",
+  "fetchedAt": "2026-05-13T02:13:11.381Z",
   "size": 4393,
   "shareFirstGeneration": 0.5212981744,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1778,
     "completionRate200nt": 0.2244,
-    "transferRate": 0.1689
+    "transferRate": 0.1689,
+    "retentionRateFullTime": 0.6086,
+    "retentionRatePartTime": 0.4456
   },
   "earnings": {
-    "median10YrsAfterEntry": 45391
+    "median10YrsAfterEntry": 45391,
+    "median1YrAfterCompletion": 40704,
+    "percentile25_10YrsAfterEntry": 23689,
+    "percentile75_10YrsAfterEntry": 69477,
+    "shareEarningAboveHsGrad": 0.617
   }
 }

--- a/data/ma/scorecard/qcc.json
+++ b/data/ma/scorecard/qcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.qcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:55.376Z",
+  "fetchedAt": "2026-05-13T02:13:12.318Z",
   "size": 6447,
   "shareFirstGeneration": 0.4770446944,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2162,
     "completionRate200nt": 0.266,
-    "transferRate": 0.1991
+    "transferRate": 0.1991,
+    "retentionRateFullTime": 0.6204,
+    "retentionRatePartTime": 0.4993
   },
   "earnings": {
-    "median10YrsAfterEntry": 45949
+    "median10YrsAfterEntry": 45949,
+    "median1YrAfterCompletion": 47136,
+    "percentile25_10YrsAfterEntry": 24330,
+    "percentile75_10YrsAfterEntry": 69322,
+    "shareEarningAboveHsGrad": 0.621
   }
 }

--- a/data/ma/scorecard/rcc.json
+++ b/data/ma/scorecard/rcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.rcc.mass.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:55.847Z",
+  "fetchedAt": "2026-05-13T02:13:12.742Z",
   "size": 1977,
   "shareFirstGeneration": 0.5338541667,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2833,
     "completionRate200nt": 0.1771,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.3614,
+    "retentionRatePartTime": 0.4294
   },
   "earnings": {
-    "median10YrsAfterEntry": 38773
+    "median10YrsAfterEntry": 38773,
+    "median1YrAfterCompletion": 41027,
+    "percentile25_10YrsAfterEntry": 16745,
+    "percentile75_10YrsAfterEntry": 63228,
+    "shareEarningAboveHsGrad": 0.6
   }
 }

--- a/data/ma/scorecard/stcc.json
+++ b/data/ma/scorecard/stcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.stcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:56.287Z",
+  "fetchedAt": "2026-05-13T02:13:13.173Z",
   "size": 4759,
   "shareFirstGeneration": 0.4805900621,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.318,
     "completionRate200nt": 0.3318,
-    "transferRate": 0.1432
+    "transferRate": 0.1432,
+    "retentionRateFullTime": 0.6268,
+    "retentionRatePartTime": 0.4548
   },
   "earnings": {
-    "median10YrsAfterEntry": 36966
+    "median10YrsAfterEntry": 36966,
+    "median1YrAfterCompletion": 39700,
+    "percentile25_10YrsAfterEntry": 16733,
+    "percentile75_10YrsAfterEntry": 59183,
+    "shareEarningAboveHsGrad": 0.57
   }
 }

--- a/data/md/scorecard/aacc.json
+++ b/data/md/scorecard/aacc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.aacc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:57.273Z",
+  "fetchedAt": "2026-05-13T02:13:14.090Z",
   "size": 8997,
   "shareFirstGeneration": 0.4391517129,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3136,
     "completionRate200nt": 0.3122,
-    "transferRate": 0.1864
+    "transferRate": 0.1864,
+    "retentionRateFullTime": 0.6911,
+    "retentionRatePartTime": 0.5018
   },
   "earnings": {
-    "median10YrsAfterEntry": 46219
+    "median10YrsAfterEntry": 46219,
+    "median1YrAfterCompletion": 38078,
+    "percentile25_10YrsAfterEntry": 24064,
+    "percentile75_10YrsAfterEntry": 71274,
+    "shareEarningAboveHsGrad": 0.637
   }
 }

--- a/data/md/scorecard/allegany.json
+++ b/data/md/scorecard/allegany.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.allegany.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:56.823Z",
+  "fetchedAt": "2026-05-13T02:13:13.639Z",
   "size": 1831,
   "shareFirstGeneration": 0.4775086505,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.396,
     "completionRate200nt": 0.4968,
-    "transferRate": 0.2
+    "transferRate": 0.2,
+    "retentionRateFullTime": 0.6608,
+    "retentionRatePartTime": 0.6087
   },
   "earnings": {
-    "median10YrsAfterEntry": 38476
+    "median10YrsAfterEntry": 38476,
+    "median1YrAfterCompletion": 42411,
+    "percentile25_10YrsAfterEntry": 22152,
+    "percentile75_10YrsAfterEntry": 58595,
+    "shareEarningAboveHsGrad": 0.534
   }
 }

--- a/data/md/scorecard/bccc.json
+++ b/data/md/scorecard/bccc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:57.844Z",
+  "fetchedAt": "2026-05-13T02:13:14.573Z",
   "size": 3700,
   "shareFirstGeneration": 0.5645879733,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1705,
     "completionRate200nt": 0.1637,
-    "transferRate": 0.1648
+    "transferRate": 0.1648,
+    "retentionRateFullTime": 0.4792,
+    "retentionRatePartTime": 0.3096
   },
   "earnings": {
-    "median10YrsAfterEntry": 36025
+    "median10YrsAfterEntry": 36025,
+    "median1YrAfterCompletion": 47247,
+    "percentile25_10YrsAfterEntry": 17349,
+    "percentile75_10YrsAfterEntry": 53239,
+    "shareEarningAboveHsGrad": 0.531
   }
 }

--- a/data/md/scorecard/carroll.json
+++ b/data/md/scorecard/carroll.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.carrollcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:58.319Z",
+  "fetchedAt": "2026-05-13T02:13:15.007Z",
   "size": 1990,
   "shareFirstGeneration": 0.4131736527,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3871,
     "completionRate200nt": 0.5308,
-    "transferRate": 0.2229
+    "transferRate": 0.2229,
+    "retentionRateFullTime": 0.7376,
+    "retentionRatePartTime": 0.5253
   },
   "earnings": {
-    "median10YrsAfterEntry": 44349
+    "median10YrsAfterEntry": 44349,
+    "median1YrAfterCompletion": 41144,
+    "percentile25_10YrsAfterEntry": 22917,
+    "percentile75_10YrsAfterEntry": 70105,
+    "shareEarningAboveHsGrad": 0.585
   }
 }

--- a/data/md/scorecard/ccbc.json
+++ b/data/md/scorecard/ccbc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ccbcmd.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:00.181Z",
+  "fetchedAt": "2026-05-13T02:13:16.988Z",
   "size": 13872,
   "shareFirstGeneration": 0.465512917,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1894,
     "completionRate200nt": 0.1977,
-    "transferRate": 0.2181
+    "transferRate": 0.2181,
+    "retentionRateFullTime": 0.5612,
+    "retentionRatePartTime": 0.4077
   },
   "earnings": {
-    "median10YrsAfterEntry": 43729
+    "median10YrsAfterEntry": 43729,
+    "median1YrAfterCompletion": 47951,
+    "percentile25_10YrsAfterEntry": 23632,
+    "percentile75_10YrsAfterEntry": 66286,
+    "shareEarningAboveHsGrad": 0.62
   }
 }

--- a/data/md/scorecard/cecil.json
+++ b/data/md/scorecard/cecil.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cecil.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:58.791Z",
+  "fetchedAt": "2026-05-13T02:13:15.453Z",
   "size": 1363,
   "shareFirstGeneration": 0.5329787234,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3744,
     "completionRate200nt": 0.345,
-    "transferRate": 0.1689
+    "transferRate": 0.1689,
+    "retentionRateFullTime": 0.6164,
+    "retentionRatePartTime": 0.4819
   },
   "earnings": {
-    "median10YrsAfterEntry": 43952
+    "median10YrsAfterEntry": 43952,
+    "median1YrAfterCompletion": 27866,
+    "percentile25_10YrsAfterEntry": 24774,
+    "percentile75_10YrsAfterEntry": 66812,
+    "shareEarningAboveHsGrad": 0.571
   }
 }

--- a/data/md/scorecard/chesapeake.json
+++ b/data/md/scorecard/chesapeake.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.chesapeake.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:59.228Z",
+  "fetchedAt": "2026-05-13T02:13:15.913Z",
   "size": 1320,
   "shareFirstGeneration": 0.5363766049,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3503,
     "completionRate200nt": 0.244,
-    "transferRate": 0.2437
+    "transferRate": 0.2437,
+    "retentionRateFullTime": 0.6323,
+    "retentionRatePartTime": 0.5
   },
   "earnings": {
-    "median10YrsAfterEntry": 36301
+    "median10YrsAfterEntry": 36301,
+    "median1YrAfterCompletion": 41300,
+    "percentile25_10YrsAfterEntry": 19100,
+    "percentile75_10YrsAfterEntry": 56196,
+    "shareEarningAboveHsGrad": 0.484
   }
 }

--- a/data/md/scorecard/csm.json
+++ b/data/md/scorecard/csm.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.csmd.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:13:59.695Z",
+  "fetchedAt": "2026-05-13T02:13:16.377Z",
   "size": 4512,
   "shareFirstGeneration": 0.4511520737,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3304,
     "completionRate200nt": 0.4,
-    "transferRate": 0.1894
+    "transferRate": 0.1894,
+    "retentionRateFullTime": 0.6576,
+    "retentionRatePartTime": 0.398
   },
   "earnings": {
-    "median10YrsAfterEntry": 44435
+    "median10YrsAfterEntry": 44435,
+    "median1YrAfterCompletion": 39619,
+    "percentile25_10YrsAfterEntry": 23525,
+    "percentile75_10YrsAfterEntry": 70743,
+    "shareEarningAboveHsGrad": 0.632
   }
 }

--- a/data/md/scorecard/frederick.json
+++ b/data/md/scorecard/frederick.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.frederick.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:00.659Z",
+  "fetchedAt": "2026-05-13T02:13:17.454Z",
   "size": 4203,
   "shareFirstGeneration": 0.4339869281,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3738,
     "completionRate200nt": 0.4006,
-    "transferRate": 0.2379
+    "transferRate": 0.2379,
+    "retentionRateFullTime": 0.6589,
+    "retentionRatePartTime": 0.4862
   },
   "earnings": {
-    "median10YrsAfterEntry": 46449
+    "median10YrsAfterEntry": 46449,
+    "median1YrAfterCompletion": 42473,
+    "percentile25_10YrsAfterEntry": 26189,
+    "percentile75_10YrsAfterEntry": 70468,
+    "shareEarningAboveHsGrad": 0.63
   }
 }

--- a/data/md/scorecard/garrett.json
+++ b/data/md/scorecard/garrett.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.garrettcollege.edu/index.php",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:01.341Z",
+  "fetchedAt": "2026-05-13T02:13:17.877Z",
   "size": 411,
   "shareFirstGeneration": 0.409610984,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3396,
     "completionRate200nt": 0.331,
-    "transferRate": 0.2453
+    "transferRate": 0.2453,
+    "retentionRateFullTime": 0.5024,
+    "retentionRatePartTime": 0.3333
   },
   "earnings": {
-    "median10YrsAfterEntry": 35823
+    "median10YrsAfterEntry": 35823,
+    "median1YrAfterCompletion": 17189,
+    "percentile25_10YrsAfterEntry": 18551,
+    "percentile75_10YrsAfterEntry": 55658,
+    "shareEarningAboveHsGrad": 0.491
   }
 }

--- a/data/md/scorecard/hagerstown.json
+++ b/data/md/scorecard/hagerstown.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.hagerstowncc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:01.806Z",
+  "fetchedAt": "2026-05-13T02:13:18.314Z",
   "size": 2948,
   "shareFirstGeneration": 0.4760594386,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3896,
     "completionRate200nt": 0.4069,
-    "transferRate": 0.1622
+    "transferRate": 0.1622,
+    "retentionRateFullTime": 0.6779,
+    "retentionRatePartTime": 0.5418
   },
   "earnings": {
-    "median10YrsAfterEntry": 41615
+    "median10YrsAfterEntry": 41615,
+    "median1YrAfterCompletion": 44215,
+    "percentile25_10YrsAfterEntry": 23217,
+    "percentile75_10YrsAfterEntry": 60641,
+    "shareEarningAboveHsGrad": 0.6
   }
 }

--- a/data/md/scorecard/harford.json
+++ b/data/md/scorecard/harford.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.harford.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:02.263Z",
+  "fetchedAt": "2026-05-13T02:13:18.845Z",
   "size": 3696,
   "shareFirstGeneration": 0.4127358491,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3926,
     "completionRate200nt": 0.4612,
-    "transferRate": 0.2131
+    "transferRate": 0.2131,
+    "retentionRateFullTime": 0.6657,
+    "retentionRatePartTime": 0.5278
   },
   "earnings": {
-    "median10YrsAfterEntry": 44608
+    "median10YrsAfterEntry": 44608,
+    "median1YrAfterCompletion": 41402,
+    "percentile25_10YrsAfterEntry": 24777,
+    "percentile75_10YrsAfterEntry": 68409,
+    "shareEarningAboveHsGrad": 0.583
   }
 }

--- a/data/md/scorecard/howardcc.json
+++ b/data/md/scorecard/howardcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.howardcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:02.759Z",
+  "fetchedAt": "2026-05-13T02:13:19.324Z",
   "size": 6649,
   "shareFirstGeneration": 0.3873409013,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2402,
     "completionRate200nt": 0.3289,
-    "transferRate": 0.2598
+    "transferRate": 0.2598,
+    "retentionRateFullTime": 0.6876,
+    "retentionRatePartTime": 0.4851
   },
   "earnings": {
-    "median10YrsAfterEntry": 49020
+    "median10YrsAfterEntry": 49020,
+    "median1YrAfterCompletion": 50859,
+    "percentile25_10YrsAfterEntry": 25196,
+    "percentile75_10YrsAfterEntry": 77530,
+    "shareEarningAboveHsGrad": 0.673
   }
 }

--- a/data/md/scorecard/montgomery.json
+++ b/data/md/scorecard/montgomery.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.montgomerycollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:03.265Z",
+  "fetchedAt": "2026-05-13T02:13:19.900Z",
   "size": 13773,
   "shareFirstGeneration": 0.4362119725,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3244,
     "completionRate200nt": 0.3407,
-    "transferRate": 0.1931
+    "transferRate": 0.1931,
+    "retentionRateFullTime": 0.7467,
+    "retentionRatePartTime": 0.5104
   },
   "earnings": {
-    "median10YrsAfterEntry": 50159
+    "median10YrsAfterEntry": 50159,
+    "median1YrAfterCompletion": 29914,
+    "percentile25_10YrsAfterEntry": 26375,
+    "percentile75_10YrsAfterEntry": 77215,
+    "shareEarningAboveHsGrad": 0.692
   }
 }

--- a/data/md/scorecard/pgcc.json
+++ b/data/md/scorecard/pgcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.pgcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:03.708Z",
+  "fetchedAt": "2026-05-13T02:13:20.343Z",
   "size": 8815,
   "shareFirstGeneration": 0.4608466769,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1842,
     "completionRate200nt": 0.3217,
-    "transferRate": 0.1446
+    "transferRate": 0.1446,
+    "retentionRateFullTime": 0.6745,
+    "retentionRatePartTime": 0.5079
   },
   "earnings": {
-    "median10YrsAfterEntry": 47548
+    "median10YrsAfterEntry": 47548,
+    "median1YrAfterCompletion": 44417,
+    "percentile25_10YrsAfterEntry": 25064,
+    "percentile75_10YrsAfterEntry": 74457,
+    "shareEarningAboveHsGrad": 0.675
   }
 }

--- a/data/md/scorecard/wor-wic.json
+++ b/data/md/scorecard/wor-wic.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.worwic.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:04.189Z",
+  "fetchedAt": "2026-05-13T02:13:20.819Z",
   "size": 2169,
   "shareFirstGeneration": 0.4895209581,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2708,
     "completionRate200nt": 0.3134,
-    "transferRate": 0.2656
+    "transferRate": 0.2656,
+    "retentionRateFullTime": 0.6647,
+    "retentionRatePartTime": 0.534
   },
   "earnings": {
-    "median10YrsAfterEntry": 36748
+    "median10YrsAfterEntry": 36748,
+    "median1YrAfterCompletion": 47951,
+    "percentile25_10YrsAfterEntry": 21348,
+    "percentile75_10YrsAfterEntry": 55114,
+    "shareEarningAboveHsGrad": 0.496
   }
 }

--- a/data/me/scorecard/cmcc.json
+++ b/data/me/scorecard/cmcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.cmcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:04.712Z",
+  "fetchedAt": "2026-05-13T02:13:21.289Z",
   "size": 2952,
   "shareFirstGeneration": 0.4681571816,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3031,
     "completionRate200nt": 0.3395,
-    "transferRate": 0.1695
+    "transferRate": 0.1695,
+    "retentionRateFullTime": 0.5682,
+    "retentionRatePartTime": 0.3102
   },
   "earnings": {
-    "median10YrsAfterEntry": 42448
+    "median10YrsAfterEntry": 42448,
+    "median1YrAfterCompletion": 39555,
+    "percentile25_10YrsAfterEntry": 26707,
+    "percentile75_10YrsAfterEntry": 60852,
+    "shareEarningAboveHsGrad": 0.595
   }
 }

--- a/data/me/scorecard/emcc.json
+++ b/data/me/scorecard/emcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.emcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:05.155Z",
+  "fetchedAt": "2026-05-13T02:13:21.748Z",
   "size": 1840,
   "shareFirstGeneration": 0.4134036145,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3209,
     "completionRate200nt": 0.4039,
-    "transferRate": 0.0977
+    "transferRate": 0.0977,
+    "retentionRateFullTime": 0.5629,
+    "retentionRatePartTime": 0.4037
   },
   "earnings": {
-    "median10YrsAfterEntry": 41704
+    "median10YrsAfterEntry": 41704,
+    "median1YrAfterCompletion": 46300,
+    "percentile25_10YrsAfterEntry": 25840,
+    "percentile75_10YrsAfterEntry": 65503,
+    "shareEarningAboveHsGrad": 0.59
   }
 }

--- a/data/me/scorecard/kvcc.json
+++ b/data/me/scorecard/kvcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.kvcc.me.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:05.592Z",
+  "fetchedAt": "2026-05-13T02:13:22.174Z",
   "size": 1597,
   "shareFirstGeneration": 0.4951361868,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3865,
     "completionRate200nt": 0.4975,
-    "transferRate": 0.1288
+    "transferRate": 0.1288,
+    "retentionRateFullTime": 0.6437,
+    "retentionRatePartTime": 0.5066
   },
   "earnings": {
-    "median10YrsAfterEntry": 36035
+    "median10YrsAfterEntry": 36035,
+    "median1YrAfterCompletion": 42578,
+    "percentile25_10YrsAfterEntry": 21549,
+    "percentile75_10YrsAfterEntry": 54062,
+    "shareEarningAboveHsGrad": 0.52
   }
 }

--- a/data/me/scorecard/nmcc.json
+++ b/data/me/scorecard/nmcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.nmcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:06.140Z",
+  "fetchedAt": "2026-05-13T02:13:22.660Z",
   "size": 638,
   "shareFirstGeneration": 0.4671532847,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4231,
     "completionRate200nt": 0.3571,
-    "transferRate": 0.1058
+    "transferRate": 0.1058,
+    "retentionRateFullTime": 0.4828,
+    "retentionRatePartTime": 0.3333
   },
   "earnings": {
-    "median10YrsAfterEntry": 43348
+    "median10YrsAfterEntry": 43348,
+    "median1YrAfterCompletion": 41476,
+    "percentile25_10YrsAfterEntry": 24065,
+    "percentile75_10YrsAfterEntry": 54954,
+    "shareEarningAboveHsGrad": 0.547
   }
 }

--- a/data/me/scorecard/smcc.json
+++ b/data/me/scorecard/smcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.smccme.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:06.755Z",
+  "fetchedAt": "2026-05-13T02:13:23.119Z",
   "size": 5675,
   "shareFirstGeneration": 0.3910998553,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2819,
     "completionRate200nt": 0.2612,
-    "transferRate": 0.1558
+    "transferRate": 0.1558,
+    "retentionRateFullTime": 0.5729,
+    "retentionRatePartTime": 0.4768
   },
   "earnings": {
-    "median10YrsAfterEntry": 41661
+    "median10YrsAfterEntry": 41661,
+    "median1YrAfterCompletion": 42029,
+    "percentile25_10YrsAfterEntry": 21198,
+    "percentile75_10YrsAfterEntry": 59974,
+    "shareEarningAboveHsGrad": 0.623
   }
 }

--- a/data/me/scorecard/wccc.json
+++ b/data/me/scorecard/wccc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wccc.me.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:07.270Z",
+  "fetchedAt": "2026-05-13T02:13:23.580Z",
   "size": 443,
   "shareFirstGeneration": 0.4411764706,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5517,
     "completionRate200nt": 0.5,
-    "transferRate": 0.1034
+    "transferRate": 0.1034,
+    "retentionRateFullTime": 0.6078,
+    "retentionRatePartTime": 0.3448
   },
   "earnings": {
-    "median10YrsAfterEntry": 34407
+    "median10YrsAfterEntry": 34407,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": 20455,
+    "percentile75_10YrsAfterEntry": 47980,
+    "shareEarningAboveHsGrad": 0.5
   }
 }

--- a/data/me/scorecard/yccc.json
+++ b/data/me/scorecard/yccc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.yccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:07.733Z",
+  "fetchedAt": "2026-05-13T02:13:24.036Z",
   "size": 1133,
   "shareFirstGeneration": 0.4810725552,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3383,
     "completionRate200nt": 0.3448,
-    "transferRate": 0.1654
+    "transferRate": 0.1654,
+    "retentionRateFullTime": 0.568,
+    "retentionRatePartTime": 0.3664
   },
   "earnings": {
-    "median10YrsAfterEntry": 44873
+    "median10YrsAfterEntry": 44873,
+    "median1YrAfterCompletion": 36028,
+    "percentile25_10YrsAfterEntry": 23391,
+    "percentile75_10YrsAfterEntry": 58729,
+    "shareEarningAboveHsGrad": 0.498
   }
 }

--- a/data/mi/scorecard/alpena-community-college.json
+++ b/data/mi/scorecard/alpena-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.alpenacc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:08.210Z",
+  "fetchedAt": "2026-05-13T02:13:24.479Z",
   "size": 732,
   "shareFirstGeneration": 0.4283646889,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 36442
+    "median10YrsAfterEntry": 36442,
+    "median1YrAfterCompletion": 33191,
+    "percentile25_10YrsAfterEntry": 18123,
+    "percentile75_10YrsAfterEntry": 57939,
+    "shareEarningAboveHsGrad": 0.559
   }
 }

--- a/data/mi/scorecard/bay-de-noc-community-college.json
+++ b/data/mi/scorecard/bay-de-noc-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.baycollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:11.026Z",
+  "fetchedAt": "2026-05-13T02:13:27.398Z",
   "size": 1223,
   "shareFirstGeneration": 0.4387895461,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3004,
     "completionRate200nt": 0.25,
-    "transferRate": 0.2305
+    "transferRate": 0.2305,
+    "retentionRateFullTime": 0.5944,
+    "retentionRatePartTime": 0.2925
   },
   "earnings": {
-    "median10YrsAfterEntry": 35090
+    "median10YrsAfterEntry": 35090,
+    "median1YrAfterCompletion": 38209,
+    "percentile25_10YrsAfterEntry": 17425,
+    "percentile75_10YrsAfterEntry": 53602,
+    "shareEarningAboveHsGrad": 0.523
   }
 }

--- a/data/mi/scorecard/bay-mills-community-college.json
+++ b/data/mi/scorecard/bay-mills-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "bmcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:10.569Z",
+  "fetchedAt": "2026-05-13T02:13:26.961Z",
   "size": 662,
   "shareFirstGeneration": 0.5614035088,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 30048
+    "median10YrsAfterEntry": 30048,
+    "median1YrAfterCompletion": 32240,
+    "percentile25_10YrsAfterEntry": 15081,
+    "percentile75_10YrsAfterEntry": 45074,
+    "shareEarningAboveHsGrad": 0.362
   }
 }

--- a/data/mi/scorecard/delta-college.json
+++ b/data/mi/scorecard/delta-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.delta.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:12.079Z",
+  "fetchedAt": "2026-05-13T02:13:28.304Z",
   "size": 6573,
   "shareFirstGeneration": 0.4151443724,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2682,
     "completionRate200nt": 0.219,
-    "transferRate": 0.216
+    "transferRate": 0.216,
+    "retentionRateFullTime": 0.6239,
+    "retentionRatePartTime": 0.4493
   },
   "earnings": {
-    "median10YrsAfterEntry": 37781
+    "median10YrsAfterEntry": 37781,
+    "median1YrAfterCompletion": 46967,
+    "percentile25_10YrsAfterEntry": 20533,
+    "percentile75_10YrsAfterEntry": 58045,
+    "shareEarningAboveHsGrad": 0.539
   }
 }

--- a/data/mi/scorecard/glen-oaks-community-college.json
+++ b/data/mi/scorecard/glen-oaks-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.glenoaks.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:12.518Z",
+  "fetchedAt": "2026-05-13T02:13:28.734Z",
   "size": 600,
   "shareFirstGeneration": 0.5286783042,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4298,
     "completionRate200nt": 0.4309,
-    "transferRate": 0.193
+    "transferRate": 0.193,
+    "retentionRateFullTime": 0.6443,
+    "retentionRatePartTime": 0.5254
   },
   "earnings": {
-    "median10YrsAfterEntry": 37540
+    "median10YrsAfterEntry": 37540,
+    "median1YrAfterCompletion": 38205,
+    "percentile25_10YrsAfterEntry": 19802,
+    "percentile75_10YrsAfterEntry": 56719,
+    "shareEarningAboveHsGrad": 0.514
   }
 }

--- a/data/mi/scorecard/gogebic-community-college.json
+++ b/data/mi/scorecard/gogebic-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "gogebic.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:13.004Z",
+  "fetchedAt": "2026-05-13T02:13:29.404Z",
   "size": 511,
   "shareFirstGeneration": 0.3898635478,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3561,
     "completionRate200nt": 0.3563,
-    "transferRate": 0.3182
+    "transferRate": 0.3182,
+    "retentionRateFullTime": 0.637,
+    "retentionRatePartTime": 0.5417
   },
   "earnings": {
-    "median10YrsAfterEntry": 40950
+    "median10YrsAfterEntry": 40950,
+    "median1YrAfterCompletion": 37816,
+    "percentile25_10YrsAfterEntry": 22211,
+    "percentile75_10YrsAfterEntry": 61817,
+    "shareEarningAboveHsGrad": 0.514
   }
 }

--- a/data/mi/scorecard/grand-rapids-community-college.json
+++ b/data/mi/scorecard/grand-rapids-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.grcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:13.513Z",
+  "fetchedAt": "2026-05-13T02:13:29.867Z",
   "size": 10698,
   "shareFirstGeneration": 0.4142663504,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2113,
     "completionRate200nt": 0.2645,
-    "transferRate": 0.2034
+    "transferRate": 0.2034,
+    "retentionRateFullTime": 0.5913,
+    "retentionRatePartTime": 0.4961
   },
   "earnings": {
-    "median10YrsAfterEntry": 38377
+    "median10YrsAfterEntry": 38377,
+    "median1YrAfterCompletion": 38948,
+    "percentile25_10YrsAfterEntry": 19532,
+    "percentile75_10YrsAfterEntry": 56633,
+    "shareEarningAboveHsGrad": 0.567
   }
 }

--- a/data/mi/scorecard/henry-ford-college.json
+++ b/data/mi/scorecard/henry-ford-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.hfcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:08.690Z",
+  "fetchedAt": "2026-05-13T02:13:25.118Z",
   "size": 8643,
   "shareFirstGeneration": 0.5072463768,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 34795
+    "median10YrsAfterEntry": 34795,
+    "median1YrAfterCompletion": 44045,
+    "percentile25_10YrsAfterEntry": 15471,
+    "percentile75_10YrsAfterEntry": 56860,
+    "shareEarningAboveHsGrad": 0.551
   }
 }

--- a/data/mi/scorecard/jackson-college.json
+++ b/data/mi/scorecard/jackson-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.jccmi.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:09.210Z",
+  "fetchedAt": "2026-05-13T02:13:25.561Z",
   "size": 3422,
   "shareFirstGeneration": 0.4578696343,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 36898
+    "median10YrsAfterEntry": 36898,
+    "median1YrAfterCompletion": 36400,
+    "percentile25_10YrsAfterEntry": 18666,
+    "percentile75_10YrsAfterEntry": 55412,
+    "shareEarningAboveHsGrad": 0.551
   }
 }

--- a/data/mi/scorecard/kalamazoo-valley-community-college.json
+++ b/data/mi/scorecard/kalamazoo-valley-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.kvcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:14.025Z",
+  "fetchedAt": "2026-05-13T02:13:30.317Z",
   "size": 4997,
   "shareFirstGeneration": 0.384593191,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2818,
     "completionRate200nt": 0.2868,
-    "transferRate": 0.2338
+    "transferRate": 0.2338,
+    "retentionRateFullTime": 0.6398,
+    "retentionRatePartTime": 0.5038
   },
   "earnings": {
-    "median10YrsAfterEntry": 38618
+    "median10YrsAfterEntry": 38618,
+    "median1YrAfterCompletion": 38888,
+    "percentile25_10YrsAfterEntry": 18872,
+    "percentile75_10YrsAfterEntry": 58903,
+    "shareEarningAboveHsGrad": 0.536
   }
 }

--- a/data/mi/scorecard/kellogg-community-college.json
+++ b/data/mi/scorecard/kellogg-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.kellogg.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:14.474Z",
+  "fetchedAt": "2026-05-13T02:13:30.794Z",
   "size": 2971,
   "shareFirstGeneration": 0.4804983749,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2991,
     "completionRate200nt": 0.2877,
-    "transferRate": 0.0897
+    "transferRate": 0.0897,
+    "retentionRateFullTime": 0.6203,
+    "retentionRatePartTime": 0.4061
   },
   "earnings": {
-    "median10YrsAfterEntry": 38329
+    "median10YrsAfterEntry": 38329,
+    "median1YrAfterCompletion": 39909,
+    "percentile25_10YrsAfterEntry": 19971,
+    "percentile75_10YrsAfterEntry": 56170,
+    "shareEarningAboveHsGrad": 0.56
   }
 }

--- a/data/mi/scorecard/keweenaw-bay-ojibwa-community-college.json
+++ b/data/mi/scorecard/keweenaw-bay-ojibwa-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.kbocc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:22.809Z",
+  "fetchedAt": "2026-05-13T02:13:38.603Z",
   "size": 139,
   "shareFirstGeneration": 0.5789473684,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1111,
     "completionRate200nt": 0.1818,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.7273,
+    "retentionRatePartTime": 0.4091
   },
   "earnings": {
-    "median10YrsAfterEntry": 22340
+    "median10YrsAfterEntry": 22340,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": 4613,
+    "percentile75_10YrsAfterEntry": 36492,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/mi/scorecard/kirtland-community-college.json
+++ b/data/mi/scorecard/kirtland-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.kirtland.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:15.056Z",
+  "fetchedAt": "2026-05-13T02:13:31.231Z",
   "size": 1023,
   "shareFirstGeneration": 0.4646194927,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3407,
     "completionRate200nt": 0.3765,
-    "transferRate": 0.1648
+    "transferRate": 0.1648,
+    "retentionRateFullTime": 0.6146,
+    "retentionRatePartTime": 0.4697
   },
   "earnings": {
-    "median10YrsAfterEntry": 35831
+    "median10YrsAfterEntry": 35831,
+    "median1YrAfterCompletion": 50769,
+    "percentile25_10YrsAfterEntry": 18693,
+    "percentile75_10YrsAfterEntry": 53972,
+    "shareEarningAboveHsGrad": 0.457
   }
 }

--- a/data/mi/scorecard/lake-michigan-college.json
+++ b/data/mi/scorecard/lake-michigan-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.lakemichigancollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:15.560Z",
+  "fetchedAt": "2026-05-13T02:13:31.688Z",
   "size": 2105,
   "shareFirstGeneration": 0.4440242057,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2159,
     "completionRate200nt": 0.2923,
-    "transferRate": 0.2492
+    "transferRate": 0.2492,
+    "retentionRateFullTime": 0.8449,
+    "retentionRatePartTime": 0.538
   },
   "earnings": {
-    "median10YrsAfterEntry": 34466
+    "median10YrsAfterEntry": 34466,
+    "median1YrAfterCompletion": 44772,
+    "percentile25_10YrsAfterEntry": 17184,
+    "percentile75_10YrsAfterEntry": 51380,
+    "shareEarningAboveHsGrad": 0.436
   }
 }

--- a/data/mi/scorecard/lansing-community-college.json
+++ b/data/mi/scorecard/lansing-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.lcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:16.027Z",
+  "fetchedAt": "2026-05-13T02:13:32.146Z",
   "size": 8207,
   "shareFirstGeneration": 0.3814018879,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.251,
     "completionRate200nt": 0.2793,
-    "transferRate": 0.252
+    "transferRate": 0.252,
+    "retentionRateFullTime": 0.7015,
+    "retentionRatePartTime": 0.5072
   },
   "earnings": {
-    "median10YrsAfterEntry": 39206
+    "median10YrsAfterEntry": 39206,
+    "median1YrAfterCompletion": 47741,
+    "percentile25_10YrsAfterEntry": 19040,
+    "percentile75_10YrsAfterEntry": 60426,
+    "shareEarningAboveHsGrad": 0.565
   }
 }

--- a/data/mi/scorecard/macomb-community-college.json
+++ b/data/mi/scorecard/macomb-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.macomb.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:16.510Z",
+  "fetchedAt": "2026-05-13T02:13:32.578Z",
   "size": 13876,
   "shareFirstGeneration": 0.4866837388,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1797,
     "completionRate200nt": 0.2229,
-    "transferRate": 0.315
+    "transferRate": 0.315,
+    "retentionRateFullTime": 0.613,
+    "retentionRatePartTime": 0.5559
   },
   "earnings": {
-    "median10YrsAfterEntry": 41596
+    "median10YrsAfterEntry": 41596,
+    "median1YrAfterCompletion": 41044,
+    "percentile25_10YrsAfterEntry": 21143,
+    "percentile75_10YrsAfterEntry": 63899,
+    "shareEarningAboveHsGrad": 0.589
   }
 }

--- a/data/mi/scorecard/mid-michigan-college.json
+++ b/data/mi/scorecard/mid-michigan-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.midmich.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:16.995Z",
+  "fetchedAt": "2026-05-13T02:13:33.045Z",
   "size": 2098,
   "shareFirstGeneration": 0.4401154401,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2752,
     "completionRate200nt": 0.2547,
-    "transferRate": 0.2651
+    "transferRate": 0.2651,
+    "retentionRateFullTime": 0.6364,
+    "retentionRatePartTime": 0.3819
   },
   "earnings": {
-    "median10YrsAfterEntry": 37319
+    "median10YrsAfterEntry": 37319,
+    "median1YrAfterCompletion": 35458,
+    "percentile25_10YrsAfterEntry": 21167,
+    "percentile75_10YrsAfterEntry": 57525,
+    "shareEarningAboveHsGrad": 0.495
   }
 }

--- a/data/mi/scorecard/monroe-county-community-college.json
+++ b/data/mi/scorecard/monroe-county-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.monroeccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:17.455Z",
+  "fetchedAt": "2026-05-13T02:13:33.478Z",
   "size": 1435,
   "shareFirstGeneration": 0.479202773,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3412,
     "completionRate200nt": 0.3607,
-    "transferRate": 0.1765
+    "transferRate": 0.1765,
+    "retentionRateFullTime": 0.6519,
+    "retentionRatePartTime": 0.478
   },
   "earnings": {
-    "median10YrsAfterEntry": 41646
+    "median10YrsAfterEntry": 41646,
+    "median1YrAfterCompletion": 47177,
+    "percentile25_10YrsAfterEntry": 22144,
+    "percentile75_10YrsAfterEntry": 65997,
+    "shareEarningAboveHsGrad": 0.55
   }
 }

--- a/data/mi/scorecard/montcalm-community-college.json
+++ b/data/mi/scorecard/montcalm-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.montcalm.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:18.018Z",
+  "fetchedAt": "2026-05-13T02:13:33.913Z",
   "size": 1122,
   "shareFirstGeneration": 0.4845814978,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3061,
     "completionRate200nt": 0.3011,
-    "transferRate": 0.2245
+    "transferRate": 0.2245,
+    "retentionRateFullTime": 0.5682,
+    "retentionRatePartTime": 0.5545
   },
   "earnings": {
-    "median10YrsAfterEntry": 35499
+    "median10YrsAfterEntry": 35499,
+    "median1YrAfterCompletion": 45335,
+    "percentile25_10YrsAfterEntry": 18970,
+    "percentile75_10YrsAfterEntry": 52313,
+    "shareEarningAboveHsGrad": 0.499
   }
 }

--- a/data/mi/scorecard/mott-community-college.json
+++ b/data/mi/scorecard/mott-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.mcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:11.499Z",
+  "fetchedAt": "2026-05-13T02:13:27.860Z",
   "size": 5251,
   "shareFirstGeneration": 0.4028740056,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3189,
     "completionRate200nt": 0.255,
-    "transferRate": 0.1417
+    "transferRate": 0.1417,
+    "retentionRateFullTime": 0.5975,
+    "retentionRatePartTime": 0.4682
   },
   "earnings": {
-    "median10YrsAfterEntry": 32538
+    "median10YrsAfterEntry": 32538,
+    "median1YrAfterCompletion": 37461,
+    "percentile25_10YrsAfterEntry": 15045,
+    "percentile75_10YrsAfterEntry": 52285,
+    "shareEarningAboveHsGrad": 0.462
   }
 }

--- a/data/mi/scorecard/muskegon-community-college.json
+++ b/data/mi/scorecard/muskegon-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.muskegoncc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:18.479Z",
+  "fetchedAt": "2026-05-13T02:13:34.378Z",
   "size": 2760,
   "shareFirstGeneration": 0.4171287739,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2848,
     "completionRate200nt": 0.3091,
-    "transferRate": 0.2184
+    "transferRate": 0.2184,
+    "retentionRateFullTime": 0.6945,
+    "retentionRatePartTime": 0.3371
   },
   "earnings": {
-    "median10YrsAfterEntry": 36549
+    "median10YrsAfterEntry": 36549,
+    "median1YrAfterCompletion": 39934,
+    "percentile25_10YrsAfterEntry": 18602,
+    "percentile75_10YrsAfterEntry": 54797,
+    "shareEarningAboveHsGrad": 0.51
   }
 }

--- a/data/mi/scorecard/north-central-michigan-college.json
+++ b/data/mi/scorecard/north-central-michigan-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ncmich.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:19.042Z",
+  "fetchedAt": "2026-05-13T02:13:34.834Z",
   "size": 942,
   "shareFirstGeneration": 0.420738975,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2938,
     "completionRate200nt": 0.2857,
-    "transferRate": 0.2203
+    "transferRate": 0.2203,
+    "retentionRateFullTime": 0.656,
+    "retentionRatePartTime": 0.431
   },
   "earnings": {
-    "median10YrsAfterEntry": 36594
+    "median10YrsAfterEntry": 36594,
+    "median1YrAfterCompletion": 33575,
+    "percentile25_10YrsAfterEntry": 18987,
+    "percentile75_10YrsAfterEntry": 53225,
+    "shareEarningAboveHsGrad": 0.466
   }
 }

--- a/data/mi/scorecard/northwestern-michigan-college.json
+++ b/data/mi/scorecard/northwestern-michigan-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nmc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:09.651Z",
+  "fetchedAt": "2026-05-13T02:13:26.025Z",
   "size": 2813,
   "shareFirstGeneration": 0.3807138384,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 38167
+    "median10YrsAfterEntry": 38167,
+    "median1YrAfterCompletion": 46908,
+    "percentile25_10YrsAfterEntry": 22451,
+    "percentile75_10YrsAfterEntry": 56520,
+    "shareEarningAboveHsGrad": 0.548
   }
 }

--- a/data/mi/scorecard/oakland-community-college.json
+++ b/data/mi/scorecard/oakland-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.oaklandcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:19.556Z",
+  "fetchedAt": "2026-05-13T02:13:35.298Z",
   "size": 12748,
   "shareFirstGeneration": 0.4285465622,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2065,
     "completionRate200nt": 0.226,
-    "transferRate": 0.2462
+    "transferRate": 0.2462,
+    "retentionRateFullTime": 0.5581,
+    "retentionRatePartTime": 0.472
   },
   "earnings": {
-    "median10YrsAfterEntry": 37395
+    "median10YrsAfterEntry": 37395,
+    "median1YrAfterCompletion": 43679,
+    "percentile25_10YrsAfterEntry": 16677,
+    "percentile75_10YrsAfterEntry": 59461,
+    "shareEarningAboveHsGrad": 0.548
   }
 }

--- a/data/mi/scorecard/saginaw-chippewa-tribal-college.json
+++ b/data/mi/scorecard/saginaw-chippewa-tribal-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sagchip.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:22.347Z",
+  "fetchedAt": "2026-05-13T02:13:38.153Z",
   "size": 164,
   "shareFirstGeneration": 0.5806451613,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3333,
     "completionRate200nt": 0,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.7778,
+    "retentionRatePartTime": 0.6
   },
   "earnings": {
-    "median10YrsAfterEntry": null
+    "median10YrsAfterEntry": null,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": null,
+    "percentile75_10YrsAfterEntry": null,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/mi/scorecard/schoolcraft-community-college-district.json
+++ b/data/mi/scorecard/schoolcraft-community-college-district.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.schoolcraft.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:10.123Z",
+  "fetchedAt": "2026-05-13T02:13:26.507Z",
   "size": 7511,
   "shareFirstGeneration": 0.4256217738,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 42722
+    "median10YrsAfterEntry": 42722,
+    "median1YrAfterCompletion": 41790,
+    "percentile25_10YrsAfterEntry": 22218,
+    "percentile75_10YrsAfterEntry": 64896,
+    "shareEarningAboveHsGrad": 0.579
   }
 }

--- a/data/mi/scorecard/southwestern-michigan-college.json
+++ b/data/mi/scorecard/southwestern-michigan-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.swmich.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:20.492Z",
+  "fetchedAt": "2026-05-13T02:13:36.174Z",
   "size": 1431,
   "shareFirstGeneration": 0.4141048825,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3766,
     "completionRate200nt": 0.2874,
-    "transferRate": 0.1392
+    "transferRate": 0.1392,
+    "retentionRateFullTime": 0.5696,
+    "retentionRatePartTime": 0.3371
   },
   "earnings": {
-    "median10YrsAfterEntry": 37303
+    "median10YrsAfterEntry": 37303,
+    "median1YrAfterCompletion": 36470,
+    "percentile25_10YrsAfterEntry": 21248,
+    "percentile75_10YrsAfterEntry": 54818,
+    "shareEarningAboveHsGrad": 0.501
   }
 }

--- a/data/mi/scorecard/st-clair-county-community-college.json
+++ b/data/mi/scorecard/st-clair-county-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sc4.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:20.022Z",
+  "fetchedAt": "2026-05-13T02:13:35.726Z",
   "size": 2138,
   "shareFirstGeneration": 0.4259868421,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3354,
     "completionRate200nt": 0.3694,
-    "transferRate": 0.2492
+    "transferRate": 0.2492,
+    "retentionRateFullTime": 0.6,
+    "retentionRatePartTime": 0.5385
   },
   "earnings": {
-    "median10YrsAfterEntry": 40177
+    "median10YrsAfterEntry": 40177,
+    "median1YrAfterCompletion": 47694,
+    "percentile25_10YrsAfterEntry": 20720,
+    "percentile75_10YrsAfterEntry": 62796,
+    "shareEarningAboveHsGrad": 0.544
   }
 }

--- a/data/mi/scorecard/washtenaw-community-college.json
+++ b/data/mi/scorecard/washtenaw-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wccnet.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:20.943Z",
+  "fetchedAt": "2026-05-13T02:13:36.797Z",
   "size": 7816,
   "shareFirstGeneration": 0.3917378917,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3294,
     "completionRate200nt": 0.3579,
-    "transferRate": 0.2095
+    "transferRate": 0.2095,
+    "retentionRateFullTime": 0.6436,
+    "retentionRatePartTime": 0.5604
   },
   "earnings": {
-    "median10YrsAfterEntry": 39449
+    "median10YrsAfterEntry": 39449,
+    "median1YrAfterCompletion": 42780,
+    "percentile25_10YrsAfterEntry": 18980,
+    "percentile75_10YrsAfterEntry": 62107,
+    "shareEarningAboveHsGrad": 0.524
   }
 }

--- a/data/mi/scorecard/wayne-county-community-college-district.json
+++ b/data/mi/scorecard/wayne-county-community-college-district.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.wcccd.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:21.391Z",
+  "fetchedAt": "2026-05-13T02:13:37.263Z",
   "size": 7423,
   "shareFirstGeneration": 0.5362029208,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2211,
     "completionRate200nt": 0.3029,
-    "transferRate": 0.1859
+    "transferRate": 0.1859,
+    "retentionRateFullTime": 0.5442,
+    "retentionRatePartTime": 0.3817
   },
   "earnings": {
-    "median10YrsAfterEntry": 29079
+    "median10YrsAfterEntry": 29079,
+    "median1YrAfterCompletion": 35189,
+    "percentile25_10YrsAfterEntry": 11953,
+    "percentile75_10YrsAfterEntry": 48505,
+    "shareEarningAboveHsGrad": 0.442
   }
 }

--- a/data/mi/scorecard/west-shore-community-college.json
+++ b/data/mi/scorecard/west-shore-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.westshore.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:21.885Z",
+  "fetchedAt": "2026-05-13T02:13:37.693Z",
   "size": 782,
   "shareFirstGeneration": 0.4340425532,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2717,
     "completionRate200nt": 0.3445,
-    "transferRate": 0.2935
+    "transferRate": 0.2935,
+    "retentionRateFullTime": 0.6774,
+    "retentionRatePartTime": 0.4578
   },
   "earnings": {
-    "median10YrsAfterEntry": 36115
+    "median10YrsAfterEntry": 36115,
+    "median1YrAfterCompletion": 42377,
+    "percentile25_10YrsAfterEntry": 19511,
+    "percentile75_10YrsAfterEntry": 55927,
+    "shareEarningAboveHsGrad": 0.519
   }
 }

--- a/data/ms/scorecard/coahoma-community-college.json
+++ b/data/ms/scorecard/coahoma-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.coahomacc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:23.257Z",
+  "fetchedAt": "2026-05-13T02:13:39.071Z",
   "size": 1144,
   "shareFirstGeneration": 0.4230769231,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4101,
     "completionRate200nt": 0.4053,
-    "transferRate": 0.1767
+    "transferRate": 0.1767,
+    "retentionRateFullTime": 0.7833,
+    "retentionRatePartTime": 0.3333
   },
   "earnings": {
-    "median10YrsAfterEntry": 24289
+    "median10YrsAfterEntry": 24289,
+    "median1YrAfterCompletion": 20872,
+    "percentile25_10YrsAfterEntry": 12590,
+    "percentile75_10YrsAfterEntry": 39288,
+    "shareEarningAboveHsGrad": 0.307
   }
 }

--- a/data/ms/scorecard/copiah-lincoln-community-college.json
+++ b/data/ms/scorecard/copiah-lincoln-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.colin.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:23.732Z",
+  "fetchedAt": "2026-05-13T02:13:39.502Z",
   "size": 1922,
   "shareFirstGeneration": 0.4113520408,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4991,
     "completionRate200nt": 0.6964,
-    "transferRate": 0.1416
+    "transferRate": 0.1416,
+    "retentionRateFullTime": 0.7262,
+    "retentionRatePartTime": 0.2
   },
   "earnings": {
-    "median10YrsAfterEntry": 31241
+    "median10YrsAfterEntry": 31241,
+    "median1YrAfterCompletion": 29827,
+    "percentile25_10YrsAfterEntry": 17521,
+    "percentile75_10YrsAfterEntry": 49086,
+    "shareEarningAboveHsGrad": 0.49
   }
 }

--- a/data/ms/scorecard/east-central-community-college.json
+++ b/data/ms/scorecard/east-central-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.eccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:24.221Z",
+  "fetchedAt": "2026-05-13T02:13:39.931Z",
   "size": 1520,
   "shareFirstGeneration": 0.3713178295,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.361,
     "completionRate200nt": 0.4175,
-    "transferRate": 0.152
+    "transferRate": 0.152,
+    "retentionRateFullTime": 0.6014,
+    "retentionRatePartTime": 0.05
   },
   "earnings": {
-    "median10YrsAfterEntry": 32421
+    "median10YrsAfterEntry": 32421,
+    "median1YrAfterCompletion": 26766,
+    "percentile25_10YrsAfterEntry": 17712,
+    "percentile75_10YrsAfterEntry": 48709,
+    "shareEarningAboveHsGrad": 0.515
   }
 }

--- a/data/ms/scorecard/east-mississippi-community-college.json
+++ b/data/ms/scorecard/east-mississippi-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.eastms.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:24.704Z",
+  "fetchedAt": "2026-05-13T02:13:40.406Z",
   "size": 2838,
   "shareFirstGeneration": 0.375272094,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4766,
     "completionRate200nt": 0.4358,
-    "transferRate": 0.1681
+    "transferRate": 0.1681,
+    "retentionRateFullTime": 0.6608,
+    "retentionRatePartTime": 0.1842
   },
   "earnings": {
-    "median10YrsAfterEntry": 33772
+    "median10YrsAfterEntry": 33772,
+    "median1YrAfterCompletion": 34349,
+    "percentile25_10YrsAfterEntry": 18565,
+    "percentile75_10YrsAfterEntry": 51247,
+    "shareEarningAboveHsGrad": 0.444
   }
 }

--- a/data/ms/scorecard/hinds-community-college.json
+++ b/data/ms/scorecard/hinds-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.hindscc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:25.187Z",
+  "fetchedAt": "2026-05-13T02:13:40.856Z",
   "size": 6397,
   "shareFirstGeneration": 0.3823441247,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4328,
     "completionRate200nt": 0.4595,
-    "transferRate": 0.1645
+    "transferRate": 0.1645,
+    "retentionRateFullTime": 0.5786,
+    "retentionRatePartTime": 0.2266
   },
   "earnings": {
-    "median10YrsAfterEntry": 30774
+    "median10YrsAfterEntry": 30774,
+    "median1YrAfterCompletion": 31611,
+    "percentile25_10YrsAfterEntry": 16453,
+    "percentile75_10YrsAfterEntry": 47856,
+    "shareEarningAboveHsGrad": 0.47
   }
 }

--- a/data/ms/scorecard/holmes-community-college.json
+++ b/data/ms/scorecard/holmes-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.holmescc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:25.637Z",
+  "fetchedAt": "2026-05-13T02:13:41.314Z",
   "size": 3958,
   "shareFirstGeneration": 0.3853889382,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3904,
     "completionRate200nt": 0.4702,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.558,
+    "retentionRatePartTime": 0.2456
   },
   "earnings": {
-    "median10YrsAfterEntry": 32922
+    "median10YrsAfterEntry": 32922,
+    "median1YrAfterCompletion": 31942,
+    "percentile25_10YrsAfterEntry": 17578,
+    "percentile75_10YrsAfterEntry": 49249,
+    "shareEarningAboveHsGrad": 0.508
   }
 }

--- a/data/ms/scorecard/itawamba-community-college.json
+++ b/data/ms/scorecard/itawamba-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.iccms.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:26.112Z",
+  "fetchedAt": "2026-05-13T02:13:41.755Z",
   "size": 4167,
   "shareFirstGeneration": 0.4135005533,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5035,
     "completionRate200nt": 0.4779,
-    "transferRate": 0.1558
+    "transferRate": 0.1558,
+    "retentionRateFullTime": 0.7352,
+    "retentionRatePartTime": 0.1818
   },
   "earnings": {
-    "median10YrsAfterEntry": 32912
+    "median10YrsAfterEntry": 32912,
+    "median1YrAfterCompletion": 33540,
+    "percentile25_10YrsAfterEntry": 18475,
+    "percentile75_10YrsAfterEntry": 47240,
+    "shareEarningAboveHsGrad": 0.49
   }
 }

--- a/data/ms/scorecard/jones-county-junior-college.json
+++ b/data/ms/scorecard/jones-county-junior-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.jcjc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:26.558Z",
+  "fetchedAt": "2026-05-13T02:13:42.195Z",
   "size": 3535,
   "shareFirstGeneration": 0.4018340975,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4092,
     "completionRate200nt": 0.3733,
-    "transferRate": 0.1526
+    "transferRate": 0.1526,
+    "retentionRateFullTime": 0.5593,
+    "retentionRatePartTime": 0.1607
   },
   "earnings": {
-    "median10YrsAfterEntry": 33377
+    "median10YrsAfterEntry": 33377,
+    "median1YrAfterCompletion": 29785,
+    "percentile25_10YrsAfterEntry": 18228,
+    "percentile75_10YrsAfterEntry": 51177,
+    "shareEarningAboveHsGrad": 0.482
   }
 }

--- a/data/ms/scorecard/meridian-community-college.json
+++ b/data/ms/scorecard/meridian-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.meridiancc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:27.028Z",
+  "fetchedAt": "2026-05-13T02:13:42.618Z",
   "size": 2156,
   "shareFirstGeneration": 0.4185750636,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.344,
     "completionRate200nt": 0.4902,
-    "transferRate": 0.117
+    "transferRate": 0.117,
+    "retentionRateFullTime": 0.6615,
+    "retentionRatePartTime": 0.1923
   },
   "earnings": {
-    "median10YrsAfterEntry": 31002
+    "median10YrsAfterEntry": 31002,
+    "median1YrAfterCompletion": 38486,
+    "percentile25_10YrsAfterEntry": 16778,
+    "percentile75_10YrsAfterEntry": 49370,
+    "shareEarningAboveHsGrad": 0.467
   }
 }

--- a/data/ms/scorecard/mississippi-delta-community-college.json
+++ b/data/ms/scorecard/mississippi-delta-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.msdelta.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:27.492Z",
+  "fetchedAt": "2026-05-13T02:13:43.076Z",
   "size": 1413,
   "shareFirstGeneration": 0.4243323442,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3118,
     "completionRate200nt": 0.5816,
-    "transferRate": 0.1648
+    "transferRate": 0.1648,
+    "retentionRateFullTime": 0.5517,
+    "retentionRatePartTime": 0.0952
   },
   "earnings": {
-    "median10YrsAfterEntry": 28421
+    "median10YrsAfterEntry": 28421,
+    "median1YrAfterCompletion": 28461,
+    "percentile25_10YrsAfterEntry": 15170,
+    "percentile75_10YrsAfterEntry": 45091,
+    "shareEarningAboveHsGrad": 0.377
   }
 }

--- a/data/ms/scorecard/mississippi-gulf-coast-community-college.json
+++ b/data/ms/scorecard/mississippi-gulf-coast-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.mgccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:27.947Z",
+  "fetchedAt": "2026-05-13T02:13:43.522Z",
   "size": 6353,
   "shareFirstGeneration": 0.435149809,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4754,
     "completionRate200nt": 0.4883,
-    "transferRate": 0.1053
+    "transferRate": 0.1053,
+    "retentionRateFullTime": 0.6239,
+    "retentionRatePartTime": 0.2273
   },
   "earnings": {
-    "median10YrsAfterEntry": 33017
+    "median10YrsAfterEntry": 33017,
+    "median1YrAfterCompletion": 34792,
+    "percentile25_10YrsAfterEntry": 16481,
+    "percentile75_10YrsAfterEntry": 52584,
+    "shareEarningAboveHsGrad": 0.499
   }
 }

--- a/data/ms/scorecard/northeast-mississippi-community-college.json
+++ b/data/ms/scorecard/northeast-mississippi-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nemcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:28.390Z",
+  "fetchedAt": "2026-05-13T02:13:43.978Z",
   "size": 2698,
   "shareFirstGeneration": 0.4473826228,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3362,
     "completionRate200nt": 0.3573,
-    "transferRate": 0.2621
+    "transferRate": 0.2621,
+    "retentionRateFullTime": 0.6841,
+    "retentionRatePartTime": 0.2727
   },
   "earnings": {
-    "median10YrsAfterEntry": 34081
+    "median10YrsAfterEntry": 34081,
+    "median1YrAfterCompletion": 38017,
+    "percentile25_10YrsAfterEntry": 19311,
+    "percentile75_10YrsAfterEntry": 49169,
+    "shareEarningAboveHsGrad": 0.527
   }
 }

--- a/data/ms/scorecard/northwest-mississippi-community-college.json
+++ b/data/ms/scorecard/northwest-mississippi-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.northwestms.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:28.828Z",
+  "fetchedAt": "2026-05-13T02:13:44.407Z",
   "size": 5452,
   "shareFirstGeneration": 0.4165450122,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4532,
     "completionRate200nt": 0.4566,
-    "transferRate": 0.1535
+    "transferRate": 0.1535,
+    "retentionRateFullTime": 0.6767,
+    "retentionRatePartTime": 0.4063
   },
   "earnings": {
-    "median10YrsAfterEntry": 36396
+    "median10YrsAfterEntry": 36396,
+    "median1YrAfterCompletion": 32587,
+    "percentile25_10YrsAfterEntry": 19430,
+    "percentile75_10YrsAfterEntry": 54473,
+    "shareEarningAboveHsGrad": 0.517
   }
 }

--- a/data/ms/scorecard/pearl-river-community-college.json
+++ b/data/ms/scorecard/pearl-river-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.prcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:29.290Z",
+  "fetchedAt": "2026-05-13T02:13:44.882Z",
   "size": 4903,
   "shareFirstGeneration": 0.4233390119,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3747,
     "completionRate200nt": 0.395,
-    "transferRate": 0.1569
+    "transferRate": 0.1569,
+    "retentionRateFullTime": 0.6472,
+    "retentionRatePartTime": 0.1493
   },
   "earnings": {
-    "median10YrsAfterEntry": 33019
+    "median10YrsAfterEntry": 33019,
+    "median1YrAfterCompletion": 33824,
+    "percentile25_10YrsAfterEntry": 16868,
+    "percentile75_10YrsAfterEntry": 53245,
+    "shareEarningAboveHsGrad": 0.493
   }
 }

--- a/data/ms/scorecard/southwest-mississippi-community-college.json
+++ b/data/ms/scorecard/southwest-mississippi-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.smcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:29.796Z",
+  "fetchedAt": "2026-05-13T02:13:45.308Z",
   "size": 1474,
   "shareFirstGeneration": 0.4214079074,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5586,
     "completionRate200nt": 0.4165,
-    "transferRate": 0.1352
+    "transferRate": 0.1352,
+    "retentionRateFullTime": 0.6923,
+    "retentionRatePartTime": 0.2857
   },
   "earnings": {
-    "median10YrsAfterEntry": 33227
+    "median10YrsAfterEntry": 33227,
+    "median1YrAfterCompletion": 51221,
+    "percentile25_10YrsAfterEntry": 17386,
+    "percentile75_10YrsAfterEntry": 50991,
+    "shareEarningAboveHsGrad": 0.437
   }
 }

--- a/data/nc/scorecard/alamance.json
+++ b/data/nc/scorecard/alamance.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.alamancecc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:30.258Z",
+  "fetchedAt": "2026-05-13T02:13:45.745Z",
   "size": 3080,
   "shareFirstGeneration": 0.4630779848,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3934,
     "completionRate200nt": 0.3537,
-    "transferRate": 0.1869
+    "transferRate": 0.1869,
+    "retentionRateFullTime": 0.7213,
+    "retentionRatePartTime": 0.6293
   },
   "earnings": {
-    "median10YrsAfterEntry": 34241
+    "median10YrsAfterEntry": 34241,
+    "median1YrAfterCompletion": 35073,
+    "percentile25_10YrsAfterEntry": 18692,
+    "percentile75_10YrsAfterEntry": 49425,
+    "shareEarningAboveHsGrad": 0.479
   }
 }

--- a/data/nc/scorecard/asheville-buncombe-technical.json
+++ b/data/nc/scorecard/asheville-buncombe-technical.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.abtech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:30.730Z",
+  "fetchedAt": "2026-05-13T02:13:46.181Z",
   "size": 5110,
   "shareFirstGeneration": 0.3876208897,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3984,
     "completionRate200nt": 0.3624,
-    "transferRate": 0.0885
+    "transferRate": 0.0885,
+    "retentionRateFullTime": 0.5905,
+    "retentionRatePartTime": 0.473
   },
   "earnings": {
-    "median10YrsAfterEntry": 36048
+    "median10YrsAfterEntry": 36048,
+    "median1YrAfterCompletion": 35528,
+    "percentile25_10YrsAfterEntry": 17505,
+    "percentile75_10YrsAfterEntry": 54112,
+    "shareEarningAboveHsGrad": 0.523
   }
 }

--- a/data/nc/scorecard/beaufort-county.json
+++ b/data/nc/scorecard/beaufort-county.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.beaufortccc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:31.240Z",
+  "fetchedAt": "2026-05-13T02:13:46.638Z",
   "size": 1074,
   "shareFirstGeneration": 0.4951923077,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4771,
     "completionRate200nt": 0.4,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.7558,
+    "retentionRatePartTime": 0.4286
   },
   "earnings": {
-    "median10YrsAfterEntry": 32519
+    "median10YrsAfterEntry": 32519,
+    "median1YrAfterCompletion": 31180,
+    "percentile25_10YrsAfterEntry": 16959,
+    "percentile75_10YrsAfterEntry": 50058,
+    "shareEarningAboveHsGrad": 0.437
   }
 }

--- a/data/nc/scorecard/bladen.json
+++ b/data/nc/scorecard/bladen.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://bladencc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:31.713Z",
+  "fetchedAt": "2026-05-13T02:13:47.086Z",
   "size": 1030,
   "shareFirstGeneration": 0.4740061162,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2273,
     "completionRate200nt": 0.3095,
-    "transferRate": 0.2273
+    "transferRate": 0.2273,
+    "retentionRateFullTime": 0.6667,
+    "retentionRatePartTime": 0.4815
   },
   "earnings": {
-    "median10YrsAfterEntry": 30591
+    "median10YrsAfterEntry": 30591,
+    "median1YrAfterCompletion": 53830,
+    "percentile25_10YrsAfterEntry": 15394,
+    "percentile75_10YrsAfterEntry": 46801,
+    "shareEarningAboveHsGrad": 0.377
   }
 }

--- a/data/nc/scorecard/blue-ridge.json
+++ b/data/nc/scorecard/blue-ridge.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.blueridge.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:32.160Z",
+  "fetchedAt": "2026-05-13T02:13:47.542Z",
   "size": 1758,
   "shareFirstGeneration": 0.4593639576,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4972,
     "completionRate200nt": 0.4178,
-    "transferRate": 0.1412
+    "transferRate": 0.1412,
+    "retentionRateFullTime": 0.7021,
+    "retentionRatePartTime": 0.4854
   },
   "earnings": {
-    "median10YrsAfterEntry": 36324
+    "median10YrsAfterEntry": 36324,
+    "median1YrAfterCompletion": 37784,
+    "percentile25_10YrsAfterEntry": 19103,
+    "percentile75_10YrsAfterEntry": 53491,
+    "shareEarningAboveHsGrad": 0.464
   }
 }

--- a/data/nc/scorecard/brunswick.json
+++ b/data/nc/scorecard/brunswick.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.brunswickcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:32.631Z",
+  "fetchedAt": "2026-05-13T02:13:47.969Z",
   "size": 1211,
   "shareFirstGeneration": 0.4298724954,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4035,
     "completionRate200nt": 0.5158,
-    "transferRate": 0.1404
+    "transferRate": 0.1404,
+    "retentionRateFullTime": 0.6623,
+    "retentionRatePartTime": 0.3981
   },
   "earnings": {
-    "median10YrsAfterEntry": 36668
+    "median10YrsAfterEntry": 36668,
+    "median1YrAfterCompletion": 35997,
+    "percentile25_10YrsAfterEntry": 19412,
+    "percentile75_10YrsAfterEntry": 53973,
+    "shareEarningAboveHsGrad": 0.393
   }
 }

--- a/data/nc/scorecard/caldwell.json
+++ b/data/nc/scorecard/caldwell.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://cccti.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:33.173Z",
+  "fetchedAt": "2026-05-13T02:13:48.386Z",
   "size": 2393,
   "shareFirstGeneration": 0.5032139578,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4474,
     "completionRate200nt": 0.4597,
-    "transferRate": 0.1743
+    "transferRate": 0.1743,
+    "retentionRateFullTime": 0.7059,
+    "retentionRatePartTime": 0.5023
   },
   "earnings": {
-    "median10YrsAfterEntry": 34515
+    "median10YrsAfterEntry": 34515,
+    "median1YrAfterCompletion": 34593,
+    "percentile25_10YrsAfterEntry": 18928,
+    "percentile75_10YrsAfterEntry": 51021,
+    "shareEarningAboveHsGrad": 0.474
   }
 }

--- a/data/nc/scorecard/cape-fear.json
+++ b/data/nc/scorecard/cape-fear.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cfcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:33.687Z",
+  "fetchedAt": "2026-05-13T02:13:48.848Z",
   "size": 9764,
   "shareFirstGeneration": 0.3828345567,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3446,
     "completionRate200nt": 0.3698,
-    "transferRate": 0.0176
+    "transferRate": 0.0176,
+    "retentionRateFullTime": 0.6747,
+    "retentionRatePartTime": 0.5621
   },
   "earnings": {
-    "median10YrsAfterEntry": 38654
+    "median10YrsAfterEntry": 38654,
+    "median1YrAfterCompletion": 35317,
+    "percentile25_10YrsAfterEntry": 19768,
+    "percentile75_10YrsAfterEntry": 58224,
+    "shareEarningAboveHsGrad": 0.496
   }
 }

--- a/data/nc/scorecard/carteret.json
+++ b/data/nc/scorecard/carteret.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://carteret.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:34.200Z",
+  "fetchedAt": "2026-05-13T02:13:49.298Z",
   "size": 1172,
   "shareFirstGeneration": 0.4782608696,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4898,
     "completionRate200nt": 0.4407,
-    "transferRate": 0.1429
+    "transferRate": 0.1429,
+    "retentionRateFullTime": 0.6165,
+    "retentionRatePartTime": 0.5743
   },
   "earnings": {
-    "median10YrsAfterEntry": 33357
+    "median10YrsAfterEntry": 33357,
+    "median1YrAfterCompletion": 35075,
+    "percentile25_10YrsAfterEntry": 16208,
+    "percentile75_10YrsAfterEntry": 50992,
+    "shareEarningAboveHsGrad": 0.433
   }
 }

--- a/data/nc/scorecard/catawba-valley.json
+++ b/data/nc/scorecard/catawba-valley.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cvcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:34.644Z",
+  "fetchedAt": "2026-05-13T02:13:49.746Z",
   "size": 2741,
   "shareFirstGeneration": 0.4953424658,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3519,
     "completionRate200nt": 0.3889,
-    "transferRate": 0.3305
+    "transferRate": 0.3305,
+    "retentionRateFullTime": 0.6489,
+    "retentionRatePartTime": 0.5278
   },
   "earnings": {
-    "median10YrsAfterEntry": 36977
+    "median10YrsAfterEntry": 36977,
+    "median1YrAfterCompletion": 33668,
+    "percentile25_10YrsAfterEntry": 21101,
+    "percentile75_10YrsAfterEntry": 53434,
+    "shareEarningAboveHsGrad": 0.514
   }
 }

--- a/data/nc/scorecard/central-carolina.json
+++ b/data/nc/scorecard/central-carolina.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:35.087Z",
+  "fetchedAt": "2026-05-13T02:13:50.210Z",
   "size": 3237,
   "shareFirstGeneration": 0.4618345093,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4293,
     "completionRate200nt": 0.4778,
-    "transferRate": 0.1631
+    "transferRate": 0.1631,
+    "retentionRateFullTime": 0.7251,
+    "retentionRatePartTime": 0.5856
   },
   "earnings": {
-    "median10YrsAfterEntry": 33525
+    "median10YrsAfterEntry": 33525,
+    "median1YrAfterCompletion": 32911,
+    "percentile25_10YrsAfterEntry": 17814,
+    "percentile75_10YrsAfterEntry": 48995,
+    "shareEarningAboveHsGrad": 0.439
   }
 }

--- a/data/nc/scorecard/central-piedmont.json
+++ b/data/nc/scorecard/central-piedmont.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cpcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:35.546Z",
+  "fetchedAt": "2026-05-13T02:13:50.678Z",
   "size": 15067,
   "shareFirstGeneration": 0.4085784988,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3091,
     "completionRate200nt": 0.3102,
-    "transferRate": 0.2591
+    "transferRate": 0.2591,
+    "retentionRateFullTime": 0.6986,
+    "retentionRatePartTime": 0.5526
   },
   "earnings": {
-    "median10YrsAfterEntry": 37865
+    "median10YrsAfterEntry": 37865,
+    "median1YrAfterCompletion": 37962,
+    "percentile25_10YrsAfterEntry": 19054,
+    "percentile75_10YrsAfterEntry": 56787,
+    "shareEarningAboveHsGrad": 0.492
   }
 }

--- a/data/nc/scorecard/cleveland.json
+++ b/data/nc/scorecard/cleveland.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.clevelandcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:36.015Z",
+  "fetchedAt": "2026-05-13T02:13:51.136Z",
   "size": 1097,
   "shareFirstGeneration": 0.4858757062,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3152,
     "completionRate200nt": 0.1346,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.2016,
+    "retentionRatePartTime": 0.3902
   },
   "earnings": {
-    "median10YrsAfterEntry": 33755
+    "median10YrsAfterEntry": 33755,
+    "median1YrAfterCompletion": 32277,
+    "percentile25_10YrsAfterEntry": 18172,
+    "percentile75_10YrsAfterEntry": 49874,
+    "shareEarningAboveHsGrad": 0.42
   }
 }

--- a/data/nc/scorecard/coastal-carolina.json
+++ b/data/nc/scorecard/coastal-carolina.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.coastalcarolina.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:36.452Z",
+  "fetchedAt": "2026-05-13T02:13:51.570Z",
   "size": 2724,
   "shareFirstGeneration": 0.4489583333,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4936,
     "completionRate200nt": 0.4684,
-    "transferRate": 0.1841
+    "transferRate": 0.1841,
+    "retentionRateFullTime": 0.5859,
+    "retentionRatePartTime": 0.3625
   },
   "earnings": {
-    "median10YrsAfterEntry": 36444
+    "median10YrsAfterEntry": 36444,
+    "median1YrAfterCompletion": 28082,
+    "percentile25_10YrsAfterEntry": 19043,
+    "percentile75_10YrsAfterEntry": 54243,
+    "shareEarningAboveHsGrad": 0.489
   }
 }

--- a/data/nc/scorecard/college-of-the-albemarle.json
+++ b/data/nc/scorecard/college-of-the-albemarle.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.albemarle.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:36.964Z",
+  "fetchedAt": "2026-05-13T02:13:52.029Z",
   "size": 2001,
   "shareFirstGeneration": 0.4525862069,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3478,
     "completionRate200nt": 0.4294,
-    "transferRate": 0.3116
+    "transferRate": 0.3116,
+    "retentionRateFullTime": 0.716,
+    "retentionRatePartTime": 0.5053
   },
   "earnings": {
-    "median10YrsAfterEntry": 33234
+    "median10YrsAfterEntry": 33234,
+    "median1YrAfterCompletion": 34395,
+    "percentile25_10YrsAfterEntry": 17302,
+    "percentile75_10YrsAfterEntry": 48725,
+    "shareEarningAboveHsGrad": 0.361
   }
 }

--- a/data/nc/scorecard/craven.json
+++ b/data/nc/scorecard/craven.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://cravencc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:37.434Z",
+  "fetchedAt": "2026-05-13T02:13:52.505Z",
   "size": 1989,
   "shareFirstGeneration": 0.4514767932,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4836,
     "completionRate200nt": 0.5,
-    "transferRate": 0.1311
+    "transferRate": 0.1311,
+    "retentionRateFullTime": 0.6643,
+    "retentionRatePartTime": 0.6649
   },
   "earnings": {
-    "median10YrsAfterEntry": 34231
+    "median10YrsAfterEntry": 34231,
+    "median1YrAfterCompletion": 33660,
+    "percentile25_10YrsAfterEntry": 18107,
+    "percentile75_10YrsAfterEntry": 52521,
+    "shareEarningAboveHsGrad": 0.519
   }
 }

--- a/data/nc/scorecard/davidson-davie.json
+++ b/data/nc/scorecard/davidson-davie.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.davidsondavie.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:38.113Z",
+  "fetchedAt": "2026-05-13T02:13:52.930Z",
   "size": 2633,
   "shareFirstGeneration": 0.4899367453,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4594,
     "completionRate200nt": 0.4649,
-    "transferRate": 0.125
+    "transferRate": 0.125,
+    "retentionRateFullTime": 0.6561,
+    "retentionRatePartTime": 0.4848
   },
   "earnings": {
-    "median10YrsAfterEntry": 36337
+    "median10YrsAfterEntry": 36337,
+    "median1YrAfterCompletion": 36990,
+    "percentile25_10YrsAfterEntry": 20986,
+    "percentile75_10YrsAfterEntry": 52294,
+    "shareEarningAboveHsGrad": 0.453
   }
 }

--- a/data/nc/scorecard/durham-technical.json
+++ b/data/nc/scorecard/durham-technical.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.durhamtech.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:38.563Z",
+  "fetchedAt": "2026-05-13T02:13:53.588Z",
   "size": 3890,
   "shareFirstGeneration": 0.4234461849,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4493,
     "completionRate200nt": 0.3929,
-    "transferRate": 0.1522
+    "transferRate": 0.1522,
+    "retentionRateFullTime": 0.6643,
+    "retentionRatePartTime": 0.4772
   },
   "earnings": {
-    "median10YrsAfterEntry": 36142
+    "median10YrsAfterEntry": 36142,
+    "median1YrAfterCompletion": 49815,
+    "percentile25_10YrsAfterEntry": 18641,
+    "percentile75_10YrsAfterEntry": 53466,
+    "shareEarningAboveHsGrad": 0.517
   }
 }

--- a/data/nc/scorecard/edgecombe.json
+++ b/data/nc/scorecard/edgecombe.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.edgecombe.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:39.016Z",
+  "fetchedAt": "2026-05-13T02:13:54.018Z",
   "size": 1397,
   "shareFirstGeneration": 0.5399334443,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3654,
     "completionRate200nt": 0.5758,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.7917,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 33267
+    "median10YrsAfterEntry": 33267,
+    "median1YrAfterCompletion": 38286,
+    "percentile25_10YrsAfterEntry": 16944,
+    "percentile75_10YrsAfterEntry": 48422,
+    "shareEarningAboveHsGrad": 0.427
   }
 }

--- a/data/nc/scorecard/fayetteville-technical.json
+++ b/data/nc/scorecard/fayetteville-technical.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.faytechcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:39.510Z",
+  "fetchedAt": "2026-05-13T02:13:54.483Z",
   "size": 9471,
   "shareFirstGeneration": 0.4509353462,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.235,
     "completionRate200nt": 0.253,
-    "transferRate": 0.1774
+    "transferRate": 0.1774,
+    "retentionRateFullTime": 0.5806,
+    "retentionRatePartTime": 0.4233
   },
   "earnings": {
-    "median10YrsAfterEntry": 31861
+    "median10YrsAfterEntry": 31861,
+    "median1YrAfterCompletion": 41705,
+    "percentile25_10YrsAfterEntry": 16162,
+    "percentile75_10YrsAfterEntry": 48844,
+    "shareEarningAboveHsGrad": 0.455
   }
 }

--- a/data/nc/scorecard/forsyth-technical.json
+++ b/data/nc/scorecard/forsyth-technical.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.forsythtech.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:39.985Z",
+  "fetchedAt": "2026-05-13T02:13:54.920Z",
   "size": 7113,
   "shareFirstGeneration": 0.444701795,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.342,
     "completionRate200nt": 0.3283,
-    "transferRate": 0.1214
+    "transferRate": 0.1214,
+    "retentionRateFullTime": 0.7317,
+    "retentionRatePartTime": 0.3676
   },
   "earnings": {
-    "median10YrsAfterEntry": 34139
+    "median10YrsAfterEntry": 34139,
+    "median1YrAfterCompletion": 39115,
+    "percentile25_10YrsAfterEntry": 18534,
+    "percentile75_10YrsAfterEntry": 50990,
+    "shareEarningAboveHsGrad": 0.47
   }
 }

--- a/data/nc/scorecard/gaston.json
+++ b/data/nc/scorecard/gaston.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.gaston.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:40.453Z",
+  "fetchedAt": "2026-05-13T02:13:55.351Z",
   "size": 3518,
   "shareFirstGeneration": 0.4826932195,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.6313,
     "completionRate200nt": 0.5349,
-    "transferRate": 0.1194
+    "transferRate": 0.1194,
+    "retentionRateFullTime": 0.5441,
+    "retentionRatePartTime": 0.4367
   },
   "earnings": {
-    "median10YrsAfterEntry": 35386
+    "median10YrsAfterEntry": 35386,
+    "median1YrAfterCompletion": 37690,
+    "percentile25_10YrsAfterEntry": 18295,
+    "percentile75_10YrsAfterEntry": 51204,
+    "shareEarningAboveHsGrad": 0.459
   }
 }

--- a/data/nc/scorecard/guilford-technical.json
+++ b/data/nc/scorecard/guilford-technical.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.gtcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:40.930Z",
+  "fetchedAt": "2026-05-13T02:13:55.809Z",
   "size": 9260,
   "shareFirstGeneration": 0.4366756714,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.311,
     "completionRate200nt": 0.3368,
-    "transferRate": 0.1409
+    "transferRate": 0.1409,
+    "retentionRateFullTime": 0.6422,
+    "retentionRatePartTime": 0.4878
   },
   "earnings": {
-    "median10YrsAfterEntry": 33934
+    "median10YrsAfterEntry": 33934,
+    "median1YrAfterCompletion": 36501,
+    "percentile25_10YrsAfterEntry": 17279,
+    "percentile75_10YrsAfterEntry": 50701,
+    "shareEarningAboveHsGrad": 0.486
   }
 }

--- a/data/nc/scorecard/halifax.json
+++ b/data/nc/scorecard/halifax.json
@@ -6,7 +6,7 @@
   "schoolUrl": "halifaxcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:41.377Z",
+  "fetchedAt": "2026-05-13T02:13:56.262Z",
   "size": 723,
   "shareFirstGeneration": 0.5560081466,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3514,
     "completionRate200nt": 0.5172,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.6129,
+    "retentionRatePartTime": 0.4839
   },
   "earnings": {
-    "median10YrsAfterEntry": 31644
+    "median10YrsAfterEntry": 31644,
+    "median1YrAfterCompletion": 41271,
+    "percentile25_10YrsAfterEntry": 17027,
+    "percentile75_10YrsAfterEntry": 45833,
+    "shareEarningAboveHsGrad": 0.401
   }
 }

--- a/data/nc/scorecard/haywood.json
+++ b/data/nc/scorecard/haywood.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.haywood.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:41.843Z",
+  "fetchedAt": "2026-05-13T02:13:56.717Z",
   "size": 849,
   "shareFirstGeneration": 0.424437299,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3359,
     "completionRate200nt": 0.4916,
-    "transferRate": 0.1563
+    "transferRate": 0.1563,
+    "retentionRateFullTime": 0.6357,
+    "retentionRatePartTime": 0.4737
   },
   "earnings": {
-    "median10YrsAfterEntry": 34770
+    "median10YrsAfterEntry": 34770,
+    "median1YrAfterCompletion": 38092,
+    "percentile25_10YrsAfterEntry": 18523,
+    "percentile75_10YrsAfterEntry": 50743,
+    "shareEarningAboveHsGrad": 0.452
   }
 }

--- a/data/nc/scorecard/isothermal.json
+++ b/data/nc/scorecard/isothermal.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.isothermal.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:42.292Z",
+  "fetchedAt": "2026-05-13T02:13:57.169Z",
   "size": 1169,
   "shareFirstGeneration": 0.5138888889,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5549,
     "completionRate200nt": 0.5176,
-    "transferRate": 0.3049
+    "transferRate": 0.3049,
+    "retentionRateFullTime": 0.711,
+    "retentionRatePartTime": 0.7193
   },
   "earnings": {
-    "median10YrsAfterEntry": 33325
+    "median10YrsAfterEntry": 33325,
+    "median1YrAfterCompletion": 32924,
+    "percentile25_10YrsAfterEntry": 17282,
+    "percentile75_10YrsAfterEntry": 48473,
+    "shareEarningAboveHsGrad": 0.41
   }
 }

--- a/data/nc/scorecard/james-sprunt.json
+++ b/data/nc/scorecard/james-sprunt.json
@@ -6,7 +6,7 @@
   "schoolUrl": "jamessprunt.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:42.864Z",
+  "fetchedAt": "2026-05-13T02:13:57.635Z",
   "size": 799,
   "shareFirstGeneration": 0.5197215777,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4779,
     "completionRate200nt": 0.4306,
-    "transferRate": 0.0177
+    "transferRate": 0.0177,
+    "retentionRateFullTime": 0.7677,
+    "retentionRatePartTime": 0.4912
   },
   "earnings": {
-    "median10YrsAfterEntry": 29307
+    "median10YrsAfterEntry": 29307,
+    "median1YrAfterCompletion": 24341,
+    "percentile25_10YrsAfterEntry": 15375,
+    "percentile75_10YrsAfterEntry": 46074,
+    "shareEarningAboveHsGrad": 0.422
   }
 }

--- a/data/nc/scorecard/johnston.json
+++ b/data/nc/scorecard/johnston.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.johnstoncc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:43.338Z",
+  "fetchedAt": "2026-05-13T02:13:58.061Z",
   "size": 3453,
   "shareFirstGeneration": 0.4661654135,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3661,
     "completionRate200nt": 0.3236,
-    "transferRate": 0.2351
+    "transferRate": 0.2351,
+    "retentionRateFullTime": 0.6678,
+    "retentionRatePartTime": 0.4811
   },
   "earnings": {
-    "median10YrsAfterEntry": 37310
+    "median10YrsAfterEntry": 37310,
+    "median1YrAfterCompletion": 38533,
+    "percentile25_10YrsAfterEntry": 20703,
+    "percentile75_10YrsAfterEntry": 53369,
+    "shareEarningAboveHsGrad": 0.527
   }
 }

--- a/data/nc/scorecard/lenoir.json
+++ b/data/nc/scorecard/lenoir.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.lenoircc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:43.803Z",
+  "fetchedAt": "2026-05-13T02:13:58.643Z",
   "size": 1469,
   "shareFirstGeneration": 0.4756756757,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3568,
     "completionRate200nt": 0.3267,
-    "transferRate": 0.2216
+    "transferRate": 0.2216,
+    "retentionRateFullTime": 0.6457,
+    "retentionRatePartTime": 0.4679
   },
   "earnings": {
-    "median10YrsAfterEntry": 33866
+    "median10YrsAfterEntry": 33866,
+    "median1YrAfterCompletion": 39792,
+    "percentile25_10YrsAfterEntry": 18287,
+    "percentile75_10YrsAfterEntry": 50037,
+    "shareEarningAboveHsGrad": 0.487
   }
 }

--- a/data/nc/scorecard/martin.json
+++ b/data/nc/scorecard/martin.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.martincc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:44.292Z",
+  "fetchedAt": "2026-05-13T02:13:59.072Z",
   "size": 313,
   "shareFirstGeneration": 0.5414364641,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3929,
     "completionRate200nt": 0.4688,
-    "transferRate": 0.1071
+    "transferRate": 0.1071,
+    "retentionRateFullTime": 0.7609,
+    "retentionRatePartTime": 0.5294
   },
   "earnings": {
-    "median10YrsAfterEntry": 26016
+    "median10YrsAfterEntry": 26016,
+    "median1YrAfterCompletion": 28131,
+    "percentile25_10YrsAfterEntry": 13138,
+    "percentile75_10YrsAfterEntry": 38307,
+    "shareEarningAboveHsGrad": 0.302
   }
 }

--- a/data/nc/scorecard/mayland.json
+++ b/data/nc/scorecard/mayland.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.mayland.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:44.900Z",
+  "fetchedAt": "2026-05-13T02:13:59.498Z",
   "size": 362,
   "shareFirstGeneration": 0.5164179104,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.46,
     "completionRate200nt": 0.5,
-    "transferRate": 0.12
+    "transferRate": 0.12,
+    "retentionRateFullTime": 0.7619,
+    "retentionRatePartTime": 0.4773
   },
   "earnings": {
-    "median10YrsAfterEntry": 34663
+    "median10YrsAfterEntry": 34663,
+    "median1YrAfterCompletion": 34534,
+    "percentile25_10YrsAfterEntry": 16040,
+    "percentile75_10YrsAfterEntry": 51340,
+    "shareEarningAboveHsGrad": 0.463
   }
 }

--- a/data/nc/scorecard/mcdowell-technical.json
+++ b/data/nc/scorecard/mcdowell-technical.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.mcdowelltech.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:45.375Z",
+  "fetchedAt": "2026-05-13T02:13:59.929Z",
   "size": 608,
   "shareFirstGeneration": 0.4986595174,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4839,
     "completionRate200nt": 0.5714,
-    "transferRate": 0.129
+    "transferRate": 0.129,
+    "retentionRateFullTime": 0.8049,
+    "retentionRatePartTime": 0.5678
   },
   "earnings": {
-    "median10YrsAfterEntry": 33035
+    "median10YrsAfterEntry": 33035,
+    "median1YrAfterCompletion": 44113,
+    "percentile25_10YrsAfterEntry": 16057,
+    "percentile75_10YrsAfterEntry": 47000,
+    "shareEarningAboveHsGrad": 0.473
   }
 }

--- a/data/nc/scorecard/mitchell.json
+++ b/data/nc/scorecard/mitchell.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.mitchellcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:45.849Z",
+  "fetchedAt": "2026-05-13T02:14:00.390Z",
   "size": 1948,
   "shareFirstGeneration": 0.4906444906,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2792,
     "completionRate200nt": 0.2254,
-    "transferRate": 0.1917
+    "transferRate": 0.1917,
+    "retentionRateFullTime": 0.6085,
+    "retentionRatePartTime": 0.487
   },
   "earnings": {
-    "median10YrsAfterEntry": 33298
+    "median10YrsAfterEntry": 33298,
+    "median1YrAfterCompletion": 32764,
+    "percentile25_10YrsAfterEntry": 16742,
+    "percentile75_10YrsAfterEntry": 50931,
+    "shareEarningAboveHsGrad": 0.413
   }
 }

--- a/data/nc/scorecard/montgomery.json
+++ b/data/nc/scorecard/montgomery.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.montgomery.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:46.297Z",
+  "fetchedAt": "2026-05-13T02:14:00.818Z",
   "size": 852,
   "shareFirstGeneration": 0.4524590164,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.8387,
     "completionRate200nt": 0.5769,
-    "transferRate": 0
+    "transferRate": 0,
+    "retentionRateFullTime": 0.5,
+    "retentionRatePartTime": 0.6293
   },
   "earnings": {
-    "median10YrsAfterEntry": 32742
+    "median10YrsAfterEntry": 32742,
+    "median1YrAfterCompletion": 35440,
+    "percentile25_10YrsAfterEntry": 19718,
+    "percentile75_10YrsAfterEntry": 47673,
+    "shareEarningAboveHsGrad": 0.441
   }
 }

--- a/data/nc/scorecard/nash.json
+++ b/data/nc/scorecard/nash.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nashcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:46.759Z",
+  "fetchedAt": "2026-05-13T02:14:01.256Z",
   "size": 1689,
   "shareFirstGeneration": 0.5313207547,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4128,
     "completionRate200nt": 0.5545,
-    "transferRate": 0.2785
+    "transferRate": 0.2785,
+    "retentionRateFullTime": 0.7476,
+    "retentionRatePartTime": 0.6125
   },
   "earnings": {
-    "median10YrsAfterEntry": 34912
+    "median10YrsAfterEntry": 34912,
+    "median1YrAfterCompletion": 38263,
+    "percentile25_10YrsAfterEntry": 19820,
+    "percentile75_10YrsAfterEntry": 49927,
+    "shareEarningAboveHsGrad": 0.453
   }
 }

--- a/data/nc/scorecard/pamlico.json
+++ b/data/nc/scorecard/pamlico.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.pamlicocc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:47.228Z",
+  "fetchedAt": "2026-05-13T02:14:01.776Z",
   "size": 165,
   "shareFirstGeneration": 0.5354330709,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5385,
     "completionRate200nt": 0.4706,
-    "transferRate": 0.2308
+    "transferRate": 0.2308,
+    "retentionRateFullTime": 0.5714,
+    "retentionRatePartTime": 0.2778
   },
   "earnings": {
-    "median10YrsAfterEntry": 30005
+    "median10YrsAfterEntry": 30005,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": 13699,
+    "percentile75_10YrsAfterEntry": 43863,
+    "shareEarningAboveHsGrad": 0.407
   }
 }

--- a/data/nc/scorecard/piedmont.json
+++ b/data/nc/scorecard/piedmont.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.piedmontcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:47.878Z",
+  "fetchedAt": "2026-05-13T02:14:02.220Z",
   "size": 457,
   "shareFirstGeneration": 0.5399515738,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2,
     "completionRate200nt": 0.5333,
-    "transferRate": 0.1
+    "transferRate": 0.1,
+    "retentionRateFullTime": 0.6,
+    "retentionRatePartTime": 0.3429
   },
   "earnings": {
-    "median10YrsAfterEntry": 33274
+    "median10YrsAfterEntry": 33274,
+    "median1YrAfterCompletion": 27198,
+    "percentile25_10YrsAfterEntry": 16011,
+    "percentile75_10YrsAfterEntry": 46283,
+    "shareEarningAboveHsGrad": 0.48
   }
 }

--- a/data/nc/scorecard/pitt.json
+++ b/data/nc/scorecard/pitt.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://pittcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:48.321Z",
+  "fetchedAt": "2026-05-13T02:14:02.902Z",
   "size": 5317,
   "shareFirstGeneration": 0.4325191216,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3529,
     "completionRate200nt": 0.3181,
-    "transferRate": 0.1667
+    "transferRate": 0.1667,
+    "retentionRateFullTime": 0.6484,
+    "retentionRatePartTime": 0.4652
   },
   "earnings": {
-    "median10YrsAfterEntry": 37259
+    "median10YrsAfterEntry": 37259,
+    "median1YrAfterCompletion": 38431,
+    "percentile25_10YrsAfterEntry": 20857,
+    "percentile75_10YrsAfterEntry": 56515,
+    "shareEarningAboveHsGrad": 0.494
   }
 }

--- a/data/nc/scorecard/randolph.json
+++ b/data/nc/scorecard/randolph.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.randolph.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:48.788Z",
+  "fetchedAt": "2026-05-13T02:14:03.334Z",
   "size": 1417,
   "shareFirstGeneration": 0.5864374403,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5818,
     "completionRate200nt": 0.5663,
-    "transferRate": 0.1212
+    "transferRate": 0.1212,
+    "retentionRateFullTime": 0.6825,
+    "retentionRatePartTime": 0.4868
   },
   "earnings": {
-    "median10YrsAfterEntry": 33336
+    "median10YrsAfterEntry": 33336,
+    "median1YrAfterCompletion": 28166,
+    "percentile25_10YrsAfterEntry": 18813,
+    "percentile75_10YrsAfterEntry": 47556,
+    "shareEarningAboveHsGrad": 0.442
   }
 }

--- a/data/nc/scorecard/richmond.json
+++ b/data/nc/scorecard/richmond.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://richmondcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:49.227Z",
+  "fetchedAt": "2026-05-13T02:14:03.758Z",
   "size": 1352,
   "shareFirstGeneration": 0.498973306,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4605,
     "completionRate200nt": 0.4886,
-    "transferRate": 0.1447
+    "transferRate": 0.1447,
+    "retentionRateFullTime": 0.7034,
+    "retentionRatePartTime": 0.527
   },
   "earnings": {
-    "median10YrsAfterEntry": 29951
+    "median10YrsAfterEntry": 29951,
+    "median1YrAfterCompletion": 36661,
+    "percentile25_10YrsAfterEntry": 15569,
+    "percentile75_10YrsAfterEntry": 46814,
+    "shareEarningAboveHsGrad": 0.394
   }
 }

--- a/data/nc/scorecard/roanoke-chowan.json
+++ b/data/nc/scorecard/roanoke-chowan.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.roanokechowan.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:49.666Z",
+  "fetchedAt": "2026-05-13T02:14:04.200Z",
   "size": 309,
   "shareFirstGeneration": 0.5555555556,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3684,
     "completionRate200nt": 0.2857,
-    "transferRate": 0.2105
+    "transferRate": 0.2105,
+    "retentionRateFullTime": 0.7778,
+    "retentionRatePartTime": 0.2941
   },
   "earnings": {
-    "median10YrsAfterEntry": 29324
+    "median10YrsAfterEntry": 29324,
+    "median1YrAfterCompletion": 29733,
+    "percentile25_10YrsAfterEntry": 16009,
+    "percentile75_10YrsAfterEntry": 44145,
+    "shareEarningAboveHsGrad": 0.406
   }
 }

--- a/data/nc/scorecard/robeson.json
+++ b/data/nc/scorecard/robeson.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.robeson.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:50.128Z",
+  "fetchedAt": "2026-05-13T02:14:04.659Z",
   "size": 1551,
   "shareFirstGeneration": 0.5506072874,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3265,
     "completionRate200nt": 0.365,
-    "transferRate": 0.1497
+    "transferRate": 0.1497,
+    "retentionRateFullTime": 0.5682,
+    "retentionRatePartTime": 0.3178
   },
   "earnings": {
-    "median10YrsAfterEntry": 29036
+    "median10YrsAfterEntry": 29036,
+    "median1YrAfterCompletion": 39346,
+    "percentile25_10YrsAfterEntry": 15020,
+    "percentile75_10YrsAfterEntry": 45807,
+    "shareEarningAboveHsGrad": 0.331
   }
 }

--- a/data/nc/scorecard/rockingham.json
+++ b/data/nc/scorecard/rockingham.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.rockinghamcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:50.573Z",
+  "fetchedAt": "2026-05-13T02:14:05.115Z",
   "size": 1065,
   "shareFirstGeneration": 0.5221088435,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3507,
     "completionRate200nt": 0.3373,
-    "transferRate": 0.128
+    "transferRate": 0.128,
+    "retentionRateFullTime": 0.6829,
+    "retentionRatePartTime": 0.4918
   },
   "earnings": {
-    "median10YrsAfterEntry": 32480
+    "median10YrsAfterEntry": 32480,
+    "median1YrAfterCompletion": 38815,
+    "percentile25_10YrsAfterEntry": 17360,
+    "percentile75_10YrsAfterEntry": 46513,
+    "shareEarningAboveHsGrad": 0.472
   }
 }

--- a/data/nc/scorecard/rowan-cabarrus.json
+++ b/data/nc/scorecard/rowan-cabarrus.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.rccc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:51.096Z",
+  "fetchedAt": "2026-05-13T02:14:05.570Z",
   "size": 4164,
   "shareFirstGeneration": 0.4724231465,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.351,
     "completionRate200nt": 0.3498,
-    "transferRate": 0.159
+    "transferRate": 0.159,
+    "retentionRateFullTime": 0.6043,
+    "retentionRatePartTime": 0.5078
   },
   "earnings": {
-    "median10YrsAfterEntry": 34936
+    "median10YrsAfterEntry": 34936,
+    "median1YrAfterCompletion": 37723,
+    "percentile25_10YrsAfterEntry": 18452,
+    "percentile75_10YrsAfterEntry": 51811,
+    "shareEarningAboveHsGrad": 0.403
   }
 }

--- a/data/nc/scorecard/sampson.json
+++ b/data/nc/scorecard/sampson.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.sampsoncc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:51.542Z",
+  "fetchedAt": "2026-05-13T02:14:06.000Z",
   "size": 846,
   "shareFirstGeneration": 0.5265957447,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5648,
     "completionRate200nt": 0.5644,
-    "transferRate": 0.1019
+    "transferRate": 0.1019,
+    "retentionRateFullTime": 0.6601,
+    "retentionRatePartTime": 0.4878
   },
   "earnings": {
-    "median10YrsAfterEntry": 33409
+    "median10YrsAfterEntry": 33409,
+    "median1YrAfterCompletion": 43715,
+    "percentile25_10YrsAfterEntry": 17985,
+    "percentile75_10YrsAfterEntry": 46374,
+    "shareEarningAboveHsGrad": 0.425
   }
 }

--- a/data/nc/scorecard/sandhills.json
+++ b/data/nc/scorecard/sandhills.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.sandhills.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:52.042Z",
+  "fetchedAt": "2026-05-13T02:14:06.431Z",
   "size": 2539,
   "shareFirstGeneration": 0.4576012223,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5279,
     "completionRate200nt": 0.5211,
-    "transferRate": 0.2111
+    "transferRate": 0.2111,
+    "retentionRateFullTime": 0.8018,
+    "retentionRatePartTime": 0.505
   },
   "earnings": {
-    "median10YrsAfterEntry": 31656
+    "median10YrsAfterEntry": 31656,
+    "median1YrAfterCompletion": 36448,
+    "percentile25_10YrsAfterEntry": 16726,
+    "percentile75_10YrsAfterEntry": 47301,
+    "shareEarningAboveHsGrad": 0.44
   }
 }

--- a/data/nc/scorecard/south-piedmont.json
+++ b/data/nc/scorecard/south-piedmont.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.spcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:52.488Z",
+  "fetchedAt": "2026-05-13T02:14:06.887Z",
   "size": 1833,
   "shareFirstGeneration": 0.4736147757,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3807,
     "completionRate200nt": 0.4012,
-    "transferRate": 0.1472
+    "transferRate": 0.1472,
+    "retentionRateFullTime": 0.5695,
+    "retentionRatePartTime": 0.482
   },
   "earnings": {
-    "median10YrsAfterEntry": 37308
+    "median10YrsAfterEntry": 37308,
+    "median1YrAfterCompletion": 41980,
+    "percentile25_10YrsAfterEntry": 20068,
+    "percentile75_10YrsAfterEntry": 53753,
+    "shareEarningAboveHsGrad": 0.418
   }
 }

--- a/data/nc/scorecard/southeastern.json
+++ b/data/nc/scorecard/southeastern.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sccnc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:52.961Z",
+  "fetchedAt": "2026-05-13T02:14:07.325Z",
   "size": 820,
   "shareFirstGeneration": 0.4717314488,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4348,
     "completionRate200nt": 0.6327,
-    "transferRate": 0.2609
+    "transferRate": 0.2609,
+    "retentionRateFullTime": 0.5696,
+    "retentionRatePartTime": 0.325
   },
   "earnings": {
-    "median10YrsAfterEntry": 30284
+    "median10YrsAfterEntry": 30284,
+    "median1YrAfterCompletion": 39536,
+    "percentile25_10YrsAfterEntry": 15100,
+    "percentile75_10YrsAfterEntry": 47045,
+    "shareEarningAboveHsGrad": 0.43
   }
 }

--- a/data/nc/scorecard/southwestern.json
+++ b/data/nc/scorecard/southwestern.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.southwesterncc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:53.424Z",
+  "fetchedAt": "2026-05-13T02:14:07.785Z",
   "size": 1249,
   "shareFirstGeneration": 0.4419642857,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.531,
     "completionRate200nt": 0.6232,
-    "transferRate": 0.0619
+    "transferRate": 0.0619,
+    "retentionRateFullTime": 0.7473,
+    "retentionRatePartTime": 0.5213
   },
   "earnings": {
-    "median10YrsAfterEntry": 34145
+    "median10YrsAfterEntry": 34145,
+    "median1YrAfterCompletion": 34518,
+    "percentile25_10YrsAfterEntry": 17801,
+    "percentile75_10YrsAfterEntry": 51667,
+    "shareEarningAboveHsGrad": 0.44
   }
 }

--- a/data/nc/scorecard/stanly.json
+++ b/data/nc/scorecard/stanly.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.stanly.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:53.881Z",
+  "fetchedAt": "2026-05-13T02:14:08.222Z",
   "size": 1465,
   "shareFirstGeneration": 0.5099526066,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4776,
     "completionRate200nt": 0.7391,
-    "transferRate": 0.1119
+    "transferRate": 0.1119,
+    "retentionRateFullTime": 0.6316,
+    "retentionRatePartTime": 0.52
   },
   "earnings": {
-    "median10YrsAfterEntry": 36686
+    "median10YrsAfterEntry": 36686,
+    "median1YrAfterCompletion": 38792,
+    "percentile25_10YrsAfterEntry": 19705,
+    "percentile75_10YrsAfterEntry": 52468,
+    "shareEarningAboveHsGrad": 0.504
   }
 }

--- a/data/nc/scorecard/surry.json
+++ b/data/nc/scorecard/surry.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://surry.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:54.338Z",
+  "fetchedAt": "2026-05-13T02:14:08.664Z",
   "size": 1475,
   "shareFirstGeneration": 0.5387885228,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.064,
     "completionRate200nt": 0.0822,
-    "transferRate": 0.3293
+    "transferRate": 0.3293,
+    "retentionRateFullTime": 0.7313,
+    "retentionRatePartTime": 0.6114
   },
   "earnings": {
-    "median10YrsAfterEntry": 36012
+    "median10YrsAfterEntry": 36012,
+    "median1YrAfterCompletion": 41132,
+    "percentile25_10YrsAfterEntry": 21238,
+    "percentile75_10YrsAfterEntry": 51838,
+    "shareEarningAboveHsGrad": 0.499
   }
 }

--- a/data/nc/scorecard/tri-county.json
+++ b/data/nc/scorecard/tri-county.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.tricountycc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:54.785Z",
+  "fetchedAt": "2026-05-13T02:14:09.109Z",
   "size": 472,
   "shareFirstGeneration": 0.4590163934,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5429,
     "completionRate200nt": 0.6087,
-    "transferRate": 0.1
+    "transferRate": 0.1,
+    "retentionRateFullTime": 0.7619,
+    "retentionRatePartTime": 0.5769
   },
   "earnings": {
-    "median10YrsAfterEntry": 32232
+    "median10YrsAfterEntry": 32232,
+    "median1YrAfterCompletion": 34483,
+    "percentile25_10YrsAfterEntry": 15228,
+    "percentile75_10YrsAfterEntry": 48314,
+    "shareEarningAboveHsGrad": 0.382
   }
 }

--- a/data/nc/scorecard/vance-granville.json
+++ b/data/nc/scorecard/vance-granville.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.vgcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:55.262Z",
+  "fetchedAt": "2026-05-13T02:14:09.578Z",
   "size": 1665,
   "shareFirstGeneration": 0.5153439153,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5259,
     "completionRate200nt": 0.5118,
-    "transferRate": 0.1333
+    "transferRate": 0.1333,
+    "retentionRateFullTime": 0.7564,
+    "retentionRatePartTime": 0.5688
   },
   "earnings": {
-    "median10YrsAfterEntry": 34304
+    "median10YrsAfterEntry": 34304,
+    "median1YrAfterCompletion": 37672,
+    "percentile25_10YrsAfterEntry": 17061,
+    "percentile75_10YrsAfterEntry": 50529,
+    "shareEarningAboveHsGrad": 0.408
   }
 }

--- a/data/nc/scorecard/wake-technical.json
+++ b/data/nc/scorecard/wake-technical.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.waketech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:55.719Z",
+  "fetchedAt": "2026-05-13T02:14:10.040Z",
   "size": 19675,
   "shareFirstGeneration": 0.3840341255,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3296,
     "completionRate200nt": 0.3908,
-    "transferRate": 0.1769
+    "transferRate": 0.1769,
+    "retentionRateFullTime": 0.7179,
+    "retentionRatePartTime": 0.5501
   },
   "earnings": {
-    "median10YrsAfterEntry": 41769
+    "median10YrsAfterEntry": 41769,
+    "median1YrAfterCompletion": 38942,
+    "percentile25_10YrsAfterEntry": 23081,
+    "percentile75_10YrsAfterEntry": 62435,
+    "shareEarningAboveHsGrad": 0.555
   }
 }

--- a/data/nc/scorecard/wayne.json
+++ b/data/nc/scorecard/wayne.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.waynecc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:56.286Z",
+  "fetchedAt": "2026-05-13T02:14:10.507Z",
   "size": 2739,
   "shareFirstGeneration": 0.4739093242,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4931,
     "completionRate200nt": 0.6316,
-    "transferRate": 0.1528
+    "transferRate": 0.1528,
+    "retentionRateFullTime": 0.6701,
+    "retentionRatePartTime": 0.6952
   },
   "earnings": {
-    "median10YrsAfterEntry": 34148
+    "median10YrsAfterEntry": 34148,
+    "median1YrAfterCompletion": 36704,
+    "percentile25_10YrsAfterEntry": 18213,
+    "percentile75_10YrsAfterEntry": 49961,
+    "shareEarningAboveHsGrad": 0.489
   }
 }

--- a/data/nc/scorecard/western-piedmont.json
+++ b/data/nc/scorecard/western-piedmont.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.wpcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:56.756Z",
+  "fetchedAt": "2026-05-13T02:14:10.939Z",
   "size": 1339,
   "shareFirstGeneration": 0.460982659,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4872,
     "completionRate200nt": 0.5286,
-    "transferRate": 0.2308
+    "transferRate": 0.2308,
+    "retentionRateFullTime": 0.7522,
+    "retentionRatePartTime": 0.5714
   },
   "earnings": {
-    "median10YrsAfterEntry": 34195
+    "median10YrsAfterEntry": 34195,
+    "median1YrAfterCompletion": 34965,
+    "percentile25_10YrsAfterEntry": 17048,
+    "percentile75_10YrsAfterEntry": 48630,
+    "shareEarningAboveHsGrad": 0.444
   }
 }

--- a/data/nc/scorecard/wilkes.json
+++ b/data/nc/scorecard/wilkes.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wilkescc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:14:57.224Z",
+  "fetchedAt": "2026-05-13T02:14:11.380Z",
   "size": 1355,
   "shareFirstGeneration": 0.4842436975,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.5536,
     "completionRate200nt": 0.5714,
-    "transferRate": 0.0607
+    "transferRate": 0.0607,
+    "retentionRateFullTime": 0.6865,
+    "retentionRatePartTime": 0.5963
   },
   "earnings": {
-    "median10YrsAfterEntry": 34728
+    "median10YrsAfterEntry": 34728,
+    "median1YrAfterCompletion": 34672,
+    "percentile25_10YrsAfterEntry": 18574,
+    "percentile75_10YrsAfterEntry": 48863,
+    "shareEarningAboveHsGrad": 0.447
   }
 }

--- a/data/nc/scorecard/wilson.json
+++ b/data/nc/scorecard/wilson.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wilsoncc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:57.686Z",
+  "fetchedAt": "2026-05-13T02:14:11.809Z",
   "size": 1373,
   "shareFirstGeneration": 0.5092936803,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2727,
     "completionRate200nt": 0.3559,
-    "transferRate": 0.2121
+    "transferRate": 0.2121,
+    "retentionRateFullTime": 0.7347,
+    "retentionRatePartTime": 0.5102
   },
   "earnings": {
-    "median10YrsAfterEntry": 32973
+    "median10YrsAfterEntry": 32973,
+    "median1YrAfterCompletion": 43622,
+    "percentile25_10YrsAfterEntry": 16817,
+    "percentile75_10YrsAfterEntry": 48646,
+    "shareEarningAboveHsGrad": 0.429
   }
 }

--- a/data/nh/scorecard/gbcc.json
+++ b/data/nh/scorecard/gbcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.greatbay.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:58.132Z",
+  "fetchedAt": "2026-05-13T02:14:12.264Z",
   "size": 1259,
   "shareFirstGeneration": 0.3459570113,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3351,
     "completionRate200nt": 0.3618,
-    "transferRate": 0.2287
+    "transferRate": 0.2287,
+    "retentionRateFullTime": 0.6603,
+    "retentionRatePartTime": 0.5102
   },
   "earnings": {
-    "median10YrsAfterEntry": 42397
+    "median10YrsAfterEntry": 42397,
+    "median1YrAfterCompletion": 43175,
+    "percentile25_10YrsAfterEntry": 24592,
+    "percentile75_10YrsAfterEntry": 70375,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/nh/scorecard/lrcc.json
+++ b/data/nh/scorecard/lrcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.lrcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:58.568Z",
+  "fetchedAt": "2026-05-13T02:14:12.691Z",
   "size": 482,
   "shareFirstGeneration": 0.4258289703,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4615,
     "completionRate200nt": 0.4388,
-    "transferRate": 0.1648
+    "transferRate": 0.1648,
+    "retentionRateFullTime": 0.5579,
+    "retentionRatePartTime": 0.451
   },
   "earnings": {
-    "median10YrsAfterEntry": 51182
+    "median10YrsAfterEntry": 51182,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": 24669,
+    "percentile75_10YrsAfterEntry": 68520,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/nh/scorecard/mccnh.json
+++ b/data/nh/scorecard/mccnh.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mccnh.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:59.018Z",
+  "fetchedAt": "2026-05-13T02:14:13.170Z",
   "size": 1587,
   "shareFirstGeneration": 0.424439624,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.413,
     "completionRate200nt": 0.3864,
-    "transferRate": 0.1304
+    "transferRate": 0.1304,
+    "retentionRateFullTime": 0.6075,
+    "retentionRatePartTime": 0.5156
   },
   "earnings": {
-    "median10YrsAfterEntry": 49063
+    "median10YrsAfterEntry": 49063,
+    "median1YrAfterCompletion": 40415,
+    "percentile25_10YrsAfterEntry": 27685,
+    "percentile75_10YrsAfterEntry": 73089,
+    "shareEarningAboveHsGrad": 0.644
   }
 }

--- a/data/nh/scorecard/nashuacc.json
+++ b/data/nh/scorecard/nashuacc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "nashuacc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:14:59.463Z",
+  "fetchedAt": "2026-05-13T02:14:13.607Z",
   "size": 1135,
   "shareFirstGeneration": 0.4053191489,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3765,
     "completionRate200nt": 0.3564,
-    "transferRate": 0.2118
+    "transferRate": 0.2118,
+    "retentionRateFullTime": 0.6414,
+    "retentionRatePartTime": 0.4894
   },
   "earnings": {
-    "median10YrsAfterEntry": 46164
+    "median10YrsAfterEntry": 46164,
+    "median1YrAfterCompletion": 34583,
+    "percentile25_10YrsAfterEntry": 19366,
+    "percentile75_10YrsAfterEntry": 66755,
+    "shareEarningAboveHsGrad": 0.664
   }
 }

--- a/data/nh/scorecard/nhti.json
+++ b/data/nh/scorecard/nhti.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nhti.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:00.181Z",
+  "fetchedAt": "2026-05-13T02:14:14.075Z",
   "size": 2154,
   "shareFirstGeneration": 0.3721153846,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2929,
     "completionRate200nt": 0.3515,
-    "transferRate": 0.2243
+    "transferRate": 0.2243,
+    "retentionRateFullTime": 0.6916,
+    "retentionRatePartTime": 0.4953
   },
   "earnings": {
-    "median10YrsAfterEntry": 48943
+    "median10YrsAfterEntry": 48943,
+    "median1YrAfterCompletion": 48281,
+    "percentile25_10YrsAfterEntry": 29414,
+    "percentile75_10YrsAfterEntry": 69257,
+    "shareEarningAboveHsGrad": 0.697
   }
 }

--- a/data/nh/scorecard/rvcc.json
+++ b/data/nh/scorecard/rvcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.rivervalley.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:00.725Z",
+  "fetchedAt": "2026-05-13T02:14:14.496Z",
   "size": 608,
   "shareFirstGeneration": 0.4411177645,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2188,
     "completionRate200nt": 0.3429,
-    "transferRate": 0.3438
+    "transferRate": 0.3438,
+    "retentionRateFullTime": 0.4138,
+    "retentionRatePartTime": 0.4588
   },
   "earnings": {
-    "median10YrsAfterEntry": 44700
+    "median10YrsAfterEntry": 44700,
+    "median1YrAfterCompletion": 47651,
+    "percentile25_10YrsAfterEntry": 24761,
+    "percentile75_10YrsAfterEntry": 75167,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/nh/scorecard/wmcc.json
+++ b/data/nh/scorecard/wmcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wmcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:01.260Z",
+  "fetchedAt": "2026-05-13T02:14:14.950Z",
   "size": 450,
   "shareFirstGeneration": 0.4526748971,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.618,
     "completionRate200nt": 0.6421,
-    "transferRate": 0.1011
+    "transferRate": 0.1011,
+    "retentionRateFullTime": 0.84,
+    "retentionRatePartTime": 0.5435
   },
   "earnings": {
-    "median10YrsAfterEntry": 35037
+    "median10YrsAfterEntry": 35037,
+    "median1YrAfterCompletion": 49704,
+    "percentile25_10YrsAfterEntry": 19064,
+    "percentile75_10YrsAfterEntry": 53053,
+    "shareEarningAboveHsGrad": 0.633
   }
 }

--- a/data/nj/scorecard/atlantic-cape.json
+++ b/data/nj/scorecard/atlantic-cape.json
@@ -6,7 +6,7 @@
   "schoolUrl": "atlanticcape.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:01.732Z",
+  "fetchedAt": "2026-05-13T02:14:15.408Z",
   "size": 3755,
   "shareFirstGeneration": 0.5764,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3003,
     "completionRate200nt": 0.3462,
-    "transferRate": 0.1372
+    "transferRate": 0.1372,
+    "retentionRateFullTime": 0.5741,
+    "retentionRatePartTime": 0.4766
   },
   "earnings": {
-    "median10YrsAfterEntry": 34241
+    "median10YrsAfterEntry": 34241,
+    "median1YrAfterCompletion": 31184,
+    "percentile25_10YrsAfterEntry": 17052,
+    "percentile75_10YrsAfterEntry": 54724,
+    "shareEarningAboveHsGrad": 0.487
   }
 }

--- a/data/nj/scorecard/bergen.json
+++ b/data/nj/scorecard/bergen.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.bergen.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:02.195Z",
+  "fetchedAt": "2026-05-13T02:14:15.875Z",
   "size": 10557,
   "shareFirstGeneration": 0.4935856993,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2069,
     "completionRate200nt": 0.3122,
-    "transferRate": 0.153
+    "transferRate": 0.153,
+    "retentionRateFullTime": 0.6397,
+    "retentionRatePartTime": 0.4313
   },
   "earnings": {
-    "median10YrsAfterEntry": 46624
+    "median10YrsAfterEntry": 46624,
+    "median1YrAfterCompletion": 32872,
+    "percentile25_10YrsAfterEntry": 24615,
+    "percentile75_10YrsAfterEntry": 72304,
+    "shareEarningAboveHsGrad": 0.658
   }
 }

--- a/data/nj/scorecard/brookdale.json
+++ b/data/nj/scorecard/brookdale.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.brookdalecc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:02.670Z",
+  "fetchedAt": "2026-05-13T02:14:16.305Z",
   "size": 7901,
   "shareFirstGeneration": 0.4851943245,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2992,
     "completionRate200nt": 0.3568,
-    "transferRate": 0.1372
+    "transferRate": 0.1372,
+    "retentionRateFullTime": 0.6955,
+    "retentionRatePartTime": 0.5775
   },
   "earnings": {
-    "median10YrsAfterEntry": 44379
+    "median10YrsAfterEntry": 44379,
+    "median1YrAfterCompletion": 33617,
+    "percentile25_10YrsAfterEntry": 22624,
+    "percentile75_10YrsAfterEntry": 69122,
+    "shareEarningAboveHsGrad": 0.602
   }
 }

--- a/data/nj/scorecard/camden.json
+++ b/data/nj/scorecard/camden.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.camdencc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:03.148Z",
+  "fetchedAt": "2026-05-13T02:14:16.765Z",
   "size": 6636,
   "shareFirstGeneration": 0.5308092056,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3086,
     "completionRate200nt": 0.3916,
-    "transferRate": 0.1248
+    "transferRate": 0.1248,
+    "retentionRateFullTime": 0.6315,
+    "retentionRatePartTime": 0.4846
   },
   "earnings": {
-    "median10YrsAfterEntry": 41212
+    "median10YrsAfterEntry": 41212,
+    "median1YrAfterCompletion": 41350,
+    "percentile25_10YrsAfterEntry": 21821,
+    "percentile75_10YrsAfterEntry": 62807,
+    "shareEarningAboveHsGrad": 0.583
   }
 }

--- a/data/nj/scorecard/ccm.json
+++ b/data/nj/scorecard/ccm.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ccm.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:03.603Z",
+  "fetchedAt": "2026-05-13T02:14:17.189Z",
   "size": 5360,
   "shareFirstGeneration": 0.4333022388,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3557,
     "completionRate200nt": 0.4255,
-    "transferRate": 0.1701
+    "transferRate": 0.1701,
+    "retentionRateFullTime": 0.76,
+    "retentionRatePartTime": 0.6086
   },
   "earnings": {
-    "median10YrsAfterEntry": 50243
+    "median10YrsAfterEntry": 50243,
+    "median1YrAfterCompletion": 30577,
+    "percentile25_10YrsAfterEntry": 28555,
+    "percentile75_10YrsAfterEntry": 74926,
+    "shareEarningAboveHsGrad": 0.673
   }
 }

--- a/data/nj/scorecard/essex.json
+++ b/data/nj/scorecard/essex.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.essex.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:04.097Z",
+  "fetchedAt": "2026-05-13T02:14:17.716Z",
   "size": 5855,
   "shareFirstGeneration": 0.5717774763,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.199,
     "completionRate200nt": 0.2769,
-    "transferRate": 0.1247
+    "transferRate": 0.1247,
+    "retentionRateFullTime": 0.5585,
+    "retentionRatePartTime": 0.3936
   },
   "earnings": {
-    "median10YrsAfterEntry": 37230
+    "median10YrsAfterEntry": 37230,
+    "median1YrAfterCompletion": 30419,
+    "percentile25_10YrsAfterEntry": 18112,
+    "percentile75_10YrsAfterEntry": 58258,
+    "shareEarningAboveHsGrad": 0.53
   }
 }

--- a/data/nj/scorecard/hccc.json
+++ b/data/nj/scorecard/hccc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.hccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:04.614Z",
+  "fetchedAt": "2026-05-13T02:14:18.178Z",
   "size": 6626,
   "shareFirstGeneration": 0.5876705407,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2574,
     "completionRate200nt": 0.2998,
-    "transferRate": 0.0762
+    "transferRate": 0.0762,
+    "retentionRateFullTime": 0.613,
+    "retentionRatePartTime": 0.4336
   },
   "earnings": {
-    "median10YrsAfterEntry": 34333
+    "median10YrsAfterEntry": 34333,
+    "median1YrAfterCompletion": 28176,
+    "percentile25_10YrsAfterEntry": 15126,
+    "percentile75_10YrsAfterEntry": 55589,
+    "shareEarningAboveHsGrad": 0.515
   }
 }

--- a/data/nj/scorecard/mercer.json
+++ b/data/nj/scorecard/mercer.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:05.106Z",
+  "fetchedAt": "2026-05-13T02:14:18.610Z",
   "size": 5404,
   "shareFirstGeneration": 0.4995196926,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.249,
     "completionRate200nt": 0.2772,
-    "transferRate": 0.1728
+    "transferRate": 0.1728,
+    "retentionRateFullTime": 0.6667,
+    "retentionRatePartTime": 0.479
   },
   "earnings": {
-    "median10YrsAfterEntry": 43264
+    "median10YrsAfterEntry": 43264,
+    "median1YrAfterCompletion": 36650,
+    "percentile25_10YrsAfterEntry": 23440,
+    "percentile75_10YrsAfterEntry": 64959,
+    "shareEarningAboveHsGrad": 0.616
   }
 }

--- a/data/nj/scorecard/middlesex.json
+++ b/data/nj/scorecard/middlesex.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.middlesexcollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:05.577Z",
+  "fetchedAt": "2026-05-13T02:14:19.041Z",
   "size": 8469,
   "shareFirstGeneration": 0.5032330616,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.334,
     "completionRate200nt": 0.4013,
-    "transferRate": 0.1534
+    "transferRate": 0.1534,
+    "retentionRateFullTime": 0.7233,
+    "retentionRatePartTime": 0.4895
   },
   "earnings": {
-    "median10YrsAfterEntry": 46861
+    "median10YrsAfterEntry": 46861,
+    "median1YrAfterCompletion": 33603,
+    "percentile25_10YrsAfterEntry": 24120,
+    "percentile75_10YrsAfterEntry": 71712,
+    "shareEarningAboveHsGrad": 0.657
   }
 }

--- a/data/nj/scorecard/ocean.json
+++ b/data/nj/scorecard/ocean.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ocean.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:06.049Z",
+  "fetchedAt": "2026-05-13T02:14:19.491Z",
   "size": 5424,
   "shareFirstGeneration": 0.5195270512,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4151,
     "completionRate200nt": 0.4382,
-    "transferRate": 0.1016
+    "transferRate": 0.1016,
+    "retentionRateFullTime": 0.6906,
+    "retentionRatePartTime": 0.4576
   },
   "earnings": {
-    "median10YrsAfterEntry": 45210
+    "median10YrsAfterEntry": 45210,
+    "median1YrAfterCompletion": 29547,
+    "percentile25_10YrsAfterEntry": 23779,
+    "percentile75_10YrsAfterEntry": 68956,
+    "shareEarningAboveHsGrad": 0.606
   }
 }

--- a/data/nj/scorecard/passaic.json
+++ b/data/nj/scorecard/passaic.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://web.pccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:06.500Z",
+  "fetchedAt": "2026-05-13T02:14:20.005Z",
   "size": 4260,
   "shareFirstGeneration": 0.6052892562,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1925,
     "completionRate200nt": 0.2138,
-    "transferRate": 0.1724
+    "transferRate": 0.1724,
+    "retentionRateFullTime": 0.6004,
+    "retentionRatePartTime": 0.4382
   },
   "earnings": {
-    "median10YrsAfterEntry": 36972
+    "median10YrsAfterEntry": 36972,
+    "median1YrAfterCompletion": 26354,
+    "percentile25_10YrsAfterEntry": 17181,
+    "percentile75_10YrsAfterEntry": 56914,
+    "shareEarningAboveHsGrad": 0.491
   }
 }

--- a/data/nj/scorecard/rcbc.json
+++ b/data/nj/scorecard/rcbc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.rcbc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:07.407Z",
+  "fetchedAt": "2026-05-13T02:14:20.894Z",
   "size": 6267,
   "shareFirstGeneration": 0.4777368597,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3588,
     "completionRate200nt": 0.4092,
-    "transferRate": 0.1528
+    "transferRate": 0.1528,
+    "retentionRateFullTime": 0.5809,
+    "retentionRatePartTime": 0.4722
   },
   "earnings": {
-    "median10YrsAfterEntry": 44745
+    "median10YrsAfterEntry": 44745,
+    "median1YrAfterCompletion": 33825,
+    "percentile25_10YrsAfterEntry": 25146,
+    "percentile75_10YrsAfterEntry": 66925,
+    "shareEarningAboveHsGrad": 0.634
   }
 }

--- a/data/nj/scorecard/rcsj-cumberland.json
+++ b/data/nj/scorecard/rcsj-cumberland.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://rcsj.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:07.845Z",
+  "fetchedAt": "2026-05-13T02:14:21.385Z",
   "size": 2074,
   "shareFirstGeneration": 0.4896961229,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.329,
     "completionRate200nt": 0.3583,
-    "transferRate": 0.0933
+    "transferRate": 0.0933,
+    "retentionRateFullTime": 0.625,
+    "retentionRatePartTime": 0.5174
   },
   "earnings": {
-    "median10YrsAfterEntry": 41751
+    "median10YrsAfterEntry": 41751,
+    "median1YrAfterCompletion": 33995,
+    "percentile25_10YrsAfterEntry": 22437,
+    "percentile75_10YrsAfterEntry": 63313,
+    "shareEarningAboveHsGrad": 0.606
   }
 }

--- a/data/nj/scorecard/rcsj-gloucester.json
+++ b/data/nj/scorecard/rcsj-gloucester.json
@@ -6,7 +6,7 @@
   "schoolUrl": "rcsj.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:08.315Z",
+  "fetchedAt": "2026-05-13T02:14:21.822Z",
   "size": 4234,
   "shareFirstGeneration": 0.4896961229,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3871,
     "completionRate200nt": 0.3713,
-    "transferRate": 0.2129
+    "transferRate": 0.2129,
+    "retentionRateFullTime": 0.6231,
+    "retentionRatePartTime": 0.5132
   },
   "earnings": {
-    "median10YrsAfterEntry": 41751
+    "median10YrsAfterEntry": 41751,
+    "median1YrAfterCompletion": 33995,
+    "percentile25_10YrsAfterEntry": 22437,
+    "percentile75_10YrsAfterEntry": 63313,
+    "shareEarningAboveHsGrad": 0.606
   }
 }

--- a/data/nj/scorecard/rvcc.json
+++ b/data/nj/scorecard/rvcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.raritanval.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:06.965Z",
+  "fetchedAt": "2026-05-13T02:14:20.438Z",
   "size": 5416,
   "shareFirstGeneration": 0.4724680433,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3087,
     "completionRate200nt": 0.4029,
-    "transferRate": 0.2183
+    "transferRate": 0.2183,
+    "retentionRateFullTime": 0.6844,
+    "retentionRatePartTime": 0.5797
   },
   "earnings": {
-    "median10YrsAfterEntry": 48145
+    "median10YrsAfterEntry": 48145,
+    "median1YrAfterCompletion": 34443,
+    "percentile25_10YrsAfterEntry": 28451,
+    "percentile75_10YrsAfterEntry": 73834,
+    "shareEarningAboveHsGrad": 0.654
   }
 }

--- a/data/nj/scorecard/salem.json
+++ b/data/nj/scorecard/salem.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.salemcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:09.014Z",
+  "fetchedAt": "2026-05-13T02:14:22.271Z",
   "size": 910,
   "shareFirstGeneration": 0.4953488372,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4012,
     "completionRate200nt": 0.4096,
-    "transferRate": 0.1018
+    "transferRate": 0.1018,
+    "retentionRateFullTime": 0.6595,
+    "retentionRatePartTime": 0.5522
   },
   "earnings": {
-    "median10YrsAfterEntry": 38020
+    "median10YrsAfterEntry": 38020,
+    "median1YrAfterCompletion": 36523,
+    "percentile25_10YrsAfterEntry": 20593,
+    "percentile75_10YrsAfterEntry": 63867,
+    "shareEarningAboveHsGrad": 0.532
   }
 }

--- a/data/nj/scorecard/sussex.json
+++ b/data/nj/scorecard/sussex.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sussex.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:09.466Z",
+  "fetchedAt": "2026-05-13T02:14:22.728Z",
   "size": 2086,
   "shareFirstGeneration": 0.4326375712,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3697,
     "completionRate200nt": 0.48,
-    "transferRate": 0.1247
+    "transferRate": 0.1247,
+    "retentionRateFullTime": 0.5763,
+    "retentionRatePartTime": 0.3826
   },
   "earnings": {
-    "median10YrsAfterEntry": 44664
+    "median10YrsAfterEntry": 44664,
+    "median1YrAfterCompletion": 26001,
+    "percentile25_10YrsAfterEntry": 24917,
+    "percentile75_10YrsAfterEntry": 67845,
+    "shareEarningAboveHsGrad": 0.612
   }
 }

--- a/data/nj/scorecard/ucnj.json
+++ b/data/nj/scorecard/ucnj.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.ucc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:09.997Z",
+  "fetchedAt": "2026-05-13T02:14:23.160Z",
   "size": 7939,
   "shareFirstGeneration": 0.5370780299,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3542,
     "completionRate200nt": 0.3944,
-    "transferRate": 0.0611
+    "transferRate": 0.0611,
+    "retentionRateFullTime": 0.6583,
+    "retentionRatePartTime": 0.5969
   },
   "earnings": {
-    "median10YrsAfterEntry": 41595
+    "median10YrsAfterEntry": 41595,
+    "median1YrAfterCompletion": 37476,
+    "percentile25_10YrsAfterEntry": 20181,
+    "percentile75_10YrsAfterEntry": 63773,
+    "shareEarningAboveHsGrad": 0.589
   }
 }

--- a/data/nj/scorecard/warren.json
+++ b/data/nj/scorecard/warren.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.warren.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:10.462Z",
+  "fetchedAt": "2026-05-13T02:14:23.792Z",
   "size": 836,
   "shareFirstGeneration": 0.4978632479,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3889,
     "completionRate200nt": 0.5563,
-    "transferRate": 0.1667
+    "transferRate": 0.1667,
+    "retentionRateFullTime": 0.6491,
+    "retentionRatePartTime": 0.5217
   },
   "earnings": {
-    "median10YrsAfterEntry": 43359
+    "median10YrsAfterEntry": 43359,
+    "median1YrAfterCompletion": 27868,
+    "percentile25_10YrsAfterEntry": 22704,
+    "percentile75_10YrsAfterEntry": 63708,
+    "shareEarningAboveHsGrad": 0.593
   }
 }

--- a/data/ny/scorecard/bmcc.json
+++ b/data/ny/scorecard/bmcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bmcc.cuny.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:10.910Z",
+  "fetchedAt": "2026-05-13T02:14:24.223Z",
   "size": 18623,
   "shareFirstGeneration": 0.5309888579,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2466,
     "completionRate200nt": 0.299,
-    "transferRate": 0.1901
+    "transferRate": 0.1901,
+    "retentionRateFullTime": 0.6116,
+    "retentionRatePartTime": 0.4226
   },
   "earnings": {
-    "median10YrsAfterEntry": 42306
+    "median10YrsAfterEntry": 42306,
+    "median1YrAfterCompletion": 25604,
+    "percentile25_10YrsAfterEntry": 19289,
+    "percentile75_10YrsAfterEntry": 64717,
+    "shareEarningAboveHsGrad": 0.62
   }
 }

--- a/data/ny/scorecard/bronx-cc.json
+++ b/data/ny/scorecard/bronx-cc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bcc.cuny.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:11.478Z",
+  "fetchedAt": "2026-05-13T02:14:24.659Z",
   "size": 5964,
   "shareFirstGeneration": 0.5240631164,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1622,
     "completionRate200nt": 0.2161,
-    "transferRate": 0.1356
+    "transferRate": 0.1356,
+    "retentionRateFullTime": 0.5102,
+    "retentionRatePartTime": 0.4889
   },
   "earnings": {
-    "median10YrsAfterEntry": 41307
+    "median10YrsAfterEntry": 41307,
+    "median1YrAfterCompletion": 29416,
+    "percentile25_10YrsAfterEntry": 18821,
+    "percentile75_10YrsAfterEntry": 62930,
+    "shareEarningAboveHsGrad": 0.613
   }
 }

--- a/data/ny/scorecard/guttman-cc.json
+++ b/data/ny/scorecard/guttman-cc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://guttman.cuny.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:11.922Z",
+  "fetchedAt": "2026-05-13T02:14:25.083Z",
   "size": 978,
   "shareFirstGeneration": 0.529739777,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2288,
     "completionRate200nt": 0.2835,
-    "transferRate": 0.1922
+    "transferRate": 0.1922,
+    "retentionRateFullTime": 0.5247,
+    "retentionRatePartTime": 0.375
   },
   "earnings": {
-    "median10YrsAfterEntry": null
+    "median10YrsAfterEntry": null,
+    "median1YrAfterCompletion": 21190,
+    "percentile25_10YrsAfterEntry": null,
+    "percentile75_10YrsAfterEntry": null,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/ny/scorecard/hostos-cc.json
+++ b/data/ny/scorecard/hostos-cc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.hostos.cuny.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:12.379Z",
+  "fetchedAt": "2026-05-13T02:14:25.553Z",
   "size": 4900,
   "shareFirstGeneration": 0.5426944972,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1607,
     "completionRate200nt": 0.2079,
-    "transferRate": 0.166
+    "transferRate": 0.166,
+    "retentionRateFullTime": 0.5422,
+    "retentionRatePartTime": 0.4427
   },
   "earnings": {
-    "median10YrsAfterEntry": 40485
+    "median10YrsAfterEntry": 40485,
+    "median1YrAfterCompletion": 30041,
+    "percentile25_10YrsAfterEntry": 18641,
+    "percentile75_10YrsAfterEntry": 60405,
+    "shareEarningAboveHsGrad": 0.55
   }
 }

--- a/data/ny/scorecard/kingsborough-cc.json
+++ b/data/ny/scorecard/kingsborough-cc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.kbcc.cuny.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:12.869Z",
+  "fetchedAt": "2026-05-13T02:14:26.007Z",
   "size": 7670,
   "shareFirstGeneration": 0.4779240899,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2758,
     "completionRate200nt": 0.2899,
-    "transferRate": 0.1788
+    "transferRate": 0.1788,
+    "retentionRateFullTime": 0.6357,
+    "retentionRatePartTime": 0.4815
   },
   "earnings": {
-    "median10YrsAfterEntry": 42621
+    "median10YrsAfterEntry": 42621,
+    "median1YrAfterCompletion": 28264,
+    "percentile25_10YrsAfterEntry": 20166,
+    "percentile75_10YrsAfterEntry": 67676,
+    "shareEarningAboveHsGrad": 0.607
   }
 }

--- a/data/ny/scorecard/laguardia-cc.json
+++ b/data/ny/scorecard/laguardia-cc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.lagcc.cuny.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:13.322Z",
+  "fetchedAt": "2026-05-13T02:14:26.439Z",
   "size": 11254,
   "shareFirstGeneration": 0.5400579887,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2389,
     "completionRate200nt": 0.295,
-    "transferRate": 0.1625
+    "transferRate": 0.1625,
+    "retentionRateFullTime": 0.5716,
+    "retentionRatePartTime": 0.39
   },
   "earnings": {
-    "median10YrsAfterEntry": 41653
+    "median10YrsAfterEntry": 41653,
+    "median1YrAfterCompletion": 26851,
+    "percentile25_10YrsAfterEntry": 19367,
+    "percentile75_10YrsAfterEntry": 66179,
+    "shareEarningAboveHsGrad": 0.613
   }
 }

--- a/data/ny/scorecard/queensborough-cc.json
+++ b/data/ny/scorecard/queensborough-cc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.qcc.cuny.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:13.793Z",
+  "fetchedAt": "2026-05-13T02:14:26.967Z",
   "size": 8940,
   "shareFirstGeneration": 0.5189328744,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2405,
     "completionRate200nt": 0.2718,
-    "transferRate": 0.192
+    "transferRate": 0.192,
+    "retentionRateFullTime": 0.6451,
+    "retentionRatePartTime": 0.3922
   },
   "earnings": {
-    "median10YrsAfterEntry": 44214
+    "median10YrsAfterEntry": 44214,
+    "median1YrAfterCompletion": 22936,
+    "percentile25_10YrsAfterEntry": 20990,
+    "percentile75_10YrsAfterEntry": 69408,
+    "shareEarningAboveHsGrad": 0.639
   }
 }

--- a/data/oh/scorecard/belmont-college.json
+++ b/data/oh/scorecard/belmont-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.belmontcollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:19.420Z",
+  "fetchedAt": "2026-05-13T02:14:32.142Z",
   "size": 600,
   "shareFirstGeneration": 0.5089430894,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4261,
     "completionRate200nt": 0.4344,
-    "transferRate": 0.0435
+    "transferRate": 0.0435,
+    "retentionRateFullTime": 0.5846,
+    "retentionRatePartTime": 0.3158
   },
   "earnings": {
-    "median10YrsAfterEntry": 35329
+    "median10YrsAfterEntry": 35329,
+    "median1YrAfterCompletion": 44610,
+    "percentile25_10YrsAfterEntry": 18238,
+    "percentile75_10YrsAfterEntry": 56456,
+    "shareEarningAboveHsGrad": 0.524
   }
 }

--- a/data/oh/scorecard/central-ohio-technical-college.json
+++ b/data/oh/scorecard/central-ohio-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cotc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:14.235Z",
+  "fetchedAt": "2026-05-13T02:14:27.397Z",
   "size": 1941,
   "shareFirstGeneration": 0.5031958164,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39168
+    "median10YrsAfterEntry": 39168,
+    "median1YrAfterCompletion": 53229,
+    "percentile25_10YrsAfterEntry": 20554,
+    "percentile75_10YrsAfterEntry": 59572,
+    "shareEarningAboveHsGrad": 0.571
   }
 }

--- a/data/oh/scorecard/cincinnati-state-technical-and-community-college.json
+++ b/data/oh/scorecard/cincinnati-state-technical-and-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cincinnatistate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:14.752Z",
+  "fetchedAt": "2026-05-13T02:14:27.837Z",
   "size": 5667,
   "shareFirstGeneration": 0.4643213573,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 40137
+    "median10YrsAfterEntry": 40137,
+    "median1YrAfterCompletion": 49323,
+    "percentile25_10YrsAfterEntry": 21530,
+    "percentile75_10YrsAfterEntry": 60507,
+    "shareEarningAboveHsGrad": 0.567
   }
 }

--- a/data/oh/scorecard/clark-state-college.json
+++ b/data/oh/scorecard/clark-state-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.clarkstate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:15.243Z",
+  "fetchedAt": "2026-05-13T02:14:28.267Z",
   "size": 3456,
   "shareFirstGeneration": 0.5274801244,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39584
+    "median10YrsAfterEntry": 39584,
+    "median1YrAfterCompletion": 42047,
+    "percentile25_10YrsAfterEntry": 20697,
+    "percentile75_10YrsAfterEntry": 57400,
+    "shareEarningAboveHsGrad": 0.511
   }
 }

--- a/data/oh/scorecard/columbus-state-community-college.json
+++ b/data/oh/scorecard/columbus-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.cscc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:19.915Z",
+  "fetchedAt": "2026-05-13T02:14:32.652Z",
   "size": 17549,
   "shareFirstGeneration": 0.4379317351,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39435
+    "median10YrsAfterEntry": 39435,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": 19965,
+    "percentile75_10YrsAfterEntry": 58491,
+    "shareEarningAboveHsGrad": 0.575
   }
 }

--- a/data/oh/scorecard/cuyahoga-community-college-district.json
+++ b/data/oh/scorecard/cuyahoga-community-college-district.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.tri-c.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:20.400Z",
+  "fetchedAt": "2026-05-13T02:14:33.127Z",
   "size": 13382,
   "shareFirstGeneration": 0.4882839421,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3086,
     "completionRate200nt": 0.3342,
-    "transferRate": 0.1475
+    "transferRate": 0.1475,
+    "retentionRateFullTime": 0.5672,
+    "retentionRatePartTime": 0.4038
   },
   "earnings": {
-    "median10YrsAfterEntry": 35654
+    "median10YrsAfterEntry": 35654,
+    "median1YrAfterCompletion": 38851,
+    "percentile25_10YrsAfterEntry": 17099,
+    "percentile75_10YrsAfterEntry": 53448,
+    "shareEarningAboveHsGrad": 0.482
   }
 }

--- a/data/oh/scorecard/edison-state-community-college.json
+++ b/data/oh/scorecard/edison-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.edisonohio.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:20.857Z",
+  "fetchedAt": "2026-05-13T02:14:33.582Z",
   "size": 1302,
   "shareFirstGeneration": 0.5187566988,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41360
+    "median10YrsAfterEntry": 41360,
+    "median1YrAfterCompletion": 46542,
+    "percentile25_10YrsAfterEntry": 22936,
+    "percentile75_10YrsAfterEntry": 60836,
+    "shareEarningAboveHsGrad": 0.528
   }
 }

--- a/data/oh/scorecard/hocking-college.json
+++ b/data/oh/scorecard/hocking-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.hocking.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:21.317Z",
+  "fetchedAt": "2026-05-13T02:14:34.022Z",
   "size": 1311,
   "shareFirstGeneration": 0.4532019704,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3716,
     "completionRate200nt": 0.3027,
-    "transferRate": 0.1345
+    "transferRate": 0.1345,
+    "retentionRateFullTime": 0.4289,
+    "retentionRatePartTime": 0.1905
   },
   "earnings": {
-    "median10YrsAfterEntry": 37791
+    "median10YrsAfterEntry": 37791,
+    "median1YrAfterCompletion": 33200,
+    "percentile25_10YrsAfterEntry": 20664,
+    "percentile75_10YrsAfterEntry": 55570,
+    "shareEarningAboveHsGrad": 0.526
   }
 }

--- a/data/oh/scorecard/james-a-rhodes-state-college.json
+++ b/data/oh/scorecard/james-a-rhodes-state-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.rhodesstate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:15.772Z",
+  "fetchedAt": "2026-05-13T02:14:28.812Z",
   "size": 1590,
   "shareFirstGeneration": 0.4724809483,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41855
+    "median10YrsAfterEntry": 41855,
+    "median1YrAfterCompletion": 47896,
+    "percentile25_10YrsAfterEntry": 24639,
+    "percentile75_10YrsAfterEntry": 59836,
+    "shareEarningAboveHsGrad": 0.574
   }
 }

--- a/data/oh/scorecard/lakeland-community-college.json
+++ b/data/oh/scorecard/lakeland-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.lakelandcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:21.787Z",
+  "fetchedAt": "2026-05-13T02:14:34.668Z",
   "size": 2773,
   "shareFirstGeneration": 0.4900584795,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2353,
     "completionRate200nt": 0.2819,
-    "transferRate": 0.1824
+    "transferRate": 0.1824,
+    "retentionRateFullTime": 0.6216,
+    "retentionRatePartTime": 0.5382
   },
   "earnings": {
-    "median10YrsAfterEntry": 39612
+    "median10YrsAfterEntry": 39612,
+    "median1YrAfterCompletion": 48984,
+    "percentile25_10YrsAfterEntry": 20617,
+    "percentile75_10YrsAfterEntry": 59546,
+    "shareEarningAboveHsGrad": 0.576
   }
 }

--- a/data/oh/scorecard/lorain-county-community-college.json
+++ b/data/oh/scorecard/lorain-county-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.lorainccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:16.286Z",
+  "fetchedAt": "2026-05-13T02:14:29.282Z",
   "size": 5373,
   "shareFirstGeneration": 0.5126231527,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 38837
+    "median10YrsAfterEntry": 38837,
+    "median1YrAfterCompletion": 41713,
+    "percentile25_10YrsAfterEntry": 19860,
+    "percentile75_10YrsAfterEntry": 58085,
+    "shareEarningAboveHsGrad": 0.542
   }
 }

--- a/data/oh/scorecard/marion-technical-college.json
+++ b/data/oh/scorecard/marion-technical-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mtc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:16.779Z",
+  "fetchedAt": "2026-05-13T02:14:29.709Z",
   "size": 1475,
   "shareFirstGeneration": 0.5040214477,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 41495
+    "median10YrsAfterEntry": 41495,
+    "median1YrAfterCompletion": 43998,
+    "percentile25_10YrsAfterEntry": 23062,
+    "percentile75_10YrsAfterEntry": 59326,
+    "shareEarningAboveHsGrad": 0.532
   }
 }

--- a/data/oh/scorecard/north-central-state-college.json
+++ b/data/oh/scorecard/north-central-state-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.ncstatecollege.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:17.890Z",
+  "fetchedAt": "2026-05-13T02:14:30.638Z",
   "size": 1273,
   "shareFirstGeneration": 0.4966118103,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 38158
+    "median10YrsAfterEntry": 38158,
+    "median1YrAfterCompletion": 47054,
+    "percentile25_10YrsAfterEntry": 19672,
+    "percentile75_10YrsAfterEntry": 55523,
+    "shareEarningAboveHsGrad": 0.498
   }
 }

--- a/data/oh/scorecard/northwest-state-community-college.json
+++ b/data/oh/scorecard/northwest-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://northweststate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:22.281Z",
+  "fetchedAt": "2026-05-13T02:14:35.130Z",
   "size": 1115,
   "shareFirstGeneration": 0.4823663254,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4564,
     "completionRate200nt": 0.5607,
-    "transferRate": 0.1074
+    "transferRate": 0.1074,
+    "retentionRateFullTime": 0.6918,
+    "retentionRatePartTime": 0.5207
   },
   "earnings": {
-    "median10YrsAfterEntry": 40004
+    "median10YrsAfterEntry": 40004,
+    "median1YrAfterCompletion": 41925,
+    "percentile25_10YrsAfterEntry": 23146,
+    "percentile75_10YrsAfterEntry": 57229,
+    "shareEarningAboveHsGrad": 0.561
   }
 }

--- a/data/oh/scorecard/owens-community-college.json
+++ b/data/oh/scorecard/owens-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.owens.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:22.762Z",
+  "fetchedAt": "2026-05-13T02:14:35.592Z",
   "size": 4361,
   "shareFirstGeneration": 0.4428790984,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3511,
     "completionRate200nt": 0.362,
-    "transferRate": 0.1755
+    "transferRate": 0.1755,
+    "retentionRateFullTime": 0.6,
+    "retentionRatePartTime": 0.4902
   },
   "earnings": {
-    "median10YrsAfterEntry": 37275
+    "median10YrsAfterEntry": 37275,
+    "median1YrAfterCompletion": 48168,
+    "percentile25_10YrsAfterEntry": 19291,
+    "percentile75_10YrsAfterEntry": 56978,
+    "shareEarningAboveHsGrad": 0.559
   }
 }

--- a/data/oh/scorecard/sinclair-community-college.json
+++ b/data/oh/scorecard/sinclair-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.sinclair.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:18.440Z",
+  "fetchedAt": "2026-05-13T02:14:31.126Z",
   "size": 13308,
   "shareFirstGeneration": 0.4523201076,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 37558
+    "median10YrsAfterEntry": 37558,
+    "median1YrAfterCompletion": 38408,
+    "percentile25_10YrsAfterEntry": 18939,
+    "percentile75_10YrsAfterEntry": 56634,
+    "shareEarningAboveHsGrad": 0.522
   }
 }

--- a/data/oh/scorecard/southern-state-community-college.json
+++ b/data/oh/scorecard/southern-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.sscc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:23.809Z",
+  "fetchedAt": "2026-05-13T02:14:36.475Z",
   "size": 761,
   "shareFirstGeneration": 0.5214408233,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.37,
     "completionRate200nt": 0.3413,
-    "transferRate": 0.13
+    "transferRate": 0.13,
+    "retentionRateFullTime": 0.6371,
+    "retentionRatePartTime": 0.5169
   },
   "earnings": {
-    "median10YrsAfterEntry": 35463
+    "median10YrsAfterEntry": 35463,
+    "median1YrAfterCompletion": 40283,
+    "percentile25_10YrsAfterEntry": 18617,
+    "percentile75_10YrsAfterEntry": 52108,
+    "shareEarningAboveHsGrad": 0.496
   }
 }

--- a/data/oh/scorecard/stark-state-college.json
+++ b/data/oh/scorecard/stark-state-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.starkstate.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:23.363Z",
+  "fetchedAt": "2026-05-13T02:14:36.041Z",
   "size": 5749,
   "shareFirstGeneration": 0.5142787996,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2302,
     "completionRate200nt": 0.2889,
-    "transferRate": 0.1751
+    "transferRate": 0.1751,
+    "retentionRateFullTime": 0.4959,
+    "retentionRatePartTime": 0.3929
   },
   "earnings": {
-    "median10YrsAfterEntry": 34661
+    "median10YrsAfterEntry": 34661,
+    "median1YrAfterCompletion": 39757,
+    "percentile25_10YrsAfterEntry": 16724,
+    "percentile75_10YrsAfterEntry": 53293,
+    "shareEarningAboveHsGrad": 0.585
   }
 }

--- a/data/oh/scorecard/terra-state-community-college.json
+++ b/data/oh/scorecard/terra-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://terra.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:24.252Z",
+  "fetchedAt": "2026-05-13T02:14:36.902Z",
   "size": 1028,
   "shareFirstGeneration": 0.528057554,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3879,
     "completionRate200nt": 0.3861,
-    "transferRate": 0.303
+    "transferRate": 0.303,
+    "retentionRateFullTime": 0.6797,
+    "retentionRatePartTime": 0.4792
   },
   "earnings": {
-    "median10YrsAfterEntry": 36612
+    "median10YrsAfterEntry": 36612,
+    "median1YrAfterCompletion": 39500,
+    "percentile25_10YrsAfterEntry": 19336,
+    "percentile75_10YrsAfterEntry": 55697,
+    "shareEarningAboveHsGrad": 0.538
   }
 }

--- a/data/oh/scorecard/washington-state-community-college.json
+++ b/data/oh/scorecard/washington-state-community-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wsco.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:18.948Z",
+  "fetchedAt": "2026-05-13T02:14:31.585Z",
   "size": 1484,
   "shareFirstGeneration": 0.4715099715,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 37988
+    "median10YrsAfterEntry": 37988,
+    "median1YrAfterCompletion": 37783,
+    "percentile25_10YrsAfterEntry": 20293,
+    "percentile75_10YrsAfterEntry": 55956,
+    "shareEarningAboveHsGrad": 0.491
   }
 }

--- a/data/oh/scorecard/zane-state-college.json
+++ b/data/oh/scorecard/zane-state-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.zanestate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:17.451Z",
+  "fetchedAt": "2026-05-13T02:14:30.172Z",
   "size": 715,
   "shareFirstGeneration": 0.4825253664,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 35006
+    "median10YrsAfterEntry": 35006,
+    "median1YrAfterCompletion": 31550,
+    "percentile25_10YrsAfterEntry": 16919,
+    "percentile75_10YrsAfterEntry": 53106,
+    "shareEarningAboveHsGrad": 0.519
   }
 }

--- a/data/pa/scorecard/bucks.json
+++ b/data/pa/scorecard/bucks.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bucks.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:24.742Z",
+  "fetchedAt": "2026-05-13T02:14:37.345Z",
   "size": 5289,
   "shareFirstGeneration": 0.4724637681,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3232,
     "completionRate200nt": 0.3252,
-    "transferRate": 0.2195
+    "transferRate": 0.2195,
+    "retentionRateFullTime": 0.751,
+    "retentionRatePartTime": 0.5179
   },
   "earnings": {
-    "median10YrsAfterEntry": 47324
+    "median10YrsAfterEntry": 47324,
+    "median1YrAfterCompletion": 33535,
+    "percentile25_10YrsAfterEntry": 27775,
+    "percentile75_10YrsAfterEntry": 72979,
+    "shareEarningAboveHsGrad": 0.672
   }
 }

--- a/data/pa/scorecard/butler.json
+++ b/data/pa/scorecard/butler.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.bc3.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:25.337Z",
+  "fetchedAt": "2026-05-13T02:14:37.809Z",
   "size": 1789,
   "shareFirstGeneration": 0.4273670558,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3719,
     "completionRate200nt": 0.3776,
-    "transferRate": 0.2494
+    "transferRate": 0.2494,
+    "retentionRateFullTime": 0.6485,
+    "retentionRatePartTime": 0.4797
   },
   "earnings": {
-    "median10YrsAfterEntry": 38891
+    "median10YrsAfterEntry": 38891,
+    "median1YrAfterCompletion": 33177,
+    "percentile25_10YrsAfterEntry": 21424,
+    "percentile75_10YrsAfterEntry": 57496,
+    "shareEarningAboveHsGrad": 0.567
   }
 }

--- a/data/pa/scorecard/ccac.json
+++ b/data/pa/scorecard/ccac.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.ccac.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:25.798Z",
+  "fetchedAt": "2026-05-13T02:14:38.272Z",
   "size": 9544,
   "shareFirstGeneration": 0.4062852538,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2422,
     "completionRate200nt": 0.2926,
-    "transferRate": 0.17
+    "transferRate": 0.17,
+    "retentionRateFullTime": 0.6274,
+    "retentionRatePartTime": 0.4726
   },
   "earnings": {
-    "median10YrsAfterEntry": 39449
+    "median10YrsAfterEntry": 39449,
+    "median1YrAfterCompletion": 45760,
+    "percentile25_10YrsAfterEntry": 20865,
+    "percentile75_10YrsAfterEntry": 58783,
+    "shareEarningAboveHsGrad": 0.578
   }
 }

--- a/data/pa/scorecard/ccbc.json
+++ b/data/pa/scorecard/ccbc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.ccbc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:26.267Z",
+  "fetchedAt": "2026-05-13T02:14:38.720Z",
   "size": 1247,
   "shareFirstGeneration": 0.4003436426,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1243,
     "completionRate200nt": 0.25,
-    "transferRate": 0.284
+    "transferRate": 0.284,
+    "retentionRateFullTime": 0.5366,
+    "retentionRatePartTime": 0.4653
   },
   "earnings": {
-    "median10YrsAfterEntry": 45090
+    "median10YrsAfterEntry": 45090,
+    "median1YrAfterCompletion": 44714,
+    "percentile25_10YrsAfterEntry": 27222,
+    "percentile75_10YrsAfterEntry": 71536,
+    "shareEarningAboveHsGrad": 0.624
   }
 }

--- a/data/pa/scorecard/ccp.json
+++ b/data/pa/scorecard/ccp.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.ccp.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:26.740Z",
+  "fetchedAt": "2026-05-13T02:14:39.368Z",
   "size": 11948,
   "shareFirstGeneration": 0.5541367666,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2444,
     "completionRate200nt": 0.2426,
-    "transferRate": 0.1197
+    "transferRate": 0.1197,
+    "retentionRateFullTime": 0.5992,
+    "retentionRatePartTime": 0.4024
   },
   "earnings": {
-    "median10YrsAfterEntry": 40852
+    "median10YrsAfterEntry": 40852,
+    "median1YrAfterCompletion": 33314,
+    "percentile25_10YrsAfterEntry": 20601,
+    "percentile75_10YrsAfterEntry": 61228,
+    "shareEarningAboveHsGrad": 0.567
   }
 }

--- a/data/pa/scorecard/dccc.json
+++ b/data/pa/scorecard/dccc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.dccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:27.243Z",
+  "fetchedAt": "2026-05-13T02:14:39.994Z",
   "size": 6861,
   "shareFirstGeneration": 0.4708105838,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2407,
     "completionRate200nt": 0.2487,
-    "transferRate": 0.1115
+    "transferRate": 0.1115,
+    "retentionRateFullTime": 0.5954,
+    "retentionRatePartTime": 0.4566
   },
   "earnings": {
-    "median10YrsAfterEntry": 45391
+    "median10YrsAfterEntry": 45391,
+    "median1YrAfterCompletion": 42896,
+    "percentile25_10YrsAfterEntry": 24711,
+    "percentile75_10YrsAfterEntry": 68513,
+    "shareEarningAboveHsGrad": 0.64
   }
 }

--- a/data/pa/scorecard/hacc.json
+++ b/data/pa/scorecard/hacc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.hacc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:27.715Z",
+  "fetchedAt": "2026-05-13T02:14:40.432Z",
   "size": 9533,
   "shareFirstGeneration": 0.4940503432,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2074,
     "completionRate200nt": 0.2596,
-    "transferRate": 0.2306
+    "transferRate": 0.2306,
+    "retentionRateFullTime": 0.5387,
+    "retentionRatePartTime": 0.4397
   },
   "earnings": {
-    "median10YrsAfterEntry": 42007
+    "median10YrsAfterEntry": 42007,
+    "median1YrAfterCompletion": 43493,
+    "percentile25_10YrsAfterEntry": 24137,
+    "percentile75_10YrsAfterEntry": 62654,
+    "shareEarningAboveHsGrad": 0.635
   }
 }

--- a/data/pa/scorecard/lccc.json
+++ b/data/pa/scorecard/lccc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.lccc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:28.272Z",
+  "fetchedAt": "2026-05-13T02:14:40.868Z",
   "size": 4148,
   "shareFirstGeneration": 0.5108769545,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3032,
     "completionRate200nt": 0.3308,
-    "transferRate": 0.186
+    "transferRate": 0.186,
+    "retentionRateFullTime": 0.5904,
+    "retentionRatePartTime": 0.4129
   },
   "earnings": {
-    "median10YrsAfterEntry": 42436
+    "median10YrsAfterEntry": 42436,
+    "median1YrAfterCompletion": 38915,
+    "percentile25_10YrsAfterEntry": 25257,
+    "percentile75_10YrsAfterEntry": 62508,
+    "shareEarningAboveHsGrad": 0.597
   }
 }

--- a/data/pa/scorecard/luzerne.json
+++ b/data/pa/scorecard/luzerne.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.luzerne.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:28.727Z",
+  "fetchedAt": "2026-05-13T02:14:41.313Z",
   "size": 3317,
   "shareFirstGeneration": 0.5491088358,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2268,
     "completionRate200nt": 0.2849,
-    "transferRate": 0.1657
+    "transferRate": 0.1657,
+    "retentionRateFullTime": 0.5992,
+    "retentionRatePartTime": 0.4586
   },
   "earnings": {
-    "median10YrsAfterEntry": 40437
+    "median10YrsAfterEntry": 40437,
+    "median1YrAfterCompletion": 40198,
+    "percentile25_10YrsAfterEntry": 23227,
+    "percentile75_10YrsAfterEntry": 60655,
+    "shareEarningAboveHsGrad": 0.572
   }
 }

--- a/data/pa/scorecard/mc3.json
+++ b/data/pa/scorecard/mc3.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mc3.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:29.300Z",
+  "fetchedAt": "2026-05-13T02:14:42.103Z",
   "size": 7301,
   "shareFirstGeneration": 0.4310221587,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2787,
     "completionRate200nt": 0.2956,
-    "transferRate": 0.1887
+    "transferRate": 0.1887,
+    "retentionRateFullTime": 0.6707,
+    "retentionRatePartTime": 0.5
   },
   "earnings": {
-    "median10YrsAfterEntry": 46108
+    "median10YrsAfterEntry": 46108,
+    "median1YrAfterCompletion": 39186,
+    "percentile25_10YrsAfterEntry": 24260,
+    "percentile75_10YrsAfterEntry": 69180,
+    "shareEarningAboveHsGrad": 0.653
   }
 }

--- a/data/pa/scorecard/northampton.json
+++ b/data/pa/scorecard/northampton.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.northampton.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:29.765Z",
+  "fetchedAt": "2026-05-13T02:14:42.562Z",
   "size": 7667,
   "shareFirstGeneration": 0.4803605924,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2361,
     "completionRate200nt": 0.2774,
-    "transferRate": 0.2021
+    "transferRate": 0.2021,
+    "retentionRateFullTime": 0.6359,
+    "retentionRatePartTime": 0.3941
   },
   "earnings": {
-    "median10YrsAfterEntry": 41566
+    "median10YrsAfterEntry": 41566,
+    "median1YrAfterCompletion": 37066,
+    "percentile25_10YrsAfterEntry": 23180,
+    "percentile75_10YrsAfterEntry": 62111,
+    "shareEarningAboveHsGrad": 0.586
   }
 }

--- a/data/pa/scorecard/pa-highlands.json
+++ b/data/pa/scorecard/pa-highlands.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.pennhighlands.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:30.237Z",
+  "fetchedAt": "2026-05-13T02:14:43.020Z",
   "size": 788,
   "shareFirstGeneration": 0.4697469747,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3825,
     "completionRate200nt": 0.4717,
-    "transferRate": 0.1694
+    "transferRate": 0.1694,
+    "retentionRateFullTime": 0.5864,
+    "retentionRatePartTime": 0.5106
   },
   "earnings": {
-    "median10YrsAfterEntry": 38752
+    "median10YrsAfterEntry": 38752,
+    "median1YrAfterCompletion": 27785,
+    "percentile25_10YrsAfterEntry": 22580,
+    "percentile75_10YrsAfterEntry": 56482,
+    "shareEarningAboveHsGrad": 0.499
   }
 }

--- a/data/pa/scorecard/penn-college.json
+++ b/data/pa/scorecard/penn-college.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.pct.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:31.691Z",
+  "fetchedAt": "2026-05-13T02:14:44.363Z",
   "size": 4464,
   "shareFirstGeneration": 0.3634732687,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 52567
+    "median10YrsAfterEntry": 52567,
+    "median1YrAfterCompletion": 53167,
+    "percentile25_10YrsAfterEntry": 33752,
+    "percentile75_10YrsAfterEntry": 76561,
+    "shareEarningAboveHsGrad": 0.731
   }
 }

--- a/data/pa/scorecard/racc.json
+++ b/data/pa/scorecard/racc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.racc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:30.687Z",
+  "fetchedAt": "2026-05-13T02:14:43.460Z",
   "size": 3703,
   "shareFirstGeneration": 0.5391644909,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3363,
     "completionRate200nt": 0.2794,
-    "transferRate": 0.1321
+    "transferRate": 0.1321,
+    "retentionRateFullTime": 0.6559,
+    "retentionRatePartTime": 0.4829
   },
   "earnings": {
-    "median10YrsAfterEntry": 39082
+    "median10YrsAfterEntry": 39082,
+    "median1YrAfterCompletion": 36380,
+    "percentile25_10YrsAfterEntry": 21317,
+    "percentile75_10YrsAfterEntry": 58433,
+    "shareEarningAboveHsGrad": 0.548
   }
 }

--- a/data/pa/scorecard/westmoreland.json
+++ b/data/pa/scorecard/westmoreland.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://westmoreland.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:31.239Z",
+  "fetchedAt": "2026-05-13T02:14:43.927Z",
   "size": 2441,
   "shareFirstGeneration": 0.4435674822,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3092,
     "completionRate200nt": 0.3043,
-    "transferRate": 0.1776
+    "transferRate": 0.1776,
+    "retentionRateFullTime": 0.6693,
+    "retentionRatePartTime": 0.4431
   },
   "earnings": {
-    "median10YrsAfterEntry": 37439
+    "median10YrsAfterEntry": 37439,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": 19381,
+    "percentile75_10YrsAfterEntry": 57126,
+    "shareEarningAboveHsGrad": 0.572
   }
 }

--- a/data/ri/scorecard/ccri.json
+++ b/data/ri/scorecard/ccri.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ccri.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:32.344Z",
+  "fetchedAt": "2026-05-13T02:14:44.795Z",
   "size": 11171,
   "shareFirstGeneration": 0.5347347676,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2615,
     "completionRate200nt": 0.2917,
-    "transferRate": 0.0984
+    "transferRate": 0.0984,
+    "retentionRateFullTime": 0.5929,
+    "retentionRatePartTime": 0.4363
   },
   "earnings": {
-    "median10YrsAfterEntry": 42659
+    "median10YrsAfterEntry": 42659,
+    "median1YrAfterCompletion": 36367,
+    "percentile25_10YrsAfterEntry": 22183,
+    "percentile75_10YrsAfterEntry": 66610,
+    "shareEarningAboveHsGrad": 0.546
   }
 }

--- a/data/sc/scorecard/aiken.json
+++ b/data/sc/scorecard/aiken.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.atc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:32.872Z",
+  "fetchedAt": "2026-05-13T02:14:45.263Z",
   "size": 1925,
   "shareFirstGeneration": 0.4752186589,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.335,
     "completionRate200nt": 0.3109,
-    "transferRate": 0.1675
+    "transferRate": 0.1675,
+    "retentionRateFullTime": 0.5321,
+    "retentionRatePartTime": 0.3838
   },
   "earnings": {
-    "median10YrsAfterEntry": 39225
+    "median10YrsAfterEntry": 39225,
+    "median1YrAfterCompletion": 40941,
+    "percentile25_10YrsAfterEntry": 23391,
+    "percentile75_10YrsAfterEntry": 60452,
+    "shareEarningAboveHsGrad": 0.448
   }
 }

--- a/data/sc/scorecard/central-carolina.json
+++ b/data/sc/scorecard/central-carolina.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.cctech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:33.386Z",
+  "fetchedAt": "2026-05-13T02:14:45.694Z",
   "size": 2163,
   "shareFirstGeneration": 0.4624183007,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3427,
     "completionRate200nt": 0.3697,
-    "transferRate": 0.1538
+    "transferRate": 0.1538,
+    "retentionRateFullTime": 0.5319,
+    "retentionRatePartTime": 0.3207
   },
   "earnings": {
-    "median10YrsAfterEntry": 32603
+    "median10YrsAfterEntry": 32603,
+    "median1YrAfterCompletion": 39368,
+    "percentile25_10YrsAfterEntry": 18051,
+    "percentile75_10YrsAfterEntry": 48220,
+    "shareEarningAboveHsGrad": 0.449
   }
 }

--- a/data/sc/scorecard/denmark.json
+++ b/data/sc/scorecard/denmark.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.denmarktech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:33.832Z",
+  "fetchedAt": "2026-05-13T02:14:46.142Z",
   "size": 519,
   "shareFirstGeneration": 0.4751243781,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.125,
     "completionRate200nt": 0.2241,
-    "transferRate": 0.2292
+    "transferRate": 0.2292,
+    "retentionRateFullTime": 0.4737,
+    "retentionRatePartTime": 0.4
   },
   "earnings": {
-    "median10YrsAfterEntry": 25351
+    "median10YrsAfterEntry": 25351,
+    "median1YrAfterCompletion": 19050,
+    "percentile25_10YrsAfterEntry": 12199,
+    "percentile75_10YrsAfterEntry": 40642,
+    "shareEarningAboveHsGrad": 0.253
   }
 }

--- a/data/sc/scorecard/florence-darlington.json
+++ b/data/sc/scorecard/florence-darlington.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.fdtc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:34.299Z",
+  "fetchedAt": "2026-05-13T02:14:46.595Z",
   "size": 3055,
   "shareFirstGeneration": 0.4830039526,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3369,
     "completionRate200nt": 0.2663,
-    "transferRate": 0.1806
+    "transferRate": 0.1806,
+    "retentionRateFullTime": 0.5816,
+    "retentionRatePartTime": 0.3371
   },
   "earnings": {
-    "median10YrsAfterEntry": 32748
+    "median10YrsAfterEntry": 32748,
+    "median1YrAfterCompletion": 31645,
+    "percentile25_10YrsAfterEntry": 18552,
+    "percentile75_10YrsAfterEntry": 51709,
+    "shareEarningAboveHsGrad": 0.457
   }
 }

--- a/data/sc/scorecard/greenville.json
+++ b/data/sc/scorecard/greenville.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.gvltec.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:34.754Z",
+  "fetchedAt": "2026-05-13T02:14:47.029Z",
   "size": 8916,
   "shareFirstGeneration": 0.4249955301,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 39473
+    "median10YrsAfterEntry": 39473,
+    "median1YrAfterCompletion": 37610,
+    "percentile25_10YrsAfterEntry": 22325,
+    "percentile75_10YrsAfterEntry": 58378,
+    "shareEarningAboveHsGrad": 0.57
   }
 }

--- a/data/sc/scorecard/horry-georgetown.json
+++ b/data/sc/scorecard/horry-georgetown.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.hgtc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:35.229Z",
+  "fetchedAt": "2026-05-13T02:14:47.457Z",
   "size": 6274,
   "shareFirstGeneration": 0.4201631702,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3782,
     "completionRate200nt": 0.3252,
-    "transferRate": 0.109
+    "transferRate": 0.109,
+    "retentionRateFullTime": 0.642,
+    "retentionRatePartTime": 0.3966
   },
   "earnings": {
-    "median10YrsAfterEntry": 35507
+    "median10YrsAfterEntry": 35507,
+    "median1YrAfterCompletion": 37706,
+    "percentile25_10YrsAfterEntry": 18794,
+    "percentile75_10YrsAfterEntry": 53910,
+    "shareEarningAboveHsGrad": 0.45
   }
 }

--- a/data/sc/scorecard/lowcountry.json
+++ b/data/sc/scorecard/lowcountry.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.tcl.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:38.225Z",
+  "fetchedAt": "2026-05-13T02:14:50.318Z",
   "size": 1679,
   "shareFirstGeneration": 0.4473924977,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1765,
     "completionRate200nt": 0.1656,
-    "transferRate": 0.268
+    "transferRate": 0.268,
+    "retentionRateFullTime": 0.5819,
+    "retentionRatePartTime": 0.3982
   },
   "earnings": {
-    "median10YrsAfterEntry": 35090
+    "median10YrsAfterEntry": 35090,
+    "median1YrAfterCompletion": 42055,
+    "percentile25_10YrsAfterEntry": 19877,
+    "percentile75_10YrsAfterEntry": 53992,
+    "shareEarningAboveHsGrad": 0.477
   }
 }

--- a/data/sc/scorecard/midlands.json
+++ b/data/sc/scorecard/midlands.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.midlandstech.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:35.681Z",
+  "fetchedAt": "2026-05-13T02:14:48.081Z",
   "size": 7564,
   "shareFirstGeneration": 0.396505616,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1793,
     "completionRate200nt": 0.2011,
-    "transferRate": 0.255
+    "transferRate": 0.255,
+    "retentionRateFullTime": 0.4869,
+    "retentionRatePartTime": 0.3311
   },
   "earnings": {
-    "median10YrsAfterEntry": 38701
+    "median10YrsAfterEntry": 38701,
+    "median1YrAfterCompletion": 37657,
+    "percentile25_10YrsAfterEntry": 21433,
+    "percentile75_10YrsAfterEntry": 57987,
+    "shareEarningAboveHsGrad": 0.524
   }
 }

--- a/data/sc/scorecard/northeastern.json
+++ b/data/sc/scorecard/northeastern.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.netc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:36.261Z",
+  "fetchedAt": "2026-05-13T02:14:48.555Z",
   "size": 921,
   "shareFirstGeneration": 0.5460251046,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2143,
     "completionRate200nt": 0.4177,
-    "transferRate": 0.2857
+    "transferRate": 0.2857,
+    "retentionRateFullTime": 0.7021,
+    "retentionRatePartTime": 0.3918
   },
   "earnings": {
-    "median10YrsAfterEntry": 32141
+    "median10YrsAfterEntry": 32141,
+    "median1YrAfterCompletion": 38509,
+    "percentile25_10YrsAfterEntry": 18277,
+    "percentile75_10YrsAfterEntry": 45777,
+    "shareEarningAboveHsGrad": 0.4
   }
 }

--- a/data/sc/scorecard/orangeburg-calhoun.json
+++ b/data/sc/scorecard/orangeburg-calhoun.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.octech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:36.719Z",
+  "fetchedAt": "2026-05-13T02:14:48.990Z",
   "size": 1539,
   "shareFirstGeneration": 0.4570475396,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3228,
     "completionRate200nt": 0.4551,
-    "transferRate": 0.1772
+    "transferRate": 0.1772,
+    "retentionRateFullTime": 0.6555,
+    "retentionRatePartTime": 0.3121
   },
   "earnings": {
-    "median10YrsAfterEntry": 35761
+    "median10YrsAfterEntry": 35761,
+    "median1YrAfterCompletion": 53257,
+    "percentile25_10YrsAfterEntry": 18482,
+    "percentile75_10YrsAfterEntry": 53657,
+    "shareEarningAboveHsGrad": 0.455
   }
 }

--- a/data/sc/scorecard/piedmont.json
+++ b/data/sc/scorecard/piedmont.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.ptc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:37.285Z",
+  "fetchedAt": "2026-05-13T02:14:49.430Z",
   "size": 3977,
   "shareFirstGeneration": 0.4747097844,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3307,
     "completionRate200nt": 0.4531,
-    "transferRate": 0.0956
+    "transferRate": 0.0956,
+    "retentionRateFullTime": 0.6147,
+    "retentionRatePartTime": 0.3904
   },
   "earnings": {
-    "median10YrsAfterEntry": 35768
+    "median10YrsAfterEntry": 35768,
+    "median1YrAfterCompletion": 37589,
+    "percentile25_10YrsAfterEntry": 19937,
+    "percentile75_10YrsAfterEntry": 52341,
+    "shareEarningAboveHsGrad": 0.48
   }
 }

--- a/data/sc/scorecard/spartanburg.json
+++ b/data/sc/scorecard/spartanburg.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.sccsc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:37.724Z",
+  "fetchedAt": "2026-05-13T02:14:49.888Z",
   "size": 5006,
   "shareFirstGeneration": 0.4840036563,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2824,
     "completionRate200nt": 0.3562,
-    "transferRate": 0.0987
+    "transferRate": 0.0987,
+    "retentionRateFullTime": 0.6321,
+    "retentionRatePartTime": 0.4233
   },
   "earnings": {
-    "median10YrsAfterEntry": 37097
+    "median10YrsAfterEntry": 37097,
+    "median1YrAfterCompletion": 39077,
+    "percentile25_10YrsAfterEntry": 21043,
+    "percentile75_10YrsAfterEntry": 54197,
+    "shareEarningAboveHsGrad": 0.504
   }
 }

--- a/data/sc/scorecard/tri-county.json
+++ b/data/sc/scorecard/tri-county.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.tctc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:38.923Z",
+  "fetchedAt": "2026-05-13T02:14:50.776Z",
   "size": 5071,
   "shareFirstGeneration": 0.3887915937,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4243,
     "completionRate200nt": 0.4418,
-    "transferRate": 0.3463
+    "transferRate": 0.3463,
+    "retentionRateFullTime": 0.5524,
+    "retentionRatePartTime": 0.4202
   },
   "earnings": {
-    "median10YrsAfterEntry": 40101
+    "median10YrsAfterEntry": 40101,
+    "median1YrAfterCompletion": 41529,
+    "percentile25_10YrsAfterEntry": 22733,
+    "percentile75_10YrsAfterEntry": 60526,
+    "shareEarningAboveHsGrad": 0.488
   }
 }

--- a/data/sc/scorecard/trident.json
+++ b/data/sc/scorecard/trident.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.tridenttech.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:39.429Z",
+  "fetchedAt": "2026-05-13T02:14:51.243Z",
   "size": 10512,
   "shareFirstGeneration": 0.4282700422,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2963,
     "completionRate200nt": 0.3353,
-    "transferRate": 0.2395
+    "transferRate": 0.2395,
+    "retentionRateFullTime": 0.592,
+    "retentionRatePartTime": 0.3374
   },
   "earnings": {
-    "median10YrsAfterEntry": 38253
+    "median10YrsAfterEntry": 38253,
+    "median1YrAfterCompletion": 43348,
+    "percentile25_10YrsAfterEntry": 20578,
+    "percentile75_10YrsAfterEntry": 58165,
+    "shareEarningAboveHsGrad": 0.549
   }
 }

--- a/data/sc/scorecard/williamsburg.json
+++ b/data/sc/scorecard/williamsburg.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.wiltech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:39.943Z",
+  "fetchedAt": "2026-05-13T02:14:51.670Z",
   "size": 448,
   "shareFirstGeneration": 0.5408560311,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1515,
     "completionRate200nt": 0.2727,
-    "transferRate": 0.2424
+    "transferRate": 0.2424,
+    "retentionRateFullTime": 0.6957,
+    "retentionRatePartTime": 0.5556
   },
   "earnings": {
-    "median10YrsAfterEntry": 29935
+    "median10YrsAfterEntry": 29935,
+    "median1YrAfterCompletion": null,
+    "percentile25_10YrsAfterEntry": 17026,
+    "percentile75_10YrsAfterEntry": 44503,
+    "shareEarningAboveHsGrad": 0.329
   }
 }

--- a/data/sc/scorecard/york.json
+++ b/data/sc/scorecard/york.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.yorktech.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:40.414Z",
+  "fetchedAt": "2026-05-13T02:14:52.105Z",
   "size": 3816,
   "shareFirstGeneration": 0.4216768916,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3024,
     "completionRate200nt": 0.371,
-    "transferRate": 0.1642
+    "transferRate": 0.1642,
+    "retentionRateFullTime": 0.6494,
+    "retentionRatePartTime": 0.3047
   },
   "earnings": {
-    "median10YrsAfterEntry": 37257
+    "median10YrsAfterEntry": 37257,
+    "median1YrAfterCompletion": 36809,
+    "percentile25_10YrsAfterEntry": 19597,
+    "percentile75_10YrsAfterEntry": 55453,
+    "shareEarningAboveHsGrad": 0.467
   }
 }

--- a/data/tn/scorecard/chattanooga-state.json
+++ b/data/tn/scorecard/chattanooga-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.chattanoogastate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:40.910Z",
+  "fetchedAt": "2026-05-13T02:14:52.569Z",
   "size": 5284,
   "shareFirstGeneration": 0.4602997092,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2593,
     "completionRate200nt": 0.2508,
-    "transferRate": 0.1388
+    "transferRate": 0.1388,
+    "retentionRateFullTime": 0.5671,
+    "retentionRatePartTime": 0.2713
   },
   "earnings": {
-    "median10YrsAfterEntry": 37598
+    "median10YrsAfterEntry": 37598,
+    "median1YrAfterCompletion": 38260,
+    "percentile25_10YrsAfterEntry": 19870,
+    "percentile75_10YrsAfterEntry": 56331,
+    "shareEarningAboveHsGrad": 0.527
   }
 }

--- a/data/tn/scorecard/cleveland-state.json
+++ b/data/tn/scorecard/cleveland-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.clevelandstatecc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:41.383Z",
+  "fetchedAt": "2026-05-13T02:14:53.038Z",
   "size": 1975,
   "shareFirstGeneration": 0.513496144,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3675,
     "completionRate200nt": 0.3237,
-    "transferRate": 0.1209
+    "transferRate": 0.1209,
+    "retentionRateFullTime": 0.5195,
+    "retentionRatePartTime": 0.4
   },
   "earnings": {
-    "median10YrsAfterEntry": 36671
+    "median10YrsAfterEntry": 36671,
+    "median1YrAfterCompletion": 39978,
+    "percentile25_10YrsAfterEntry": 19319,
+    "percentile75_10YrsAfterEntry": 54778,
+    "shareEarningAboveHsGrad": 0.521
   }
 }

--- a/data/tn/scorecard/columbia-state.json
+++ b/data/tn/scorecard/columbia-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.columbiastate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:41.858Z",
+  "fetchedAt": "2026-05-13T02:14:53.476Z",
   "size": 3897,
   "shareFirstGeneration": 0.4403048264,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2963,
     "completionRate200nt": 0.3084,
-    "transferRate": 0.1731
+    "transferRate": 0.1731,
+    "retentionRateFullTime": 0.5548,
+    "retentionRatePartTime": 0.398
   },
   "earnings": {
-    "median10YrsAfterEntry": 40256
+    "median10YrsAfterEntry": 40256,
+    "median1YrAfterCompletion": 38474,
+    "percentile25_10YrsAfterEntry": 22723,
+    "percentile75_10YrsAfterEntry": 59308,
+    "shareEarningAboveHsGrad": 0.575
   }
 }

--- a/data/tn/scorecard/dyersburg-state.json
+++ b/data/tn/scorecard/dyersburg-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.dscc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:42.320Z",
+  "fetchedAt": "2026-05-13T02:14:53.920Z",
   "size": 2103,
   "shareFirstGeneration": 0.56006628,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3354,
     "completionRate200nt": 0.3056,
-    "transferRate": 0.1214
+    "transferRate": 0.1214,
+    "retentionRateFullTime": 0.6337,
+    "retentionRatePartTime": 0.4595
   },
   "earnings": {
-    "median10YrsAfterEntry": 36132
+    "median10YrsAfterEntry": 36132,
+    "median1YrAfterCompletion": 61845,
+    "percentile25_10YrsAfterEntry": 18634,
+    "percentile75_10YrsAfterEntry": 52500,
+    "shareEarningAboveHsGrad": 0.477
   }
 }

--- a/data/tn/scorecard/jackson-state.json
+++ b/data/tn/scorecard/jackson-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.jscc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:42.790Z",
+  "fetchedAt": "2026-05-13T02:14:54.371Z",
   "size": 2511,
   "shareFirstGeneration": 0.5222786238,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2585,
     "completionRate200nt": 0.2792,
-    "transferRate": 0.13
+    "transferRate": 0.13,
+    "retentionRateFullTime": 0.5434,
+    "retentionRatePartTime": 0.2581
   },
   "earnings": {
-    "median10YrsAfterEntry": 35224
+    "median10YrsAfterEntry": 35224,
+    "median1YrAfterCompletion": 42560,
+    "percentile25_10YrsAfterEntry": 19220,
+    "percentile75_10YrsAfterEntry": 52040,
+    "shareEarningAboveHsGrad": 0.515
   }
 }

--- a/data/tn/scorecard/motlow-state.json
+++ b/data/tn/scorecard/motlow-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mscc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:43.237Z",
+  "fetchedAt": "2026-05-13T02:14:54.828Z",
   "size": 3962,
   "shareFirstGeneration": 0.5163893091,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3356,
     "completionRate200nt": 0.3178,
-    "transferRate": 0.1397
+    "transferRate": 0.1397,
+    "retentionRateFullTime": 0.554,
+    "retentionRatePartTime": 0.4605
   },
   "earnings": {
-    "median10YrsAfterEntry": 40397
+    "median10YrsAfterEntry": 40397,
+    "median1YrAfterCompletion": 32318,
+    "percentile25_10YrsAfterEntry": 21840,
+    "percentile75_10YrsAfterEntry": 57391,
+    "shareEarningAboveHsGrad": 0.51
   }
 }

--- a/data/tn/scorecard/nashville-state.json
+++ b/data/tn/scorecard/nashville-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nscc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:43.705Z",
+  "fetchedAt": "2026-05-13T02:14:55.260Z",
   "size": 5653,
   "shareFirstGeneration": 0.4709806538,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1846,
     "completionRate200nt": 0.2004,
-    "transferRate": 0.1514
+    "transferRate": 0.1514,
+    "retentionRateFullTime": 0.4412,
+    "retentionRatePartTime": 0.4684
   },
   "earnings": {
-    "median10YrsAfterEntry": 38519
+    "median10YrsAfterEntry": 38519,
+    "median1YrAfterCompletion": 34662,
+    "percentile25_10YrsAfterEntry": 19748,
+    "percentile75_10YrsAfterEntry": 57206,
+    "shareEarningAboveHsGrad": 0.552
   }
 }

--- a/data/tn/scorecard/northeast-state.json
+++ b/data/tn/scorecard/northeast-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.northeaststate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:44.182Z",
+  "fetchedAt": "2026-05-13T02:14:55.904Z",
   "size": 4404,
   "shareFirstGeneration": 0.5300117693,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.333,
     "completionRate200nt": 0.3646,
-    "transferRate": 0.0852
+    "transferRate": 0.0852,
+    "retentionRateFullTime": 0.5947,
+    "retentionRatePartTime": 0.5143
   },
   "earnings": {
-    "median10YrsAfterEntry": 34553
+    "median10YrsAfterEntry": 34553,
+    "median1YrAfterCompletion": 33442,
+    "percentile25_10YrsAfterEntry": 18955,
+    "percentile75_10YrsAfterEntry": 51368,
+    "shareEarningAboveHsGrad": 0.468
   }
 }

--- a/data/tn/scorecard/pellissippi-state.json
+++ b/data/tn/scorecard/pellissippi-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.pstcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:44.629Z",
+  "fetchedAt": "2026-05-13T02:14:56.348Z",
   "size": 6715,
   "shareFirstGeneration": 0.4301046418,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3149,
     "completionRate200nt": 0.3143,
-    "transferRate": 0.2169
+    "transferRate": 0.2169,
+    "retentionRateFullTime": 0.5822,
+    "retentionRatePartTime": 0.5455
   },
   "earnings": {
-    "median10YrsAfterEntry": 38440
+    "median10YrsAfterEntry": 38440,
+    "median1YrAfterCompletion": 33260,
+    "percentile25_10YrsAfterEntry": 20815,
+    "percentile75_10YrsAfterEntry": 57443,
+    "shareEarningAboveHsGrad": 0.531
   }
 }

--- a/data/tn/scorecard/southwest-tn.json
+++ b/data/tn/scorecard/southwest-tn.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.southwest.tn.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:45.161Z",
+  "fetchedAt": "2026-05-13T02:14:56.803Z",
   "size": 5047,
   "shareFirstGeneration": 0.4572353213,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1899,
     "completionRate200nt": 0.2376,
-    "transferRate": 0.1564
+    "transferRate": 0.1564,
+    "retentionRateFullTime": 0.4571,
+    "retentionRatePartTime": 0.187
   },
   "earnings": {
-    "median10YrsAfterEntry": 34071
+    "median10YrsAfterEntry": 34071,
+    "median1YrAfterCompletion": 35491,
+    "percentile25_10YrsAfterEntry": 17590,
+    "percentile75_10YrsAfterEntry": 51079,
+    "shareEarningAboveHsGrad": 0.457
   }
 }

--- a/data/tn/scorecard/volunteer-state.json
+++ b/data/tn/scorecard/volunteer-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.volstate.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:45.674Z",
+  "fetchedAt": "2026-05-13T02:14:57.225Z",
   "size": 5339,
   "shareFirstGeneration": 0.4577534791,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2818,
     "completionRate200nt": 0.2689,
-    "transferRate": 0.1373
+    "transferRate": 0.1373,
+    "retentionRateFullTime": 0.5123,
+    "retentionRatePartTime": 0.3741
   },
   "earnings": {
-    "median10YrsAfterEntry": 41150
+    "median10YrsAfterEntry": 41150,
+    "median1YrAfterCompletion": 36410,
+    "percentile25_10YrsAfterEntry": 24273,
+    "percentile75_10YrsAfterEntry": 58163,
+    "shareEarningAboveHsGrad": 0.58
   }
 }

--- a/data/tn/scorecard/walters-state.json
+++ b/data/tn/scorecard/walters-state.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ws.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:46.160Z",
+  "fetchedAt": "2026-05-13T02:14:57.695Z",
   "size": 3591,
   "shareFirstGeneration": 0.5582978723,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3333,
     "completionRate200nt": 0.3932,
-    "transferRate": 0.1056
+    "transferRate": 0.1056,
+    "retentionRateFullTime": 0.5295,
+    "retentionRatePartTime": 0.5172
   },
   "earnings": {
-    "median10YrsAfterEntry": 37085
+    "median10YrsAfterEntry": 37085,
+    "median1YrAfterCompletion": 36617,
+    "percentile25_10YrsAfterEntry": 21488,
+    "percentile75_10YrsAfterEntry": 53290,
+    "shareEarningAboveHsGrad": 0.49
   }
 }

--- a/data/va/scorecard/brcc.json
+++ b/data/va/scorecard/brcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.brcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:48.611Z",
+  "fetchedAt": "2026-05-13T02:14:59.998Z",
   "size": 2730,
   "shareFirstGeneration": 0.4760900141,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4037,
     "completionRate200nt": 0.3742,
-    "transferRate": 0.0882
+    "transferRate": 0.0882,
+    "retentionRateFullTime": 0.6456,
+    "retentionRatePartTime": 0.4657
   },
   "earnings": {
-    "median10YrsAfterEntry": 42644
+    "median10YrsAfterEntry": 42644,
+    "median1YrAfterCompletion": 37475,
+    "percentile25_10YrsAfterEntry": 25141,
+    "percentile75_10YrsAfterEntry": 60692,
+    "shareEarningAboveHsGrad": 0.587
   }
 }

--- a/data/va/scorecard/brightpoint.json
+++ b/data/va/scorecard/brightpoint.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.brightpoint.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:49.226Z",
+  "fetchedAt": "2026-05-13T02:15:00.441Z",
   "size": 5792,
   "shareFirstGeneration": 0.4151495449,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3834,
     "completionRate200nt": 0.42,
-    "transferRate": 0.1768
+    "transferRate": 0.1768,
+    "retentionRateFullTime": 0.6825,
+    "retentionRatePartTime": 0.4316
   },
   "earnings": {
-    "median10YrsAfterEntry": 41223
+    "median10YrsAfterEntry": 41223,
+    "median1YrAfterCompletion": 33567,
+    "percentile25_10YrsAfterEntry": 22526,
+    "percentile75_10YrsAfterEntry": 61976,
+    "shareEarningAboveHsGrad": 0.6
   }
 }

--- a/data/va/scorecard/camp.json
+++ b/data/va/scorecard/camp.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.pdc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:49.686Z",
+  "fetchedAt": "2026-05-13T02:15:00.964Z",
   "size": 613,
   "shareFirstGeneration": 0.495256167,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3571,
     "completionRate200nt": 0.2584,
-    "transferRate": 0.1161
+    "transferRate": 0.1161,
+    "retentionRateFullTime": 0.5789,
+    "retentionRatePartTime": 0.2766
   },
   "earnings": {
-    "median10YrsAfterEntry": 36031
+    "median10YrsAfterEntry": 36031,
+    "median1YrAfterCompletion": 33316,
+    "percentile25_10YrsAfterEntry": 20130,
+    "percentile75_10YrsAfterEntry": 54676,
+    "shareEarningAboveHsGrad": 0.405
   }
 }

--- a/data/va/scorecard/cvcc.json
+++ b/data/va/scorecard/cvcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.centralvirginia.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:50.265Z",
+  "fetchedAt": "2026-05-13T02:15:01.422Z",
   "size": 2249,
   "shareFirstGeneration": 0.4324142569,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4458,
     "completionRate200nt": 0.5067,
-    "transferRate": 0.125
+    "transferRate": 0.125,
+    "retentionRateFullTime": 0.6405,
+    "retentionRatePartTime": 0.4392
   },
   "earnings": {
-    "median10YrsAfterEntry": 36627
+    "median10YrsAfterEntry": 36627,
+    "median1YrAfterCompletion": 35672,
+    "percentile25_10YrsAfterEntry": 20812,
+    "percentile75_10YrsAfterEntry": 53563,
+    "shareEarningAboveHsGrad": 0.494
   }
 }

--- a/data/va/scorecard/dcc.json
+++ b/data/va/scorecard/dcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.danville.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:50.727Z",
+  "fetchedAt": "2026-05-13T02:15:01.862Z",
   "size": 1306,
   "shareFirstGeneration": 0.4956063269,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3927,
     "completionRate200nt": 0.4514,
-    "transferRate": 0.085
+    "transferRate": 0.085,
+    "retentionRateFullTime": 0.6548,
+    "retentionRatePartTime": 0.3971
   },
   "earnings": {
-    "median10YrsAfterEntry": 31664
+    "median10YrsAfterEntry": 31664,
+    "median1YrAfterCompletion": 32352,
+    "percentile25_10YrsAfterEntry": 15892,
+    "percentile75_10YrsAfterEntry": 47724,
+    "shareEarningAboveHsGrad": 0.44
   }
 }

--- a/data/va/scorecard/escc.json
+++ b/data/va/scorecard/escc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.es.vccs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:51.204Z",
+  "fetchedAt": "2026-05-13T02:15:02.314Z",
   "size": 495,
   "shareFirstGeneration": 0.6287128713,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4107,
     "completionRate200nt": 0.3768,
-    "transferRate": 0.1071
+    "transferRate": 0.1071,
+    "retentionRateFullTime": 0.6742,
+    "retentionRatePartTime": 0.4348
   },
   "earnings": {
-    "median10YrsAfterEntry": 32418
+    "median10YrsAfterEntry": 32418,
+    "median1YrAfterCompletion": 31696,
+    "percentile25_10YrsAfterEntry": 16066,
+    "percentile75_10YrsAfterEntry": 48637,
+    "shareEarningAboveHsGrad": 0.408
   }
 }

--- a/data/va/scorecard/gcc.json
+++ b/data/va/scorecard/gcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.germanna.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:46.635Z",
+  "fetchedAt": "2026-05-13T02:14:58.135Z",
   "size": 5508,
   "shareFirstGeneration": 0.4231354642,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4647,
     "completionRate200nt": 0.411,
-    "transferRate": 0.1162
+    "transferRate": 0.1162,
+    "retentionRateFullTime": 0.6365,
+    "retentionRatePartTime": 0.4905
   },
   "earnings": {
-    "median10YrsAfterEntry": 39644
+    "median10YrsAfterEntry": 39644,
+    "median1YrAfterCompletion": 34134,
+    "percentile25_10YrsAfterEntry": 21503,
+    "percentile75_10YrsAfterEntry": 63559,
+    "shareEarningAboveHsGrad": 0.534
   }
 }

--- a/data/va/scorecard/laurelridge.json
+++ b/data/va/scorecard/laurelridge.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.laurelridge.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:51.688Z",
+  "fetchedAt": "2026-05-13T02:15:02.739Z",
   "size": 3195,
   "shareFirstGeneration": 0.5097545626,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.446,
     "completionRate200nt": 0.4162,
-    "transferRate": 0.15
+    "transferRate": 0.15,
+    "retentionRateFullTime": 0.6866,
+    "retentionRatePartTime": 0.4562
   },
   "earnings": {
-    "median10YrsAfterEntry": 41000
+    "median10YrsAfterEntry": 41000,
+    "median1YrAfterCompletion": 38268,
+    "percentile25_10YrsAfterEntry": 23671,
+    "percentile75_10YrsAfterEntry": 62528,
+    "shareEarningAboveHsGrad": 0.548
   }
 }

--- a/data/va/scorecard/mecc.json
+++ b/data/va/scorecard/mecc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mecc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:52.227Z",
+  "fetchedAt": "2026-05-13T02:15:03.165Z",
   "size": 1282,
   "shareFirstGeneration": 0.5711206897,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.48,
     "completionRate200nt": 0.5409,
-    "transferRate": 0.0533
+    "transferRate": 0.0533,
+    "retentionRateFullTime": 0.6431,
+    "retentionRatePartTime": 0.3299
   },
   "earnings": {
-    "median10YrsAfterEntry": 32622
+    "median10YrsAfterEntry": 32622,
+    "median1YrAfterCompletion": 35864,
+    "percentile25_10YrsAfterEntry": 18506,
+    "percentile75_10YrsAfterEntry": 47785,
+    "shareEarningAboveHsGrad": 0.435
   }
 }

--- a/data/va/scorecard/mgcc.json
+++ b/data/va/scorecard/mgcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mgcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:52.741Z",
+  "fetchedAt": "2026-05-13T02:15:03.613Z",
   "size": 425,
   "shareFirstGeneration": 0.4938574939,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3772,
     "completionRate200nt": 0.4914,
-    "transferRate": 0.0614
+    "transferRate": 0.0614,
+    "retentionRateFullTime": 0.5962,
+    "retentionRatePartTime": 0.5385
   },
   "earnings": {
-    "median10YrsAfterEntry": 34293
+    "median10YrsAfterEntry": 34293,
+    "median1YrAfterCompletion": 38955,
+    "percentile25_10YrsAfterEntry": 18395,
+    "percentile75_10YrsAfterEntry": 52948,
+    "shareEarningAboveHsGrad": 0.518
   }
 }

--- a/data/va/scorecard/nova.json
+++ b/data/va/scorecard/nova.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.nvcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:47.125Z",
+  "fetchedAt": "2026-05-13T02:14:58.573Z",
   "size": 33048,
   "shareFirstGeneration": 0.4111453334,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3305,
     "completionRate200nt": 0.4206,
-    "transferRate": 0.1626
+    "transferRate": 0.1626,
+    "retentionRateFullTime": 0.7084,
+    "retentionRatePartTime": 0.5254
   },
   "earnings": {
-    "median10YrsAfterEntry": 53557
+    "median10YrsAfterEntry": 53557,
+    "median1YrAfterCompletion": 37218,
+    "percentile25_10YrsAfterEntry": 29461,
+    "percentile75_10YrsAfterEntry": 82798,
+    "shareEarningAboveHsGrad": 0.685
   }
 }

--- a/data/va/scorecard/nrcc.json
+++ b/data/va/scorecard/nrcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.nr.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:53.186Z",
+  "fetchedAt": "2026-05-13T02:15:04.071Z",
   "size": 1965,
   "shareFirstGeneration": 0.43281471,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4989,
     "completionRate200nt": 0.4749,
-    "transferRate": 0.0658
+    "transferRate": 0.0658,
+    "retentionRateFullTime": 0.6754,
+    "retentionRatePartTime": 0.5366
   },
   "earnings": {
-    "median10YrsAfterEntry": 40025
+    "median10YrsAfterEntry": 40025,
+    "median1YrAfterCompletion": 37888,
+    "percentile25_10YrsAfterEntry": 22670,
+    "percentile75_10YrsAfterEntry": 58527,
+    "shareEarningAboveHsGrad": 0.561
   }
 }

--- a/data/va/scorecard/phcc.json
+++ b/data/va/scorecard/phcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.patrickhenry.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:53.632Z",
+  "fetchedAt": "2026-05-13T02:15:04.508Z",
   "size": 1350,
   "shareFirstGeneration": 0.5436081243,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4153,
     "completionRate200nt": 0.4805,
-    "transferRate": 0.1085
+    "transferRate": 0.1085,
+    "retentionRateFullTime": 0.6242,
+    "retentionRatePartTime": 0.3905
   },
   "earnings": {
-    "median10YrsAfterEntry": 33323
+    "median10YrsAfterEntry": 33323,
+    "median1YrAfterCompletion": 31934,
+    "percentile25_10YrsAfterEntry": 17869,
+    "percentile75_10YrsAfterEntry": 49534,
+    "shareEarningAboveHsGrad": 0.435
   }
 }

--- a/data/va/scorecard/pvcc.json
+++ b/data/va/scorecard/pvcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.pvcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:54.103Z",
+  "fetchedAt": "2026-05-13T02:15:04.967Z",
   "size": 3045,
   "shareFirstGeneration": 0.4461538462,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3859,
     "completionRate200nt": 0.3856,
-    "transferRate": 0.1239
+    "transferRate": 0.1239,
+    "retentionRateFullTime": 0.6771,
+    "retentionRatePartTime": 0.4593
   },
   "earnings": {
-    "median10YrsAfterEntry": 40752
+    "median10YrsAfterEntry": 40752,
+    "median1YrAfterCompletion": 39541,
+    "percentile25_10YrsAfterEntry": 22904,
+    "percentile75_10YrsAfterEntry": 60923,
+    "shareEarningAboveHsGrad": 0.554
   }
 }

--- a/data/va/scorecard/rcc.json
+++ b/data/va/scorecard/rcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.rappahannock.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:54.567Z",
+  "fetchedAt": "2026-05-13T02:15:05.433Z",
   "size": 1367,
   "shareFirstGeneration": 0.5078683834,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4527,
     "completionRate200nt": 0.4435,
-    "transferRate": 0.0608
+    "transferRate": 0.0608,
+    "retentionRateFullTime": 0.6503,
+    "retentionRatePartTime": 0.5514
   },
   "earnings": {
-    "median10YrsAfterEntry": 36121
+    "median10YrsAfterEntry": 36121,
+    "median1YrAfterCompletion": 41146,
+    "percentile25_10YrsAfterEntry": 20031,
+    "percentile75_10YrsAfterEntry": 53166,
+    "shareEarningAboveHsGrad": 0.499
   }
 }

--- a/data/va/scorecard/reynolds.json
+++ b/data/va/scorecard/reynolds.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.reynolds.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:47.607Z",
+  "fetchedAt": "2026-05-13T02:14:59.022Z",
   "size": 5586,
   "shareFirstGeneration": 0.4503195816,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3223,
     "completionRate200nt": 0.3525,
-    "transferRate": 0.1517
+    "transferRate": 0.1517,
+    "retentionRateFullTime": 0.6845,
+    "retentionRatePartTime": 0.4088
   },
   "earnings": {
-    "median10YrsAfterEntry": 39529
+    "median10YrsAfterEntry": 39529,
+    "median1YrAfterCompletion": 38017,
+    "percentile25_10YrsAfterEntry": 20381,
+    "percentile75_10YrsAfterEntry": 58422,
+    "shareEarningAboveHsGrad": 0.553
   }
 }

--- a/data/va/scorecard/svcc.json
+++ b/data/va/scorecard/svcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.southside.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:55.020Z",
+  "fetchedAt": "2026-05-13T02:15:06.028Z",
   "size": 1807,
   "shareFirstGeneration": 0.5234962406,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4177,
     "completionRate200nt": 0.3952,
-    "transferRate": 0.1266
+    "transferRate": 0.1266,
+    "retentionRateFullTime": 0.7052,
+    "retentionRatePartTime": 0.5074
   },
   "earnings": {
-    "median10YrsAfterEntry": 32371
+    "median10YrsAfterEntry": 32371,
+    "median1YrAfterCompletion": 38825,
+    "percentile25_10YrsAfterEntry": 17047,
+    "percentile75_10YrsAfterEntry": 48129,
+    "shareEarningAboveHsGrad": 0.425
   }
 }

--- a/data/va/scorecard/swcc.json
+++ b/data/va/scorecard/swcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "sw.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:55.694Z",
+  "fetchedAt": "2026-05-13T02:15:06.462Z",
   "size": 1651,
   "shareFirstGeneration": 0.5296198055,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4613,
     "completionRate200nt": 0.4703,
-    "transferRate": 0.088
+    "transferRate": 0.088,
+    "retentionRateFullTime": 0.6124,
+    "retentionRatePartTime": 0.4206
   },
   "earnings": {
-    "median10YrsAfterEntry": 34221
+    "median10YrsAfterEntry": 34221,
+    "median1YrAfterCompletion": 30802,
+    "percentile25_10YrsAfterEntry": 17453,
+    "percentile75_10YrsAfterEntry": 50270,
+    "shareEarningAboveHsGrad": 0.439
   }
 }

--- a/data/va/scorecard/tcc.json
+++ b/data/va/scorecard/tcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.tcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:48.130Z",
+  "fetchedAt": "2026-05-13T02:14:59.542Z",
   "size": 12082,
   "shareFirstGeneration": 0.415897866,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3171,
     "completionRate200nt": 0.3634,
-    "transferRate": 0.1518
+    "transferRate": 0.1518,
+    "retentionRateFullTime": 0.6384,
+    "retentionRatePartTime": 0.3812
   },
   "earnings": {
-    "median10YrsAfterEntry": 38349
+    "median10YrsAfterEntry": 38349,
+    "median1YrAfterCompletion": 35996,
+    "percentile25_10YrsAfterEntry": 19562,
+    "percentile75_10YrsAfterEntry": 58123,
+    "shareEarningAboveHsGrad": 0.557
   }
 }

--- a/data/va/scorecard/vhcc.json
+++ b/data/va/scorecard/vhcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.vhcc.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:56.232Z",
+  "fetchedAt": "2026-05-13T02:15:06.926Z",
   "size": 1349,
   "shareFirstGeneration": 0.5,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4006,
     "completionRate200nt": 0.4549,
-    "transferRate": 0.0932
+    "transferRate": 0.0932,
+    "retentionRateFullTime": 0.5992,
+    "retentionRatePartTime": 0.4173
   },
   "earnings": {
-    "median10YrsAfterEntry": 32681
+    "median10YrsAfterEntry": 32681,
+    "median1YrAfterCompletion": 30930,
+    "percentile25_10YrsAfterEntry": 18350,
+    "percentile75_10YrsAfterEntry": 49153,
+    "shareEarningAboveHsGrad": 0.447
   }
 }

--- a/data/va/scorecard/vpcc.json
+++ b/data/va/scorecard/vpcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://vpcc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:56.700Z",
+  "fetchedAt": "2026-05-13T02:15:07.364Z",
   "size": 3941,
   "shareFirstGeneration": 0.3903576983,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3393,
     "completionRate200nt": 0.375,
-    "transferRate": 0.1578
+    "transferRate": 0.1578,
+    "retentionRateFullTime": 0.5802,
+    "retentionRatePartTime": 0.3869
   },
   "earnings": {
-    "median10YrsAfterEntry": 37996
+    "median10YrsAfterEntry": 37996,
+    "median1YrAfterCompletion": 34405,
+    "percentile25_10YrsAfterEntry": 19221,
+    "percentile75_10YrsAfterEntry": 57708,
+    "shareEarningAboveHsGrad": 0.539
   }
 }

--- a/data/va/scorecard/vwcc.json
+++ b/data/va/scorecard/vwcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.virginiawestern.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:57.245Z",
+  "fetchedAt": "2026-05-13T02:15:07.796Z",
   "size": 3898,
   "shareFirstGeneration": 0.4424214838,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4012,
     "completionRate200nt": 0.4607,
-    "transferRate": 0.142
+    "transferRate": 0.142,
+    "retentionRateFullTime": 0.6274,
+    "retentionRatePartTime": 0.4424
   },
   "earnings": {
-    "median10YrsAfterEntry": 38787
+    "median10YrsAfterEntry": 38787,
+    "median1YrAfterCompletion": 36217,
+    "percentile25_10YrsAfterEntry": 21582,
+    "percentile75_10YrsAfterEntry": 56450,
+    "shareEarningAboveHsGrad": 0.55
   }
 }

--- a/data/va/scorecard/wcc.json
+++ b/data/va/scorecard/wcc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wcc.vccs.edu/",
   "ownership": 1,
   "predominantDegree": 1,
-  "fetchedAt": "2026-05-12T00:15:57.719Z",
+  "fetchedAt": "2026-05-13T02:15:08.223Z",
   "size": 1255,
   "shareFirstGeneration": 0.4707207207,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4737,
     "completionRate200nt": 0.4691,
-    "transferRate": 0.0769
+    "transferRate": 0.0769,
+    "retentionRateFullTime": 0.726,
+    "retentionRatePartTime": 0.4634
   },
   "earnings": {
-    "median10YrsAfterEntry": 34303
+    "median10YrsAfterEntry": 34303,
+    "median1YrAfterCompletion": 34417,
+    "percentile25_10YrsAfterEntry": 18495,
+    "percentile75_10YrsAfterEntry": 51565,
+    "shareEarningAboveHsGrad": 0.495
   }
 }

--- a/data/vt/scorecard/ccv.json
+++ b/data/vt/scorecard/ccv.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.ccv.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:58.273Z",
+  "fetchedAt": "2026-05-13T02:15:08.662Z",
   "size": 2841,
   "shareFirstGeneration": 0.5074090705,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1963,
     "completionRate200nt": 0.2981,
-    "transferRate": 0.243
+    "transferRate": 0.243,
+    "retentionRateFullTime": 0.4899,
+    "retentionRatePartTime": 0.3258
   },
   "earnings": {
-    "median10YrsAfterEntry": 36234
+    "median10YrsAfterEntry": 36234,
+    "median1YrAfterCompletion": 34293,
+    "percentile25_10YrsAfterEntry": 17441,
+    "percentile75_10YrsAfterEntry": 56454,
+    "shareEarningAboveHsGrad": 0.521
   }
 }

--- a/data/wv/scorecard/blueridge.json
+++ b/data/wv/scorecard/blueridge.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.blueridgectc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:58.751Z",
+  "fetchedAt": "2026-05-13T02:15:09.035Z",
   "size": 1661,
   "shareFirstGeneration": 0.5343777198,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3232,
     "completionRate200nt": 0.6123,
-    "transferRate": 0.1263
+    "transferRate": 0.1263,
+    "retentionRateFullTime": 0.7837,
+    "retentionRatePartTime": 0.4968
   },
   "earnings": {
-    "median10YrsAfterEntry": 39293
+    "median10YrsAfterEntry": 39293,
+    "median1YrAfterCompletion": 34268,
+    "percentile25_10YrsAfterEntry": 19202,
+    "percentile75_10YrsAfterEntry": 58443,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/wv/scorecard/bridgevalley.json
+++ b/data/wv/scorecard/bridgevalley.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.bridgevalley.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:59.220Z",
+  "fetchedAt": "2026-05-13T02:15:09.652Z",
   "size": 1854,
   "shareFirstGeneration": 0.5512510089,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3421,
     "completionRate200nt": 0.3458,
-    "transferRate": 0.1316
+    "transferRate": 0.1316,
+    "retentionRateFullTime": 0.467,
+    "retentionRatePartTime": 0.3478
   },
   "earnings": {
-    "median10YrsAfterEntry": 36432
+    "median10YrsAfterEntry": 36432,
+    "median1YrAfterCompletion": 48340,
+    "percentile25_10YrsAfterEntry": 20059,
+    "percentile75_10YrsAfterEntry": 57225,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/wv/scorecard/eastern.json
+++ b/data/wv/scorecard/eastern.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.easternwv.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:15:59.702Z",
+  "fetchedAt": "2026-05-13T02:15:10.106Z",
   "size": 225,
   "shareFirstGeneration": 0.6338028169,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4167,
     "completionRate200nt": 0.6563,
-    "transferRate": 0.1389
+    "transferRate": 0.1389,
+    "retentionRateFullTime": 0.6364,
+    "retentionRatePartTime": 0.625
   },
   "earnings": {
-    "median10YrsAfterEntry": 31636
+    "median10YrsAfterEntry": 31636,
+    "median1YrAfterCompletion": 30706,
+    "percentile25_10YrsAfterEntry": 18573,
+    "percentile75_10YrsAfterEntry": 44720,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/wv/scorecard/mountwest.json
+++ b/data/wv/scorecard/mountwest.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.mctc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:16:00.279Z",
+  "fetchedAt": "2026-05-13T02:15:10.571Z",
   "size": 1160,
   "shareFirstGeneration": 0.5185185185,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.1905,
     "completionRate200nt": 0.1971,
-    "transferRate": 0.0582
+    "transferRate": 0.0582,
+    "retentionRateFullTime": 0.3769,
+    "retentionRatePartTime": 0.303
   },
   "earnings": {
-    "median10YrsAfterEntry": 28951
+    "median10YrsAfterEntry": 28951,
+    "median1YrAfterCompletion": 38840,
+    "percentile25_10YrsAfterEntry": 13902,
+    "percentile75_10YrsAfterEntry": 47079,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/wv/scorecard/newriver.json
+++ b/data/wv/scorecard/newriver.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.newriver.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:16:00.933Z",
+  "fetchedAt": "2026-05-13T02:15:11.027Z",
   "size": 770,
   "shareFirstGeneration": 0.587040619,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3598,
     "completionRate200nt": 0.3196,
-    "transferRate": 0.0688
+    "transferRate": 0.0688,
+    "retentionRateFullTime": 0.5976,
+    "retentionRatePartTime": 0.3137
   },
   "earnings": {
-    "median10YrsAfterEntry": 29073
+    "median10YrsAfterEntry": 29073,
+    "median1YrAfterCompletion": 32457,
+    "percentile25_10YrsAfterEntry": 14158,
+    "percentile75_10YrsAfterEntry": 43901,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/wv/scorecard/pierpont.json
+++ b/data/wv/scorecard/pierpont.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.pierpont.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:16:01.402Z",
+  "fetchedAt": "2026-05-13T02:15:11.478Z",
   "size": 959,
   "shareFirstGeneration": 0.4822888283,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.4215,
     "completionRate200nt": 0.4169,
-    "transferRate": 0.0843
+    "transferRate": 0.0843,
+    "retentionRateFullTime": 0.5902,
+    "retentionRatePartTime": 0.2097
   },
   "earnings": {
-    "median10YrsAfterEntry": 35132
+    "median10YrsAfterEntry": 35132,
+    "median1YrAfterCompletion": 37659,
+    "percentile25_10YrsAfterEntry": 17707,
+    "percentile75_10YrsAfterEntry": 54406,
+    "shareEarningAboveHsGrad": null
   }
 }

--- a/data/wv/scorecard/southern.json
+++ b/data/wv/scorecard/southern.json
@@ -6,7 +6,7 @@
   "schoolUrl": "https://www.southernwv.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:16:01.863Z",
+  "fetchedAt": "2026-05-13T02:15:12.014Z",
   "size": 1064,
   "shareFirstGeneration": 0.6130604288,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.2876,
     "completionRate200nt": 0.3137,
-    "transferRate": 0.0618
+    "transferRate": 0.0618,
+    "retentionRateFullTime": 0.4969,
+    "retentionRatePartTime": 0.3333
   },
   "earnings": {
-    "median10YrsAfterEntry": 32153
+    "median10YrsAfterEntry": 32153,
+    "median1YrAfterCompletion": 20873,
+    "percentile25_10YrsAfterEntry": 16783,
+    "percentile75_10YrsAfterEntry": 48892,
+    "shareEarningAboveHsGrad": 0.416
   }
 }

--- a/data/wv/scorecard/wvncc.json
+++ b/data/wv/scorecard/wvncc.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wvncc.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:16:02.368Z",
+  "fetchedAt": "2026-05-13T02:15:12.538Z",
   "size": 1014,
   "shareFirstGeneration": 0.4854910714,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": 0.3333,
     "completionRate200nt": 0.309,
-    "transferRate": 0.1264
+    "transferRate": 0.1264,
+    "retentionRateFullTime": 0.6121,
+    "retentionRatePartTime": 0.6667
   },
   "earnings": {
-    "median10YrsAfterEntry": 30162
+    "median10YrsAfterEntry": 30162,
+    "median1YrAfterCompletion": 34276,
+    "percentile25_10YrsAfterEntry": 15886,
+    "percentile75_10YrsAfterEntry": 48309,
+    "shareEarningAboveHsGrad": 0.461
   }
 }

--- a/data/wv/scorecard/wvup.json
+++ b/data/wv/scorecard/wvup.json
@@ -6,7 +6,7 @@
   "schoolUrl": "www.wvup.edu/",
   "ownership": 1,
   "predominantDegree": 2,
-  "fetchedAt": "2026-05-12T00:16:02.879Z",
+  "fetchedAt": "2026-05-13T02:15:12.971Z",
   "size": 1868,
   "shareFirstGeneration": 0.449031171,
   "cost": {
@@ -32,9 +32,15 @@
   "completion": {
     "completionRate150nt": null,
     "completionRate200nt": null,
-    "transferRate": null
+    "transferRate": null,
+    "retentionRateFullTime": null,
+    "retentionRatePartTime": null
   },
   "earnings": {
-    "median10YrsAfterEntry": 35171
+    "median10YrsAfterEntry": 35171,
+    "median1YrAfterCompletion": 47476,
+    "percentile25_10YrsAfterEntry": 18143,
+    "percentile75_10YrsAfterEntry": 55301,
+    "shareEarningAboveHsGrad": 0.5
   }
 }

--- a/scripts/lib/college-scorecard.ts
+++ b/scripts/lib/college-scorecard.ts
@@ -54,6 +54,22 @@ const FIELDS = [
   "latest.completion.completion_rate_less_than_4yr_200nt",
   "latest.completion.transfer_rate.less_than_4yr.full_time",
   "latest.earnings.10_yrs_after_entry.median",
+  // Tier 1 outcomes additions — see issue #405.
+  // Retention is the strongest leading indicator of completion; CCs often
+  // have wildly different FT vs PT retention so we surface both.
+  "latest.student.retention_rate.lt_four_year.full_time",
+  "latest.student.retention_rate.lt_four_year.part_time",
+  // 1yr earnings is a faster post-completion signal than the headline 10yr
+  // figure (which mixes completers and non-completers entering the
+  // workforce). 10yr percentiles (P25 / P75) give us a distribution
+  // alongside the median for the existing earnings tile.
+  "latest.earnings.1_yr_after_completion.median",
+  "latest.earnings.10_yrs_after_entry.working_not_enrolled.earnings_percentile.25",
+  "latest.earnings.10_yrs_after_entry.working_not_enrolled.earnings_percentile.75",
+  // % of former students earning above $28k (federal threshold ~ median
+  // for a HS graduate). The fed Scorecard's flagship "did college pay off"
+  // outcome stat. Available where the 10yr earnings cohort is large enough.
+  "latest.earnings.10_yrs_after_entry.percent_greater_than_28000",
 ];
 
 const FIELDS_PARAM = FIELDS.join(",");
@@ -128,11 +144,26 @@ export interface ScorecardRecord {
     completionRate200nt: number | null;
     /** Transfer-out rate for full-time <4yr students (0–1). */
     transferRate: number | null;
+    /** 1st-year retention rate for full-time students at <4yr schools (0–1). */
+    retentionRateFullTime: number | null;
+    /** 1st-year retention rate for part-time students at <4yr schools (0–1). */
+    retentionRatePartTime: number | null;
   };
 
   earnings: {
     /** Median earnings 10 years after enrollment entry, $. */
     median10YrsAfterEntry: number | null;
+    /** Median earnings 1 year after completion, $. Faster signal than the
+     * 10yr figure; only includes completers, so a cleaner per-cohort number. */
+    median1YrAfterCompletion: number | null;
+    /** 25th percentile, 10 years after entry — working, not enrolled, $. */
+    percentile25_10YrsAfterEntry: number | null;
+    /** 75th percentile, 10 years after entry — working, not enrolled, $. */
+    percentile75_10YrsAfterEntry: number | null;
+    /** Share of former students earning above $28k 10 years after entry —
+     * roughly the median wage for a high-school graduate (0–1). Federal
+     * Scorecard's flagship "did college pay off" outcome metric. */
+    shareEarningAboveHsGrad: number | null;
   };
 }
 
@@ -165,6 +196,13 @@ interface ScorecardApiRow {
   "latest.completion.completion_rate_less_than_4yr_200nt"?: number | null;
   "latest.completion.transfer_rate.less_than_4yr.full_time"?: number | null;
   "latest.earnings.10_yrs_after_entry.median"?: number | null;
+  // Tier 1 (issue #405)
+  "latest.student.retention_rate.lt_four_year.full_time"?: number | null;
+  "latest.student.retention_rate.lt_four_year.part_time"?: number | null;
+  "latest.earnings.1_yr_after_completion.median"?: number | null;
+  "latest.earnings.10_yrs_after_entry.working_not_enrolled.earnings_percentile.25"?: number | null;
+  "latest.earnings.10_yrs_after_entry.working_not_enrolled.earnings_percentile.75"?: number | null;
+  "latest.earnings.10_yrs_after_entry.percent_greater_than_28000"?: number | null;
 }
 
 interface ScorecardApiResponse {
@@ -225,10 +263,26 @@ function rowToRecord(row: ScorecardApiRow): ScorecardRecord {
         row["latest.completion.completion_rate_less_than_4yr_200nt"] ?? null,
       transferRate:
         row["latest.completion.transfer_rate.less_than_4yr.full_time"] ?? null,
+      retentionRateFullTime:
+        row["latest.student.retention_rate.lt_four_year.full_time"] ?? null,
+      retentionRatePartTime:
+        row["latest.student.retention_rate.lt_four_year.part_time"] ?? null,
     },
     earnings: {
       median10YrsAfterEntry:
         row["latest.earnings.10_yrs_after_entry.median"] ?? null,
+      median1YrAfterCompletion:
+        row["latest.earnings.1_yr_after_completion.median"] ?? null,
+      percentile25_10YrsAfterEntry:
+        row[
+          "latest.earnings.10_yrs_after_entry.working_not_enrolled.earnings_percentile.25"
+        ] ?? null,
+      percentile75_10YrsAfterEntry:
+        row[
+          "latest.earnings.10_yrs_after_entry.working_not_enrolled.earnings_percentile.75"
+        ] ?? null,
+      shareEarningAboveHsGrad:
+        row["latest.earnings.10_yrs_after_entry.percent_greater_than_28000"] ?? null,
     },
   };
 }


### PR DESCRIPTION
Closes #405.

## Summary

Adds 6 new fields from the federal Scorecard API and renders them as two new tile sections on every college page. The biggest improvements over the federal site:

- **Retention rate (1st-year)** — the strongest leading indicator of completion; the fed site doesn't prominently feature it
- **% earning above \$28k** — the fed Scorecard's flagship "did college pay off" metric, also buried on their UI
- **Earnings range (P25 / P75)** — distribution alongside the median, instead of a single number that hides variance

## Sections added

### After enrollment

- **1st-year retention** (full-time) — PT retention surfaces inside the tile's tooltip when present, so you see the FT/PT gap without crowding the tile
- **Transfer rate** — moved here from the old bottom row
- **Completion rate (200%)** — pairs with the 150% tile in the top row

### Earnings & debt

- **Earnings 1 yr after completion** — faster post-grad signal than the 10-year figure
- **Median earnings, 10 yrs** — now with \"\$X – \$Y\" P25–P75 range as subtext
- **Earn above \$28k**
- **Median debt at completion** — moved here from old bottom row
- **Take federal loans** — only surfaces for schools where it's > 0 (skips low-debt CCs like Caldwell where loanRate is 0%)

## Verified output

Caldwell Community College (NC) sample after re-ingest:

| Field | Value |
|---|---|
| 1st-year retention (FT) | 70.6% |
| 1st-year retention (PT) | 50.2% (in tooltip) |
| Earnings 1 yr after | \$34,593 |
| Median earnings 10 yrs | \$34,515 (range \$18,928–\$51,021) |
| Earn above \$28k | 47.4% |
| Federal loan rate | 0% (tile correctly omitted) |

Math checks: the Tier 1 numbers all match the API. Verified against `https://api.data.gov/ed/collegescorecard/v1/schools?id=198118` directly.

## Graceful degradation

Every new tile renders only when its value is non-null. The two new sections (\"After enrollment\", \"Earnings & debt\") render only when at least one of their fields is populated. No \"wall of —\" risk.

## Scope

- 380 colleges re-ingested across all states (Scorecard API is free, ran ~10 min locally).
- 15 institutions skipped — no IPEDS unitid mapped, same as before.
- No new dependencies. Pure additive change to existing pipeline.

## Test plan

- [x] Field probe against API for Caldwell — confirmed all 6 fields return data
- [x] \`tsc --noEmit\` clean
- [x] Local render on Caldwell — all sections appear, values match, tooltips populate
- [x] 380 colleges re-ingested without errors
- [ ] After merge + Vercel deploy: load Caldwell on prod, confirm the new \"After enrollment\" and \"Earnings & debt\" sections appear
- [ ] Spot-check a college with sparse data (e.g., a small AL or WV CC) to confirm graceful omission of suppressed tiles

## Follow-ups (separate issues, not in this PR)

- **#406 Tier 2** — per-program (CIP-level) earnings, debt, completion. Bigger lift; needs a new data file shape and a different page (the \`/[state]/program/[slug]\` route). Biggest content differentiator over the fed site.
- **#407 Tier 3** — demographics, equity gaps, locale, online share. Lower-effort but adds up to a "Student body & equity" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)