### PR TITLE
docs(claude): require plain-English summary at top of every PR body

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,17 @@ Merging is the user's job — they click "Squash and merge" on GitHub. Don't run
 
 Never push a commit and _hope_ the user hasn't merged yet. That's what caused the lost commits.
 
+## Pull request descriptions — lead with plain English
+
+Every PR body must open with a short section that a non-technical reader could understand, written before the detailed tables / test plan / dependencies / commit lists. Two things to cover, in this order:
+
+1. **What changes for someone using the site.** Concrete and specific: "the college page now shows a '1st-year retention 71%' tile in a new 'After enrollment' section." Not abstract: "improved transparency around outcomes." Name the page, the element, the visible value when relevant. If the change is invisible to users (build fix, infra refactor), say so plainly — "users see nothing new; this unblocks deploys that were failing at the 250 MB function-size cap" — instead of trying to manufacture a UX angle.
+2. **What changes on the technical front, when there's a story worth telling.** A sentence or two on the mechanism: which file does the work, what the underlying data source is, what the gotcha was. Reviewers (and you, six months from now) learn what's possible by reading this.
+
+Resist marketing copy. "Empowers students to make informed decisions" tells the reviewer nothing. "Adds three new tiles (retention, 1-year earnings, '% earning above HS median') sourced from federal College Scorecard API fields we weren't fetching before" tells them exactly what landed. **Completely accurate beats vaguely impressive every time** — if a change only helps a subset of pages, or has a known gap, name it.
+
+The detailed tables, file lists, test plans, and dependency notes that already populate PR bodies stay — this is an addition at the top, not a replacement.
+
 ## Verifying your work — three checks, in order
 
 Typecheck passing and a scraper completing without errors are necessary but not sufficient. Data can be wrong, APIs can return the right shape with broken content, and a PR that looks fine in isolation can break the UI for real users. Do these three, every time:


### PR DESCRIPTION
## What changes for someone using the site

Nothing visible to a student or visitor. This is a process change for me (and any other agent working in this repo): every future PR I open will lead with two short paragraphs explaining what the change does in plain language, before diving into the technical detail. The aim is that you can read the first 30 seconds of any PR I open and know whether to merge, without scrolling through tables of file paths and reconciliation math.

## What changes on the technical front

Adds a new section to `CLAUDE.md` titled \"Pull request descriptions — lead with plain English.\" Since `CLAUDE.md` is loaded into every Claude Code session as project context, this rule is now always-on — it applies to every PR I write from here forward, regardless of which workflow spawned the work.

The rule itself is two requirements:

1. **What changes for someone using the site.** Concrete and named, not vague. \"The college page now shows a '1st-year retention 71%' tile in a new 'After enrollment' section\" beats \"improved transparency around outcomes.\" For infra-only PRs that have no UX angle, say so directly — \"users see nothing new; this unblocks Vercel deploys\" — instead of inventing one.
2. **What changes on the technical front, when there's a story.** A sentence or two on which file does the work, what data source it taps, what gotcha it dodged. Reviewers (and future-me) learn what's possible by reading this.

Plus an explicit prohibition on marketing copy. \"Empowers students to make informed decisions\" tells the reviewer nothing — name the specific tile that landed.

## Why this is in CLAUDE.md

CLAUDE.md's own \"Where guidance lives\" section maps universal rules (\"every session, every task — what should I always do?\") to the CLAUDE.md file, and situational workflow rules to skills. This is a universal rule — every PR, every workflow — so CLAUDE.md is the right home. Skills like `auto-add-state` and `add-new-state` will inherit this because they're invoked inside the same session that loads CLAUDE.md.

## Test plan

- [x] Section added in the right structural slot (after the \"Git — narrate as you go\" section, before \"Verifying your work\")
- [ ] On the next PR I write after this merges, confirm the body actually leads with the two required paragraphs