### PR TITLE
feat(scorecard): state benchmarks on cost/outcome tiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,8 @@ next-env.d.ts
 # scraper caches (e.g. tmp/scns/crslist-*.txt — re-downloadable, ~80 MB)
 /tmp/
 
+# benchmark build cache (bulk Scorecard CSV, re-downloadable)
+/.cache/
+
 # blog-pipeline regenerable slices (snapshot/cooldown stay; per-state computed slices regenerate)
 .blog-pipeline/slices/

--- a/app/[state]/college/[id]/CollegeScorecardSection.tsx
+++ b/app/[state]/college/[id]/CollegeScorecardSection.tsx
@@ -10,6 +10,7 @@
 
 import {
   getScorecard,
+  getBenchmark,
   formatDollar,
   formatPercent,
   type ScorecardRecord,
@@ -21,11 +22,37 @@ interface Props {
   collegeName: string;
 }
 
+/**
+ * Build a one-line comparison string like "11% below VA CC median ($2,847)".
+ * Returns undefined when benchmark data is missing or the difference is
+ * negligible (< 3%).
+ */
+function benchmarkLabel(
+  value: number | null | undefined,
+  metric: string,
+  stateAbbr: string,
+  fmt: "dollar" | "percent",
+): string | undefined {
+  if (value == null) return undefined;
+  const bench = getBenchmark(metric, stateAbbr);
+  if (!bench || bench.median === 0) return undefined;
+
+  const diff = value - bench.median;
+  const pctDiff = Math.abs(Math.round((diff / bench.median) * 100));
+  if (pctDiff < 3) return `near ${stateAbbr.toUpperCase()} CC median`;
+
+  const direction = diff > 0 ? "above" : "below";
+  const formattedMedian =
+    fmt === "dollar" ? formatDollar(bench.median) : formatPercent(bench.median);
+  return `${pctDiff}% ${direction} ${stateAbbr.toUpperCase()} CC median (${formattedMedian})`;
+}
+
 function StatCard({
   label,
   value,
   sub,
   tooltip,
+  benchmark,
 }: {
   label: string;
   value: string;
@@ -37,6 +64,7 @@ function StatCard({
    * who tap-and-hold also get the tooltip via the OS-level long-press menu.
    */
   tooltip?: string;
+  benchmark?: string;
 }) {
   return (
     <div className="rounded-lg border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4">
@@ -58,6 +86,11 @@ function StatCard({
       {sub && (
         <div className="mt-0.5 text-xs text-gray-500 dark:text-slate-400">
           {sub}
+        </div>
+      )}
+      {benchmark && (
+        <div className="mt-1 text-xs font-medium text-teal-700 dark:text-teal-400">
+          {benchmark}
         </div>
       )}
     </div>
@@ -202,7 +235,7 @@ function CostBreakdown({ record }: { record: ScorecardRecord }) {
  * more likely to graduate than those who don't), and the federal
  * Scorecard site doesn't prominently feature it.
  */
-function OutcomesSection({ record }: { record: ScorecardRecord }) {
+function OutcomesSection({ record, state }: { record: ScorecardRecord; state: string }) {
   const retentionFt = record.completion.retentionRateFullTime;
   const retentionPt = record.completion.retentionRatePartTime;
   const transfer = record.completion.transferRate;
@@ -226,6 +259,7 @@ function OutcomesSection({ record }: { record: ScorecardRecord }) {
             value={formatPercent(retentionFt)}
             sub="full-time students"
             tooltip={retentionTooltip}
+            benchmark={benchmarkLabel(retentionFt, "retentionFt", state, "percent")}
           />
         )}
         {transfer != null && (
@@ -234,6 +268,7 @@ function OutcomesSection({ record }: { record: ScorecardRecord }) {
             value={formatPercent(transfer)}
             sub="to a 4-year school"
             tooltip="Share of full-time students who transferred out to a 4-year institution. Important for community colleges where transferring is a common goal."
+            benchmark={benchmarkLabel(transfer, "transferRate", state, "percent")}
           />
         )}
         {completion200 != null && (
@@ -242,6 +277,7 @@ function OutcomesSection({ record }: { record: ScorecardRecord }) {
             value={formatPercent(completion200)}
             sub="200% of normal time"
             tooltip="Share of students who completed within 200% of the normal program length — i.e., 4 years for a 2-year associate's. Broader, more realistic figure for working students."
+            benchmark={benchmarkLabel(completion200, "completionRate200", state, "percent")}
           />
         )}
       </div>
@@ -255,7 +291,7 @@ function OutcomesSection({ record }: { record: ScorecardRecord }) {
  * stat, plus loan rate and median debt. Together these answer "did the
  * money pay off."
  */
-function EarningsSection({ record }: { record: ScorecardRecord }) {
+function EarningsSection({ record, state }: { record: ScorecardRecord; state: string }) {
   const earn1Yr = record.earnings.median1YrAfterCompletion;
   const earn10Yr = record.earnings.median10YrsAfterEntry;
   const p25 = record.earnings.percentile25_10YrsAfterEntry;
@@ -291,6 +327,7 @@ function EarningsSection({ record }: { record: ScorecardRecord }) {
             value={formatDollar(earn1Yr)}
             sub="median, completers"
             tooltip="Median annual earnings one year after completion, completers only. Faster post-graduation signal than the 10-year figure (which mixes completers and non-completers)."
+            benchmark={benchmarkLabel(earn1Yr, "earnings1Yr", state, "dollar")}
           />
         )}
         {earn10Yr != null && (
@@ -303,6 +340,7 @@ function EarningsSection({ record }: { record: ScorecardRecord }) {
                 ? `Median annual earnings 10 years after first entering college. The range shown is the 25th–75th percentile (middle half of working former students), so half earn within this band and half are outside it.`
                 : "Median annual earnings 10 years after first entering college, working former students."
             }
+            benchmark={benchmarkLabel(earn10Yr, "earnings10Yr", state, "dollar")}
           />
         )}
         {aboveHs != null && (
@@ -311,6 +349,7 @@ function EarningsSection({ record }: { record: ScorecardRecord }) {
             value={formatPercent(aboveHs)}
             sub="10 yrs after entry"
             tooltip="Share of former students earning more than $28,000 — roughly the median annual wage for someone with only a high school diploma. The federal Scorecard's headline 'did college pay off' metric."
+            benchmark={benchmarkLabel(aboveHs, "aboveHsGrad", state, "percent")}
           />
         )}
       </div>
@@ -322,6 +361,7 @@ function EarningsSection({ record }: { record: ScorecardRecord }) {
               value={formatDollar(debt)}
               sub="federal loans, completers"
               tooltip="Median federal student loan debt for students who completed their program. Excludes private loans."
+              benchmark={benchmarkLabel(debt, "medianDebt", state, "dollar")}
             />
           )}
           {loanRate != null && loanRate > 0 && (
@@ -393,16 +433,19 @@ export default function CollegeScorecardSection({
           value={formatDollar(record.cost.tuitionInState)}
           sub="per year (sticker)"
           tooltip="Published tuition and required fees for in-state students. Does not include books, transportation, or living expenses."
+          benchmark={benchmarkLabel(record.cost.tuitionInState, "tuitionInState", state, "dollar")}
         />
         <StatCard
           label="Receive Pell"
           value={formatPercent(record.aid.pellGrantRate)}
           sub="federal grant"
+          benchmark={benchmarkLabel(record.aid.pellGrantRate, "pellRate", state, "percent")}
         />
         <StatCard
           label="Completion rate"
           value={formatPercent(record.completion.completionRate150nt)}
           sub="150% of normal time"
+          benchmark={benchmarkLabel(record.completion.completionRate150nt, "completionRate150", state, "percent")}
         />
       </div>
 
@@ -425,9 +468,9 @@ export default function CollegeScorecardSection({
         </div>
       )}
 
-      <OutcomesSection record={record} />
+      <OutcomesSection record={record} state={state} />
 
-      <EarningsSection record={record} />
+      <EarningsSection record={record} state={state} />
 
       <p className="mt-4 text-xs text-gray-500 dark:text-slate-400">
         Source:{" "}

--- a/data/_benchmarks/scorecard.json
+++ b/data/_benchmarks/scorecard.json
@@ -1,0 +1,1187 @@
+{
+  "generatedAt": "2026-05-13T03:04:53.598Z",
+  "totalColleges": 380,
+  "national": {
+    "tuitionInState": {
+      "median": 4728,
+      "count": 380,
+      "percentiles": {
+        "5": 2369.55,
+        "10": 2580.9,
+        "15": 2671.4,
+        "20": 3044,
+        "25": 3355.5,
+        "30": 3632.4,
+        "35": 4107.8,
+        "40": 4269.2,
+        "45": 4628.4,
+        "50": 4728,
+        "55": 4783.8,
+        "60": 5007,
+        "65": 5100,
+        "70": 5191.2,
+        "75": 5338.5,
+        "80": 5540.8,
+        "85": 5861.5,
+        "90": 6215.2,
+        "95": 6930
+      }
+    },
+    "avgNetPrice": {
+      "median": 6444,
+      "count": 380,
+      "percentiles": {
+        "5": 1661.7,
+        "10": 2788.4,
+        "15": 3581.2,
+        "20": 4127.8,
+        "25": 4615,
+        "30": 5147.2,
+        "35": 5426.15,
+        "40": 5744,
+        "45": 6047.1,
+        "50": 6444,
+        "55": 6922.5,
+        "60": 7516,
+        "65": 8060.05,
+        "70": 8762.3,
+        "75": 9243.5,
+        "80": 9960.4,
+        "85": 11180,
+        "90": 12350.1,
+        "95": 14508.55
+      }
+    },
+    "pellRate": {
+      "median": 0.332,
+      "count": 380,
+      "percentiles": {
+        "5": 0.203715,
+        "10": 0.23543,
+        "15": 0.25017,
+        "20": 0.26776,
+        "25": 0.28085,
+        "30": 0.28998,
+        "35": 0.29933,
+        "40": 0.30884,
+        "45": 0.320055,
+        "50": 0.332,
+        "55": 0.34567,
+        "60": 0.35998,
+        "65": 0.37772,
+        "70": 0.39252,
+        "75": 0.41205,
+        "80": 0.43122,
+        "85": 0.451775,
+        "90": 0.46889,
+        "95": 0.5367
+      }
+    },
+    "completionRate150": {
+      "median": 0.3559,
+      "count": 330,
+      "percentiles": {
+        "5": 0.18438,
+        "10": 0.21574,
+        "15": 0.240305,
+        "20": 0.27028,
+        "25": 0.29425,
+        "30": 0.30898,
+        "35": 0.3232,
+        "40": 0.33506,
+        "45": 0.342765,
+        "50": 0.3559,
+        "55": 0.37152,
+        "60": 0.38298,
+        "65": 0.39561,
+        "70": 0.41482,
+        "75": 0.429725,
+        "80": 0.45456,
+        "85": 0.479265,
+        "90": 0.50032,
+        "95": 0.559205
+      }
+    },
+    "completionRate200": {
+      "median": 0.37665,
+      "count": 330,
+      "percentiles": {
+        "5": 0.217515,
+        "10": 0.25278,
+        "15": 0.277005,
+        "20": 0.28764,
+        "25": 0.30275,
+        "30": 0.31714,
+        "35": 0.332025,
+        "40": 0.34836,
+        "45": 0.36181,
+        "50": 0.37665,
+        "55": 0.39497,
+        "60": 0.40886,
+        "65": 0.43008,
+        "70": 0.45191,
+        "75": 0.470125,
+        "80": 0.48844,
+        "85": 0.510255,
+        "90": 0.53346,
+        "95": 0.574135
+      }
+    },
+    "retentionFt": {
+      "median": 0.63495,
+      "count": 330,
+      "percentiles": {
+        "5": 0.50108,
+        "10": 0.54185,
+        "15": 0.559825,
+        "20": 0.57116,
+        "25": 0.58225,
+        "30": 0.59461,
+        "35": 0.60478,
+        "40": 0.61646,
+        "45": 0.626325,
+        "50": 0.63495,
+        "55": 0.641355,
+        "60": 0.64956,
+        "65": 0.660025,
+        "70": 0.66691,
+        "75": 0.677325,
+        "80": 0.68718,
+        "85": 0.70129,
+        "90": 0.72602,
+        "95": 0.75613
+      }
+    },
+    "transferRate": {
+      "median": 0.1501,
+      "count": 330,
+      "percentiles": {
+        "5": 0.04566,
+        "10": 0.06811,
+        "15": 0.082045,
+        "20": 0.09446,
+        "25": 0.103775,
+        "30": 0.11668,
+        "35": 0.12613,
+        "40": 0.1319,
+        "45": 0.1412,
+        "50": 0.1501,
+        "55": 0.156275,
+        "60": 0.1648,
+        "65": 0.1695,
+        "70": 0.17796,
+        "75": 0.189925,
+        "80": 0.21186,
+        "85": 0.22821,
+        "90": 0.24922,
+        "95": 0.284935
+      }
+    },
+    "earnings1Yr": {
+      "median": 37800,
+      "count": 372,
+      "percentiles": {
+        "5": 27985.7,
+        "10": 30814.8,
+        "15": 32702.05,
+        "20": 33568.6,
+        "25": 34381.25,
+        "30": 34890.1,
+        "35": 35978.9,
+        "40": 36501.8,
+        "45": 37460.85,
+        "50": 37800,
+        "55": 38433.15,
+        "60": 38952.2,
+        "65": 39536.75,
+        "70": 40268.9,
+        "75": 41399.75,
+        "80": 42237.8,
+        "85": 43691.6,
+        "90": 45311.4,
+        "95": 47920.75
+      }
+    },
+    "earnings10Yr": {
+      "median": 37090.5,
+      "count": 378,
+      "percentiles": {
+        "5": 30041.55,
+        "10": 31538.3,
+        "15": 32573.75,
+        "20": 33283.6,
+        "25": 34115,
+        "30": 34559.6,
+        "35": 35221.35,
+        "40": 36022.4,
+        "45": 36435.9,
+        "50": 37090.5,
+        "55": 37559.05,
+        "60": 38351,
+        "65": 39206.95,
+        "70": 40126.2,
+        "75": 40987.5,
+        "80": 41640,
+        "85": 42475,
+        "90": 44030.6,
+        "95": 46253.5
+      }
+    },
+    "aboveHsGrad": {
+      "median": 0.5185,
+      "count": 368,
+      "percentiles": {
+        "5": 0.39335,
+        "10": 0.4151,
+        "15": 0.43605,
+        "20": 0.447,
+        "25": 0.46275,
+        "30": 0.48,
+        "35": 0.49,
+        "40": 0.498,
+        "45": 0.50715,
+        "50": 0.5185,
+        "55": 0.52685,
+        "60": 0.5382,
+        "65": 0.55055,
+        "70": 0.5628,
+        "75": 0.573,
+        "80": 0.5846,
+        "85": 0.60295,
+        "90": 0.6213,
+        "95": 0.64565
+      }
+    },
+    "medianDebt": {
+      "median": 10412,
+      "count": 298,
+      "percentiles": {
+        "5": 6511.9,
+        "10": 7344.9,
+        "15": 7825.75,
+        "20": 8302.8,
+        "25": 8750,
+        "30": 9007.8,
+        "35": 9370.3,
+        "40": 9535.8,
+        "45": 9991.95,
+        "50": 10412,
+        "55": 10500,
+        "60": 10951.8,
+        "65": 11000,
+        "70": 11500,
+        "75": 12000,
+        "80": 12094.8,
+        "85": 12856.45,
+        "90": 13842.1,
+        "95": 15271.3
+      }
+    }
+  },
+  "byState": {
+    "al": {
+      "tuitionInState": {
+        "median": 5110,
+        "count": 23
+      },
+      "avgNetPrice": {
+        "median": 6142,
+        "count": 23
+      },
+      "pellRate": {
+        "median": 0.3567,
+        "count": 23
+      },
+      "completionRate150": {
+        "median": 0.3605,
+        "count": 23
+      },
+      "completionRate200": {
+        "median": 0.3388,
+        "count": 23
+      },
+      "retentionFt": {
+        "median": 0.6247,
+        "count": 23
+      },
+      "transferRate": {
+        "median": 0.1772,
+        "count": 23
+      },
+      "earnings1Yr": {
+        "median": 37458,
+        "count": 23
+      },
+      "earnings10Yr": {
+        "median": 34107,
+        "count": 23
+      },
+      "aboveHsGrad": {
+        "median": 0.494,
+        "count": 23
+      },
+      "medianDebt": {
+        "median": 9883,
+        "count": 12
+      }
+    },
+    "fl": {
+      "tuitionInState": {
+        "median": 2834,
+        "count": 28
+      },
+      "avgNetPrice": {
+        "median": 5995,
+        "count": 28
+      },
+      "pellRate": {
+        "median": 0.3439,
+        "count": 28
+      },
+      "earnings1Yr": {
+        "median": 39108,
+        "count": 28
+      },
+      "earnings10Yr": {
+        "median": 40154,
+        "count": 28
+      },
+      "aboveHsGrad": {
+        "median": 0.556,
+        "count": 28
+      },
+      "medianDebt": {
+        "median": 9126,
+        "count": 26
+      }
+    },
+    "ga": {
+      "tuitionInState": {
+        "median": 3395,
+        "count": 22
+      },
+      "avgNetPrice": {
+        "median": 5690.5,
+        "count": 22
+      },
+      "pellRate": {
+        "median": 0.43655,
+        "count": 22
+      },
+      "completionRate150": {
+        "median": 0.42715,
+        "count": 22
+      },
+      "completionRate200": {
+        "median": 0.4746,
+        "count": 22
+      },
+      "retentionFt": {
+        "median": 0.5843,
+        "count": 22
+      },
+      "transferRate": {
+        "median": 0.08255,
+        "count": 22
+      },
+      "earnings1Yr": {
+        "median": 36294.5,
+        "count": 22
+      },
+      "earnings10Yr": {
+        "median": 32975,
+        "count": 22
+      },
+      "aboveHsGrad": {
+        "median": 0.4355,
+        "count": 22
+      },
+      "medianDebt": {
+        "median": 9500,
+        "count": 15
+      }
+    },
+    "ia": {
+      "tuitionInState": {
+        "median": 6298,
+        "count": 16
+      },
+      "avgNetPrice": {
+        "median": 10932,
+        "count": 16
+      },
+      "pellRate": {
+        "median": 0.2374,
+        "count": 16
+      },
+      "completionRate150": {
+        "median": 0.4339,
+        "count": 16
+      },
+      "completionRate200": {
+        "median": 0.4388,
+        "count": 16
+      },
+      "retentionFt": {
+        "median": 0.6362,
+        "count": 16
+      },
+      "transferRate": {
+        "median": 0.1267,
+        "count": 16
+      },
+      "earnings1Yr": {
+        "median": 39572,
+        "count": 16
+      },
+      "earnings10Yr": {
+        "median": 41017,
+        "count": 16
+      },
+      "aboveHsGrad": {
+        "median": 0.61,
+        "count": 16
+      },
+      "medianDebt": {
+        "median": 11000,
+        "count": 16
+      }
+    },
+    "ky": {
+      "tuitionInState": {
+        "median": 4728,
+        "count": 16
+      },
+      "avgNetPrice": {
+        "median": 5248,
+        "count": 16
+      },
+      "pellRate": {
+        "median": 0.33255,
+        "count": 16
+      },
+      "completionRate150": {
+        "median": 0.4811,
+        "count": 16
+      },
+      "completionRate200": {
+        "median": 0.5036,
+        "count": 16
+      },
+      "retentionFt": {
+        "median": 0.6723,
+        "count": 16
+      },
+      "transferRate": {
+        "median": 0.1012,
+        "count": 16
+      },
+      "earnings1Yr": {
+        "median": 35675,
+        "count": 16
+      },
+      "earnings10Yr": {
+        "median": 35302.5,
+        "count": 16
+      },
+      "aboveHsGrad": {
+        "median": 0.485,
+        "count": 16
+      },
+      "medianDebt": {
+        "median": 10329,
+        "count": 16
+      }
+    },
+    "ma": {
+      "tuitionInState": {
+        "median": 6000,
+        "count": 15
+      },
+      "avgNetPrice": {
+        "median": 7931,
+        "count": 15
+      },
+      "pellRate": {
+        "median": 0.3785,
+        "count": 15
+      },
+      "completionRate150": {
+        "median": 0.223,
+        "count": 15
+      },
+      "completionRate200": {
+        "median": 0.2765,
+        "count": 15
+      },
+      "retentionFt": {
+        "median": 0.6224,
+        "count": 15
+      },
+      "transferRate": {
+        "median": 0.1689,
+        "count": 15
+      },
+      "earnings1Yr": {
+        "median": 40236,
+        "count": 15
+      },
+      "earnings10Yr": {
+        "median": 42862,
+        "count": 15
+      },
+      "aboveHsGrad": {
+        "median": 0.59,
+        "count": 15
+      },
+      "medianDebt": {
+        "median": 9000,
+        "count": 14
+      }
+    },
+    "md": {
+      "tuitionInState": {
+        "median": 4237,
+        "count": 16
+      },
+      "avgNetPrice": {
+        "median": 9231,
+        "count": 16
+      },
+      "pellRate": {
+        "median": 0.26805,
+        "count": 16
+      },
+      "completionRate150": {
+        "median": 0.335,
+        "count": 16
+      },
+      "completionRate200": {
+        "median": 0.33585,
+        "count": 16
+      },
+      "retentionFt": {
+        "median": 0.66275,
+        "count": 16
+      },
+      "transferRate": {
+        "median": 0.20655,
+        "count": 16
+      },
+      "earnings1Yr": {
+        "median": 41906.5,
+        "count": 16
+      },
+      "earnings10Yr": {
+        "median": 44150.5,
+        "count": 16
+      },
+      "aboveHsGrad": {
+        "median": 0.5925,
+        "count": 16
+      },
+      "medianDebt": {
+        "median": 10457.5,
+        "count": 14
+      }
+    },
+    "me": {
+      "tuitionInState": {
+        "median": 4156,
+        "count": 7
+      },
+      "avgNetPrice": {
+        "median": 6975,
+        "count": 7
+      },
+      "pellRate": {
+        "median": 0.3543,
+        "count": 7
+      },
+      "completionRate150": {
+        "median": 0.3383,
+        "count": 7
+      },
+      "completionRate200": {
+        "median": 0.3571,
+        "count": 7
+      },
+      "retentionFt": {
+        "median": 0.5682,
+        "count": 7
+      },
+      "transferRate": {
+        "median": 0.1288,
+        "count": 7
+      },
+      "earnings1Yr": {
+        "median": 41752.5,
+        "count": 6
+      },
+      "earnings10Yr": {
+        "median": 41704,
+        "count": 7
+      },
+      "aboveHsGrad": {
+        "median": 0.547,
+        "count": 7
+      },
+      "medianDebt": {
+        "median": 11059,
+        "count": 6
+      }
+    },
+    "mi": {
+      "tuitionInState": {
+        "median": 4759,
+        "count": 31
+      },
+      "avgNetPrice": {
+        "median": 5571,
+        "count": 31
+      },
+      "pellRate": {
+        "median": 0.3012,
+        "count": 31
+      },
+      "completionRate150": {
+        "median": 0.2938,
+        "count": 25
+      },
+      "completionRate200": {
+        "median": 0.2874,
+        "count": 25
+      },
+      "retentionFt": {
+        "median": 0.6364,
+        "count": 25
+      },
+      "transferRate": {
+        "median": 0.2184,
+        "count": 25
+      },
+      "earnings1Yr": {
+        "median": 39934,
+        "count": 29
+      },
+      "earnings10Yr": {
+        "median": 37311,
+        "count": 30
+      },
+      "aboveHsGrad": {
+        "median": 0.524,
+        "count": 29
+      },
+      "medianDebt": {
+        "median": 11906,
+        "count": 28
+      }
+    },
+    "ms": {
+      "tuitionInState": {
+        "median": 4078,
+        "count": 15
+      },
+      "avgNetPrice": {
+        "median": 5240,
+        "count": 15
+      },
+      "pellRate": {
+        "median": 0.4481,
+        "count": 15
+      },
+      "completionRate150": {
+        "median": 0.4101,
+        "count": 15
+      },
+      "completionRate200": {
+        "median": 0.4566,
+        "count": 15
+      },
+      "retentionFt": {
+        "median": 0.6608,
+        "count": 15
+      },
+      "transferRate": {
+        "median": 0.1535,
+        "count": 15
+      },
+      "earnings1Yr": {
+        "median": 32587,
+        "count": 15
+      },
+      "earnings10Yr": {
+        "median": 32922,
+        "count": 15
+      },
+      "aboveHsGrad": {
+        "median": 0.49,
+        "count": 15
+      },
+      "medianDebt": {
+        "median": 8318.5,
+        "count": 12
+      }
+    },
+    "nc": {
+      "tuitionInState": {
+        "median": 2575,
+        "count": 58
+      },
+      "avgNetPrice": {
+        "median": 5808.5,
+        "count": 58
+      },
+      "pellRate": {
+        "median": 0.313,
+        "count": 58
+      },
+      "completionRate150": {
+        "median": 0.40815,
+        "count": 58
+      },
+      "completionRate200": {
+        "median": 0.4623,
+        "count": 58
+      },
+      "retentionFt": {
+        "median": 0.6724,
+        "count": 58
+      },
+      "transferRate": {
+        "median": 0.14595,
+        "count": 58
+      },
+      "earnings1Yr": {
+        "median": 36661,
+        "count": 57
+      },
+      "earnings10Yr": {
+        "median": 34036.5,
+        "count": 58
+      },
+      "aboveHsGrad": {
+        "median": 0.4455,
+        "count": 58
+      },
+      "medianDebt": {
+        "median": 10500,
+        "count": 20
+      }
+    },
+    "nh": {
+      "tuitionInState": {
+        "median": 7090,
+        "count": 7
+      },
+      "avgNetPrice": {
+        "median": 15474,
+        "count": 7
+      },
+      "pellRate": {
+        "median": 0.2691,
+        "count": 7
+      },
+      "completionRate150": {
+        "median": 0.3765,
+        "count": 7
+      },
+      "completionRate200": {
+        "median": 0.3618,
+        "count": 7
+      },
+      "retentionFt": {
+        "median": 0.6414,
+        "count": 7
+      },
+      "transferRate": {
+        "median": 0.2118,
+        "count": 7
+      },
+      "earnings1Yr": {
+        "median": 45413,
+        "count": 6
+      },
+      "earnings10Yr": {
+        "median": 46164,
+        "count": 7
+      },
+      "aboveHsGrad": {
+        "median": 0.654,
+        "count": 4
+      },
+      "medianDebt": {
+        "median": 14650,
+        "count": 7
+      }
+    },
+    "nj": {
+      "tuitionInState": {
+        "median": 5415,
+        "count": 19
+      },
+      "avgNetPrice": {
+        "median": 7859,
+        "count": 19
+      },
+      "pellRate": {
+        "median": 0.3482,
+        "count": 19
+      },
+      "completionRate150": {
+        "median": 0.329,
+        "count": 19
+      },
+      "completionRate200": {
+        "median": 0.3916,
+        "count": 19
+      },
+      "retentionFt": {
+        "median": 0.6397,
+        "count": 19
+      },
+      "transferRate": {
+        "median": 0.1372,
+        "count": 19
+      },
+      "earnings1Yr": {
+        "median": 33603,
+        "count": 19
+      },
+      "earnings10Yr": {
+        "median": 43264,
+        "count": 19
+      },
+      "aboveHsGrad": {
+        "median": 0.606,
+        "count": 19
+      },
+      "medianDebt": {
+        "median": 10500,
+        "count": 18
+      }
+    },
+    "ny": {
+      "tuitionInState": {
+        "median": 5210,
+        "count": 7
+      },
+      "avgNetPrice": {
+        "median": 5297,
+        "count": 7
+      },
+      "pellRate": {
+        "median": 0.567,
+        "count": 7
+      },
+      "completionRate150": {
+        "median": 0.2389,
+        "count": 7
+      },
+      "completionRate200": {
+        "median": 0.2835,
+        "count": 7
+      },
+      "retentionFt": {
+        "median": 0.5716,
+        "count": 7
+      },
+      "transferRate": {
+        "median": 0.1788,
+        "count": 7
+      },
+      "earnings1Yr": {
+        "median": 26851,
+        "count": 7
+      },
+      "earnings10Yr": {
+        "median": 41979.5,
+        "count": 6
+      },
+      "aboveHsGrad": {
+        "median": 0.613,
+        "count": 6
+      },
+      "medianDebt": {
+        "median": 7574,
+        "count": 7
+      }
+    },
+    "oh": {
+      "tuitionInState": {
+        "median": 4698,
+        "count": 21
+      },
+      "avgNetPrice": {
+        "median": 7714,
+        "count": 21
+      },
+      "pellRate": {
+        "median": 0.2596,
+        "count": 21
+      },
+      "completionRate150": {
+        "median": 0.37,
+        "count": 9
+      },
+      "completionRate200": {
+        "median": 0.3413,
+        "count": 9
+      },
+      "retentionFt": {
+        "median": 0.6,
+        "count": 9
+      },
+      "transferRate": {
+        "median": 0.1475,
+        "count": 9
+      },
+      "earnings1Yr": {
+        "median": 41986,
+        "count": 20
+      },
+      "earnings10Yr": {
+        "median": 38158,
+        "count": 21
+      },
+      "aboveHsGrad": {
+        "median": 0.532,
+        "count": 21
+      },
+      "medianDebt": {
+        "median": 12000,
+        "count": 21
+      }
+    },
+    "pa": {
+      "tuitionInState": {
+        "median": 6480,
+        "count": 15
+      },
+      "avgNetPrice": {
+        "median": 9228,
+        "count": 15
+      },
+      "pellRate": {
+        "median": 0.3308,
+        "count": 15
+      },
+      "completionRate150": {
+        "median": 0.26155,
+        "count": 14
+      },
+      "completionRate200": {
+        "median": 0.28875,
+        "count": 14
+      },
+      "retentionFt": {
+        "median": 0.6133,
+        "count": 14
+      },
+      "transferRate": {
+        "median": 0.1818,
+        "count": 14
+      },
+      "earnings1Yr": {
+        "median": 39050.5,
+        "count": 14
+      },
+      "earnings10Yr": {
+        "median": 41566,
+        "count": 15
+      },
+      "aboveHsGrad": {
+        "median": 0.586,
+        "count": 15
+      },
+      "medianDebt": {
+        "median": 12000,
+        "count": 15
+      }
+    },
+    "sc": {
+      "tuitionInState": {
+        "median": 5137,
+        "count": 16
+      },
+      "avgNetPrice": {
+        "median": 6058.5,
+        "count": 16
+      },
+      "pellRate": {
+        "median": 0.3921,
+        "count": 16
+      },
+      "completionRate150": {
+        "median": 0.3024,
+        "count": 15
+      },
+      "completionRate200": {
+        "median": 0.3353,
+        "count": 15
+      },
+      "retentionFt": {
+        "median": 0.592,
+        "count": 15
+      },
+      "transferRate": {
+        "median": 0.1806,
+        "count": 15
+      },
+      "earnings1Yr": {
+        "median": 38509,
+        "count": 15
+      },
+      "earnings10Yr": {
+        "median": 35764.5,
+        "count": 16
+      },
+      "aboveHsGrad": {
+        "median": 0.462,
+        "count": 16
+      },
+      "medianDebt": {
+        "median": 12125,
+        "count": 14
+      }
+    },
+    "tn": {
+      "tuitionInState": {
+        "median": 4760,
+        "count": 12
+      },
+      "avgNetPrice": {
+        "median": 5811.5,
+        "count": 12
+      },
+      "pellRate": {
+        "median": 0.33145,
+        "count": 12
+      },
+      "completionRate150": {
+        "median": 0.3056,
+        "count": 12
+      },
+      "completionRate200": {
+        "median": 0.307,
+        "count": 12
+      },
+      "retentionFt": {
+        "median": 0.5487,
+        "count": 12
+      },
+      "transferRate": {
+        "median": 0.13805,
+        "count": 12
+      },
+      "earnings1Yr": {
+        "median": 36513.5,
+        "count": 12
+      },
+      "earnings10Yr": {
+        "median": 37341.5,
+        "count": 12
+      },
+      "aboveHsGrad": {
+        "median": 0.518,
+        "count": 12
+      },
+      "medianDebt": {
+        "median": 8227,
+        "count": 8
+      }
+    },
+    "va": {
+      "tuitionInState": {
+        "median": 5075,
+        "count": 23
+      },
+      "avgNetPrice": {
+        "median": 5541,
+        "count": 23
+      },
+      "pellRate": {
+        "median": 0.3032,
+        "count": 23
+      },
+      "completionRate150": {
+        "median": 0.4037,
+        "count": 23
+      },
+      "completionRate200": {
+        "median": 0.4206,
+        "count": 23
+      },
+      "retentionFt": {
+        "median": 0.6456,
+        "count": 23
+      },
+      "transferRate": {
+        "median": 0.1161,
+        "count": 23
+      },
+      "earnings1Yr": {
+        "median": 35864,
+        "count": 23
+      },
+      "earnings10Yr": {
+        "median": 36627,
+        "count": 23
+      },
+      "aboveHsGrad": {
+        "median": 0.518,
+        "count": 23
+      },
+      "medianDebt": {
+        "median": 9341,
+        "count": 16
+      }
+    },
+    "wv": {
+      "tuitionInState": {
+        "median": 4938,
+        "count": 9
+      },
+      "avgNetPrice": {
+        "median": 5329,
+        "count": 9
+      },
+      "pellRate": {
+        "median": 0.3682,
+        "count": 9
+      },
+      "completionRate150": {
+        "median": 0.3377,
+        "count": 8
+      },
+      "completionRate200": {
+        "median": 0.3327,
+        "count": 8
+      },
+      "retentionFt": {
+        "median": 0.5939,
+        "count": 8
+      },
+      "transferRate": {
+        "median": 0.1053,
+        "count": 8
+      },
+      "earnings1Yr": {
+        "median": 34276,
+        "count": 9
+      },
+      "earnings10Yr": {
+        "median": 32153,
+        "count": 9
+      },
+      "aboveHsGrad": {
+        "median": 0.461,
+        "count": 3
+      },
+      "medianDebt": {
+        "median": 9829,
+        "count": 9
+      }
+    }
+  }
+}

--- a/lib/scorecard.ts
+++ b/lib/scorecard.ts
@@ -167,6 +167,96 @@ export function formatPercent(v: number | null | undefined): string {
 }
 
 // ---------------------------------------------------------------------------
+// Benchmarks — state + national context for stat tiles (issue #411)
+// ---------------------------------------------------------------------------
+
+export interface BenchmarkBucket {
+  median: number;
+  count: number;
+}
+
+export interface NationalBenchmarkBucket extends BenchmarkBucket {
+  percentiles: Record<string, number>;
+}
+
+interface ScorecardBenchmarks {
+  generatedAt: string;
+  totalColleges: number;
+  national: Record<string, NationalBenchmarkBucket>;
+  byState: Record<string, Record<string, BenchmarkBucket>>;
+}
+
+let benchmarksCache: ScorecardBenchmarks | null | undefined;
+
+function loadBenchmarks(): ScorecardBenchmarks | null {
+  if (benchmarksCache !== undefined) return benchmarksCache;
+  const p = path.join(process.cwd(), "data", "_benchmarks", "scorecard.json");
+  if (!fs.existsSync(p)) {
+    benchmarksCache = null;
+    return null;
+  }
+  try {
+    benchmarksCache = JSON.parse(
+      fs.readFileSync(p, "utf-8"),
+    ) as ScorecardBenchmarks;
+    return benchmarksCache;
+  } catch {
+    benchmarksCache = null;
+    return null;
+  }
+}
+
+/**
+ * Return benchmark stats for a metric. Pass `state` for per-state median,
+ * omit for the national median. Returns null when benchmarks are missing
+ * or the metric/state combination has insufficient data.
+ */
+export function getBenchmark(
+  metric: string,
+  state?: string,
+): BenchmarkBucket | null {
+  const b = loadBenchmarks();
+  if (!b) return null;
+  if (state) return b.byState[state.toLowerCase()]?.[metric] ?? null;
+  return b.national[metric] ?? null;
+}
+
+/**
+ * Approximate percentile rank of `value` within the national CC
+ * distribution for `metric`. Returns 0–100 (e.g. 73 means "higher than
+ * 73% of US community colleges"). Uses linear interpolation between the
+ * stored p5…p95 breakpoints.
+ */
+export function getNationalPercentileRank(
+  metric: string,
+  value: number,
+): number | null {
+  const b = loadBenchmarks();
+  if (!b) return null;
+  const nat = b.national[metric];
+  if (!nat?.percentiles) return null;
+
+  const pcts = Object.entries(nat.percentiles)
+    .map(([k, v]) => [Number(k), v] as [number, number])
+    .sort((a, b) => a[0] - b[0]);
+
+  if (pcts.length === 0) return null;
+  if (value <= pcts[0][1]) return pcts[0][0];
+  if (value >= pcts[pcts.length - 1][1]) return pcts[pcts.length - 1][0];
+
+  for (let i = 0; i < pcts.length - 1; i++) {
+    const [p1, v1] = pcts[i];
+    const [p2, v2] = pcts[i + 1];
+    if (value >= v1 && value <= v2) {
+      if (v2 === v1) return p1;
+      const t = (value - v1) / (v2 - v1);
+      return Math.round(p1 + t * (p2 - p1));
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Per-program (CIP) reader — issue #406
 // ---------------------------------------------------------------------------
 

--- a/scripts/build-benchmarks.ts
+++ b/scripts/build-benchmarks.ts
@@ -1,0 +1,162 @@
+/**
+ * Compute state + national benchmarks from existing per-college Scorecard
+ * data. Reads every `data/{state}/scorecard/*.json`, filters to public
+ * community colleges, and emits `data/_benchmarks/scorecard.json`.
+ *
+ * Usage:  tsx scripts/build-benchmarks.ts
+ *
+ * Issue #411. The output file is committed — run this script whenever
+ * scorecard data is re-ingested (roughly annually after the October
+ * Scorecard refresh).
+ */
+
+import fs from "fs";
+import path from "path";
+
+import type { ScorecardRecord } from "@/scripts/lib/college-scorecard";
+
+// ── Metric extractors ────────────────────────────────────────────────
+
+type Extractor = (r: ScorecardRecord) => number | null | undefined;
+
+const METRICS: Record<string, Extractor> = {
+  tuitionInState: (r) => r.cost.tuitionInState,
+  avgNetPrice: (r) => r.cost.avgNetPricePublic,
+  pellRate: (r) => r.aid.pellGrantRate,
+  completionRate150: (r) => r.completion.completionRate150nt,
+  completionRate200: (r) => r.completion.completionRate200nt,
+  retentionFt: (r) => r.completion.retentionRateFullTime,
+  transferRate: (r) => r.completion.transferRate,
+  earnings1Yr: (r) => r.earnings.median1YrAfterCompletion,
+  earnings10Yr: (r) => r.earnings.median10YrsAfterEntry,
+  aboveHsGrad: (r) => r.earnings.shareEarningAboveHsGrad,
+  medianDebt: (r) => r.aid.medianDebtCompleters,
+};
+
+// ── Stats helpers ────────────────────────────────────────────────────
+
+function median(nums: number[]): number {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function percentileValue(sorted: number[], p: number): number {
+  const idx = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+interface BenchmarkBucket {
+  median: number;
+  count: number;
+}
+
+interface NationalBenchmarkBucket extends BenchmarkBucket {
+  percentiles: Record<string, number>;
+}
+
+// ── Load all scorecard records ───────────────────────────────────────
+
+function loadAllRecords(): Map<string, ScorecardRecord[]> {
+  const dataDir = path.join(process.cwd(), "data");
+  const byState = new Map<string, ScorecardRecord[]>();
+
+  for (const entry of fs.readdirSync(dataDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith("_")) continue;
+    const scDir = path.join(dataDir, entry.name, "scorecard");
+    if (!fs.existsSync(scDir)) continue;
+
+    const records: ScorecardRecord[] = [];
+    for (const file of fs.readdirSync(scDir)) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const r = JSON.parse(
+          fs.readFileSync(path.join(scDir, file), "utf-8"),
+        ) as ScorecardRecord;
+        if (r.ownership === 1) records.push(r);
+      } catch {
+        // skip malformed files
+      }
+    }
+    if (records.length > 0) byState.set(entry.name, records);
+  }
+  return byState;
+}
+
+// ── Compute benchmarks ───────────────────────────────────────────────
+
+function computeBucket(values: number[]): BenchmarkBucket | null {
+  if (values.length < 3) return null;
+  return { median: Math.round(median(values) * 1e6) / 1e6, count: values.length };
+}
+
+function computeNationalBucket(
+  values: number[],
+): NationalBenchmarkBucket | null {
+  if (values.length < 3) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const percentiles: Record<string, number> = {};
+  for (let p = 5; p <= 95; p += 5) {
+    percentiles[String(p)] =
+      Math.round(percentileValue(sorted, p) * 1e6) / 1e6;
+  }
+  return {
+    median: Math.round(median(values) * 1e6) / 1e6,
+    count: values.length,
+    percentiles,
+  };
+}
+
+function extractValues(records: ScorecardRecord[], extract: Extractor): number[] {
+  return records
+    .map(extract)
+    .filter((v): v is number => typeof v === "number" && !Number.isNaN(v));
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+const byState = loadAllRecords();
+const allRecords = Array.from(byState.values()).flat();
+
+console.log(
+  `Loaded ${allRecords.length} public CC records across ${byState.size} states`,
+);
+
+const national: Record<string, NationalBenchmarkBucket> = {};
+const stateLevel: Record<string, Record<string, BenchmarkBucket>> = {};
+
+for (const [key, extract] of Object.entries(METRICS)) {
+  const allVals = extractValues(allRecords, extract);
+  const nb = computeNationalBucket(allVals);
+  if (nb) national[key] = nb;
+
+  for (const [state, records] of byState) {
+    const vals = extractValues(records, extract);
+    const bucket = computeBucket(vals);
+    if (bucket) {
+      if (!stateLevel[state]) stateLevel[state] = {};
+      stateLevel[state][key] = bucket;
+    }
+  }
+}
+
+const output = {
+  generatedAt: new Date().toISOString(),
+  totalColleges: allRecords.length,
+  national,
+  byState: stateLevel,
+};
+
+const outDir = path.join(process.cwd(), "data", "_benchmarks");
+fs.mkdirSync(outDir, { recursive: true });
+const outPath = path.join(outDir, "scorecard.json");
+fs.writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n");
+
+console.log(`Wrote ${outPath}`);
+console.log(`  National metrics: ${Object.keys(national).length}`);
+console.log(`  States with benchmarks: ${Object.keys(stateLevel).length}`);


### PR DESCRIPTION
## What changes for someone using the site

Every cost and outcome stat tile on college pages (e.g. `/va/college/brcc`) now shows a teal one-line comparison to the state community college median. For example, the tuition tile says "$5,646" and underneath: "11% above VA CC median ($5,075)". When the college's value is within 3% of the median, it reads "near VA CC median" instead of showing a negligible percentage. This applies to all 10 stat tiles: tuition, Pell rate, completion rate (150% and 200%), retention, transfer rate, 1-year earnings, 10-year earnings, % earning above HS median, and median debt. A student can now immediately tell whether a college is cheap or expensive, high- or low-completing, etc. relative to other colleges in their state — without opening multiple tabs.

## What changes on the technical front

A new `scripts/build-benchmarks.ts` script reads every `data/*/scorecard/*.json` file (380 public CC records across 24 states), computes per-state and national medians for 11 metrics, and writes the result to `data/_benchmarks/scorecard.json` (~50 KB, committed). National benchmarks also include percentile breakpoints at every 5th percentile (p5–p95) for future "higher than X% of US community colleges" labels.

`lib/scorecard.ts` gains two new helpers: `getBenchmark(metric, state?)` returns the median + count for a metric at state or national level, and `getNationalPercentileRank(metric, value)` interpolates a 0–100 percentile rank from the stored breakpoints. The component uses `getBenchmark` for the state comparison; the percentile-rank helper is available for future use.

## Files changed

| File | What |
|---|---|
| `scripts/build-benchmarks.ts` | New — benchmark computation from existing scorecard data |
| `data/_benchmarks/scorecard.json` | New — committed benchmark output |
| `lib/scorecard.ts` | Added `getBenchmark()`, `getNationalPercentileRank()`, types |
| `app/[state]/college/[id]/CollegeScorecardSection.tsx` | Added `benchmarkLabel()` + `benchmark` prop on `StatCard` |
| `.gitignore` | Added `/.cache/` |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Loaded `/va/college/brcc` in local dev — all 10 stat tiles show teal benchmark labels
- [x] "near VA CC median" displays when value is within 3% of median (retention, completion 150%)
- [x] Dollar metrics show formatted median in parens: "11% above VA CC median ($5,075)"
- [x] Percent metrics show formatted median in parens: "24% below VA CC median (12%)"
- [ ] Verify on a state with fewer colleges (e.g. `/vt/college/...`) — should still render if ≥ 3 colleges report that metric

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)