### PR TITLE
feat(interlinks): course pages → program pathways; program pages → cross-state

### DIFF
--- a/app/[state]/course/[code]/page.tsx
+++ b/app/[state]/course/[code]/page.tsx
@@ -8,6 +8,8 @@ import { getAllStates, isValidState, getStateConfig } from "@/lib/states/registr
 import { requireStateConfig } from "@/lib/states/route-helpers";
 import { getTransferInfo, getUniversities } from "@/lib/transfer";
 import { subjectName } from "@/lib/subjects";
+import { getBestProgramForPrefix } from "@/lib/programs/registry";
+import { getQualifyingProgramSlugs } from "@/lib/programs";
 import { computeCourseAvailabilityProfile } from "@/lib/course-stats";
 import type { CourseSection } from "@/lib/types";
 import AdUnit from "@/components/AdUnit";
@@ -341,6 +343,20 @@ export default async function CoursePage(props: PageProps) {
 
   const lastUpdated = getCourseLastUpdated(state);
 
+  // Program-pathway bridge (#413): when this course's subject prefix
+  // maps to one of our curated programs and the program qualifies in
+  // this state, surface a small "Part of {program}" link so the
+  // course-detail visitor can step up to the program comparison view
+  // with earnings + per-college data.
+  const matchedProgram = getBestProgramForPrefix(prefix);
+  const qualifyingSlugs = matchedProgram
+    ? await getQualifyingProgramSlugs(state)
+    : [];
+  const programLink =
+    matchedProgram && qualifyingSlugs.includes(matchedProgram.slug)
+      ? matchedProgram
+      : null;
+
   // JSON-LD
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://communitycollegepath.com";
   const jsonLd = {
@@ -437,12 +453,25 @@ export default async function CoursePage(props: PageProps) {
 
         {/* Header */}
         <div className="mb-8">
-          <Link
-            href={`/${state}/subject/${prefix.toLowerCase()}`}
-            className="text-sm font-medium text-teal-600 dark:text-teal-400 mb-1 inline-block hover:underline"
-          >
-            {subjectName(prefix)}
-          </Link>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mb-1 text-sm">
+            <Link
+              href={`/${state}/subject/${prefix.toLowerCase()}`}
+              className="font-medium text-teal-600 dark:text-teal-400 hover:underline"
+            >
+              {subjectName(prefix)}
+            </Link>
+            {programLink && (
+              <>
+                <span className="text-gray-300 dark:text-slate-600">·</span>
+                <Link
+                  href={`/${state}/program/${programLink.slug}`}
+                  className="text-gray-500 dark:text-slate-400 hover:text-teal-600 dark:hover:text-teal-400 hover:underline"
+                >
+                  Part of the {programLink.name} pathway →
+                </Link>
+              </>
+            )}
+          </div>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-slate-100">
             {prefix} {number}
             <span className="font-normal text-gray-500 dark:text-slate-400 text-2xl ml-2">

--- a/app/[state]/program/[slug]/page.tsx
+++ b/app/[state]/program/[slug]/page.tsx
@@ -204,6 +204,25 @@ export default async function ProgramPage(props: PageProps) {
     (p) => p.slug
   );
 
+  // Cross-state nav (#413): same program in every other state where it
+  // qualifies. Builds a topic cluster — both for student comparison
+  // (\"how does nursing in NC stack up vs VA, SC, GA?\") and for SEO
+  // link equity flowing through topically-related pages.
+  const otherStatesWithThisProgram = (
+    await Promise.all(
+      getAllStates()
+        .filter((s) => s.slug !== state)
+        .map(async (s) => {
+          const slugs = await getQualifyingProgramSlugs(s.slug).catch(
+            () => [] as string[],
+          );
+          return slugs.includes(slug) ? s : null;
+        }),
+    )
+  )
+    .filter((s): s is NonNullable<typeof s> => s !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
   return (
     <>
       <script
@@ -565,6 +584,34 @@ export default async function ProgramPage(props: PageProps) {
                 </li>
               ))}
             </ul>
+          </section>
+        )}
+
+        {otherStatesWithThisProgram.length > 0 && (
+          <section className="mb-10">
+            <h2
+              id="other-states"
+              className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-1"
+            >
+              Compare {program.name} programs in other states
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-slate-400 mb-4">
+              Same comparison view, different state systems. Useful if
+              you&rsquo;re considering an out-of-state community college or
+              just want to see how {config.name}&rsquo;s {program.name.toLowerCase()}{" "}
+              programs stack up.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {otherStatesWithThisProgram.map((s) => (
+                <Link
+                  key={s.slug}
+                  href={`/${s.slug}/program/${slug}`}
+                  className="rounded-full border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1 text-sm text-gray-700 dark:text-slate-300 hover:border-teal-300 dark:hover:border-teal-600 hover:text-teal-700 dark:hover:text-teal-400 transition"
+                >
+                  {program.name} in {s.name}
+                </Link>
+              ))}
+            </div>
           </section>
         )}
 


### PR DESCRIPTION
Closes the remaining course-detail and cross-state items in #413. Builds on #417 which already wired up college and subject pages.

## What changes for someone using the site

Two more entry paths into the program-comparison hubs:

**1. Course detail pages get a "Part of the {program} pathway" link.** Visit a single-course page like [`/nc/course/nur-101`](https://communitycollegepath.com/nc/course/nur-101) and the breadcrumb row above the H1 now reads:

> **Nursing**  ·  Part of the Nursing pathway →

The new link sits beside the existing subject link, styled subtly so it doesn't compete with the main breadcrumb. A student viewing a single course can step up to the state-wide program comparison view (with awards/yr + earnings) in one click — they no longer have to guess the URL.

**2. Program pages get a "Compare {program} in other states" section.** Near the bottom of [`/nc/program/nursing`](https://communitycollegepath.com/nc/program/nursing) (above the existing "Other programs in NC" section), there's a new block listing every other covered state where the program qualifies. NC nursing currently links to nursing program pages in **12 other states** (AL, FL, KY, MA, MD, ME, MI, NJ, NY, OH, SC, VA). 

Useful for students considering out-of-state options ("how do MD nursing programs compare to NC?") and for SEO — creates a topical link cluster across state-versions of the same program. Bigger states with stronger inbound link equity (MA, NC) now pass that equity along to smaller-state versions of the same program.

## Combined with #417, the link audit at #413 is fully resolved

Both PRs together solve the original problem: program pages existed but nothing linked to them. All four high-value entry paths now interlink:

| Entry point | Wired in |
|---|---|
| College page → program | #417 |
| Subject page → program | #417 |
| Course detail page → program | **this PR** |
| Adjacent-state program → program | **this PR** |

## What changes on the technical front

- **`app/[state]/course/[code]/page.tsx`** — uses the `getBestProgramForPrefix` helper from `lib/programs/registry.ts` (added in #417) plus a `getQualifyingProgramSlugs(state)` gate so we never link to a program page that would 404 in this state. Renders as inline breadcrumb text styled subtly to not compete with the main subject link.

- **`app/[state]/program/[slug]/page.tsx`** — walks `getAllStates()` and calls `getQualifyingProgramSlugs(s.slug)` per state, filters to states where this program slug qualifies, renders pill links. Async work is `Promise.all`'d so it doesn't serialize. Pages with no other qualifying state (rare) skip the section entirely.

No new data, no new APIs, no client JS. Pure rendering of existing data + the program registry.

## Verified

- `tsc --noEmit` clean
- `/nc/course/nur-101` shows the breadcrumb link to `/nc/program/nursing`
- `/nc/program/nursing` renders 12 cross-state pill links
- Prefix→program gate works: a course in a prefix that doesn't map to any program (e.g. MUS music courses) renders unchanged
- Cross-state gate works: a program qualifying only in a few states (less popular ones) shows only those few links

## What's left from #413

- Add "Programs" to global header / footer nav
- Content depth on program pages (intro paragraph, career-path FAQ, BLS salary context)
- Anchor-text optimization on existing pill links

All three are lower-leverage than what's already shipped — the link graph is now coherent. I'd hold those for separate dedicated PRs (the content-depth one in particular is a meaty SEO content push, not a single PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)